### PR TITLE
feat(git): pull from specific base branch instead of default

### DIFF
--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -3709,11 +3709,11 @@ pub async fn run_review_with_ai(
     Ok(response)
 }
 
-/// Pull changes from remote origin
+/// Pull changes from remote origin for the specified base branch
 #[tauri::command]
-pub async fn git_pull(worktree_path: String) -> Result<String, String> {
-    log::trace!("Pulling changes for worktree: {worktree_path}");
-    git::git_pull(&worktree_path)
+pub async fn git_pull(worktree_path: String, base_branch: String) -> Result<String, String> {
+    log::trace!("Pulling changes for worktree: {worktree_path}, base branch: {base_branch}");
+    git::git_pull(&worktree_path, &base_branch)
 }
 
 // =============================================================================

--- a/src-tauri/src/projects/git.rs
+++ b/src-tauri/src/projects/git.rs
@@ -380,23 +380,23 @@ pub fn get_branches(repo_path: &str) -> Result<Vec<String>, String> {
     Ok(branches)
 }
 
-/// Pull changes from remote origin
-pub fn git_pull(repo_path: &str) -> Result<String, String> {
-    log::trace!("Pulling from origin in {repo_path}");
+/// Pull changes from remote origin for the specified base branch
+pub fn git_pull(repo_path: &str, base_branch: &str) -> Result<String, String> {
+    log::trace!("Pulling from origin/{base_branch} in {repo_path}");
 
     let output = Command::new("git")
-        .args(["pull"])
+        .args(["pull", "origin", base_branch])
         .current_dir(repo_path)
         .output()
         .map_err(|e| format!("Failed to run git pull: {e}"))?;
 
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        log::trace!("Successfully pulled from origin");
+        log::trace!("Successfully pulled from origin/{base_branch}");
         Ok(stdout)
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        log::error!("Failed to pull from origin: {stderr}");
+        log::error!("Failed to pull from origin/{base_branch}: {stderr}");
         Err(stderr)
     }
 }

--- a/src/services/git-status.ts
+++ b/src/services/git-status.ts
@@ -124,13 +124,17 @@ export async function triggerImmediateGitPoll(): Promise<void> {
  * Pull changes from remote origin.
  *
  * @param worktreePath - Path to the worktree/repository
+ * @param baseBranch - The base branch to pull from (e.g., 'main')
  * @returns Output from git pull command
  */
-export async function gitPull(worktreePath: string): Promise<string> {
+export async function gitPull(
+  worktreePath: string,
+  baseBranch: string
+): Promise<string> {
   if (!isTauri()) {
     throw new Error('Git pull only available in Tauri')
   }
-  return invoke<string>('git_pull', { worktreePath })
+  return invoke<string>('git_pull', { worktreePath, baseBranch })
 }
 
 /**


### PR DESCRIPTION
## Summary

- Modified `git_pull` command to accept a `base_branch` parameter for pulling from a specific branch
- Updated Tauri command handler to pass base branch to git operations
- Enhanced pull logic to retrieve project's `default_branch` and use it for pull operations
- Fallback to 'main' if base branch cannot be determined
- Improved logging to reflect the specific branch being pulled

## Breaking Changes

- `gitPull()` now requires a `baseBranch` parameter (previously used default remote branch)
- Tauri `git_pull` command now requires `base_branch` argument