### PR TITLE
fix: resolve type mismatch and remove unused imports

### DIFF
--- a/src-tauri/src/claude_cli/commands.rs
+++ b/src-tauri/src/claude_cli/commands.rs
@@ -3,7 +3,6 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::io::Write;
-use std::process::Command;
 use tauri::{AppHandle, Emitter};
 
 use super::config::{ensure_cli_dir, get_cli_binary_path};

--- a/src-tauri/src/platform/process.rs
+++ b/src-tauri/src/platform/process.rs
@@ -37,7 +37,7 @@ pub fn is_process_alive(pid: u32) -> bool {
         let result = GetExitCodeProcess(handle, &mut exit_code);
         CloseHandle(handle);
 
-        result != 0 && exit_code == STILL_ACTIVE
+        result != 0 && exit_code == STILL_ACTIVE as u32
     }
 }
 

--- a/src-tauri/src/platform/shell.rs
+++ b/src-tauri/src/platform/shell.rs
@@ -1,6 +1,5 @@
 // Cross-platform shell detection and command execution
 
-use std::env;
 use std::process::Command;
 
 /// Returns the user's default shell path


### PR DESCRIPTION
- Cast STILL_ACTIVE to u32 in process.rs to match exit_code type
- Remove unused std::process::Command import in commands.rs
- Remove unused std::env import in shell.rs


Fixes: #2 