### PR TITLE
feat: stream background Task sub-tools in real-time (WIP)

### DIFF
--- a/src-tauri/src/chat/background.rs
+++ b/src-tauri/src/chat/background.rs
@@ -1,0 +1,401 @@
+//! Background Task tailing for sub-agent tool calls
+//!
+//! When a Task tool runs with `run_in_background: true`, its sub-tools are written
+//! to a separate output file. This module provides functionality to tail that file
+//! and emit tool events with the proper `parent_tool_use_id` for UI grouping.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::mpsc::{self, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use serde_json::Value;
+use tauri::{AppHandle, Emitter};
+
+use super::tail::{NdjsonTailer, POLL_INTERVAL};
+
+/// Payload for tool use events sent to frontend (matches claude.rs)
+#[derive(serde::Serialize, Clone)]
+struct ToolUseEvent {
+    session_id: String,
+    worktree_id: String,
+    id: String,
+    name: String,
+    input: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_tool_use_id: Option<String>,
+}
+
+/// Payload for tool result events sent to frontend
+#[derive(serde::Serialize, Clone)]
+struct ToolResultEvent {
+    session_id: String,
+    worktree_id: String,
+    tool_use_id: String,
+    output: String,
+}
+
+/// Handle for a running background Task tailer
+pub struct BackgroundTailerHandle {
+    /// The Task tool's tool_use_id (becomes parent_tool_use_id for sub-tools)
+    #[allow(dead_code)]
+    pub task_tool_use_id: String,
+    /// Channel to signal cancellation
+    pub cancel_sender: Sender<()>,
+}
+
+/// Collection of background tailers for a session
+pub type BackgroundTailers = Arc<Mutex<HashMap<String, BackgroundTailerHandle>>>;
+
+/// Create a new BackgroundTailers collection
+pub fn new_background_tailers() -> BackgroundTailers {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+/// Parse a Task tool_result to extract the output_file path for background tasks.
+///
+/// The tool_result content is plain text in the format:
+/// ```text
+/// Async agent launched successfully.
+/// agentId: ab2b9e8 (internal ID - do not mention to user...)
+/// output_file: /path/to/output.jsonl
+/// The agent is working in the background...
+/// ```
+///
+/// Returns None if not a background task or if parsing fails.
+pub fn parse_background_task_result(content: &str) -> Option<PathBuf> {
+    // Look for "output_file: " prefix in the text
+    const PREFIX: &str = "output_file: ";
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(path_str) = trimmed.strip_prefix(PREFIX) {
+            let path = path_str.trim();
+            if !path.is_empty() {
+                return Some(PathBuf::from(path));
+            }
+        }
+    }
+
+    None
+}
+
+/// Start tailing a background Task's output file.
+///
+/// Spawns a thread that:
+/// 1. Waits for the output file to exist
+/// 2. Tails the file for new NDJSON lines
+/// 3. Emits `chat:tool_use` events with the parent Task's ID
+/// 4. Stops when the agent emits a "result" message or is cancelled
+pub fn spawn_background_tailer(
+    app: AppHandle,
+    session_id: String,
+    worktree_id: String,
+    parent_tool_use_id: String,
+    output_file: PathBuf,
+    tailers: BackgroundTailers,
+) {
+    let (cancel_tx, cancel_rx) = mpsc::channel();
+    let task_id = parent_tool_use_id.clone();
+
+    // Store handle for cleanup
+    {
+        let mut tailers_guard = tailers.lock().unwrap();
+        tailers_guard.insert(
+            task_id.clone(),
+            BackgroundTailerHandle {
+                task_tool_use_id: task_id.clone(),
+                cancel_sender: cancel_tx,
+            },
+        );
+    }
+
+    // Clone for the thread
+    let tailers_cleanup = tailers.clone();
+
+    thread::spawn(move || {
+        log::debug!(
+            "Background tailer started for task {task_id}, output: {output_file:?}"
+        );
+
+        // Wait for the file to exist (with timeout)
+        let max_wait = Duration::from_secs(30);
+        let start = std::time::Instant::now();
+
+        while !output_file.exists() {
+            if cancel_rx.try_recv().is_ok() {
+                log::debug!("Background tailer {task_id} cancelled while waiting for file");
+                return;
+            }
+            if start.elapsed() > max_wait {
+                log::warn!(
+                    "Background tailer {task_id} timed out waiting for file: {output_file:?}"
+                );
+                return;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+
+        // Create tailer
+        let mut tailer = match NdjsonTailer::new_from_start(&output_file) {
+            Ok(t) => t,
+            Err(e) => {
+                log::error!("Background tailer {task_id} failed to open file: {e}");
+                return;
+            }
+        };
+
+        log::debug!("Background tailer {task_id} now tailing {output_file:?}");
+
+        // Track tool calls for this background agent
+        let mut tool_calls: HashMap<String, ()> = HashMap::new();
+
+        // Main tailing loop
+        loop {
+            // Check for cancellation
+            if cancel_rx.try_recv().is_ok() {
+                log::debug!("Background tailer {task_id} cancelled");
+                break;
+            }
+
+            // Poll for new lines
+            let lines = match tailer.poll() {
+                Ok(l) => l,
+                Err(e) => {
+                    log::error!("Background tailer {task_id} poll error: {e}");
+                    break;
+                }
+            };
+
+            if !lines.is_empty() {
+                log::debug!("Background tailer {task_id} read {} lines", lines.len());
+            }
+
+            for line in lines {
+                if line.trim().is_empty() {
+                    continue;
+                }
+
+                // Skip metadata
+                if line.contains("\"_run_meta\"") {
+                    continue;
+                }
+
+                // Parse JSON
+                let msg: Value = match serde_json::from_str(&line) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        log::debug!("Background tailer {task_id} failed to parse line: {e}");
+                        log::debug!("Line content: {}", &line[..line.len().min(200)]);
+                        continue;
+                    }
+                };
+
+                let msg_type = msg.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                log::debug!("Background tailer {task_id} processing message type: {msg_type}");
+
+                match msg_type {
+                    "assistant" => {
+                        // Process tool_use blocks
+                        if let Some(message) = msg.get("message") {
+                            if let Some(blocks) = message.get("content").and_then(|c| c.as_array())
+                            {
+                                for block in blocks {
+                                    let block_type =
+                                        block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+                                    if block_type == "tool_use" {
+                                        let id = block
+                                            .get("id")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("")
+                                            .to_string();
+                                        let name = block
+                                            .get("name")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("")
+                                            .to_string();
+                                        let input = block
+                                            .get("input")
+                                            .cloned()
+                                            .unwrap_or(Value::Null);
+
+                                        // Track this tool call
+                                        tool_calls.insert(id.clone(), ());
+
+                                        // Emit tool_use event with parent_tool_use_id
+                                        let event = ToolUseEvent {
+                                            session_id: session_id.clone(),
+                                            worktree_id: worktree_id.clone(),
+                                            id: id.clone(),
+                                            name: name.clone(),
+                                            input,
+                                            parent_tool_use_id: Some(parent_tool_use_id.clone()),
+                                        };
+
+                                        if let Err(e) = app.emit("chat:tool_use", &event) {
+                                            log::error!(
+                                                "Background tailer {task_id} failed to emit tool_use: {e}"
+                                            );
+                                        } else {
+                                            log::debug!(
+                                                "Background tailer {task_id} emitted tool_use: {name} ({id})"
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    "user" => {
+                        // Process tool_result blocks
+                        if let Some(message) = msg.get("message") {
+                            if let Some(blocks) = message.get("content").and_then(|c| c.as_array())
+                            {
+                                for block in blocks {
+                                    let block_type =
+                                        block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+                                    if block_type == "tool_result" {
+                                        let tool_use_id = block
+                                            .get("tool_use_id")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("")
+                                            .to_string();
+                                        // Content can be a string OR an array of content blocks
+                                        let output = block
+                                            .get("content")
+                                            .map(|v| {
+                                                if let Some(s) = v.as_str() {
+                                                    s.to_string()
+                                                } else if let Some(arr) = v.as_array() {
+                                                    arr.iter()
+                                                        .filter_map(|item| {
+                                                            if item.get("type").and_then(|t| t.as_str())
+                                                                == Some("text")
+                                                            {
+                                                                item.get("text")
+                                                                    .and_then(|t| t.as_str())
+                                                                    .map(|s| s.to_string())
+                                                            } else {
+                                                                None
+                                                            }
+                                                        })
+                                                        .collect::<Vec<_>>()
+                                                        .join("\n")
+                                                } else {
+                                                    String::new()
+                                                }
+                                            })
+                                            .unwrap_or_default();
+
+                                        // Only emit if we emitted the tool_use
+                                        if tool_calls.contains_key(&tool_use_id) {
+                                            let event = ToolResultEvent {
+                                                session_id: session_id.clone(),
+                                                worktree_id: worktree_id.clone(),
+                                                tool_use_id: tool_use_id.clone(),
+                                                output,
+                                            };
+
+                                            if let Err(e) = app.emit("chat:tool_result", &event) {
+                                                log::error!(
+                                                    "Background tailer {task_id} failed to emit tool_result: {e}"
+                                                );
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    "result" => {
+                        // Agent completed
+                        log::debug!("Background tailer {task_id} agent completed");
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+
+            thread::sleep(POLL_INTERVAL);
+        }
+
+        // Remove from tailers map
+        if let Ok(mut tailers_guard) = tailers_cleanup.lock() {
+            tailers_guard.remove(&task_id);
+        }
+
+        log::debug!("Background tailer {task_id} finished");
+    });
+}
+
+/// Stop all background tailers for a session
+pub fn stop_all_background_tailers(tailers: &BackgroundTailers) {
+    if let Ok(mut tailers_guard) = tailers.lock() {
+        for (task_id, handle) in tailers_guard.drain() {
+            log::debug!("Stopping background tailer for task {task_id}");
+            let _ = handle.cancel_sender.send(());
+        }
+    }
+}
+
+/// Stop a specific background tailer
+#[allow(dead_code)]
+pub fn stop_background_tailer(tailers: &BackgroundTailers, task_tool_use_id: &str) {
+    if let Ok(mut tailers_guard) = tailers.lock() {
+        if let Some(handle) = tailers_guard.remove(task_tool_use_id) {
+            log::debug!("Stopping background tailer for task {task_tool_use_id}");
+            let _ = handle.cancel_sender.send(());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_background_task_result_valid() {
+        let content = r#"Async agent launched successfully.
+agentId: ab2b9e8 (internal ID - do not mention to user. Use to resume later if needed.)
+output_file: /tmp/agent-output.jsonl
+The agent is working in the background."#;
+        let result = parse_background_task_result(content);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), PathBuf::from("/tmp/agent-output.jsonl"));
+    }
+
+    #[test]
+    fn test_parse_background_task_result_real_format() {
+        let content = "Async agent launched successfully.\nagentId: ab2b9e8 (internal ID - do not mention to user. Use to resume later if needed.)\noutput_file: /private/tmp/claude/-Users-jean-benoit-jean-theme-scheduler-test-sweet-bison/tasks/ab2b9e8.output\nThe agent is working in the background. You will be notified when it completes—no need to check. Continue with other tasks.\nTo check progress before completion (optional), use Read or Bash tail on the output file.";
+        let result = parse_background_task_result(content);
+        assert!(result.is_some());
+        assert_eq!(
+            result.unwrap(),
+            PathBuf::from("/private/tmp/claude/-Users-jean-benoit-jean-theme-scheduler-test-sweet-bison/tasks/ab2b9e8.output")
+        );
+    }
+
+    #[test]
+    fn test_parse_background_task_result_no_output_file() {
+        let content = "Task completed successfully.\nNo background agent was launched.";
+        let result = parse_background_task_result(content);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_background_task_result_empty() {
+        let content = "";
+        let result = parse_background_task_result(content);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_new_background_tailers() {
+        let tailers = new_background_tailers();
+        assert!(tailers.lock().unwrap().is_empty());
+    }
+}

--- a/src-tauri/src/chat/claude.rs
+++ b/src-tauri/src/chat/claude.rs
@@ -1,5 +1,11 @@
+use std::collections::HashMap;
+
 use tauri::{Emitter, Manager};
 
+use super::background::{
+    new_background_tailers, parse_background_task_result, spawn_background_tailer,
+    stop_all_background_tailers,
+};
 use super::types::{ContentBlock, ThinkingLevel, ToolCall, UsageData};
 use crate::projects::github_issues::{
     get_github_contexts_dir, get_worktree_issue_refs, get_worktree_pr_refs,
@@ -568,6 +574,10 @@ pub fn tail_claude_output(
     let mut cancelled = false;
     let mut usage: Option<UsageData> = None;
 
+    // Track pending background Tasks (tool_use_id -> ()) for spawning tailers on tool_result
+    let mut pending_background_tasks: HashMap<String, ()> = HashMap::new();
+    let background_tailers = new_background_tailers();
+
     // Timeout configuration:
     // - Startup timeout: Wait up to 120 seconds for first Claude output (API connection time)
     // - Dead process timeout: After receiving output, wait 2 seconds for more if process seems dead
@@ -741,6 +751,21 @@ pub fn tail_claude_output(
                                                 usage: None, // No usage for partial responses
                                             });
                                         }
+
+                                        // Track background Task tools for spawning tailers
+                                        if name == "Task" {
+                                            if let Some(run_bg) = input
+                                                .get("run_in_background")
+                                                .and_then(|v| v.as_bool())
+                                            {
+                                                if run_bg {
+                                                    log::debug!(
+                                                        "Detected background Task tool: {id}"
+                                                    );
+                                                    pending_background_tasks.insert(id.clone(), ());
+                                                }
+                                            }
+                                        }
                                     }
                                     "thinking" => {
                                         if let Some(thinking) =
@@ -779,8 +804,52 @@ pub fn tail_claude_output(
                                         .get("tool_use_id")
                                         .and_then(|v| v.as_str())
                                         .unwrap_or("");
-                                    let output =
-                                        block.get("content").and_then(|v| v.as_str()).unwrap_or("");
+                                    // Content can be a string OR an array of content blocks
+                                    let output = block
+                                        .get("content")
+                                        .map(|v| {
+                                            if let Some(s) = v.as_str() {
+                                                s.to_string()
+                                            } else if let Some(arr) = v.as_array() {
+                                                // Extract text from content blocks
+                                                arr.iter()
+                                                    .filter_map(|item| {
+                                                        if item.get("type").and_then(|t| t.as_str())
+                                                            == Some("text")
+                                                        {
+                                                            item.get("text")
+                                                                .and_then(|t| t.as_str())
+                                                                .map(|s| s.to_string())
+                                                        } else {
+                                                            None
+                                                        }
+                                                    })
+                                                    .collect::<Vec<_>>()
+                                                    .join("\n")
+                                            } else {
+                                                String::new()
+                                            }
+                                        })
+                                        .unwrap_or_default();
+
+                                    // Check if this is a background Task result
+                                    if pending_background_tasks.remove(tool_id).is_some() {
+                                        if let Some(output_file) =
+                                            parse_background_task_result(&output)
+                                        {
+                                            log::debug!(
+                                                "Spawning background tailer for Task {tool_id}, file: {output_file:?}"
+                                            );
+                                            spawn_background_tailer(
+                                                app.clone(),
+                                                session_id.to_string(),
+                                                worktree_id.to_string(),
+                                                tool_id.to_string(),
+                                                output_file,
+                                                background_tailers.clone(),
+                                            );
+                                        }
+                                    }
 
                                     // Update matching tool call's output
                                     if let Some(tc) =
@@ -948,7 +1017,7 @@ pub fn tail_claude_output(
             // Log progress every 10 seconds during startup (only log once per 10-second mark)
             // Use subsec_millis to only log in the first 100ms of each 10-second window
             let secs = elapsed.as_secs();
-            if secs > 0 && secs % 10 == 0 && elapsed.subsec_millis() < 100 {
+            if secs > 0 && secs.is_multiple_of(10) && elapsed.subsec_millis() < 100 {
                 log::trace!(
                     "Waiting for Claude output... {secs}s elapsed, process_alive: {process_alive}"
                 );
@@ -957,6 +1026,34 @@ pub fn tail_claude_output(
 
         // Sleep before next poll
         std::thread::sleep(POLL_INTERVAL);
+    }
+
+    // Wait for background tailers to finish (they stop on their own when agents complete)
+    // Check every 500ms, with a max wait of 10 minutes for long-running agents
+    let max_background_wait = std::time::Duration::from_secs(600);
+    let background_poll = std::time::Duration::from_millis(500);
+    let background_start = std::time::Instant::now();
+
+    loop {
+        let tailers_empty = background_tailers.lock().map(|t| t.is_empty()).unwrap_or(true);
+        if tailers_empty {
+            break;
+        }
+
+        if background_start.elapsed() > max_background_wait {
+            log::warn!("Background tailers timeout, stopping remaining tailers");
+            stop_all_background_tailers(&background_tailers);
+            break;
+        }
+
+        // Log progress every 30 seconds
+        let elapsed = background_start.elapsed().as_secs();
+        if elapsed > 0 && elapsed % 30 == 0 {
+            let count = background_tailers.lock().map(|t| t.len()).unwrap_or(0);
+            log::trace!("Waiting for {count} background tailers... {elapsed}s elapsed");
+        }
+
+        std::thread::sleep(background_poll);
     }
 
     // Emit done event only if not cancelled

--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -1,3 +1,4 @@
+mod background;
 mod claude;
 mod commands;
 pub mod detached;

--- a/src-tauri/src/chat/types.rs
+++ b/src-tauri/src/chat/types.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 /// Metadata from a compaction event
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct CompactMetadata {
     /// How compaction was triggered
     pub trigger: String, // "manual" or "auto"

--- a/src-tauri/src/claude_cli/commands.rs
+++ b/src-tauri/src/claude_cli/commands.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::io::Write;
+use std::process::Command;
 use tauri::{AppHandle, Emitter};
 
 use super::config::{ensure_cli_dir, get_cli_binary_path};

--- a/src-tauri/src/platform/shell.rs
+++ b/src-tauri/src/platform/shell.rs
@@ -1,5 +1,6 @@
 // Cross-platform shell detection and command execution
 
+use std::env;
 use std::process::Command;
 
 /// Returns the user's default shell path

--- a/src/components/chat/ToolCallInline.tsx
+++ b/src/components/chat/ToolCallInline.tsx
@@ -154,6 +154,7 @@ export function TaskCallInline({
   const input = taskToolCall.input as Record<string, unknown>
   const subagentType = input.subagent_type as string | undefined
   const description = input.description as string | undefined
+  const prompt = input.prompt as string | undefined
 
   return (
     <Collapsible
@@ -201,7 +202,13 @@ export function TaskCallInline({
           )}
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="border-t border-border/50 px-3 py-2">
+          <div className="border-t border-border/50 px-3 py-2 space-y-2">
+            {/* Show prompt/instructions */}
+            {prompt && (
+              <div className="text-xs text-muted-foreground bg-muted/50 rounded p-2 whitespace-pre-wrap">
+                {prompt}
+              </div>
+            )}
             {/* Show sub-tools as compact list */}
             {subToolCalls.length > 0 ? (
               <div className="space-y-1">


### PR DESCRIPTION
## Summary

- Implement real-time streaming display of sub-tools when Tasks run with `run_in_background: true`
- Display Task prompt/instructions in the UI when expanding a Task

## What's Done

### Background Task Tailing System
- Created `src-tauri/src/chat/background.rs` module with:
  - `BackgroundTailerHandle` and `BackgroundTailers` types for managing tailers
  - `parse_background_task_result()` to extract `output_file` path from Task results
  - `spawn_background_tailer()` to tail background Task output files and emit `chat:tool_use` events with proper `parent_tool_use_id`
  - Proper cleanup when agents complete (on "result" message)

### Integration in Main Chat Flow
- Track pending background Tasks in `claude.rs` (detect `run_in_background: true` in Task tool_use)
- Spawn dedicated tailer for each background Task when its tool_result arrives
- Wait for all background tailers to complete before emitting `chat:done` (keeps status indicator active)
- Fixed content extraction bug: `tool_result.content` is an array, not a string

### UI Improvements
- Display Task prompt/instructions when expanding a Task in `ToolCallInline.tsx`

## What's NOT Working

Background Tasks are **interrupted** when the main Claude CLI process exits. The subagent output files show `[Request interrupted by user]` immediately after the main turn completes.

**Root cause:** Jean uses `--print` flag which causes Claude CLI to exit after each response. When the CLI exits, it sends interrupt signals to all running background agents.

## Solutions Under Consideration

| Option | Description | Pros | Cons |
|--------|-------------|------|------|
| **Keep CLI alive with dummy message** | Send a follow-up message to keep CLI running while Tasks execute | Localized change | Hacky, consumes tokens, adds visible message |
| **Use `--continue` instead of `--print`** | Interactive mode keeps CLI alive | Clean long-term solution | Major architectural change, high regression risk |
| **Resume interrupted Tasks** | Detect interruption, relaunch with `--resume <agentId>` | No change to main flow, Tasks resume where they stopped | Slight latency, need to track agentIds |
| **Accept limitation** | Document that background Tasks don't work in Jean | No code change | Feature doesn't work |

**Recommended:** Option 3 (Resume interrupted Tasks) seems cleanest - matches what a user would do manually.

## Test Plan

- [ ] Launch a chat that triggers background Tasks
- [ ] Verify sub-tools appear in real-time under the Task
- [ ] Verify Task prompt is visible when expanded
- [ ] Verify status indicator stays active while Tasks run
- [ ] Verify Tasks complete successfully (currently blocked by interruption issue)