### PR TITLE
fix: show permission prompts immediately during streaming

### DIFF
--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -1837,7 +1837,6 @@ Begin your investigation now.`
                   {/* Permission approval UI - shown when tools require approval (never in yolo mode) */}
                   {pendingDenials.length > 0 &&
                     activeSessionId &&
-                    !isSending &&
                     executionMode !== 'yolo' && (
                       <PermissionApproval
                         sessionId={activeSessionId}


### PR DESCRIPTION
Remove the !isSending condition that blocked permission dialogs from appearing while Claude was still streaming.

Permission prompts (for Read, Grep, Bash, etc.) now appear immediately when Claude requests them, instead of waiting for the response stream to complete.

This matches Claude Code CLI behavior where permission prompts appear immediately when requested.