### PR TITLE
feat(chat): add conversation fork and revert with git patch support

### DIFF
--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -978,6 +978,7 @@ pub async fn send_chat_message(
         &app,
         &session_id,
         &worktree_id,
+        &worktree_path,
         &session_name,
         session_order,
         &user_message_id,
@@ -1213,6 +1214,33 @@ pub async fn clear_session_history(
             Err(format!("Session not found: {session_id}"))
         }
     })
+}
+
+/// Revert a session to a specific assistant message, removing all subsequent messages.
+/// If worktree_path is provided, also reverts code changes using git patches.
+#[tauri::command]
+pub async fn revert_session_to_message(
+    app: AppHandle,
+    session_id: String,
+    assistant_message_id: String,
+    worktree_path: Option<String>,
+) -> Result<u32, String> {
+    log::trace!(
+        "Reverting session {session_id} to message {assistant_message_id} (worktree_path: {:?})",
+        worktree_path
+    );
+
+    // Truncate the session using the run_log helper
+    let deleted_count = super::run_log::truncate_session_to_message(
+        &app,
+        &session_id,
+        &assistant_message_id,
+        worktree_path.as_deref(),
+    )?;
+
+    log::trace!("Reverted session, deleted {deleted_count} runs");
+
+    Ok(deleted_count)
 }
 
 /// Set the selected model for a session
@@ -2719,8 +2747,10 @@ pub async fn resume_session(
                     );
 
                     // Create a RunLogWriter to update the manifest
+                    // Note: Empty worktree_path for resumed runs - git diff capture won't work
+                    // but that's OK since we can't accurately capture diffs for partial runs
                     if let Ok(mut writer) =
-                        RunLogWriter::resume(&app_clone, &session_id_clone, &run_id_clone)
+                        RunLogWriter::resume(&app_clone, &session_id_clone, &run_id_clone, "")
                     {
                         // Mark as completed
                         let assistant_message_id = uuid::Uuid::new_v4().to_string();
@@ -2751,8 +2781,9 @@ pub async fn resume_session(
                     log::error!("Resume failed for run: {run_id_clone}, error: {e}");
 
                     // Mark as crashed
+                    // Note: Empty worktree_path - no diff capture for crashed resumed runs
                     if let Ok(mut writer) =
-                        RunLogWriter::resume(&app_clone, &session_id_clone, &run_id_clone)
+                        RunLogWriter::resume(&app_clone, &session_id_clone, &run_id_clone, "")
                     {
                         if let Err(e) = writer.crash() {
                             log::error!("Failed to mark run as crashed: {e}");

--- a/src-tauri/src/chat/run_log.rs
+++ b/src-tauri/src/chat/run_log.rs
@@ -26,6 +26,7 @@ pub struct RunLogWriter {
     app: tauri::AppHandle,
     session_id: String,
     worktree_id: String,
+    worktree_path: String,
     session_name: String,
     order: u32,
     run_id: String,
@@ -69,6 +70,9 @@ impl RunLogWriter {
         let run_id = self.run_id.clone();
         let claude_sid = claude_session_id.map(|s| s.to_string());
 
+        // Capture git diff for revert functionality
+        let git_patch = capture_git_diff(&self.worktree_path);
+
         with_metadata_mut(
             &self.app,
             &self.session_id,
@@ -82,6 +86,7 @@ impl RunLogWriter {
                     run.assistant_message_id = Some(assistant_message_id.to_string());
                     run.claude_session_id = claude_sid.clone();
                     run.usage = usage.clone();
+                    run.git_patch = git_patch.clone();
                 }
 
                 // Update metadata's claude_session_id for resumption
@@ -194,7 +199,12 @@ impl RunLogWriter {
     ///
     /// This is used when resuming a detached process that was still running
     /// after the app restarted.
-    pub fn resume(app: &tauri::AppHandle, session_id: &str, run_id: &str) -> Result<Self, String> {
+    pub fn resume(
+        app: &tauri::AppHandle,
+        session_id: &str,
+        run_id: &str,
+        worktree_path: &str,
+    ) -> Result<Self, String> {
         let session_dir = get_session_dir(app, session_id)?;
         let jsonl_path = session_dir.join(format!("{run_id}.jsonl"));
 
@@ -214,6 +224,7 @@ impl RunLogWriter {
             app: app.clone(),
             session_id: session_id.to_string(),
             worktree_id: metadata.worktree_id.clone(),
+            worktree_path: worktree_path.to_string(),
             session_name: metadata.name.clone(),
             order: metadata.order,
             run_id: run_id.to_string(),
@@ -254,6 +265,7 @@ pub fn start_run(
     app: &tauri::AppHandle,
     session_id: &str,
     worktree_id: &str,
+    worktree_path: &str,
     session_name: &str,
     order: u32,
     user_message_id: &str,
@@ -310,8 +322,9 @@ pub fn start_run(
         cancelled: false,
         recovered: false,
         claude_session_id: None,
-        pid: None,   // Set later via set_pid() after spawning detached process
-        usage: None, // Set on completion via complete()
+        pid: None,      // Set later via set_pid() after spawning detached process
+        usage: None,    // Set on completion via complete()
+        git_patch: None, // Set on completion via complete()
     };
 
     with_metadata_mut(
@@ -337,6 +350,7 @@ pub fn start_run(
         app: app.clone(),
         session_id: session_id.to_string(),
         worktree_id: worktree_id.to_string(),
+        worktree_path: worktree_path.to_string(),
         session_name: session_name.to_string(),
         order,
         run_id,
@@ -846,6 +860,280 @@ pub fn delete_run_logs(app: &tauri::AppHandle, session_id: &str) -> Result<usize
     }
 
     Ok(deleted)
+}
+
+// ============================================================================
+// Fork / Copy Functions
+// ============================================================================
+
+/// Copy runs from source session to target session up to and including a specific assistant message.
+/// This is used for conversation forking - creating a new session with history up to a point.
+pub fn copy_runs_to_session(
+    app: &tauri::AppHandle,
+    source_session_id: &str,
+    target_session_id: &str,
+    target_worktree_id: &str,
+    target_session_name: &str,
+    target_order: u32,
+    up_to_assistant_message_id: &str,
+) -> Result<u32, String> {
+    use super::storage::{get_session_dir, load_metadata, with_metadata_mut};
+
+    // Load source metadata to get the runs list
+    let source_metadata = load_metadata(app, source_session_id)?
+        .ok_or_else(|| format!("Source session {source_session_id} not found"))?;
+
+    // Find which runs to copy (up to and including the one with the target assistant message)
+    let mut runs_to_copy: Vec<&RunEntry> = Vec::new();
+    let mut found_target = false;
+
+    for run in &source_metadata.runs {
+        runs_to_copy.push(run);
+
+        // Check if this run contains the target assistant message
+        if let Some(ref asst_id) = run.assistant_message_id {
+            if asst_id == up_to_assistant_message_id {
+                found_target = true;
+                break;
+            }
+        }
+    }
+
+    if !found_target {
+        return Err(format!(
+            "Assistant message {up_to_assistant_message_id} not found in session {source_session_id}"
+        ));
+    }
+
+    // Get source and target session directories
+    let source_dir = get_session_dir(app, source_session_id)?;
+    let target_dir = get_session_dir(app, target_session_id)?;
+
+    // Copy each run's JSONL file and create metadata entries
+    let mut copied_count = 0u32;
+
+    for run in &runs_to_copy {
+        // Copy the JSONL file
+        let source_jsonl = source_dir.join(format!("{}.jsonl", run.run_id));
+        let target_jsonl = target_dir.join(format!("{}.jsonl", run.run_id));
+
+        if source_jsonl.exists() {
+            fs::copy(&source_jsonl, &target_jsonl)
+                .map_err(|e| format!("Failed to copy JSONL file {}: {e}", run.run_id))?;
+        }
+
+        // Add run entry to target metadata
+        let run_entry = RunEntry {
+            run_id: run.run_id.clone(),
+            user_message_id: run.user_message_id.clone(),
+            user_message: run.user_message.clone(),
+            model: run.model.clone(),
+            execution_mode: run.execution_mode.clone(),
+            thinking_level: run.thinking_level.clone(),
+            started_at: run.started_at,
+            ended_at: run.ended_at,
+            status: run.status.clone(),
+            assistant_message_id: run.assistant_message_id.clone(),
+            cancelled: run.cancelled,
+            recovered: run.recovered,
+            claude_session_id: None, // Don't copy Claude session ID - fork starts fresh
+            pid: None,
+            usage: run.usage.clone(),
+            git_patch: run.git_patch.clone(), // Copy git patch for revert functionality
+        };
+
+        with_metadata_mut(
+            app,
+            target_session_id,
+            target_worktree_id,
+            target_session_name,
+            target_order,
+            |metadata| {
+                metadata.runs.push(run_entry.clone());
+                Ok(())
+            },
+        )?;
+
+        copied_count += 1;
+    }
+
+    log::trace!(
+        "Copied {copied_count} runs from session {source_session_id} to {target_session_id}"
+    );
+
+    Ok(copied_count)
+}
+
+/// Truncate a session to a specific assistant message, removing all subsequent runs
+///
+/// This deletes all runs (and their JSONL files) that come after the specified
+/// assistant message, effectively "reverting" the conversation to that point.
+/// If `worktree_path` is provided and runs have git patches, the code changes
+/// will also be reverted using `git apply -R`.
+pub fn truncate_session_to_message(
+    app: &tauri::AppHandle,
+    session_id: &str,
+    up_to_assistant_message_id: &str,
+    worktree_path: Option<&str>,
+) -> Result<u32, String> {
+    use super::storage::{get_session_dir, load_metadata, save_metadata};
+
+    // Load session metadata
+    let mut metadata = load_metadata(app, session_id)?
+        .ok_or_else(|| format!("Session {session_id} not found"))?;
+
+    // Find the index of the run containing the target assistant message
+    let target_run_index = metadata
+        .runs
+        .iter()
+        .position(|run| {
+            run.assistant_message_id
+                .as_ref()
+                .map(|id| id == up_to_assistant_message_id)
+                .unwrap_or(false)
+        })
+        .ok_or_else(|| {
+            format!("Assistant message {up_to_assistant_message_id} not found in session {session_id}")
+        })?;
+
+    // If this is already the last run, nothing to truncate
+    if target_run_index >= metadata.runs.len() - 1 {
+        log::trace!("No runs to truncate - message is already the last one");
+        return Ok(0);
+    }
+
+    // Get the session directory for deleting JSONL files
+    let session_dir = get_session_dir(app, session_id)?;
+
+    // Collect runs to delete (everything after target_run_index)
+    let runs_to_delete: Vec<RunEntry> = metadata.runs.drain(target_run_index + 1..).collect();
+    let deleted_count = runs_to_delete.len() as u32;
+
+    // Apply reverse patches in reverse order (most recent first)
+    // This undoes the code changes made by each run
+    if let Some(path) = worktree_path {
+        for run in runs_to_delete.iter().rev() {
+            if let Some(ref patch) = run.git_patch {
+                log::trace!(
+                    "Applying reverse patch for run {} ({} bytes)",
+                    run.run_id,
+                    patch.len()
+                );
+                if let Err(e) = apply_reverse_patch(path, patch) {
+                    log::warn!(
+                        "Failed to apply reverse patch for run {}: {e}",
+                        run.run_id
+                    );
+                    // Continue with other patches even if one fails
+                }
+            }
+        }
+    }
+
+    // Delete the JSONL files for removed runs
+    for run in &runs_to_delete {
+        let jsonl_path = session_dir.join(format!("{}.jsonl", run.run_id));
+        if jsonl_path.exists() {
+            if let Err(e) = fs::remove_file(&jsonl_path) {
+                log::warn!("Failed to delete JSONL file {}: {e}", run.run_id);
+            }
+        }
+    }
+
+    // Save updated metadata
+    save_metadata(app, &metadata)?;
+
+    log::trace!(
+        "Truncated session {session_id} to message {up_to_assistant_message_id}, deleted {deleted_count} runs"
+    );
+
+    Ok(deleted_count)
+}
+
+// ============================================================================
+// Git Patch Functions
+// ============================================================================
+
+/// Capture the current git diff (staged and unstaged changes) for a worktree.
+/// Returns the patch content if there are changes, None otherwise.
+fn capture_git_diff(worktree_path: &str) -> Option<String> {
+    use std::process::Command;
+
+    // Run git diff to capture all unstaged changes
+    let output = Command::new("git")
+        .args(["diff", "HEAD"])
+        .current_dir(worktree_path)
+        .output();
+
+    match output {
+        Ok(output) => {
+            if output.status.success() {
+                let diff = String::from_utf8_lossy(&output.stdout).to_string();
+                if diff.trim().is_empty() {
+                    None
+                } else {
+                    log::trace!(
+                        "Captured git diff ({} bytes) for worktree: {}",
+                        diff.len(),
+                        worktree_path
+                    );
+                    Some(diff)
+                }
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                log::warn!("git diff failed for {}: {}", worktree_path, stderr);
+                None
+            }
+        }
+        Err(e) => {
+            log::warn!("Failed to run git diff for {}: {}", worktree_path, e);
+            None
+        }
+    }
+}
+
+/// Apply a git patch in reverse to undo changes.
+/// Returns Ok(()) if successful or if the patch is empty.
+pub fn apply_reverse_patch(worktree_path: &str, patch: &str) -> Result<(), String> {
+    use std::process::Command;
+
+    if patch.trim().is_empty() {
+        return Ok(());
+    }
+
+    // Use git apply -R to reverse the patch
+    let mut child = Command::new("git")
+        .args(["apply", "-R", "--3way"])
+        .current_dir(worktree_path)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to spawn git apply: {e}"))?;
+
+    // Write the patch to stdin
+    if let Some(mut stdin) = child.stdin.take() {
+        use std::io::Write;
+        stdin
+            .write_all(patch.as_bytes())
+            .map_err(|e| format!("Failed to write patch to git apply: {e}"))?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("Failed to wait for git apply: {e}"))?;
+
+    if output.status.success() {
+        log::trace!(
+            "Successfully applied reverse patch ({} bytes) in {}",
+            patch.len(),
+            worktree_path
+        );
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!("git apply -R failed: {stderr}"))
+    }
 }
 
 // ============================================================================

--- a/src-tauri/src/chat/types.rs
+++ b/src-tauri/src/chat/types.rs
@@ -677,6 +677,9 @@ pub struct RunEntry {
     /// Token usage for this run (captured from Claude CLI result)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage: Option<UsageData>,
+    /// Git patch (diff) of changes made during this run - for revert functionality
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_patch: Option<String>,
 }
 
 /// Session metadata - single source of truth for session data and run history

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1267,6 +1267,7 @@ pub fn run() {
             // Chat commands - Session-based messaging
             chat::send_chat_message,
             chat::clear_session_history,
+            chat::revert_session_to_message,
             chat::set_session_model,
             chat::set_session_thinking_level,
             chat::cancel_chat_message,

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -19,10 +19,10 @@ use super::github_issues::{
 use super::names::generate_unique_workspace_name;
 use super::storage::{get_project_worktrees_dir, load_projects_data, save_projects_data};
 use super::types::{
-    MergeType, Project, SessionType, Worktree, WorktreeArchivedEvent, WorktreeBranchExistsEvent,
-    WorktreeCreateErrorEvent, WorktreeCreatedEvent, WorktreeCreatingEvent,
-    WorktreeDeleteErrorEvent, WorktreeDeletedEvent, WorktreeDeletingEvent, WorktreePathExistsEvent,
-    WorktreePermanentlyDeletedEvent, WorktreeUnarchivedEvent,
+    ForkSource, MergeType, Project, SessionType, Worktree, WorktreeArchivedEvent,
+    WorktreeBranchExistsEvent, WorktreeCreateErrorEvent, WorktreeCreatedEvent,
+    WorktreeCreatingEvent, WorktreeDeleteErrorEvent, WorktreeDeletedEvent, WorktreeDeletingEvent,
+    WorktreePathExistsEvent, WorktreePermanentlyDeletedEvent, WorktreeUnarchivedEvent,
 };
 use crate::claude_cli::get_cli_binary_path;
 
@@ -354,6 +354,7 @@ pub async fn create_worktree(
     issue_context: Option<IssueContext>,
     pr_context: Option<PullRequestContext>,
     custom_name: Option<String>,
+    fork_source: Option<ForkSource>,
 ) -> Result<Worktree, String> {
     log::trace!("Creating worktree for project: {project_id}");
 
@@ -469,6 +470,7 @@ pub async fn create_worktree(
     let base_clone = base.clone();
     let issue_context_clone = issue_context.clone();
     let pr_context_clone = pr_context.clone();
+    let fork_source_clone = fork_source.clone();
 
     // Spawn background thread for git operations
     thread::spawn(move || {
@@ -782,6 +784,62 @@ pub async fn create_worktree(
                     log::error!("Failed to emit worktree:error event: {emit_err}");
                 }
                 return;
+            }
+
+            // If this is a fork, copy messages from source session to new session
+            if let Some(fork_source) = fork_source_clone {
+                log::trace!(
+                    "Background: Forking conversation from session {} to worktree {}",
+                    fork_source.source_session_id,
+                    worktree_id_clone
+                );
+
+                // Create a new session for the forked worktree
+                // The session ID will be created when we initialize the index
+                use crate::chat::storage::{load_index, with_index_mut};
+                use crate::chat::run_log::copy_runs_to_session;
+
+                // Load or create index for new worktree (this creates default Session 1)
+                if let Ok(index) = load_index(&app_clone, &worktree_id_clone) {
+                    if let Some(first_session) = index.sessions.first() {
+                        let target_session_id = first_session.id.clone();
+                        let target_session_name = first_session.name.clone();
+                        let target_order = first_session.order;
+
+                        // Copy runs from source session to target session
+                        match copy_runs_to_session(
+                            &app_clone,
+                            &fork_source.source_session_id,
+                            &target_session_id,
+                            &worktree_id_clone,
+                            &target_session_name,
+                            target_order,
+                            &fork_source.up_to_message_id,
+                        ) {
+                            Ok(count) => {
+                                log::trace!(
+                                    "Background: Copied {} runs from {} to {}",
+                                    count,
+                                    fork_source.source_session_id,
+                                    target_session_id
+                                );
+
+                                // Update the message count in the index
+                                let _ = with_index_mut(&app_clone, &worktree_id_clone, |idx| {
+                                    if let Some(session) = idx.find_session_mut(&target_session_id) {
+                                        // Each run = 2 messages (user + assistant)
+                                        session.message_count = count * 2;
+                                    }
+                                    Ok(())
+                                });
+                            }
+                            Err(e) => {
+                                log::error!("Background: Failed to copy runs for fork: {e}");
+                                // Don't fail the worktree creation, just log the error
+                            }
+                        }
+                    }
+                }
             }
 
             // Emit success event

--- a/src-tauri/src/projects/types.rs
+++ b/src-tauri/src/projects/types.rs
@@ -11,6 +11,19 @@ pub enum SessionType {
     Base,
 }
 
+/// Source information for forking a conversation
+/// Used when creating a worktree as a fork of an existing conversation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForkSource {
+    /// The source worktree ID to fork from
+    pub source_worktree_id: String,
+    /// The source session ID to fork from
+    pub source_session_id: String,
+    /// The assistant message ID to fork up to (inclusive)
+    pub up_to_message_id: String,
+}
+
 /// Type of merge operation for merging worktree to base
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -32,7 +32,7 @@ import {
   useCreateSession,
   cancelChatMessage,
 } from '@/services/chat'
-import { useWorktree, useProjects, useRunScript } from '@/services/projects'
+import { useWorktree, useProjects, useRunScript, useCreateWorktree } from '@/services/projects'
 import { githubQueryKeys, useLoadedIssueContexts, useLoadedPRContexts, useAttachedSavedContexts } from '@/services/github'
 import type { LoadedIssueContext, LoadedPullRequestContext } from '@/types/github'
 import {
@@ -262,6 +262,7 @@ export function ChatWindow() {
   )
   const sendMessage = useSendMessage()
   const createSession = useCreateSession()
+  const createWorktree = useCreateWorktree()
   const setSessionModel = useSetSessionModel()
   const setSessionThinkingLevel = useSetSessionThinkingLevel()
 
@@ -1460,6 +1461,49 @@ Begin your investigation now.`
     pendingPlanMessage,
   })
 
+  // Fork conversation handler - creates a new worktree with messages up to selected point
+  const handleFork = useCallback(
+    (messageId: string) => {
+      if (!worktree?.project_id || !activeWorktreeId || !activeSessionId) return
+
+      createWorktree.mutate({
+        projectId: worktree.project_id,
+        forkSource: {
+          sourceWorktreeId: activeWorktreeId,
+          sourceSessionId: activeSessionId,
+          upToMessageId: messageId,
+        },
+      })
+    },
+    [worktree?.project_id, activeWorktreeId, activeSessionId, createWorktree]
+  )
+
+  // Revert conversation handler - truncates session to selected message and reverts code
+  const handleRevert = useCallback(
+    async (messageId: string) => {
+      if (!activeSessionId) return
+
+      try {
+        const deletedCount = await invoke<number>('revert_session_to_message', {
+          sessionId: activeSessionId,
+          assistantMessageId: messageId,
+          worktreePath: activeWorktreePath, // Pass worktree path to enable code revert via git patches
+        })
+
+        if (deletedCount > 0) {
+          // Invalidate session query to refresh messages
+          queryClient.invalidateQueries({ queryKey: ['session', activeSessionId] })
+          toast.success(`Reverted conversation and code (removed ${deletedCount} message${deletedCount > 1 ? 's' : ''})`)
+        } else {
+          toast.info('Nothing to revert - this is already the last message')
+        }
+      } catch (error) {
+        toast.error(`Failed to revert: ${error}`)
+      }
+    },
+    [activeSessionId, activeWorktreePath, queryClient]
+  )
+
   // Listen for approve-plan keyboard shortcut event
   useEffect(() => {
     const handleApprovePlanEvent = () => {
@@ -1814,6 +1858,8 @@ Begin your investigation now.`
                       isFindingFixed={isFindingFixed}
                       shouldScrollToBottom={isAtBottom}
                       onScrollToBottomHandled={handleScrollToBottomHandled}
+                      onFork={handleFork}
+                      onRevert={handleRevert}
                     />
                   )}
                   {isSending && activeSessionId && (

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -1,4 +1,6 @@
-import { memo, useCallback } from 'react'
+import { memo, useCallback, useMemo } from 'react'
+import { GitFork, Copy, RotateCcw } from 'lucide-react'
+import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { normalizePath } from '@/lib/path-utils'
 import { Markdown } from '@/components/ui/markdown'
@@ -35,6 +37,26 @@ import { ReviewFindingsList } from './ReviewFindingBlock'
 /** Format timestamp for tooltip display */
 const formatTimestamp = (timestamp: number) => {
   return new Date(timestamp * 1000).toLocaleString()
+}
+
+/** Format relative time for action bar (e.g., "5m, 39s") */
+const formatRelativeTime = (timestamp: number) => {
+  const now = Date.now() / 1000
+  const diff = Math.floor(now - timestamp)
+
+  if (diff < 60) return `${diff}s`
+  if (diff < 3600) {
+    const m = Math.floor(diff / 60)
+    const s = diff % 60
+    return `${m}m, ${s}s`
+  }
+  if (diff < 86400) {
+    const h = Math.floor(diff / 3600)
+    const m = Math.floor((diff % 3600) / 60)
+    return `${h}h, ${m}m`
+  }
+  const d = Math.floor(diff / 86400)
+  return `${d}d`
 }
 
 /** Regex to extract image paths from message content */
@@ -183,6 +205,12 @@ interface MessageItemProps {
   areQuestionsSkipped: (sessionId: string) => boolean
   /** Check if a finding has been fixed */
   isFindingFixed: (sessionId: string, key: string) => boolean
+  /** Callback when user wants to fork conversation from this message */
+  onFork?: (messageId: string) => void
+  /** Callback when user wants to revert conversation to this message */
+  onRevert?: (messageId: string) => void
+  /** Whether actions are available (assistant message, not streaming) */
+  canShowActions?: boolean
 }
 
 /**
@@ -212,9 +240,18 @@ export const MessageItem = memo(function MessageItem({
   getSubmittedAnswers,
   areQuestionsSkipped,
   isFindingFixed,
+  onFork,
+  onRevert,
+  canShowActions,
 }: MessageItemProps) {
   // Only show Approve button for the last message with ExitPlanMode
   const isLatestPlanRequest = messageIndex === lastPlanMessageIndex
+
+  // Check if this message has code modifications (Edit, Write, NotebookEdit tools)
+  const hasCodeModifications = useMemo(() => {
+    const codeModifyingTools = ['Edit', 'Write', 'NotebookEdit']
+    return message.tool_calls.some(tc => codeModifyingTools.includes(tc.name))
+  }, [message.tool_calls])
 
   // Extract image, text file, file mention, and skill paths and clean content for user messages
   const imagePaths =
@@ -243,6 +280,9 @@ export const MessageItem = memo(function MessageItem({
   const skipToolCalls =
     isSending && isLastMessage && message.role === 'assistant'
 
+  // Show revert button only if: not the last message AND has code modifications
+  const canShowRevert = !isLastMessage && hasCodeModifications
+
   // Stable callback for plan approval
   const handlePlanApproval = useCallback(() => {
     onPlanApproval(message.id)
@@ -258,6 +298,24 @@ export const MessageItem = memo(function MessageItem({
     (findingKey: string) => isFindingFixed(sessionId, findingKey),
     [isFindingFixed, sessionId]
   )
+
+  // Check if message has text content for showing action bar
+  const hasTextContent = useMemo(() => {
+    if (message.role !== 'assistant') return false
+    // Check if there's direct text content
+    if (showContent) return true
+    // Check if there are text blocks in content_blocks
+    if (message.content_blocks?.some(b => b.type === 'text')) return true
+    return false
+  }, [message.role, showContent, message.content_blocks])
+
+  // Copy message text to clipboard
+  const handleCopy = useCallback(() => {
+    const text = message.content
+    navigator.clipboard.writeText(text).then(() => {
+      toast.success('Copied to clipboard')
+    })
+  }, [message.content])
 
   // Content for the message box (shared between user and assistant)
   const messageBoxContent = (
@@ -588,11 +646,64 @@ export const MessageItem = memo(function MessageItem({
       ) : (
         <div
           className={cn(
-            'text-muted-foreground w-full min-w-0 break-words',
+            'relative group text-muted-foreground w-full min-w-0 break-words',
             message.cancelled && 'opacity-60'
           )}
         >
           {messageBoxContent}
+          {/* Action bar - shown for messages with text content */}
+          {hasTextContent && canShowActions && (
+            <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground/60">
+              <span>{formatRelativeTime(message.timestamp)}</span>
+              <span className="text-muted-foreground/30">·</span>
+              <div className="flex items-center gap-1">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={handleCopy}
+                      className="p-1 hover:text-foreground transition-colors cursor-pointer"
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="text-xs">
+                    Copy to clipboard
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() => onFork?.(message.id)}
+                      className="p-1 hover:text-foreground transition-colors cursor-pointer"
+                    >
+                      <GitFork className="h-3.5 w-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="text-xs">
+                    Fork conversation
+                  </TooltipContent>
+                </Tooltip>
+                {canShowRevert && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={() => onRevert?.(message.id)}
+                        className="p-1 hover:text-foreground transition-colors cursor-pointer"
+                      >
+                        <RotateCcw className="h-3.5 w-3.5" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="text-xs">
+                      Revert to this point
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/chat/VirtualizedMessageList.tsx
+++ b/src/components/chat/VirtualizedMessageList.tsx
@@ -92,6 +92,10 @@ interface VirtualizedMessageListProps {
   shouldScrollToBottom?: boolean
   /** Callback when scroll-to-bottom is handled */
   onScrollToBottomHandled?: () => void
+  /** Callback when user wants to fork conversation from a message */
+  onFork?: (messageId: string) => void
+  /** Callback when user wants to revert conversation to a message */
+  onRevert?: (messageId: string) => void
 }
 
 /**
@@ -127,6 +131,8 @@ export const VirtualizedMessageList = memo(
         isFindingFixed,
         shouldScrollToBottom,
         onScrollToBottomHandled,
+        onFork,
+        onRevert,
       },
       ref
     ) {
@@ -299,6 +305,11 @@ export const VirtualizedMessageList = memo(
                   getSubmittedAnswers={getSubmittedAnswers}
                   areQuestionsSkipped={areQuestionsSkipped}
                   isFindingFixed={isFindingFixed}
+                  onFork={onFork}
+                  onRevert={onRevert}
+                  canShowActions={
+                    message.role === 'assistant' && !isSending
+                  }
                 />
               </div>
             )

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -344,7 +344,7 @@ export function WorktreeItem({
         clearWorktreeLoading(worktree.id)
       }
     },
-    [worktree.path, defaultBranch, projectId]
+    [worktree.id, worktree.path, defaultBranch, projectId]
   )
 
   const handlePush = useCallback(

--- a/src/services/projects.ts
+++ b/src/services/projects.ts
@@ -17,6 +17,7 @@ import type {
   WorktreePermanentlyDeletedEvent,
   WorktreePathExistsEvent,
   WorktreeBranchExistsEvent,
+  ForkSource,
 } from '@/types/projects'
 import { useProjectsStore } from '@/store/projects-store'
 import { useChatStore } from '@/store/chat-store'
@@ -313,6 +314,7 @@ export function useCreateWorktree() {
       issueContext,
       prContext,
       customName,
+      forkSource,
     }: {
       projectId: string
       baseBranch?: string
@@ -334,18 +336,21 @@ export function useCreateWorktree() {
       }
       /** Custom worktree name (used when retrying after path conflict) */
       customName?: string
+      /** Fork source for conversation forking */
+      forkSource?: ForkSource
     }): Promise<Worktree> => {
       if (!isTauri()) {
         throw new Error('Not in Tauri context')
       }
 
-      logger.debug('Creating worktree (background)', { projectId, baseBranch, issueNumber: issueContext?.number, prNumber: prContext?.number, customName })
+      logger.debug('Creating worktree (background)', { projectId, baseBranch, issueNumber: issueContext?.number, prNumber: prContext?.number, customName, forkSource })
       const worktree = await invoke<Worktree>('create_worktree', {
         projectId,
         baseBranch,
         issueContext,
         prContext,
         customName,
+        forkSource,
       })
       // Mark as pending since creation is happening in background
       return { ...worktree, status: 'pending' as const }

--- a/src/types/projects.ts
+++ b/src/types/projects.ts
@@ -9,6 +9,19 @@ export type SessionType = 'worktree' | 'base'
 export type WorktreeStatus = 'pending' | 'ready' | 'error' | 'deleting'
 
 /**
+ * Source information for forking a conversation
+ * Used when creating a worktree as a fork of an existing conversation
+ */
+export interface ForkSource {
+  /** The source worktree ID to fork from */
+  sourceWorktreeId: string
+  /** The source session ID to fork from */
+  sourceSessionId: string
+  /** The assistant message ID to fork up to (inclusive) */
+  upToMessageId: string
+}
+
+/**
  * Check if a worktree is a base session
  */
 export function isBaseSession(worktree: Worktree): boolean {


### PR DESCRIPTION
## Summary
- Add fork button on assistant messages to create new worktree with conversation history up to that point
- Add revert button to undo messages and code changes using git patches (git apply -R)
- Show action bar with timestamp, copy, fork, and revert buttons on assistant messages

## Implementation
- Capture git diff at end of each assistant run and store in run metadata
- Apply reverse patches when reverting to restore code state
- Show revert button only on messages with code modifications (Edit/Write/NotebookEdit)
- Hide revert button on the last message (nothing to revert after it)

## Test plan
- [ ] Fork a conversation from an assistant message → new worktree created with history
- [ ] Revert to a message with code changes → messages removed and code reverted
- [ ] Verify revert button only appears on messages with Edit/Write/NotebookEdit tools
- [ ] Verify revert button hidden on last message