### PR TITLE
feat: add additionalDirectories support in project settings

### DIFF
--- a/src-tauri/src/chat/claude.rs
+++ b/src-tauri/src/chat/claude.rs
@@ -4,6 +4,7 @@ use super::types::{ContentBlock, ThinkingLevel, ToolCall, UsageData};
 use crate::projects::github_issues::{
     get_github_contexts_dir, get_worktree_issue_refs, get_worktree_pr_refs,
 };
+use crate::projects::storage::load_projects_data;
 
 // =============================================================================
 // Claude CLI execution
@@ -441,6 +442,85 @@ fn build_claude_args(
     (args, env_vars)
 }
 
+/// Read `permissions.additionalDirectories` from a directory's `.claude/settings.local.json`.
+fn read_additional_dirs_from_settings(dir: &std::path::Path) -> Vec<String> {
+    let settings_path = dir.join(".claude").join("settings.local.json");
+    if !settings_path.exists() {
+        return Vec::new();
+    }
+
+    let content = match std::fs::read_to_string(&settings_path) {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("Failed to read {settings_path:?}: {e}");
+            return Vec::new();
+        }
+    };
+
+    let settings: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("Failed to parse {settings_path:?}: {e}");
+            return Vec::new();
+        }
+    };
+
+    settings
+        .get("permissions")
+        .and_then(|p| p.get("additionalDirectories"))
+        .and_then(|d| d.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Sync `permissions.additionalDirectories` into a worktree's `.claude/settings.local.json`.
+///
+/// Reads the worktree's existing settings, merges the `additionalDirectories` key, and writes back.
+fn sync_additional_dirs_to_settings(working_dir: &std::path::Path, dirs: &[String]) {
+    let claude_dir = working_dir.join(".claude");
+    let settings_path = claude_dir.join("settings.local.json");
+
+    // Read existing worktree settings or start with empty object
+    let mut settings: serde_json::Value = if settings_path.exists() {
+        match std::fs::read_to_string(&settings_path) {
+            Ok(content) => serde_json::from_str(&content).unwrap_or(serde_json::json!({})),
+            Err(_) => serde_json::json!({}),
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    // Set additionalDirectories
+    if settings.get("permissions").is_none() {
+        settings["permissions"] = serde_json::json!({});
+    }
+    settings["permissions"]["additionalDirectories"] = serde_json::json!(dirs);
+
+    // Ensure .claude directory exists
+    if let Err(e) = std::fs::create_dir_all(&claude_dir) {
+        log::error!("Failed to create .claude directory: {e}");
+        return;
+    }
+
+    match serde_json::to_string_pretty(&settings) {
+        Ok(content) => {
+            if let Err(e) = std::fs::write(&settings_path, content) {
+                log::error!("Failed to write settings.local.json: {e}");
+            } else {
+                log::trace!(
+                    "Synced {} additionalDirectories to {settings_path:?}",
+                    dirs.len()
+                );
+            }
+        }
+        Err(e) => log::error!("Failed to serialize settings: {e}"),
+    }
+}
+
 /// Execute Claude CLI in detached mode.
 ///
 /// Spawns Claude CLI as a fully detached process that survives Jean quitting.
@@ -512,6 +592,22 @@ pub fn execute_claude_detached(
         parallel_execution_prompt_enabled,
         ai_language,
     );
+
+    // Sync project's .claude/settings.local.json additionalDirectories to worktree
+    if let Ok(data) = load_projects_data(app) {
+        if let Some(worktree) = data.find_worktree(worktree_id) {
+            if let Some(project) = data.find_project(&worktree.project_id) {
+                let project_path = std::path::Path::new(&project.path);
+                // Only sync if worktree is a different directory than the project
+                if project_path != working_dir {
+                    let dirs = read_additional_dirs_from_settings(project_path);
+                    if !dirs.is_empty() {
+                        sync_additional_dirs_to_settings(working_dir, &dirs);
+                    }
+                }
+            }
+        }
+    }
 
     // Log the full Claude CLI command for debugging
     log::debug!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1311,6 +1311,8 @@ pub fn run() {
             projects::list_worktree_files,
             projects::get_project_branches,
             projects::update_project_settings,
+            projects::get_project_additional_dirs,
+            projects::set_project_additional_dirs,
             projects::get_pr_prompt,
             projects::get_review_prompt,
             projects::save_worktree_pr,

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -2903,6 +2903,117 @@ pub async fn update_project_settings(
     Ok(updated_project)
 }
 
+/// Read additionalDirectories from a project's .claude/settings.local.json
+#[tauri::command]
+pub async fn get_project_additional_dirs(
+    app: AppHandle,
+    project_id: String,
+) -> Result<Vec<String>, String> {
+    let data = load_projects_data(&app)?;
+    let project = data
+        .find_project(&project_id)
+        .ok_or_else(|| format!("Project not found: {project_id}"))?;
+
+    let settings_path = Path::new(&project.path)
+        .join(".claude")
+        .join("settings.local.json");
+
+    if !settings_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let content = std::fs::read_to_string(&settings_path)
+        .map_err(|e| format!("Failed to read settings.local.json: {e}"))?;
+
+    let settings: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse settings.local.json: {e}"))?;
+
+    let dirs = settings
+        .get("permissions")
+        .and_then(|p| p.get("additionalDirectories"))
+        .and_then(|d| d.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(dirs)
+}
+
+/// Write additionalDirectories to a project's .claude/settings.local.json
+///
+/// Merges into the existing file, preserving other settings.
+#[tauri::command]
+pub async fn set_project_additional_dirs(
+    app: AppHandle,
+    project_id: String,
+    dirs: Vec<String>,
+) -> Result<(), String> {
+    // Validate each path exists and is a directory
+    for dir in &dirs {
+        let path = Path::new(dir);
+        if !path.exists() {
+            return Err(format!("Directory does not exist: {dir}"));
+        }
+        if !path.is_dir() {
+            return Err(format!("Path is not a directory: {dir}"));
+        }
+    }
+
+    let data = load_projects_data(&app)?;
+    let project = data
+        .find_project(&project_id)
+        .ok_or_else(|| format!("Project not found: {project_id}"))?;
+
+    let claude_dir = Path::new(&project.path).join(".claude");
+    let settings_path = claude_dir.join("settings.local.json");
+
+    // Read existing settings or start with empty object
+    let mut settings: serde_json::Value = if settings_path.exists() {
+        let content = std::fs::read_to_string(&settings_path)
+            .map_err(|e| format!("Failed to read settings.local.json: {e}"))?;
+        serde_json::from_str(&content)
+            .map_err(|e| format!("Failed to parse settings.local.json: {e}"))?
+    } else {
+        serde_json::json!({})
+    };
+
+    if dirs.is_empty() {
+        // Remove additionalDirectories
+        if let Some(permissions) = settings.get_mut("permissions") {
+            if let Some(obj) = permissions.as_object_mut() {
+                obj.remove("additionalDirectories");
+                if obj.is_empty() {
+                    if let Some(root) = settings.as_object_mut() {
+                        root.remove("permissions");
+                    }
+                }
+            }
+        }
+    } else {
+        // Set additionalDirectories
+        if settings.get("permissions").is_none() {
+            settings["permissions"] = serde_json::json!({});
+        }
+        settings["permissions"]["additionalDirectories"] = serde_json::json!(dirs);
+    }
+
+    // Ensure .claude directory exists
+    std::fs::create_dir_all(&claude_dir)
+        .map_err(|e| format!("Failed to create .claude directory: {e}"))?;
+
+    // Write settings
+    let content = serde_json::to_string_pretty(&settings)
+        .map_err(|e| format!("Failed to serialize settings: {e}"))?;
+    std::fs::write(&settings_path, content)
+        .map_err(|e| format!("Failed to write settings.local.json: {e}"))?;
+
+    log::trace!("Updated additionalDirectories in {settings_path:?}: {dirs:?}");
+    Ok(())
+}
+
 /// Rebase a worktree's branch onto the base branch
 ///
 /// This command:

--- a/src/components/projects/ProjectSettingsDialog.tsx
+++ b/src/components/projects/ProjectSettingsDialog.tsx
@@ -1,6 +1,16 @@
-import { useState } from 'react'
-import { Loader2, GitBranch, Check, ChevronsUpDown, ImageIcon, X } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import {
+  Check,
+  ChevronsUpDown,
+  FolderOpen,
+  GitBranch,
+  ImageIcon,
+  Loader2,
+  Trash2,
+  X,
+} from 'lucide-react'
 import { convertFileSrc } from '@tauri-apps/api/core'
+import { open } from '@tauri-apps/plugin-dialog'
 import {
   Dialog,
   DialogContent,
@@ -23,15 +33,18 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover'
 import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
 import { useProjectsStore } from '@/store/projects-store'
 import {
-  useProjects,
-  useProjectBranches,
-  useUpdateProjectSettings,
   useAppDataDir,
-  useSetProjectAvatar,
+  useProjectAdditionalDirs,
+  useProjectBranches,
+  useProjects,
   useRemoveProjectAvatar,
+  useSetProjectAdditionalDirs,
+  useSetProjectAvatar,
+  useUpdateProjectSettings,
 } from '@/services/projects'
 
 export function ProjectSettingsDialog() {
@@ -50,7 +63,13 @@ export function ProjectSettingsDialog() {
     error: branchesError,
   } = useProjectBranches(projectSettingsProjectId)
 
+  // Read additionalDirectories from .claude/settings.local.json
+  const { data: savedAdditionalDirs = [] } = useProjectAdditionalDirs(
+    projectSettingsDialogOpen ? projectSettingsProjectId : null
+  )
+
   const updateSettings = useUpdateProjectSettings()
+  const setAdditionalDirs = useSetProjectAdditionalDirs()
   const { data: appDataDir = '' } = useAppDataDir()
   const setProjectAvatar = useSetProjectAvatar()
   const removeProjectAvatar = useRemoveProjectAvatar()
@@ -58,6 +77,11 @@ export function ProjectSettingsDialog() {
   // Use project's default_branch as the initial value, allow local overrides
   const [localBranch, setLocalBranch] = useState<string | null>(null)
   const [branchPopoverOpen, setBranchPopoverOpen] = useState(false)
+
+  // External directories state (null = no local changes, array = local override)
+  const [localExternalDirs, setLocalExternalDirs] = useState<string[] | null>(
+    null
+  )
 
   // Track image load errors - use avatar_path as key to reset error state when it changes
   const [imgErrorKey, setImgErrorKey] = useState<string | null>(null)
@@ -86,13 +110,51 @@ export function ProjectSettingsDialog() {
     setLocalBranch(branch)
   }
 
-  const handleSave = async () => {
-    if (!projectSettingsProjectId || !selectedBranch) return
+  // External dirs: use local state if changed, otherwise the value from settings.local.json
+  const currentExternalDirs = localExternalDirs ?? savedAdditionalDirs
 
-    await updateSettings.mutateAsync({
-      projectId: projectSettingsProjectId,
-      defaultBranch: selectedBranch,
+  const handleAddExternalDir = useCallback(async () => {
+    const selected = await open({ directory: true, multiple: false })
+    if (!selected) return
+
+    setLocalExternalDirs(prev => {
+      const current = prev ?? savedAdditionalDirs
+      // Prevent duplicates
+      if (current.includes(selected)) return current
+      return [...current, selected]
     })
+  }, [savedAdditionalDirs])
+
+  const handleRemoveExternalDir = useCallback(
+    (dir: string) => {
+      setLocalExternalDirs(prev => {
+        const current = prev ?? savedAdditionalDirs
+        return current.filter(d => d !== dir)
+      })
+    },
+    [savedAdditionalDirs]
+  )
+
+  const handleSave = async () => {
+    if (!projectSettingsProjectId) return
+
+    // Save branch settings if changed
+    const branchChanged =
+      selectedBranch && selectedBranch !== project?.default_branch
+    if (branchChanged) {
+      await updateSettings.mutateAsync({
+        projectId: projectSettingsProjectId,
+        defaultBranch: selectedBranch,
+      })
+    }
+
+    // Save additional dirs if changed
+    if (localExternalDirs !== null) {
+      await setAdditionalDirs.mutateAsync({
+        projectId: projectSettingsProjectId,
+        dirs: localExternalDirs,
+      })
+    }
 
     closeProjectSettings()
   }
@@ -100,16 +162,19 @@ export function ProjectSettingsDialog() {
   const handleOpenChange = (open: boolean) => {
     if (!open) {
       setLocalBranch(null) // Reset local state when closing
+      setLocalExternalDirs(null)
       closeProjectSettings()
     }
   }
 
-  const hasChanges = project && selectedBranch !== project.default_branch
-  const isPending = updateSettings.isPending
+  const branchChanged = project && selectedBranch !== project.default_branch
+  const externalDirsChanged = localExternalDirs !== null
+  const hasChanges = branchChanged || externalDirsChanged
+  const isPending = updateSettings.isPending || setAdditionalDirs.isPending
 
   return (
     <Dialog open={projectSettingsDialogOpen} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Project Settings</DialogTitle>
           <DialogDescription>
@@ -256,6 +321,47 @@ export function ProjectSettingsDialog() {
                 </PopoverContent>
               </Popover>
             )}
+          </div>
+
+          {/* External Directories Section */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium leading-none">
+              External Directories
+            </label>
+            <p className="text-xs text-muted-foreground">
+              Additional directories Claude can read (outside the worktree)
+            </p>
+
+            {currentExternalDirs.length > 0 && (
+              <ScrollArea className="max-h-32">
+                <div className="space-y-1">
+                  {currentExternalDirs.map(dir => (
+                    <div
+                      key={dir}
+                      className="flex items-center gap-2 rounded-md border px-2 py-1.5 text-sm"
+                    >
+                      <FolderOpen className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      <span className="min-w-0 flex-1 truncate" title={dir}>
+                        {dir}
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 shrink-0"
+                        onClick={() => handleRemoveExternalDir(dir)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+            )}
+
+            <Button variant="outline" size="sm" onClick={handleAddExternalDir}>
+              <FolderOpen className="h-4 w-4" />
+              Add Directory
+            </Button>
           </div>
         </div>
 

--- a/src/services/projects.ts
+++ b/src/services/projects.ts
@@ -1728,6 +1728,69 @@ export function useUpdateProjectSettings() {
 }
 
 /**
+ * Hook to read additionalDirectories from a project's .claude/settings.local.json
+ */
+export function useProjectAdditionalDirs(projectId: string | null) {
+  return useQuery({
+    queryKey: [...projectsQueryKeys.detail(projectId ?? ''), 'additional-dirs'] as const,
+    queryFn: async (): Promise<string[]> => {
+      if (!isTauri() || !projectId) {
+        return []
+      }
+
+      try {
+        return await invoke<string[]>('get_project_additional_dirs', { projectId })
+      } catch (error) {
+        logger.error('Failed to load additional dirs', { error, projectId })
+        return []
+      }
+    },
+    enabled: !!projectId,
+    staleTime: 1000 * 30,
+  })
+}
+
+/**
+ * Hook to write additionalDirectories to a project's .claude/settings.local.json
+ */
+export function useSetProjectAdditionalDirs() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      projectId,
+      dirs,
+    }: {
+      projectId: string
+      dirs: string[]
+    }): Promise<void> => {
+      if (!isTauri()) {
+        throw new Error('Not in Tauri context')
+      }
+
+      logger.debug('Setting project additional dirs', { projectId, dirs })
+      await invoke('set_project_additional_dirs', { projectId, dirs })
+      logger.info('Additional dirs updated')
+    },
+    onSuccess: (_, { projectId }) => {
+      queryClient.invalidateQueries({
+        queryKey: [...projectsQueryKeys.detail(projectId), 'additional-dirs'],
+      })
+    },
+    onError: error => {
+      const message =
+        typeof error === 'string'
+          ? error
+          : error instanceof Error
+            ? error.message
+            : 'Unknown error occurred'
+      logger.error('Failed to save additional dirs', { error })
+      toast.error('Failed to save directories', { description: message })
+    },
+  })
+}
+
+/**
  * Hook to reorder projects in the sidebar
  */
 export function useReorderProjects() {


### PR DESCRIPTION
## Summary
- Add UI in Project Settings to manage external directories that Claude can access outside the worktree, stored in `.claude/settings.local.json` under `permissions.additionalDirectories`
- Add Tauri commands (`get_project_additional_dirs`, `set_project_additional_dirs`) to read/write the setting with validation that paths exist and are directories
- Auto-sync additional directories from the project's settings to each worktree's `.claude/settings.local.json` when launching Claude CLI

<img width="512" height="538" alt="image" src="https://github.com/user-attachments/assets/dd1e64f9-69da-49bd-a3e6-b43805e0e6f4" />
