### PR TITLE
fix(claude-cli): use npm dist-tags.latest to avoid 404 on install

### DIFF
--- a/src-tauri/src/claude_cli/commands.rs
+++ b/src-tauri/src/claude_cli/commands.rs
@@ -119,6 +119,8 @@ pub async fn check_claude_cli_installed(app: AppHandle) -> Result<ClaudeCliStatu
 struct NpmPackageInfo {
     versions: std::collections::HashMap<String, serde_json::Value>,
     time: std::collections::HashMap<String, String>,
+    #[serde(rename = "dist-tags")]
+    dist_tags: std::collections::HashMap<String, String>,
 }
 
 /// Platform-specific release information from manifest
@@ -131,6 +133,14 @@ struct PlatformInfo {
 #[derive(Debug, Deserialize)]
 struct Manifest {
     platforms: std::collections::HashMap<String, PlatformInfo>,
+}
+
+/// Parse version string into comparable parts
+fn parse_version(version: &str) -> Vec<u32> {
+    version
+        .split('.')
+        .filter_map(|s| s.parse().ok())
+        .collect()
 }
 
 /// Get available Claude CLI versions from npm registry
@@ -157,34 +167,42 @@ pub async fn get_available_cli_versions() -> Result<Vec<ReleaseInfo>, String> {
         .await
         .map_err(|e| format!("Failed to parse npm response: {e}"))?;
 
-    // Get versions with their publish times
+    // Get the latest stable version from dist-tags
+    // Versions > latest (e.g., "next" tag) don't have manifests in the bucket
+    let latest_version = package_info
+        .dist_tags
+        .get("latest")
+        .ok_or("No 'latest' tag found in npm dist-tags")?;
+    let latest_parts = parse_version(latest_version);
+
+    // Filter versions to only include those <= latest (excludes prereleases like "next")
     let mut versions: Vec<ReleaseInfo> = package_info
         .versions
         .keys()
+        .filter(|version| {
+            // Exclude prerelease versions (e.g., 1.0.0-beta)
+            if version.contains('-') {
+                return false;
+            }
+            // Exclude versions > latest
+            let parts = parse_version(version);
+            parts <= latest_parts
+        })
         .map(|version| {
             let published_at = package_info.time.get(version).cloned().unwrap_or_default();
             ReleaseInfo {
                 version: version.clone(),
                 tag_name: format!("v{version}"),
                 published_at,
-                prerelease: version.contains('-'), // e.g., 1.0.0-beta
+                prerelease: false,
             }
         })
         .collect();
 
-    // Sort by version descending (newest first) using simple string comparison
-    // This works for semver since we compare major.minor.patch numerically
+    // Sort by version descending (newest first)
     versions.sort_by(|a, b| {
-        let a_parts: Vec<u32> = a
-            .version
-            .split('.')
-            .filter_map(|s| s.parse().ok())
-            .collect();
-        let b_parts: Vec<u32> = b
-            .version
-            .split('.')
-            .filter_map(|s| s.parse().ok())
-            .collect();
+        let a_parts = parse_version(&a.version);
+        let b_parts = parse_version(&b.version);
         b_parts.cmp(&a_parts)
     });
 


### PR DESCRIPTION
## Problem
When installing Claude CLI through Jean's onboarding, the installation failed with:
`HTTP 404 Not Found`

The manifest fetch was hitting a non-existent URL because the app was trying to install version 2.1.26 (tagged as next on npm) instead of 2.1.25 (tagged as latest).

The distribution bucket only contains manifests for latest releases, not for next/prerelease versions.

## Summary
- npm registry has versions like 2.1.26 (tag `next`) that don't have manifests in the distribution bucket
- Previously, sorting by semver picked the highest version → 404 errors during installation
- Now uses `dist-tags.latest` to filter out versions > latest while still showing the 5 most recent stable versions

## Test plan
- [x] Run `bun run tauri dev`
- [x] Go to onboarding → version displayed should be the `latest` tag (e.g., 2.1.25, not 2.1.26)
- [x] Click Install → should succeed without 404 error