### PR TITLE
Fix `ENAMETOOLONG` when user's login shell is fish

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1237,9 +1237,12 @@ fn fix_macos_path() {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
 
     // Spawn a login (-l) + interactive (-i) shell to source all config files
-    // including .zshrc where tools like bun, nvm add their PATH entries
+    // including .zshrc where tools like bun, nvm add their PATH entries.
+    // Use `printenv PATH` instead of `echo $PATH` because fish shell prints
+    // $PATH as space-separated (it's a list in fish), while printenv always
+    // outputs the raw colon-separated environment variable.
     let output = silent_command(&shell)
-        .args(["-l", "-i", "-c", "echo $PATH"])
+        .args(["-l", "-i", "-c", "/usr/bin/printenv PATH"])
         .output();
 
     if let Ok(output) = output {


### PR DESCRIPTION
`fix_macos_path()` captures the user's PATH by running their login shell with `echo $PATH`. Fish shell stores PATH as a list and prints it space-separated, not colon-separated. The entire PATH string (1100+ chars) was treated as a single directory entry, and appending `/git` exceeded macOS's PATH_MAX of 1024 bytes, causing all `Command::new("git")` and Claude CLI spawns to fail with "File name too long (os error 63)".

This replaces `echo $PATH` with `/usr/bin/printenv PATH`, which reads the raw environment variable directly — always colon-separated regardless of shell.