### PR TITLE
feat: add copy and edit to pasted text file preview

### DIFF
--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -1672,6 +1672,61 @@ pub async fn save_pasted_text(app: AppHandle, content: String) -> Result<SaveTex
     })
 }
 
+/// Update the content of a pasted text file
+///
+/// Overwrites the file content atomically (temp file + rename).
+/// Returns the new file size in bytes.
+#[tauri::command]
+pub async fn update_pasted_text(
+    app: AppHandle,
+    path: String,
+    content: String,
+) -> Result<usize, String> {
+    let size = content.len();
+    log::trace!("Updating pasted text file: {path}, new size: {size} bytes");
+
+    // Check size limit
+    if size > MAX_TEXT_SIZE {
+        return Err(format!(
+            "Text too large: {size} bytes. Maximum size: {MAX_TEXT_SIZE} bytes (10MB)"
+        ));
+    }
+
+    let file_path = std::path::PathBuf::from(&path);
+
+    // Validate that the path exists
+    if !file_path.exists() {
+        return Err(format!("Text file not found: {path}"));
+    }
+
+    // Validate that the path is within allowed directories
+    let path_str = file_path.to_string_lossy();
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {e}"))?;
+    let app_data_str = app_data_dir.to_string_lossy();
+
+    let is_old_location =
+        path_str.contains(".jean/pastes/") || path_str.contains(".jean\\pastes\\");
+    let is_new_location = path_str.contains(&format!("{app_data_str}/pasted-texts/"))
+        || path_str.contains(&format!("{app_data_str}\\pasted-texts\\"));
+
+    if !is_old_location && !is_new_location {
+        return Err("Invalid path: must be within allowed directories".to_string());
+    }
+
+    // Write file atomically (temp file + rename)
+    let temp_path = file_path.with_extension("tmp");
+    std::fs::write(&temp_path, &content).map_err(|e| format!("Failed to write text file: {e}"))?;
+
+    std::fs::rename(&temp_path, &file_path)
+        .map_err(|e| format!("Failed to finalize text file: {e}"))?;
+
+    log::trace!("Text file updated: {path}");
+    Ok(size)
+}
+
 /// Delete a pasted text file
 ///
 /// Validates that the path is within allowed directories before deleting.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -603,14 +603,23 @@ impl MagicPrompts {
     /// This ensures users who never customized a prompt get auto-updated defaults.
     fn migrate_defaults(&mut self) {
         let defaults: [(fn() -> String, &mut Option<String>); 8] = [
-            (default_investigate_issue_prompt, &mut self.investigate_issue),
+            (
+                default_investigate_issue_prompt,
+                &mut self.investigate_issue,
+            ),
             (default_investigate_pr_prompt, &mut self.investigate_pr),
             (default_pr_content_prompt, &mut self.pr_content),
             (default_commit_message_prompt, &mut self.commit_message),
             (default_code_review_prompt, &mut self.code_review),
             (default_context_summary_prompt, &mut self.context_summary),
-            (default_resolve_conflicts_prompt, &mut self.resolve_conflicts),
-            (default_investigate_workflow_run_prompt, &mut self.investigate_workflow_run),
+            (
+                default_resolve_conflicts_prompt,
+                &mut self.resolve_conflicts,
+            ),
+            (
+                default_investigate_workflow_run_prompt,
+                &mut self.investigate_workflow_run,
+            ),
         ];
 
         for (default_fn, field) in defaults {
@@ -1862,6 +1871,7 @@ pub fn run() {
             chat::delete_pasted_image,
             // Chat commands - Text paste handling
             chat::save_pasted_text,
+            chat::update_pasted_text,
             chat::delete_pasted_text,
             chat::read_pasted_text,
             // Chat commands - Plan file handling

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -2738,6 +2738,7 @@ Begin your investigation now.`
                         textFiles={currentPendingTextFiles}
                         onRemove={handleRemovePendingTextFile}
                         disabled={isSending}
+                        sessionId={activeSessionId}
                       />
 
                       {/* Pending skills preview */}

--- a/src/components/chat/TextFileLightbox.tsx
+++ b/src/components/chat/TextFileLightbox.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react'
-import { FileText, Loader2 } from 'lucide-react'
+import { FileText, Loader2, Copy } from 'lucide-react'
 import { invoke } from '@/lib/transport'
+import { toast } from 'sonner'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Markdown } from '@/components/ui/markdown'
@@ -58,6 +59,13 @@ export function TextFileLightbox({ path, size }: TextFileLightboxProps) {
     }
   }, [content, isLoading, path])
 
+  const handleCopy = useCallback(() => {
+    if (content) {
+      navigator.clipboard.writeText(content)
+      toast.success('Copied to clipboard')
+    }
+  }, [content])
+
   return (
     <>
       <button
@@ -87,7 +95,7 @@ export function TextFileLightbox({ path, size }: TextFileLightboxProps) {
               </span>
             )}
           </DialogTitle>
-          <ScrollArea className="h-[calc(85vh-6rem)] mt-2">
+          <ScrollArea className="h-[calc(85vh-8rem)] mt-2">
             {isLoading ? (
               <div className="flex items-center justify-center py-8">
                 <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -106,6 +114,19 @@ export function TextFileLightbox({ path, size }: TextFileLightboxProps) {
               </pre>
             )}
           </ScrollArea>
+          {content && (
+            <div className="flex items-center gap-1 pt-2 border-t border-border/50">
+              <button
+                type="button"
+                onClick={handleCopy}
+                className="px-3 py-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors flex items-center gap-1.5 text-xs"
+                title="Copy to clipboard"
+              >
+                <Copy className="h-3.5 w-3.5" />
+                Copy
+              </button>
+            </div>
+          )}
         </DialogContent>
       </Dialog>
     </>

--- a/src/components/chat/TextFilePreview.tsx
+++ b/src/components/chat/TextFilePreview.tsx
@@ -1,10 +1,12 @@
-import { useState, useCallback } from 'react'
-import { X, FileText } from 'lucide-react'
+import { useState, useCallback, useRef } from 'react'
+import { X, FileText, Copy, Pencil, Check } from 'lucide-react'
 import { invoke } from '@/lib/transport'
+import { toast } from 'sonner'
 import type { PendingTextFile } from '@/types/chat'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Markdown } from '@/components/ui/markdown'
+import { useChatStore } from '@/store/chat-store'
 
 function isMarkdownFile(filename: string | undefined): boolean {
   if (!filename) return false
@@ -18,6 +20,8 @@ interface TextFilePreviewProps {
   onRemove: (textFileId: string) => void
   /** Whether removal is disabled (e.g., while sending) */
   disabled?: boolean
+  /** Session ID for updating text file content */
+  sessionId?: string
 }
 
 /** Format bytes to human readable string */
@@ -35,8 +39,13 @@ export function TextFilePreview({
   textFiles,
   onRemove,
   disabled,
+  sessionId,
 }: TextFilePreviewProps) {
   const [openFileId, setOpenFileId] = useState<string | null>(null)
+  const [isEditing, setIsEditing] = useState(false)
+  const [editContent, setEditContent] = useState('')
+  const [isSaving, setIsSaving] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const handleRemove = useCallback(
     async (e: React.MouseEvent, textFile: PendingTextFile) => {
@@ -58,6 +67,60 @@ export function TextFilePreview({
     },
     [disabled, onRemove]
   )
+
+  const handleCopy = useCallback((content: string) => {
+    navigator.clipboard.writeText(content)
+    toast.success('Copied to clipboard')
+  }, [])
+
+  const handleStartEdit = useCallback((content: string) => {
+    setEditContent(content)
+    setIsEditing(true)
+    // Focus textarea after render
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus()
+    })
+  }, [])
+
+  const handleCancelEdit = useCallback(() => {
+    setIsEditing(false)
+    setEditContent('')
+  }, [])
+
+  const handleSaveEdit = useCallback(
+    async (textFile: PendingTextFile) => {
+      if (!sessionId || isSaving) return
+
+      setIsSaving(true)
+      try {
+        const newSize = await invoke<number>('update_pasted_text', {
+          path: textFile.path,
+          content: editContent,
+        })
+
+        const { updatePendingTextFile } = useChatStore.getState()
+        updatePendingTextFile(sessionId, textFile.id, editContent, newSize)
+
+        setIsEditing(false)
+        setEditContent('')
+        toast.success('Text file updated')
+      } catch (error) {
+        console.error('Failed to update text file:', error)
+        toast.error('Failed to update text file', {
+          description: String(error),
+        })
+      } finally {
+        setIsSaving(false)
+      }
+    },
+    [sessionId, editContent, isSaving]
+  )
+
+  const handleDialogClose = useCallback(() => {
+    setOpenFileId(null)
+    setIsEditing(false)
+    setEditContent('')
+  }, [])
 
   const openFile = textFiles.find(tf => tf.id === openFileId)
 
@@ -100,7 +163,7 @@ export function TextFilePreview({
       {/* Preview dialog */}
       <Dialog
         open={!!openFileId}
-        onOpenChange={open => !open && setOpenFileId(null)}
+        onOpenChange={open => !open && handleDialogClose()}
       >
         <DialogContent className="!w-screen !h-dvh !max-w-screen !max-h-none !rounded-none p-0 sm:!w-[calc(100vw-4rem)] sm:!max-w-[calc(100vw-4rem)] sm:!h-auto sm:max-h-[85vh] sm:!rounded-lg sm:p-4 bg-background/95 backdrop-blur-sm">
           <DialogTitle className="text-sm font-medium flex items-center gap-2">
@@ -110,8 +173,15 @@ export function TextFilePreview({
               ({openFile ? formatBytes(openFile.size) : ''})
             </span>
           </DialogTitle>
-          <ScrollArea className="h-[calc(85vh-6rem)] mt-2">
-            {isMarkdownFile(openFile?.filename) ? (
+          <ScrollArea className="h-[calc(85vh-8rem)] mt-2">
+            {isEditing ? (
+              <textarea
+                ref={textareaRef}
+                value={editContent}
+                onChange={e => setEditContent(e.target.value)}
+                className="w-full h-full min-h-[calc(85vh-10rem)] text-xs font-mono whitespace-pre-wrap break-words p-3 bg-muted rounded-md border-none outline-none resize-none"
+              />
+            ) : isMarkdownFile(openFile?.filename) ? (
               <div className="p-3">
                 <Markdown className="text-sm">
                   {openFile?.content ?? ''}
@@ -123,6 +193,59 @@ export function TextFilePreview({
               </pre>
             )}
           </ScrollArea>
+          <div className="flex items-center gap-1 pt-2 border-t border-border/50">
+            {isEditing ? (
+              <>
+                <button
+                  type="button"
+                  onClick={handleCancelEdit}
+                  disabled={isSaving}
+                  className="px-3 py-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors text-xs"
+                  title="Cancel editing"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={() => openFile && handleSaveEdit(openFile)}
+                  disabled={isSaving}
+                  className="px-3 py-1.5 rounded-md text-primary-foreground bg-primary hover:bg-primary/90 transition-colors flex items-center gap-1 text-xs"
+                  title="Save changes"
+                >
+                  <Check className="h-3.5 w-3.5" />
+                  Save
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={() =>
+                    openFile?.content && handleCopy(openFile.content)
+                  }
+                  className="px-3 py-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors flex items-center gap-1.5 text-xs"
+                  title="Copy to clipboard"
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                  Copy
+                </button>
+                {!disabled && sessionId && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      openFile?.content !== undefined &&
+                      handleStartEdit(openFile.content)
+                    }
+                    className="px-3 py-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors flex items-center gap-1.5 text-xs"
+                    title="Edit content"
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                    Edit
+                  </button>
+                )}
+              </>
+            )}
+          </div>
         </DialogContent>
       </Dialog>
     </>

--- a/src/store/chat-store.ts
+++ b/src/store/chat-store.ts
@@ -334,6 +334,12 @@ interface ChatUIState {
 
   // Actions - Pending text files (session-based)
   addPendingTextFile: (sessionId: string, textFile: PendingTextFile) => void
+  updatePendingTextFile: (
+    sessionId: string,
+    textFileId: string,
+    content: string,
+    size: number
+  ) => void
   removePendingTextFile: (sessionId: string, textFileId: string) => void
   clearPendingTextFiles: (sessionId: string) => void
   getPendingTextFiles: (sessionId: string) => PendingTextFile[]
@@ -1383,6 +1389,20 @@ export const useChatStore = create<ChatUIState>()(
           }),
           undefined,
           'addPendingTextFile'
+        ),
+
+      updatePendingTextFile: (sessionId, textFileId, content, size) =>
+        set(
+          state => ({
+            pendingTextFiles: {
+              ...state.pendingTextFiles,
+              [sessionId]: (state.pendingTextFiles[sessionId] ?? []).map(tf =>
+                tf.id === textFileId ? { ...tf, content, size } : tf
+              ),
+            },
+          }),
+          undefined,
+          'updatePendingTextFile'
         ),
 
       removePendingTextFile: (sessionId, textFileId) =>

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -535,6 +535,12 @@ export interface SaveTextResponse {
 }
 
 /**
+ * Response from the update_pasted_text Tauri command
+ * Returns the new file size after updating content
+ */
+export type UpdateTextResponse = number
+
+/**
  * Response from the read_pasted_text Tauri command
  */
 export interface ReadTextResponse {


### PR DESCRIPTION
## Summary
- Add **Copy** and **Edit** buttons to the pasted text file preview dialog (pre-send)
- Add **Copy** button to the text file lightbox dialog (post-send)
- Buttons are placed in a bottom-left toolbar to avoid overlapping the dialog close button
- Edit mode saves changes to disk atomically and syncs the Zustand store

## Context
When pasting long text (500+ chars), the content is converted to a file attachment. Previously, users had no way to copy the content or modify it before sending — the only option was to remove the attachment entirely.
Really usefull when text for "text-to-speech" software needs to be updated.

## Test plan
- [ ] Paste a long text (500+ chars) → click the file badge → verify Copy and Edit buttons appear at bottom-left
- [ ] Copy: click Copy → verify content is in clipboard
- [ ] Edit: click Edit → modify text → Save → reopen dialog → verify changes persisted
- [ ] Edit: click Edit → modify text → Cancel → reopen → verify original content unchanged
- [ ] Send a message with text attachment → click the post-send badge → verify Copy button works
- [ ] Verify dialog close button (X) is not obscured by action buttons