### PR TITLE
fix(claude-cli): detect Homebrew-installed Claude CLI

### DIFF
--- a/src-tauri/src/chat/claude.rs
+++ b/src-tauri/src/chat/claude.rs
@@ -582,7 +582,7 @@ pub fn execute_claude_detached(
     chrome_enabled: bool,
 ) -> Result<(u32, ClaudeResponse), String> {
     use super::detached::spawn_detached_claude;
-    use crate::claude_cli::get_cli_binary_path;
+    use crate::claude_cli::resolve_cli_binary;
 
     log::trace!("Executing Claude CLI (detached) for session: {session_id}");
     log::trace!("Input file: {input_file:?}");
@@ -590,18 +590,7 @@ pub fn execute_claude_detached(
     log::trace!("Working directory: {working_dir:?}");
 
     // Get CLI path
-    let cli_path = get_cli_binary_path(app).map_err(|e| {
-        let error_msg =
-            format!("Failed to get CLI path: {e}. Please complete setup in Settings > Advanced.");
-        log::error!("{error_msg}");
-        let error_event = ErrorEvent {
-            session_id: session_id.to_string(),
-            worktree_id: worktree_id.to_string(),
-            error: error_msg.clone(),
-        };
-        let _ = app.emit_all("chat:error", &error_event);
-        error_msg
-    })?;
+    let cli_path = resolve_cli_binary(app);
 
     if !cli_path.exists() {
         let error_msg =

--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -17,7 +17,7 @@ use super::types::{
     AllSessionsEntry, AllSessionsResponse, ChatMessage, ClaudeContext, EffortLevel, MessageRole,
     RunStatus, Session, SessionDigest, ThinkingLevel, WorktreeSessions,
 };
-use crate::claude_cli::get_cli_binary_path;
+use crate::claude_cli::resolve_cli_binary;
 use crate::http_server::EmitExt;
 use crate::platform::silent_command;
 use crate::projects::storage::load_projects_data;
@@ -2379,7 +2379,7 @@ fn execute_summarization_claude(
     prompt: &str,
     model: Option<&str>,
 ) -> Result<ContextSummaryResponse, String> {
-    let cli_path = get_cli_binary_path(app)?;
+    let cli_path = resolve_cli_binary(app);
 
     if !cli_path.exists() {
         return Err("Claude CLI not installed".to_string());
@@ -2907,7 +2907,7 @@ fn execute_digest_claude(
     prompt: &str,
     model: &str,
 ) -> Result<SessionDigestResponse, String> {
-    let cli_path = get_cli_binary_path(app)?;
+    let cli_path = resolve_cli_binary(app);
 
     if !cli_path.exists() {
         return Err("Claude CLI not installed".to_string());
@@ -3271,7 +3271,7 @@ fn parse_mcp_list_output(output: &str) -> std::collections::HashMap<String, McpH
 /// Check health status of all MCP servers by running `claude mcp list`.
 #[tauri::command]
 pub async fn check_mcp_health(app: AppHandle) -> Result<McpHealthResult, String> {
-    let cli_path = get_cli_binary_path(&app)?;
+    let cli_path = resolve_cli_binary(&app);
 
     if !cli_path.exists() {
         return Err("Claude CLI not installed".to_string());

--- a/src-tauri/src/chat/naming.rs
+++ b/src-tauri/src/chat/naming.rs
@@ -3,7 +3,7 @@
 //! Uses a single Claude CLI call to generate both session and branch names
 //! based on the first message in a session.
 
-use crate::claude_cli::get_cli_binary_path;
+use crate::claude_cli::resolve_cli_binary;
 use crate::platform::silent_command;
 use crate::projects::git;
 use crate::projects::storage::{load_projects_data, save_projects_data};
@@ -290,7 +290,7 @@ fn extract_text_from_stream_json(output: &str) -> Result<String, String> {
 
 /// Generate names using Claude CLI
 fn generate_names(app: &AppHandle, request: &NamingRequest) -> Result<NamingOutput, String> {
-    let cli_path = get_cli_binary_path(app)?;
+    let cli_path = resolve_cli_binary(app);
 
     if !cli_path.exists() {
         return Err("Claude CLI not installed".to_string());

--- a/src-tauri/src/claude_cli/commands.rs
+++ b/src-tauri/src/claude_cli/commands.rs
@@ -5,7 +5,7 @@ use sha2::{Digest, Sha256};
 use std::io::Write;
 use tauri::AppHandle;
 
-use super::config::{ensure_cli_dir, get_cli_binary_path};
+use super::config::{ensure_cli_dir, get_cli_binary_path, resolve_cli_binary};
 use crate::http_server::EmitExt;
 use crate::platform::silent_command;
 
@@ -74,7 +74,7 @@ pub struct InstallProgress {
 pub async fn check_claude_cli_installed(app: AppHandle) -> Result<ClaudeCliStatus, String> {
     log::trace!("Checking Claude CLI installation status");
 
-    let binary_path = get_cli_binary_path(&app)?;
+    let binary_path = resolve_cli_binary(&app);
 
     if !binary_path.exists() {
         log::trace!("Claude CLI not found at {:?}", binary_path);
@@ -450,7 +450,7 @@ pub struct ClaudeAuthStatus {
 pub async fn check_claude_cli_auth(app: AppHandle) -> Result<ClaudeAuthStatus, String> {
     log::trace!("Checking Claude CLI authentication status");
 
-    let binary_path = get_cli_binary_path(&app)?;
+    let binary_path = resolve_cli_binary(&app);
 
     if !binary_path.exists() {
         return Ok(ClaudeAuthStatus {

--- a/src-tauri/src/claude_cli/config.rs
+++ b/src-tauri/src/claude_cli/config.rs
@@ -30,10 +30,63 @@ pub fn get_cli_binary_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(get_cli_dir(app)?.join(CLI_BINARY_NAME))
 }
 
+fn resolve_cli_binary_with(
+    embedded_binary: Option<PathBuf>,
+    path_binary: Option<PathBuf>,
+) -> PathBuf {
+    if let Some(embedded_binary) = embedded_binary {
+        return embedded_binary;
+    }
+
+    if let Some(path_binary) = path_binary {
+        return path_binary;
+    }
+
+    PathBuf::from(CLI_BINARY_NAME)
+}
+
+pub fn resolve_cli_binary(app: &AppHandle) -> PathBuf {
+    let embedded_binary = get_cli_binary_path(app).ok().filter(|path| path.exists());
+    let path_binary = which::which(CLI_BINARY_NAME).ok();
+
+    resolve_cli_binary_with(embedded_binary, path_binary)
+}
+
 /// Ensure the CLI directory exists, creating it if necessary
 pub fn ensure_cli_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let cli_dir = get_cli_dir(app)?;
     std::fs::create_dir_all(&cli_dir)
         .map_err(|e| format!("Failed to create CLI directory: {e}"))?;
     Ok(cli_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_cli_binary_prefers_embedded_binary() {
+        let embedded = PathBuf::from("/tmp/jean/claude");
+        let path_binary = PathBuf::from("/opt/homebrew/bin/claude");
+
+        let resolved = resolve_cli_binary_with(Some(embedded.clone()), Some(path_binary));
+
+        assert_eq!(resolved, embedded);
+    }
+
+    #[test]
+    fn resolve_cli_binary_uses_path_binary_when_embedded_missing() {
+        let path_binary = PathBuf::from("/opt/homebrew/bin/claude");
+
+        let resolved = resolve_cli_binary_with(None, Some(path_binary.clone()));
+
+        assert_eq!(resolved, path_binary);
+    }
+
+    #[test]
+    fn resolve_cli_binary_falls_back_to_command_name() {
+        let resolved = resolve_cli_binary_with(None, None);
+
+        assert_eq!(resolved, PathBuf::from(CLI_BINARY_NAME));
+    }
 }

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -27,7 +27,7 @@ use super::types::{
     WorktreeDeleteErrorEvent, WorktreeDeletedEvent, WorktreeDeletingEvent, WorktreePathExistsEvent,
     WorktreePermanentlyDeletedEvent, WorktreeUnarchivedEvent,
 };
-use crate::claude_cli::get_cli_binary_path;
+use crate::claude_cli::resolve_cli_binary;
 use crate::gh_cli::config::resolve_gh_binary;
 use crate::http_server::EmitExt;
 use crate::platform::silent_command;
@@ -3786,7 +3786,7 @@ fn generate_pr_content(
     model: Option<&str>,
     context: &str,
 ) -> Result<PrContentResponse, String> {
-    let cli_path = get_cli_binary_path(app)?;
+    let cli_path = resolve_cli_binary(app);
 
     if !cli_path.exists() {
         return Err("Claude CLI not installed".to_string());
@@ -4211,7 +4211,7 @@ fn generate_commit_message(
     prompt: &str,
     model: Option<&str>,
 ) -> Result<CommitMessageResponse, String> {
-    let cli_path = get_cli_binary_path(app)?;
+    let cli_path = resolve_cli_binary(app);
 
     if !cli_path.exists() {
         return Err("Claude CLI not installed".to_string());
@@ -4421,7 +4421,7 @@ fn generate_review(
     prompt: &str,
     model: Option<&str>,
 ) -> Result<ReviewResponse, String> {
-    let cli_path = get_cli_binary_path(app)?;
+    let cli_path = resolve_cli_binary(app);
 
     if !cli_path.exists() {
         return Err("Claude CLI not installed".to_string());
@@ -4699,7 +4699,7 @@ fn generate_release_notes_content(
     custom_prompt: Option<&str>,
     model: Option<&str>,
 ) -> Result<ReleaseNotesResponse, String> {
-    let cli_path = get_cli_binary_path(app)?;
+    let cli_path = resolve_cli_binary(app);
 
     if !cli_path.exists() {
         return Err("Claude CLI not installed".to_string());


### PR DESCRIPTION
## Summary
- add `resolve_cli_binary` in `claude_cli/config.rs` to prefer Jean's embedded binary but fall back to a `claude` executable found on `PATH` (covers Homebrew installs)
- use this resolver for Claude CLI status/auth checks and every runtime Claude invocation path (chat, naming, MCP health, and AI helper commands)
- keep installer output path unchanged so `install_claude_cli` still installs only into Jean's managed app-data location

## Testing
- `npm run rust:test` ✅ (96 tests passed)
- `npm run check:all` ⚠️ fails on existing repo lint errors unrelated to this change (e.g. `src/App.tsx`, `src/components/open-in/OpenInModal.tsx`, `src/components/shared/WorkflowRunsModal.tsx`)