### PR TITLE
fix(editor): Windows process spawning for VS Code launcher

### DIFF
--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -2238,8 +2238,8 @@ pub async fn open_file_in_default_app(path: String, editor: Option<String>) -> R
     #[cfg(target_os = "windows")]
     {
         let result = match editor_app.as_str() {
-            "cursor" => std::process::Command::new("cursor").arg(&path).spawn(),
-            _ => std::process::Command::new("code").arg(&path).spawn(),
+            "cursor" => std::process::Command::new("cmd").args(["/C", "cursor", &path]).spawn(),
+            _ => std::process::Command::new("cmd").args(["/C", "code", &path]).spawn(),
         };
 
         result.map_err(|e| format!("Failed to open {editor_app}: {e}"))?;

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -2833,9 +2833,8 @@ pub async fn open_worktree_in_editor(
         }
     }
 
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(target_os = "linux")]
     {
-        // VS Code and Cursor CLI work the same on all platforms
         let result = match editor_app.as_str() {
             "cursor" => std::process::Command::new("cursor")
                 .arg(&worktree_path)
@@ -2849,6 +2848,30 @@ pub async fn open_worktree_in_editor(
                     .arg(&worktree_path)
                     .spawn()
             }
+        };
+
+        match result {
+            Ok(_) => {
+                log::trace!("Successfully opened {editor_app}");
+            }
+            Err(e) => {
+                return Err(format_open_error(&editor_app, &e));
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let result = match editor_app.as_str() {
+            "cursor" => std::process::Command::new("cmd")
+                .args(["/C", "cursor", &worktree_path])
+                .spawn(),
+            "xcode" => {
+                return Err("Xcode is only available on macOS".to_string());
+            }
+            _ => std::process::Command::new("cmd")
+                .args(["/C", "code", &worktree_path])
+                .spawn(),
         };
 
         match result {


### PR DESCRIPTION
On Windows, code resolves to a .cmd shim in the VS Code bin directory.
std::process::Command ultimately uses CreateProcess, which cannot execute batch (.cmd / .bat) scripts directly.

As a result, Command::new("code") may resolve correctly via PATH, but process creation fails because the target is not a native executable.

This change routes the invocation through:

cmd /C code <path>

which allows the Windows command interpreter to execute the .cmd shim correctly.

This only affects Windows behavior and preserves existing behavior on other platforms.