### PR TITLE
feat(projects): improve worktree name generation uniqueness and variety

### DIFF
--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -534,7 +534,9 @@ pub async fn create_worktree(
             issue_branch
         }
     } else {
-        generate_unique_workspace_name(|n| data.worktree_name_exists(&project_id, n))
+        generate_unique_workspace_name(|n| {
+            data.worktree_name_exists(&project_id, n) || git::branch_exists(&project.path, n)
+        })
     };
 
     // Build worktree path: ~/jean/<project-name>/<workspace-name>

--- a/src-tauri/src/projects/names.rs
+++ b/src-tauri/src/projects/names.rs
@@ -1,21 +1,35 @@
 use rand::seq::SliceRandom;
 
-/// List of adjectives for workspace names
+/// List of adjectives for workspace names (~120 entries for ~14,400 combinations)
 const ADJECTIVES: &[&str] = &[
     "swift", "quiet", "bright", "fuzzy", "gentle", "bold", "calm", "eager", "fancy", "grand",
     "happy", "jolly", "keen", "lively", "merry", "noble", "proud", "quick", "rapid", "sharp",
     "smart", "snowy", "sunny", "sweet", "vivid", "warm", "wise", "young", "zesty", "agile",
     "brave", "clever", "daring", "epic", "fair", "golden", "honest", "iconic", "jade", "kindly",
     "loyal", "mighty", "neat", "open", "prime", "royal", "solid", "tidy", "ultra", "vital",
+    "amber", "azure", "brisk", "coral", "crisp", "dusty", "elfin", "fiery", "fleet", "frosty",
+    "gleam", "gusty", "hazy", "icy", "ivory", "jasper", "lunar", "maple", "misty", "mossy",
+    "oaken", "opal", "peach", "plush", "polar", "rosy", "rusty", "sage", "sandy", "silky",
+    "smoky", "spry", "stark", "steel", "stony", "stormy", "tawny", "terra", "vast", "velvet",
+    "wild", "windy", "woody", "ashen", "cedar", "chalk", "dawn", "dusk", "ember", "frost",
+    "gilt", "hazel", "honey", "indigo", "lemon", "lilac", "mint", "onyx", "pearl", "plum",
+    "quartz", "ruby", "slate", "stone", "thorn", "topaz", "tulip", "umber", "zinc", "birch",
 ];
 
-/// List of animals for workspace names
+/// List of animals for workspace names (~120 entries for ~14,400 combinations)
 const ANIMALS: &[&str] = &[
     "tiger", "falcon", "otter", "eagle", "wolf", "bear", "lion", "hawk", "fox", "deer", "owl",
     "swan", "crane", "whale", "shark", "raven", "heron", "finch", "robin", "wren", "hound",
     "horse", "moose", "bison", "panda", "koala", "lemur", "sloth", "gecko", "viper", "cobra",
     "python", "salmon", "trout", "bass", "perch", "carp", "tuna", "squid", "crab", "seal",
     "walrus", "orca", "dolphin", "pelican", "parrot", "toucan", "condor", "osprey", "badger",
+    "alpaca", "bobcat", "camel", "cheetah", "clam", "corgi", "coyote", "dingo", "dove", "drake",
+    "egret", "elk", "ferret", "flamingo", "gannet", "gazelle", "gibbon", "goose", "grouse",
+    "gull", "ibis", "iguana", "impala", "jackal", "jaguar", "kite", "lark", "linnet", "llama",
+    "locust", "lynx", "macaw", "marten", "mink", "moth", "myna", "newt", "okapi", "oriole",
+    "panther", "pigeon", "puffin", "quail", "rabbit", "raccoon", "ram", "shrike", "skunk",
+    "snipe", "spider", "stork", "swift", "tern", "thrush", "toad", "turtle", "urchin", "wasp",
+    "weasel", "yak", "zebra", "beetle", "mantis", "mole", "pika", "rook", "wombat", "starling",
 ];
 
 /// Generate a random workspace name in the format "adjective-animal"


### PR DESCRIPTION
## Summary

- **Enhanced uniqueness checking**: Worktree name generation now verifies that generated names don't conflict with existing git branches in addition to existing worktree records
- **Expanded word pools**: Increased adjectives from ~50 to ~120 entries and animals from ~50 to ~120 entries, providing ~14,400 possible name combinations (up from ~2,500)
- **Reduced collision probability**: Larger word pools significantly decrease the chance of name conflicts, especially in active projects with many branches

## Breaking Changes

None. This is a backward-compatible enhancement.