### PR TITLE
fix(auth): support CLI versions without auth subcommand

### DIFF
--- a/src/components/onboarding/OnboardingDialog.tsx
+++ b/src/components/onboarding/OnboardingDialog.tsx
@@ -378,7 +378,8 @@ function OnboardingDialogContent() {
 
   // Build CLI login command from binary path
   const claudeLoginCommand = claudeSetup.status?.path
-    ? `'${claudeSetup.status.path.replace(/'/g, "'\\''")}'`
+    ? `'${claudeSetup.status.path.replace(/'/g, "'\\''")}'` +
+      (claudeSetup.status.supports_auth_command ? ' auth login' : '')
     : ''
   const ghLoginCommand = ghSetup.status?.path
     ? `'${ghSetup.status.path.replace(/'/g, "'\\''")}' auth login`

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -347,8 +347,11 @@ export const GeneralPane: React.FC = () => {
     const escapedPath = isWindows
       ? `& "${cliStatus.path}"`
       : `'${cliStatus.path.replace(/'/g, "'\\''")}'`
-    openCliLoginModal('claude', escapedPath)
-  }, [cliStatus?.path, openCliLoginModal, queryClient])
+    openCliLoginModal(
+      'claude',
+      cliStatus.supports_auth_command ? escapedPath + ' auth login' : escapedPath
+    )
+  }, [cliStatus?.path, cliStatus?.supports_auth_command, openCliLoginModal, queryClient])
 
   const handleGhLogin = useCallback(async () => {
     if (!ghStatus?.path) return

--- a/src/services/claude-cli.ts
+++ b/src/services/claude-cli.ts
@@ -39,7 +39,7 @@ export function useClaudeCliStatus() {
     queryFn: async (): Promise<ClaudeCliStatus> => {
       if (!isTauri()) {
         logger.debug('Not in Tauri context, returning mock CLI status')
-        return { installed: false, version: null, path: null }
+        return { installed: false, version: null, path: null, supports_auth_command: false }
       }
 
       try {
@@ -51,7 +51,7 @@ export function useClaudeCliStatus() {
         return status
       } catch (error) {
         logger.error('Failed to check Claude CLI status', { error })
-        return { installed: false, version: null, path: null }
+        return { installed: false, version: null, path: null, supports_auth_command: false }
       }
     },
     staleTime: 1000 * 60 * 5, // 5 minutes

--- a/src/types/claude-cli.ts
+++ b/src/types/claude-cli.ts
@@ -12,6 +12,8 @@ export interface ClaudeCliStatus {
   version: string | null
   /** Path to the CLI binary (if installed) */
   path: string | null
+  /** Whether the CLI supports the `auth` subcommand (older CLIs lack it) */
+  supports_auth_command: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary

- Added `supports_auth_command` field to `ClaudeCliStatus` to detect CLI version compatibility
- Implemented runtime check for `auth` subcommand support by running `auth --help`
- Updated login command builders to conditionally append `auth login` only when supported
- Maintains backwards compatibility with older Claude CLI versions that lack the auth command

## Breaking Changes

None - this change is fully backwards compatible and gracefully handles older CLI versions.

- fixes #86 