### PR TITLE
feat(mobile): auto-close sidebar after navigation

### DIFF
--- a/src/components/projects/ProjectTreeItem.tsx
+++ b/src/components/projects/ProjectTreeItem.tsx
@@ -14,6 +14,7 @@ import { isBaseSession } from '@/types/projects'
 import { useProjectsStore } from '@/store/projects-store'
 import { useChatStore } from '@/store/chat-store'
 import { useUIStore } from '@/store/ui-store'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { useWorktrees, useAppDataDir } from '@/services/projects'
 import {
   useFetchWorktreesStatus,
@@ -38,6 +39,7 @@ interface ProjectTreeItemProps {
 }
 
 export function ProjectTreeItem({ project }: ProjectTreeItemProps) {
+  const isMobile = useIsMobile()
   const {
     expandedProjectIds,
     selectedProjectId,
@@ -97,7 +99,11 @@ export function ProjectTreeItem({ project }: ProjectTreeItemProps) {
     selectProject(project.id)
     // Clear active worktree so ChatWindow shows Session Board view
     clearActiveWorktree()
-  }, [project.id, selectProject, clearActiveWorktree])
+    // Close sidebar on mobile after navigation
+    if (isMobile) {
+      useUIStore.getState().setLeftSidebarVisible(false)
+    }
+  }, [isMobile, project.id, selectProject, clearActiveWorktree])
 
   const handleChevronClick = useCallback(
     (e: React.MouseEvent) => {

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -10,6 +10,8 @@ import { cn } from '@/lib/utils'
 import { isBaseSession, type Worktree } from '@/types/projects'
 import { useProjectsStore } from '@/store/projects-store'
 import { useChatStore } from '@/store/chat-store'
+import { useUIStore } from '@/store/ui-store'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { WorktreeContextMenu } from './WorktreeContextMenu'
 import { useRenameWorktree } from '@/services/projects'
 import { useSessions } from '@/services/chat'
@@ -48,6 +50,7 @@ export function WorktreeItem({
   projectPath,
   defaultBranch,
 }: WorktreeItemProps) {
+  const isMobile = useIsMobile()
   const {
     selectedWorktreeId,
     selectWorktree,
@@ -390,7 +393,13 @@ export function WorktreeItem({
       prNumber: worktree.pr_number,
       prUrl: worktree.pr_url,
     })
+
+    // Close sidebar on mobile after navigation
+    if (isMobile) {
+      useUIStore.getState().setLeftSidebarVisible(false)
+    }
   }, [
+    isMobile,
     projectId,
     worktree.id,
     worktree.path,


### PR DESCRIPTION
On mobile (< 768px), clicking a worktree or project in the sidebar now auto-closes the sidebar improving the UX.
