### PR TITLE
feat(session): show project name in session header

### DIFF
--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -657,6 +657,12 @@ export function SessionChatModal({
                   <ArrowLeft className="h-4 w-4" />
                 </Button>
                 <DialogTitle className="text-sm font-medium shrink-0">
+                  {project && (
+                    <span className="text-muted-foreground font-normal">
+                      {project.name}
+                      <span className="mx-1.5 text-muted-foreground/50">›</span>
+                    </span>
+                  )}
                   {isBase ? 'Base Session' : (worktree?.name ?? 'Worktree')}
                 </DialogTitle>
                 <DialogDescription className="sr-only">


### PR DESCRIPTION
## Summary

- Display project name in the session header alongside the session type
- Add visual separator (›) between project name and session identifier
- Use muted styling to keep the UI clean and non-intrusive
- Resolves #112

## Implementation

Added project name display to the `SessionChatModal` header, showing context like:
- `my-project › Base Session`
- `my-project › Worktree Name`

This allows users to immediately identify which project a session belongs to, reducing confusion when managing multiple projects across different tabs.

---

Fixes #112