### PR TITLE
fix(shell): fix CLI command escaping for Windows PowerShell

### DIFF
--- a/src/components/onboarding/OnboardingDialog.tsx
+++ b/src/components/onboarding/OnboardingDialog.tsx
@@ -23,6 +23,7 @@ import {
   useOpenCodeCliAuth,
 } from '@/services/opencode-cli'
 import { useGhCliSetup, useGhCliAuth } from '@/services/gh-cli'
+import { escapeCliCommand } from '@/lib/shell-escape'
 import {
   SetupState,
   InstallingState,
@@ -681,20 +682,22 @@ function OnboardingDialogContent() {
   const isGhReinstall = ghSetup.status?.installed && step === 'gh-setup'
 
   const claudeLoginCommand = claudeSetup.status?.path
-    ? `'${claudeSetup.status.path.replace(/'/g, "'\\''")}'` +
-      (claudeSetup.status.supports_auth_command ? ' auth login' : '')
+    ? escapeCliCommand(
+        claudeSetup.status.path,
+        claudeSetup.status.supports_auth_command ? 'auth login' : undefined
+      )
     : ''
 
   const codexLoginCommand = codexSetup.status?.path
-    ? `'${codexSetup.status.path.replace(/'/g, "'\\''")}' login`
+    ? escapeCliCommand(codexSetup.status.path, 'login')
     : ''
 
   const opencodeLoginCommand = opencodeSetup.status?.path
-    ? `'${opencodeSetup.status.path.replace(/'/g, "'\\''")}' auth login`
+    ? escapeCliCommand(opencodeSetup.status.path, 'auth login')
     : ''
 
   const ghLoginCommand = ghSetup.status?.path
-    ? `'${ghSetup.status.path.replace(/'/g, "'\\''")}' auth login`
+    ? escapeCliCommand(ghSetup.status.path, 'auth login')
     : ''
 
   const getDialogContent = () => {

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useMemo, type FC } from 'react'
 import { invoke } from '@/lib/transport'
+import { escapeCliCommand } from '@/lib/shell-escape'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { Loader2, ChevronDown, Check, ChevronsUpDown } from 'lucide-react'
@@ -419,16 +420,12 @@ export const GeneralPane: React.FC = () => {
     }
 
     // Not authenticated, open login modal
-    // Use & "path" syntax for PowerShell on Windows, single-quote escaping for Unix
-    const isWindows = navigator.userAgent.includes('Windows')
-    const escapedPath = isWindows
-      ? `& "${cliStatus.path}"`
-      : `'${cliStatus.path.replace(/'/g, "'\\''")}'`
     openCliLoginModal(
       'claude',
-      cliStatus.supports_auth_command
-        ? escapedPath + ' auth login'
-        : escapedPath
+      escapeCliCommand(
+        cliStatus.path,
+        cliStatus.supports_auth_command ? 'auth login' : undefined
+      )
     )
   }, [
     cliStatus?.path,
@@ -458,12 +455,7 @@ export const GeneralPane: React.FC = () => {
     }
 
     // Not authenticated, open login modal
-    // Use & "path" syntax for PowerShell on Windows, single-quote escaping for Unix
-    const isWindows = navigator.userAgent.includes('Windows')
-    const escapedPath = isWindows
-      ? `& "${ghStatus.path}" auth login`
-      : `'${ghStatus.path.replace(/'/g, "'\\''")}'` + ' auth login'
-    openCliLoginModal('gh', escapedPath)
+    openCliLoginModal('gh', escapeCliCommand(ghStatus.path, 'auth login'))
   }, [ghStatus?.path, openCliLoginModal, queryClient])
 
   const handleCodexLogin = useCallback(async () => {
@@ -486,12 +478,8 @@ export const GeneralPane: React.FC = () => {
       setCheckingCodexAuth(false)
     }
 
-    // Not authenticated, open login modal with `codex login`
-    const isWindows = navigator.userAgent.includes('Windows')
-    const escapedPath = isWindows
-      ? `& "${codexStatus.path}" login`
-      : `'${codexStatus.path.replace(/'/g, "'\\''")}'` + ' login'
-    openCliLoginModal('codex', escapedPath)
+    // Not authenticated, open login modal
+    openCliLoginModal('codex', escapeCliCommand(codexStatus.path, 'login'))
   }, [codexStatus?.path, openCliLoginModal, queryClient])
 
   const handleOpenCodeLogin = useCallback(async () => {
@@ -514,11 +502,10 @@ export const GeneralPane: React.FC = () => {
       setCheckingOpenCodeAuth(false)
     }
 
-    const isWindows = navigator.userAgent.includes('Windows')
-    const escapedPath = isWindows
-      ? `& "${opencodeStatus.path}" auth login`
-      : `'${opencodeStatus.path.replace(/'/g, "'\\''")}'` + ' auth login'
-    openCliLoginModal('opencode', escapedPath)
+    openCliLoginModal(
+      'opencode',
+      escapeCliCommand(opencodeStatus.path, 'auth login')
+    )
   }, [opencodeStatus?.path, openCliLoginModal, queryClient])
 
   const claudeStatusDescription = cliStatus?.installed

--- a/src/hooks/useGhLogin.ts
+++ b/src/hooks/useGhLogin.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { useGhCliStatus } from '@/services/gh-cli'
+import { escapeCliCommand } from '@/lib/shell-escape'
 import { useUIStore } from '@/store/ui-store'
 
 /**
@@ -14,11 +15,7 @@ export function useGhLogin() {
   const triggerLogin = useCallback(() => {
     if (!ghStatus?.path) return
 
-    const isWindows = navigator.userAgent.includes('Windows')
-    const escapedPath = isWindows
-      ? `& "${ghStatus.path}" auth login`
-      : `'${ghStatus.path.replace(/'/g, "'\\''")}'` + ' auth login'
-    openCliLoginModal('gh', escapedPath)
+    openCliLoginModal('gh', escapeCliCommand(ghStatus.path, 'auth login'))
   }, [ghStatus?.path, openCliLoginModal])
 
   return { triggerLogin, isGhInstalled: !!ghStatus?.installed }

--- a/src/lib/shell-escape.ts
+++ b/src/lib/shell-escape.ts
@@ -1,0 +1,14 @@
+/**
+ * Construct a shell command string with proper path escaping for the current platform.
+ *
+ * - Windows (PowerShell): `& "path" args`
+ * - Unix (sh/zsh/bash):   `'path' args`  (with internal single-quote escaping)
+ */
+export function escapeCliCommand(path: string, args?: string): string {
+  const isWindows = navigator.userAgent.includes('Windows')
+  if (isWindows) {
+    return args ? `& "${path}" ${args}` : `& "${path}"`
+  }
+  const escaped = `'${path.replace(/'/g, "'\\''")}'`
+  return args ? `${escaped} ${args}` : escaped
+}


### PR DESCRIPTION
## Summary
- Fix shell command escaping for Windows PowerShell compatibility
- Add `escapeCliCommand` utility to properly escape paths and arguments per platform
- Refactor CLI login commands across multiple components to use the new utility

## Breaking Changes
None

## Details
CLI authentication commands were failing on Windows PowerShell with "Unexpected token" errors because the code was using Unix-style single-quote escaping on all platforms. PowerShell requires different syntax.

The solution introduces a new `escapeCliCommand` utility that:
- Detects the OS via user agent
- Uses PowerShell's `& "path" args` syntax for Windows
- Uses Unix shell's `'path' args` with proper quote escaping for non-Windows platforms

This utility replaces the inline escaping logic across OnboardingDialog, GeneralPane, and useGhLogin, ensuring consistent and correct command formatting for each platform.

---

Fixes #108