### PR TITLE
test(chat): add test for WorktreeIndex::new_empty()

### DIFF
--- a/src-tauri/src/chat/storage.rs
+++ b/src-tauri/src/chat/storage.rs
@@ -778,6 +778,17 @@ mod tests {
     }
 
     #[test]
+    fn test_worktree_index_new_empty() {
+        let index = WorktreeIndex::new_empty("test-worktree".to_string());
+
+        assert_eq!(index.worktree_id, "test-worktree");
+        assert_eq!(index.sessions.len(), 0);
+        assert!(index.active_session_id.is_none());
+        assert_eq!(index.version, 1);
+        assert!(index.branch_naming_completed);
+    }
+
+    #[test]
     fn test_worktree_index_find_methods() {
         let mut index = WorktreeIndex::new("test".to_string());
         let session_id = index.sessions[0].id.clone();


### PR DESCRIPTION
## Summary
- Adds test coverage for `WorktreeIndex::new_empty()` method introduced in PR #107
- Verifies empty worktrees are created with no default sessions
- Confirms `active_session_id` is `None` and `branch_naming_completed` is set to `true`
- Ensures proper initialization of version field

This test validates the foundational building block for programmatically-created worktrees from the Rust backend.

---

Related to #107