### PR TITLE
feat(projects): add clone remote repository functionality

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1986,6 +1986,7 @@ pub fn run() {
             projects::add_project,
             projects::init_git_in_folder,
             projects::init_project,
+            projects::clone_project,
             projects::remove_project,
             projects::list_worktrees,
             projects::get_worktree,

--- a/src/components/layout/MainWindow.tsx
+++ b/src/components/layout/MainWindow.tsx
@@ -18,6 +18,7 @@ import { RemotePickerModal } from '@/components/magic/RemotePickerModal'
 import { UpdatePrDialog } from '@/components/magic/UpdatePrDialog'
 import { AddProjectDialog } from '@/components/projects/AddProjectDialog'
 import { GitInitModal } from '@/components/projects/GitInitModal'
+import { CloneProjectModal } from '@/components/projects/CloneProjectModal'
 import { QuitConfirmationDialog } from './QuitConfirmationDialog'
 import { CloseWorktreeDialog } from '@/components/chat/CloseWorktreeDialog'
 import { BranchConflictDialog } from '@/components/worktree/BranchConflictDialog'
@@ -307,6 +308,7 @@ export function MainWindow() {
       </Suspense>
       <AddProjectDialog />
       <GitInitModal />
+      <CloneProjectModal />
       <Suspense fallback={null}>
         <ArchivedModal
           open={archivedModalOpen}

--- a/src/components/projects/AddProjectDialog.tsx
+++ b/src/components/projects/AddProjectDialog.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect } from 'react'
 import { toast } from 'sonner'
 import { isNativeApp } from '@/lib/environment'
 import { invoke } from '@/lib/transport'
-import { FolderOpen, FolderPlus } from 'lucide-react'
+import { FolderOpen, FolderPlus, Globe } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -22,6 +22,11 @@ export function AddProjectDialog() {
   } = useProjectsStore()
   const addProject = useAddProject()
   const initProject = useInitProject()
+
+  const handleCloneRemote = useCallback(() => {
+    const { openCloneModal } = useProjectsStore.getState()
+    openCloneModal()
+  }, [])
 
   const isPending = addProject.isPending || initProject.isPending
 
@@ -138,11 +143,14 @@ export function AddProjectDialog() {
       } else if (e.key === 'i' || e.key === 'I') {
         e.preventDefault()
         handleInitNew()
+      } else if (e.key === 'c' || e.key === 'C') {
+        e.preventDefault()
+        handleCloneRemote()
       }
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [addProjectDialogOpen, isPending, handleAddExisting, handleInitNew])
+  }, [addProjectDialogOpen, isPending, handleAddExisting, handleInitNew, handleCloneRemote])
 
   return (
     <Dialog open={addProjectDialogOpen} onOpenChange={setAddProjectDialogOpen}>
@@ -191,6 +199,25 @@ export function AddProjectDialog() {
               </p>
             </div>
             <Kbd className="mt-1 h-6 px-1.5 text-xs shrink-0">I</Kbd>
+          </button>
+
+          <button
+            onClick={handleCloneRemote}
+            disabled={isPending}
+            className="flex items-start gap-4 rounded-lg border border-border p-4 text-left transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+          >
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+              <Globe className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <div className="flex-1 space-y-1">
+              <p className="text-sm font-medium leading-none">
+                Clone from Remote
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Clone a repository from a git URL
+              </p>
+            </div>
+            <Kbd className="mt-1 h-6 px-1.5 text-xs shrink-0">C</Kbd>
           </button>
         </div>
       </DialogContent>

--- a/src/components/projects/CloneProjectModal.tsx
+++ b/src/components/projects/CloneProjectModal.tsx
@@ -1,0 +1,212 @@
+import { useState, useCallback, useEffect, useMemo } from 'react'
+import { toast } from 'sonner'
+import { isNativeApp } from '@/lib/environment'
+import { Loader2, Globe, FolderOpen, AlertCircle } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useProjectsStore } from '@/store/projects-store'
+import { useCloneProject } from '@/services/projects'
+
+/** Extract a repository name from a git URL (strips .git suffix) */
+function extractRepoName(url: string): string {
+  const trimmed = url.trim().replace(/\/+$/, '')
+  const lastSegment = trimmed.split('/').pop() ?? trimmed.split(':').pop() ?? ''
+  return lastSegment.replace(/\.git$/, '')
+}
+
+export function CloneProjectModal() {
+  const {
+    cloneModalOpen,
+    closeCloneModal,
+    setAddProjectDialogOpen,
+    addProjectParentFolderId,
+  } = useProjectsStore()
+
+  const cloneProject = useCloneProject()
+
+  const [url, setUrl] = useState('')
+  const [destination, setDestination] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const repoName = useMemo(() => extractRepoName(url), [url])
+
+  // Reset state when modal closes
+  useEffect(() => {
+    if (!cloneModalOpen) {
+      setUrl('')
+      setDestination('')
+      setError(null)
+    }
+  }, [cloneModalOpen])
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        setError(null)
+        closeCloneModal()
+      }
+    },
+    [closeCloneModal]
+  )
+
+  const handleBrowse = useCallback(async () => {
+    if (!isNativeApp()) return
+
+    try {
+      const { save } = await import('@tauri-apps/plugin-dialog')
+      const selected = await save({
+        title: 'Choose clone destination',
+        defaultPath: repoName || 'repo',
+      })
+
+      if (selected && typeof selected === 'string') {
+        setDestination(selected)
+      }
+    } catch (error) {
+      // User cancelled
+      if (error instanceof Error && error.message.includes('cancel')) return
+    }
+  }, [repoName])
+
+  const handleClone = useCallback(async () => {
+    const trimmedUrl = url.trim()
+    if (!trimmedUrl) {
+      setError('Please enter a git URL.')
+      return
+    }
+    if (!destination) {
+      setError('Please choose a destination directory.')
+      return
+    }
+
+    setError(null)
+
+    // Close modals immediately, use toast for progress
+    closeCloneModal()
+    setAddProjectDialogOpen(false)
+
+    const toastId = toast.loading(`Cloning ${repoName || 'repository'}...`)
+
+    try {
+      await cloneProject.mutateAsync({
+        url: trimmedUrl,
+        path: destination,
+        parentId: addProjectParentFolderId ?? undefined,
+      })
+      toast.dismiss(toastId)
+    } catch {
+      // Error toast is handled by the mutation's onError
+      toast.dismiss(toastId)
+    }
+  }, [
+    url,
+    destination,
+    repoName,
+    cloneProject,
+    addProjectParentFolderId,
+    closeCloneModal,
+    setAddProjectDialogOpen,
+  ])
+
+  return (
+    <Dialog open={cloneModalOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Globe className="h-5 w-5" />
+            Clone Repository
+          </DialogTitle>
+          <DialogDescription>
+            Clone a remote git repository by URL.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {/* Git URL input */}
+          <div className="space-y-1.5">
+            <Label htmlFor="clone-url" className="text-xs">
+              Repository URL
+            </Label>
+            <Input
+              id="clone-url"
+              placeholder="https://github.com/user/repo.git"
+              value={url}
+              onChange={e => setUrl(e.target.value)}
+              disabled={cloneProject.isPending}
+              autoFocus
+              onKeyDown={e => {
+                if (e.key === 'Enter' && url.trim() && destination) {
+                  e.preventDefault()
+                  handleClone()
+                }
+              }}
+            />
+          </div>
+
+          {/* Destination picker */}
+          <div className="space-y-1.5">
+            <Label className="text-xs">Destination</Label>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                className="flex-1 justify-start"
+                onClick={handleBrowse}
+                disabled={cloneProject.isPending}
+              >
+                <FolderOpen className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="truncate text-sm">
+                  {destination || 'Choose destination...'}
+                </span>
+              </Button>
+            </div>
+            {destination && (
+              <p className="truncate text-xs text-muted-foreground">
+                {destination}
+              </p>
+            )}
+          </div>
+
+          {/* Error display */}
+          {error && (
+            <div className="flex items-start gap-2 rounded-lg bg-destructive/10 p-3 text-destructive">
+              <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+              <div className="text-sm">{error}</div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={cloneProject.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleClone}
+            disabled={
+              cloneProject.isPending || !url.trim() || !destination
+            }
+          >
+            {cloneProject.isPending && (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            )}
+            Clone
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default CloneProjectModal

--- a/src/store/projects-store.ts
+++ b/src/store/projects-store.ts
@@ -34,6 +34,9 @@ interface ProjectsUIState {
   gitInitModalOpen: boolean
   gitInitModalPath: string | null
 
+  // Clone project modal state
+  cloneModalOpen: boolean
+
   // Jean.json config wizard state
   jeanConfigWizardOpen: boolean
   jeanConfigWizardProjectId: string | null
@@ -74,6 +77,8 @@ interface ProjectsUIState {
   closeProjectSettings: () => void
   openGitInitModal: (path: string) => void
   closeGitInitModal: () => void
+  openCloneModal: () => void
+  closeCloneModal: () => void
   openJeanConfigWizard: (projectId: string) => void
   closeJeanConfigWizard: () => void
   setEditingFolderId: (id: string | null) => void
@@ -98,6 +103,7 @@ export const useProjectsStore = create<ProjectsUIState>()(
       projectSettingsInitialPane: null,
       gitInitModalOpen: false,
       gitInitModalPath: null,
+      cloneModalOpen: false,
       jeanConfigWizardOpen: false,
       jeanConfigWizardProjectId: null,
       editingFolderId: null,
@@ -296,6 +302,12 @@ export const useProjectsStore = create<ProjectsUIState>()(
           undefined,
           'closeGitInitModal'
         ),
+
+      openCloneModal: () =>
+        set({ cloneModalOpen: true }, undefined, 'openCloneModal'),
+
+      closeCloneModal: () =>
+        set({ cloneModalOpen: false }, undefined, 'closeCloneModal'),
 
       openJeanConfigWizard: projectId =>
         set(


### PR DESCRIPTION
## Summary

- Add `clone_project` Tauri command to clone git repositories from remote URLs
- Implement git helper functions: `clone_repo()` for repository cloning and `extract_repo_name_from_url()` for URL parsing
- Create `CloneProjectModal` UI component with URL input and destination picker
- Add clone state management to projects store with `openCloneModal`/`closeCloneModal` actions
- Integrate clone option into `AddProjectDialog` with keyboard shortcut (C)
- Auto-expand cloned project, show config wizard, and create base session on successful clone

## Implementation Details

**Backend:**
- `clone_project` command validates git URL format, clones repo, extracts metadata, and registers project
- Git helpers handle HTTPS/SSH URL formats and manage the cloning process

**Frontend:**
- Modal provides URL input with auto-detection of repository name
- File browser for selecting destination directory
- Closes dialogs on success and shows toast notifications
- Keyboard shortcut support (press C in Add Project dialog)