### PR TITLE
feat(terminal): add iTerm2 support as terminal option

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,7 +83,7 @@ pub struct AppPreferences {
     #[serde(default = "default_effort_level")]
     pub default_effort_level: String, // Effort level for Opus 4.6: low, medium, high, max
     #[serde(default = "default_terminal")]
-    pub terminal: String, // Terminal app: terminal, warp, ghostty
+    pub terminal: String, // Terminal app: terminal, warp, ghostty, iterm2
     #[serde(default = "default_editor")]
     pub editor: String, // Editor app: zed, vscode, cursor, xcode
     #[serde(default = "default_open_in")]
@@ -1101,8 +1101,8 @@ pub fn load_preferences_sync(app: &AppHandle) -> Result<AppPreferences, String> 
     }
     let contents = std::fs::read_to_string(&prefs_path)
         .map_err(|e| format!("Failed to read preferences file: {e}"))?;
-    let preferences: AppPreferences = serde_json::from_str(&contents)
-        .map_err(|e| format!("Failed to parse preferences: {e}"))?;
+    let preferences: AppPreferences =
+        serde_json::from_str(&contents).map_err(|e| format!("Failed to parse preferences: {e}"))?;
     Ok(preferences)
 }
 

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -3130,6 +3130,27 @@ pub async fn open_worktree_in_terminal(
                     Err(e) => return Err(format_open_error("Ghostty", &e)),
                 }
             }
+            "iterm2" => {
+                // Open new window/tab in iTerm2 and cd into the directory
+                format!(
+                    r#"tell application "iTerm"
+                    activate
+                    if (count of windows) = 0 then
+                        set newWindow to (create window with default profile)
+                        set sess to current session of newWindow
+                    else
+                        tell current window
+                            set newTab to (create tab with default profile)
+                            set sess to current session of newTab
+                        end tell
+                    end if
+                    tell sess
+                        write text "cd '{}' && clear"
+                    end tell
+                end tell"#,
+                    escaped_path
+                )
+            }
             _ => {
                 // Default to Terminal.app
                 format!(

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -658,7 +658,7 @@ export interface AppPreferences {
   selected_model: ClaudeModel // Claude model ID passed to --model flag
   thinking_level: ThinkingLevel // Thinking level: 'off' | 'think' | 'megathink' | 'ultrathink'
   default_effort_level: EffortLevel // Effort level for Opus 4.6 adaptive thinking: 'low' | 'medium' | 'high' | 'max'
-  terminal: TerminalApp // Terminal app: 'terminal' | 'warp' | 'ghostty'
+  terminal: TerminalApp // Terminal app: 'terminal' | 'warp' | 'ghostty' | 'iterm2'
   editor: EditorApp // Editor app: 'zed' | 'vscode' | 'cursor' | 'xcode'
   open_in: OpenInDefault // Default Open In action: 'editor' | 'terminal' | 'finder' | 'github'
   auto_branch_naming: boolean // Automatically generate branch names from first message
@@ -908,6 +908,7 @@ export type TerminalApp =
   | 'terminal'
   | 'warp'
   | 'ghostty'
+  | 'iterm2'
   | 'windows-terminal'
   | 'powershell'
   | 'cmd'
@@ -923,6 +924,7 @@ export const terminalOptions: { value: TerminalApp; label: string }[] =
         { value: 'terminal', label: 'Terminal' },
         { value: 'warp', label: 'Warp' },
         { value: 'ghostty', label: 'Ghostty' },
+        { value: 'iterm2', label: 'iTerm2' },
       ]
 
 export type EditorApp = 'zed' | 'vscode' | 'cursor' | 'xcode'


### PR DESCRIPTION
  ## Summary
  - Add iTerm2 as a terminal option alongside Terminal.app, Warp, and Ghostty
  - Uses AppleScript to open a new tab in the current iTerm2 window (or a new window if none exists) and cd into the worktree directory
  - Updates TypeScript types and terminal options list
