### PR TITLE
fix(chat): make file mention popover full-width aligned to form

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -84,6 +84,7 @@ export const ChatInput = memo(function ChatInput({
   const [fileMentionAnchor, setFileMentionAnchor] = useState<{
     top: number
     left: number
+    containerWidth: number
   } | null>(null)
   const [atTriggerIndex, setAtTriggerIndex] = useState<number | null>(null)
 
@@ -244,7 +245,7 @@ export const ChatInput = memo(function ChatInput({
           setFileMentionOpen(true)
 
           // Anchor at the top-left of the form so popover appears above the input
-          setFileMentionAnchor({ top: 0, left: 16 })
+          setFileMentionAnchor({ top: 0, left: 0, containerWidth: formRef.current?.offsetWidth ?? 0 })
         }
       } else if (atTriggerIndex !== null && fileMentionOpen) {
         // Continuing to type after @, update query
@@ -279,7 +280,7 @@ export const ChatInput = memo(function ChatInput({
               setFileMentionQuery(query)
               setFileMentionOpen(true)
               // Anchor at the top-left of the form so popover appears above the input
-              setFileMentionAnchor({ top: 0, left: 16 })
+              setFileMentionAnchor({ top: 0, left: 0, containerWidth: formRef.current?.offsetWidth ?? 0 })
             }
             break
           }
@@ -961,7 +962,7 @@ export const ChatInput = memo(function ChatInput({
         onSelectFile={handleFileSelect}
         searchQuery={fileMentionQuery}
         anchorPosition={fileMentionAnchor}
-        containerRef={formRef}
+        containerWidth={fileMentionAnchor?.containerWidth}
         handleRef={fileMentionHandleRef}
       />
 

--- a/src/components/chat/FileMentionPopover.tsx
+++ b/src/components/chat/FileMentionPopover.tsx
@@ -42,8 +42,8 @@ interface FileMentionPopoverProps {
   searchQuery: string
   /** Position for the anchor (relative to textarea container) */
   anchorPosition: { top: number; left: number } | null
-  /** Reference to the container for positioning (reserved for future use) */
-  containerRef?: React.RefObject<HTMLElement | null>
+  /** Width of the container (textarea) for popover sizing */
+  containerWidth?: number
   /** Ref to expose navigation methods to parent */
   handleRef?: React.RefObject<FileMentionPopoverHandle | null>
 }
@@ -55,6 +55,7 @@ export function FileMentionPopover({
   onSelectFile,
   searchQuery,
   anchorPosition,
+  containerWidth,
   handleRef,
 }: FileMentionPopoverProps) {
   const queryClient = useQueryClient()
@@ -130,16 +131,20 @@ export function FileMentionPopover({
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverAnchor
+        className="-mx-4 md:-mx-6"
         style={{
           position: 'absolute',
           top: anchorPosition.top,
-          left: anchorPosition.left,
+          left: 0,
+          right: 0,
           pointerEvents: 'none',
         }}
       />
       <PopoverContent
-        className="w-96 p-0"
+        className="p-0"
+        style={containerWidth ? { width: containerWidth } : undefined}
         align="start"
+        collisionPadding={0}
         side="top"
         sideOffset={12}
         onOpenAutoFocus={e => e.preventDefault()}


### PR DESCRIPTION
  ## Summary
  - Long file paths in the `@` mention popover were truncated and hard to read because the popover was narrower than the input area
  - The popover now matches the full width of the form container by:
    - Measuring the form's `offsetWidth` when the popover opens and passing it as an explicit `width` style
    - Using negative margins (`-mx-4 md:-mx-6`) on the Radix anchor to escape the textarea section's padding, so the popover aligns flush with the form edges
    - Setting `collisionPadding={0}` to prevent Radix from adding extra offset