### PR TITLE
fix(chat): clear waiting state on plan approval to unblock queue processor

### DIFF
--- a/src/components/chat/hooks/usePlanDialogApproval.ts
+++ b/src/components/chat/hooks/usePlanDialogApproval.ts
@@ -6,6 +6,7 @@ import {
   chatQueryKeys,
   markPlanApproved as markPlanApprovedService,
 } from '@/services/chat'
+import { invoke } from '@/lib/transport'
 import { buildMcpConfigJson } from '@/services/mcp'
 import { generateId } from '@/lib/uuid'
 import type {
@@ -13,6 +14,7 @@ import type {
   QueuedMessage,
   ThinkingLevel,
   EffortLevel,
+  WorktreeSessions,
 } from '@/types/chat'
 import type { Session } from '@/types/chat'
 import type { McpServerInfo } from '@/types/chat'
@@ -91,7 +93,61 @@ export function usePlanDialogApproval({
             }
           }
         )
+
+        // Optimistically clear waiting_for_input in sessions cache to prevent
+        // stale "waiting" status during the refetch window
+        queryClient.setQueryData<WorktreeSessions>(
+          chatQueryKeys.sessions(activeWorktreeId),
+          old => {
+            if (!old) return old
+            return {
+              ...old,
+              sessions: old.sessions.map(s =>
+                s.id === activeSessionId
+                  ? {
+                      ...s,
+                      waiting_for_input: false,
+                      pending_plan_message_id: undefined,
+                      waiting_for_input_type: undefined,
+                    }
+                  : s
+              ),
+            }
+          }
+        )
+
+        queryClient.invalidateQueries({
+          queryKey: chatQueryKeys.sessions(activeWorktreeId),
+        })
       }
+
+      // Clear Zustand waiting state so the queue processor can process the message
+      const {
+        enqueueMessage,
+        setExecutionMode,
+        setWaitingForInput,
+        setPendingPlanMessageId,
+        clearToolCalls,
+        clearStreamingContentBlocks,
+        setSessionReviewing,
+      } = useChatStore.getState()
+
+      setWaitingForInput(activeSessionId, false)
+      setPendingPlanMessageId(activeSessionId, null)
+      clearToolCalls(activeSessionId)
+      clearStreamingContentBlocks(activeSessionId)
+      setSessionReviewing(activeSessionId, false)
+
+      // Persist cleared waiting state to backend so refetch loads correct data
+      invoke('update_session_state', {
+        worktreeId: activeWorktreeId,
+        worktreePath: activeWorktreePath,
+        sessionId: activeSessionId,
+        waitingForInput: false,
+        waitingForInputType: null,
+      }).catch(err => {
+        console.error('[usePlanDialogApproval] Failed to clear waiting state:', err)
+      })
 
       // Build approval message
       const defaultText =
@@ -102,8 +158,6 @@ export function usePlanDialogApproval({
         ? `I've updated the plan. Please review and execute:\n\n<updated-plan>\n${updatedPlan}\n</updated-plan>`
         : defaultText
 
-      // Queue instead of immediate execution
-      const { enqueueMessage, setExecutionMode } = useChatStore.getState()
       setExecutionMode(activeSessionId, mode)
 
       const modelOverride = mode === 'yolo' ? yoloModelRef.current : buildModelRef.current


### PR DESCRIPTION
## Problem

Closes #141

When approving a plan in the dialog (ChatWindow), the session would loop — showing the same plan again instead of starting implementation. This affected all backends (Claude CLI, Codex, OpenCode).

## Root Cause

`usePlanDialogApproval` (used by ChatWindow) was missing critical state clearing that its canvas counterpart `usePlanApproval` already had.

The queue processor (`useQueueProcessor`) gates on `waitingForInputSessionIds`:

```ts
if (waitingForInputSessionIds[sessionId]) continue // ← approval message permanently blocked
```

Since the dialog approval never cleared this Zustand flag, the queued approval message was blocked forever. Claude CLI / Codex / OpenCode never received the approval → session stayed in "waiting" → same plan reappeared.

## Fix

Added the missing state clearing to `usePlanDialogApproval`, matching what `usePlanApproval` (canvas path) already does correctly:

- `setWaitingForInput(id, false)` — unblocks the queue processor (**root cause**)
- `setPendingPlanMessageId(id, null)` — prevents session-card-utils re-detecting the plan as pending
- `clearToolCalls` / `clearStreamingContentBlocks` — clears stale streaming state
- Optimistic `WorktreeSessions` cache update — prevents stale `waiting_for_input: true` in session list
- `invoke('update_session_state')` — persists cleared state to backend so refetches are correct