### PR TITLE
fix(cli): add Homebrew/system CLI detection for all backends

### DIFF
--- a/src-tauri/src/claude_cli/config.rs
+++ b/src-tauri/src/claude_cli/config.rs
@@ -30,11 +30,30 @@ pub fn get_cli_binary_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(get_cli_dir(app)?.join(CLI_BINARY_NAME))
 }
 
-/// Resolve Claude binary path in Jean-managed app data only.
+/// Resolve the Claude CLI binary to use for commands.
 ///
-/// This intentionally does not fall back to PATH/global installs.
+/// Returns the embedded binary path if it exists, otherwise falls back to
+/// resolving `claude` from PATH.
 pub fn resolve_cli_binary(app: &AppHandle) -> PathBuf {
-    get_cli_binary_path(app).unwrap_or_else(|_| PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME))
+    let embedded_binary = get_cli_binary_path(app).ok().filter(|path| path.exists());
+    let path_binary = which::which(CLI_BINARY_NAME).ok();
+
+    resolve_cli_binary_with(embedded_binary, path_binary)
+}
+
+fn resolve_cli_binary_with(
+    embedded_binary: Option<PathBuf>,
+    path_binary: Option<PathBuf>,
+) -> PathBuf {
+    if let Some(embedded_binary) = embedded_binary {
+        return embedded_binary;
+    }
+
+    if let Some(path_binary) = path_binary {
+        return path_binary;
+    }
+
+    PathBuf::from(CLI_BINARY_NAME)
 }
 
 /// Ensure the CLI directory exists, creating it if necessary
@@ -50,10 +69,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fallback_path_is_jean_managed_location_shape() {
-        let resolved = PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME);
+    fn resolve_cli_binary_prefers_embedded_binary() {
+        let embedded = PathBuf::from("/tmp/jean/claude");
+        let path_binary = PathBuf::from("/opt/homebrew/bin/claude");
 
-        assert!(resolved.ends_with(CLI_BINARY_NAME));
-        assert!(resolved.to_string_lossy().contains(CLI_DIR_NAME));
+        let resolved = resolve_cli_binary_with(Some(embedded.clone()), Some(path_binary));
+
+        assert_eq!(resolved, embedded);
+    }
+
+    #[test]
+    fn resolve_cli_binary_uses_path_binary_when_embedded_missing() {
+        let path_binary = PathBuf::from("/opt/homebrew/bin/claude");
+
+        let resolved = resolve_cli_binary_with(None, Some(path_binary.clone()));
+
+        assert_eq!(resolved, path_binary);
+    }
+
+    #[test]
+    fn resolve_cli_binary_falls_back_to_command_name() {
+        let resolved = resolve_cli_binary_with(None, None);
+
+        assert_eq!(resolved, PathBuf::from(CLI_BINARY_NAME));
     }
 }

--- a/src-tauri/src/codex_cli/config.rs
+++ b/src-tauri/src/codex_cli/config.rs
@@ -30,11 +30,30 @@ pub fn get_cli_binary_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(get_cli_dir(app)?.join(CLI_BINARY_NAME))
 }
 
-/// Resolve Codex binary path in Jean-managed app data only.
+/// Resolve the Codex CLI binary to use for commands.
 ///
-/// This intentionally does not fall back to PATH/global installs.
+/// Returns the embedded binary path if it exists, otherwise falls back to
+/// resolving `codex` from PATH.
 pub fn resolve_cli_binary(app: &AppHandle) -> PathBuf {
-    get_cli_binary_path(app).unwrap_or_else(|_| PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME))
+    let embedded_binary = get_cli_binary_path(app).ok().filter(|path| path.exists());
+    let path_binary = which::which(CLI_BINARY_NAME).ok();
+
+    resolve_cli_binary_with(embedded_binary, path_binary)
+}
+
+fn resolve_cli_binary_with(
+    embedded_binary: Option<PathBuf>,
+    path_binary: Option<PathBuf>,
+) -> PathBuf {
+    if let Some(embedded_binary) = embedded_binary {
+        return embedded_binary;
+    }
+
+    if let Some(path_binary) = path_binary {
+        return path_binary;
+    }
+
+    PathBuf::from(CLI_BINARY_NAME)
 }
 
 /// Ensure the CLI directory exists, creating it if necessary
@@ -50,10 +69,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fallback_path_is_jean_managed_location_shape() {
-        let resolved = PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME);
+    fn resolve_cli_binary_prefers_embedded_binary() {
+        let embedded = PathBuf::from("/tmp/jean/codex");
+        let path_binary = PathBuf::from("/opt/homebrew/bin/codex");
 
-        assert!(resolved.ends_with(CLI_BINARY_NAME));
-        assert!(resolved.to_string_lossy().contains(CLI_DIR_NAME));
+        let resolved = resolve_cli_binary_with(Some(embedded.clone()), Some(path_binary));
+
+        assert_eq!(resolved, embedded);
+    }
+
+    #[test]
+    fn resolve_cli_binary_uses_path_binary_when_embedded_missing() {
+        let path_binary = PathBuf::from("/opt/homebrew/bin/codex");
+
+        let resolved = resolve_cli_binary_with(None, Some(path_binary.clone()));
+
+        assert_eq!(resolved, path_binary);
+    }
+
+    #[test]
+    fn resolve_cli_binary_falls_back_to_command_name() {
+        let resolved = resolve_cli_binary_with(None, None);
+
+        assert_eq!(resolved, PathBuf::from(CLI_BINARY_NAME));
     }
 }

--- a/src-tauri/src/gh_cli/config.rs
+++ b/src-tauri/src/gh_cli/config.rs
@@ -34,12 +34,32 @@ pub fn get_gh_cli_binary_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(get_gh_cli_dir(app)?.join(GH_CLI_BINARY_NAME))
 }
 
-/// Resolve GitHub CLI binary path in Jean-managed app data only.
+/// Resolve the GitHub CLI binary to use for commands.
 ///
-/// This intentionally does not fall back to PATH/global installs.
+/// Returns the embedded binary path if it exists, otherwise falls back to
+/// resolving `gh` from PATH.
 pub fn resolve_gh_binary(app: &AppHandle) -> PathBuf {
-    get_gh_cli_binary_path(app)
-        .unwrap_or_else(|_| PathBuf::from(GH_CLI_DIR_NAME).join(GH_CLI_BINARY_NAME))
+    let embedded_binary = get_gh_cli_binary_path(app)
+        .ok()
+        .filter(|path| path.exists());
+    let path_binary = which::which(GH_CLI_BINARY_NAME).ok();
+
+    resolve_gh_binary_with(embedded_binary, path_binary)
+}
+
+fn resolve_gh_binary_with(
+    embedded_binary: Option<PathBuf>,
+    path_binary: Option<PathBuf>,
+) -> PathBuf {
+    if let Some(embedded_binary) = embedded_binary {
+        return embedded_binary;
+    }
+
+    if let Some(path_binary) = path_binary {
+        return path_binary;
+    }
+
+    PathBuf::from(GH_CLI_BINARY_NAME)
 }
 
 /// Ensure the CLI directory exists, creating it if necessary
@@ -55,10 +75,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fallback_path_is_jean_managed_location_shape() {
-        let resolved = PathBuf::from(GH_CLI_DIR_NAME).join(GH_CLI_BINARY_NAME);
+    fn resolve_gh_binary_prefers_embedded_binary() {
+        let embedded = PathBuf::from("/tmp/jean/gh");
+        let path_binary = PathBuf::from("/opt/homebrew/bin/gh");
 
-        assert!(resolved.ends_with(GH_CLI_BINARY_NAME));
-        assert!(resolved.to_string_lossy().contains(GH_CLI_DIR_NAME));
+        let resolved = resolve_gh_binary_with(Some(embedded.clone()), Some(path_binary));
+
+        assert_eq!(resolved, embedded);
+    }
+
+    #[test]
+    fn resolve_gh_binary_uses_path_binary_when_embedded_missing() {
+        let path_binary = PathBuf::from("/opt/homebrew/bin/gh");
+
+        let resolved = resolve_gh_binary_with(None, Some(path_binary.clone()));
+
+        assert_eq!(resolved, path_binary);
+    }
+
+    #[test]
+    fn resolve_gh_binary_falls_back_to_command_name() {
+        let resolved = resolve_gh_binary_with(None, None);
+
+        assert_eq!(resolved, PathBuf::from(GH_CLI_BINARY_NAME));
     }
 }

--- a/src-tauri/src/opencode_cli/config.rs
+++ b/src-tauri/src/opencode_cli/config.rs
@@ -12,7 +12,9 @@ pub const CLI_BINARY_NAME: &str = "opencode.exe";
 #[cfg(not(windows))]
 pub const CLI_BINARY_NAME: &str = "opencode";
 
-/// Get the directory where OpenCode CLI is installed.
+/// Get the directory where OpenCode CLI is installed
+///
+/// Returns: `~/Library/Application Support/jean/opencode-cli/`
 pub fn get_cli_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let app_data_dir = app
         .path()
@@ -21,21 +23,40 @@ pub fn get_cli_dir(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(app_data_dir.join(CLI_DIR_NAME))
 }
 
-/// Get the full path to the OpenCode CLI binary.
+/// Get the full path to the OpenCode CLI binary
 ///
-/// Returns: `opencode-cli/opencode` (macOS/Linux) or `opencode-cli/opencode.exe` (Windows)
+/// Returns: `~/Library/Application Support/jean/opencode-cli/opencode`
 pub fn get_cli_binary_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(get_cli_dir(app)?.join(CLI_BINARY_NAME))
 }
 
-/// Resolve OpenCode binary path in Jean-managed app data only.
+/// Resolve the OpenCode CLI binary to use for commands.
 ///
-/// This intentionally does not fall back to PATH/global installs.
+/// Returns the embedded binary path if it exists, otherwise falls back to
+/// resolving `opencode` from PATH.
 pub fn resolve_cli_binary(app: &AppHandle) -> PathBuf {
-    get_cli_binary_path(app).unwrap_or_else(|_| PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME))
+    let embedded_binary = get_cli_binary_path(app).ok().filter(|path| path.exists());
+    let path_binary = which::which(CLI_BINARY_NAME).ok();
+
+    resolve_cli_binary_with(embedded_binary, path_binary)
 }
 
-/// Ensure the CLI directory exists.
+fn resolve_cli_binary_with(
+    embedded_binary: Option<PathBuf>,
+    path_binary: Option<PathBuf>,
+) -> PathBuf {
+    if let Some(embedded_binary) = embedded_binary {
+        return embedded_binary;
+    }
+
+    if let Some(path_binary) = path_binary {
+        return path_binary;
+    }
+
+    PathBuf::from(CLI_BINARY_NAME)
+}
+
+/// Ensure the CLI directory exists, creating it if necessary
 pub fn ensure_cli_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let cli_dir = get_cli_dir(app)?;
     std::fs::create_dir_all(&cli_dir)
@@ -48,10 +69,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fallback_path_is_jean_managed_location_shape() {
-        let resolved = PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME);
+    fn resolve_cli_binary_prefers_embedded_binary() {
+        let embedded = PathBuf::from("/tmp/jean/opencode");
+        let path_binary = PathBuf::from("/opt/homebrew/bin/opencode");
 
-        assert!(resolved.ends_with(CLI_BINARY_NAME));
-        assert!(resolved.to_string_lossy().contains(CLI_DIR_NAME));
+        let resolved = resolve_cli_binary_with(Some(embedded.clone()), Some(path_binary));
+
+        assert_eq!(resolved, embedded);
+    }
+
+    #[test]
+    fn resolve_cli_binary_uses_path_binary_when_embedded_missing() {
+        let path_binary = PathBuf::from("/opt/homebrew/bin/opencode");
+
+        let resolved = resolve_cli_binary_with(None, Some(path_binary.clone()));
+
+        assert_eq!(resolved, path_binary);
+    }
+
+    #[test]
+    fn resolve_cli_binary_falls_back_to_command_name() {
+        let resolved = resolve_cli_binary_with(None, None);
+
+        assert_eq!(resolved, PathBuf::from(CLI_BINARY_NAME));
     }
 }


### PR DESCRIPTION
This PR restores PATH fallback functionality for all CLI backends (Claude, Codex, OpenCode, GitHub).

## Changes
- Claude CLI: detect Homebrew-installed `claude`
- Codex CLI: detect Homebrew-installed `codex`
- OpenCode CLI: detect Homebrew-installed `opencode`
- GitHub CLI: detect Homebrew-installed `gh`

## Fallback Chain
1. Embedded binary (in Jean's app data)
2. PATH lookup (Homebrew, npm global, etc.)
3. Bare command name (final fallback)

## Background
This restores functionality originally implemented in PR #64 that was subsequently removed in commit 11a99c1 during the OpenCode integration. The removal was noted as "intentional" but limits users who prefer managing CLIs via Homebrew or other package managers.

## Testing
- All four CLI modules now use consistent binary resolution
- Unit tests verify fallback precedence (embedded → PATH → bare command)

Fixes: Follow-up to PR #64