### PR TITLE
feat(notifications): dynamic notification sounds with system & custom support

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1491,6 +1491,199 @@ async fn send_native_notification(
     }
 }
 
+// =============================================================================
+// Notification Sounds
+// =============================================================================
+
+/// macOS system alert tones directory
+#[cfg(target_os = "macos")]
+const MACOS_ALERT_TONES_DIR: &str =
+    "/System/Library/PrivateFrameworks/ToneLibrary.framework/Versions/A/Resources/AlertTones/Modern";
+
+/// Supported audio file extensions for custom sounds
+const SOUND_EXTENSIONS: &[&str] = &["m4r", "mp3", "wav", "ogg", "m4a", "aac"];
+
+#[derive(Serialize, Clone)]
+struct NotificationSoundEntry {
+    id: String,
+    label: String,
+    category: String,
+}
+
+fn get_custom_sounds_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {e}"))?;
+    let dir = app_data_dir.join("custom-sounds");
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("Failed to create custom-sounds directory: {e}"))?;
+    Ok(dir)
+}
+
+#[tauri::command]
+async fn list_notification_sounds(app: AppHandle) -> Result<Vec<NotificationSoundEntry>, String> {
+    let mut sounds = vec![NotificationSoundEntry {
+        id: "none".to_string(),
+        label: "None".to_string(),
+        category: "default".to_string(),
+    }];
+
+    // Scan macOS system alert tones
+    #[cfg(target_os = "macos")]
+    {
+        let tones_dir = std::path::Path::new(MACOS_ALERT_TONES_DIR);
+        if tones_dir.exists() {
+            if let Ok(entries) = std::fs::read_dir(tones_dir) {
+                let mut system_sounds: Vec<NotificationSoundEntry> = entries
+                    .filter_map(|e| e.ok())
+                    .filter(|e| {
+                        e.path()
+                            .extension()
+                            .is_some_and(|ext| ext.eq_ignore_ascii_case("m4r"))
+                    })
+                    .map(|e| {
+                        let stem = e
+                            .path()
+                            .file_stem()
+                            .unwrap_or_default()
+                            .to_string_lossy()
+                            .to_string();
+                        NotificationSoundEntry {
+                            id: format!("system:{stem}"),
+                            label: stem.clone(),
+                            category: "system".to_string(),
+                        }
+                    })
+                    .collect();
+                system_sounds.sort_by(|a, b| a.label.cmp(&b.label));
+                sounds.extend(system_sounds);
+            }
+        }
+    }
+
+    // Scan custom sounds directory
+    let custom_dir = get_custom_sounds_dir(&app)?;
+    if custom_dir.exists() {
+        if let Ok(entries) = std::fs::read_dir(&custom_dir) {
+            let mut custom_sounds: Vec<NotificationSoundEntry> = entries
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    e.path().extension().is_some_and(|ext| {
+                        let ext_lower = ext.to_string_lossy().to_lowercase();
+                        SOUND_EXTENSIONS.contains(&ext_lower.as_str())
+                    })
+                })
+                .map(|e| {
+                    let filename = e.file_name().to_string_lossy().to_string();
+                    let stem = e
+                        .path()
+                        .file_stem()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .to_string();
+                    NotificationSoundEntry {
+                        id: format!("custom:{filename}"),
+                        label: stem,
+                        category: "custom".to_string(),
+                    }
+                })
+                .collect();
+            custom_sounds.sort_by(|a, b| a.label.cmp(&b.label));
+            sounds.extend(custom_sounds);
+        }
+    }
+
+    Ok(sounds)
+}
+
+#[tauri::command]
+async fn get_sound_file_path(app: AppHandle, sound_id: String) -> Result<Option<String>, String> {
+    if sound_id == "none" {
+        return Ok(None);
+    }
+
+    if let Some(name) = sound_id.strip_prefix("system:") {
+        #[cfg(target_os = "macos")]
+        {
+            let path =
+                std::path::PathBuf::from(MACOS_ALERT_TONES_DIR).join(format!("{name}.m4r"));
+            if path.exists() {
+                return Ok(Some(path.to_string_lossy().to_string()));
+            }
+        }
+        return Err(format!("System sound not found: {name}"));
+    }
+
+    if let Some(filename) = sound_id.strip_prefix("custom:") {
+        let custom_dir = get_custom_sounds_dir(&app)?;
+        let path = custom_dir.join(filename);
+        if path.exists() {
+            return Ok(Some(path.to_string_lossy().to_string()));
+        }
+        return Err(format!("Custom sound not found: {filename}"));
+    }
+
+    Err(format!("Invalid sound ID format: {sound_id}"))
+}
+
+#[tauri::command]
+async fn import_custom_sound(app: AppHandle, source_path: String) -> Result<String, String> {
+    let source = std::path::Path::new(&source_path);
+    if !source.exists() {
+        return Err("Source file does not exist".to_string());
+    }
+
+    let filename = source
+        .file_name()
+        .ok_or("Invalid source file path")?
+        .to_string_lossy()
+        .to_string();
+
+    // Validate extension
+    let ext = source
+        .extension()
+        .ok_or("File has no extension")?
+        .to_string_lossy()
+        .to_lowercase();
+    if !SOUND_EXTENSIONS.contains(&ext.as_str()) {
+        return Err(format!(
+            "Unsupported audio format: .{ext}. Supported: {}",
+            SOUND_EXTENSIONS.join(", ")
+        ));
+    }
+
+    let custom_dir = get_custom_sounds_dir(&app)?;
+    let dest = custom_dir.join(&filename);
+
+    std::fs::copy(source, &dest)
+        .map_err(|e| format!("Failed to copy sound file: {e}"))?;
+
+    Ok(format!("custom:{filename}"))
+}
+
+#[tauri::command]
+async fn delete_custom_sound(app: AppHandle, sound_id: String) -> Result<(), String> {
+    let filename = sound_id
+        .strip_prefix("custom:")
+        .ok_or("Can only delete custom sounds")?;
+
+    // Validate filename to prevent path traversal
+    if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+        return Err("Invalid filename".to_string());
+    }
+
+    let custom_dir = get_custom_sounds_dir(&app)?;
+    let path = custom_dir.join(filename);
+
+    if path.exists() {
+        std::fs::remove_file(&path)
+            .map_err(|e| format!("Failed to delete sound file: {e}"))?;
+    }
+
+    Ok(())
+}
+
 // Recovery functions - simple pattern for saving JSON data to disk
 fn get_recovery_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let app_data_dir = app
@@ -2224,6 +2417,11 @@ pub fn run() {
             load_ui_state,
             save_ui_state,
             send_native_notification,
+            // Notification sound commands
+            list_notification_sounds,
+            get_sound_file_path,
+            import_custom_sound,
+            delete_custom_sound,
             save_emergency_data,
             load_emergency_data,
             cleanup_old_recovery_files,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,13 +37,14 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost data: blob: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'",
+      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost data: blob: https:; media-src 'self' asset: http://asset.localhost; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'",
       "assetProtocol": {
         "enable": true,
         "scope": {
           "allow": [
             "**/.jean/images/**",
-            "$APPDATA/**"
+            "$APPDATA/**",
+            "/System/Library/PrivateFrameworks/ToneLibrary.framework/**"
           ],
           "requireLiteralLeadingDot": false
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,6 @@ import { useQueueProcessor } from './hooks/useQueueProcessor'
 import { useBackgroundInvestigation } from './hooks/useBackgroundInvestigation'
 import { useAutoArchiveOnMerge } from './hooks/useAutoArchiveOnMerge'
 import useStreamingEvents from './components/chat/hooks/useStreamingEvents'
-import { preloadAllSounds } from './lib/sounds'
 
 /** Loading screen shown while preloading initial data (browser mode only). */
 function WebLoadingScreen() {
@@ -483,9 +482,6 @@ function App() {
     logger.info('🚀 Frontend application starting up')
     initializeCommandSystem()
     logger.debug('Command system initialized')
-
-    // Preload notification sounds for instant playback
-    preloadAllSounds()
 
     // Kill any orphaned terminals from previous session/reload
     // This ensures cleanup even if beforeunload didn't complete

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -9,7 +9,7 @@ import { chatQueryKeys } from '@/services/chat'
 import { isTauri, saveWorktreePr, projectsQueryKeys } from '@/services/projects'
 import type { Project, Worktree } from '@/types/projects'
 import { preferencesQueryKeys } from '@/services/preferences'
-import type { AppPreferences, NotificationSound } from '@/types/preferences'
+import type { AppPreferences } from '@/types/preferences'
 import { triggerImmediateGitPoll } from '@/services/git-status'
 import { isAskUserQuestion, isExitPlanMode } from '@/types/chat'
 import { playNotificationSound } from '@/lib/sounds'
@@ -494,8 +494,7 @@ export default function useStreamingEvents({
 
           // Play waiting sound if not currently viewing this session
           if (!isCurrentlyViewing) {
-            const waitingSound = (preferences?.waiting_sound ??
-              'none') as NotificationSound
+            const waitingSound = preferences?.waiting_sound ?? 'none'
             playNotificationSound(waitingSound)
           }
         }
@@ -604,8 +603,7 @@ export default function useStreamingEvents({
 
         // Play waiting sound if not currently viewing this session
         if (!isCurrentlyViewing) {
-          const waitingSound = (preferences?.waiting_sound ??
-            'none') as NotificationSound
+          const waitingSound = preferences?.waiting_sound ?? 'none'
           playNotificationSound(waitingSound)
         }
       } else {
@@ -706,8 +704,7 @@ export default function useStreamingEvents({
 
         // Play review sound if not currently viewing this session
         if (!isCurrentlyViewing) {
-          const reviewSound = (preferences?.review_sound ??
-            'none') as NotificationSound
+          const reviewSound = preferences?.review_sound ?? 'none'
           playNotificationSound(reviewSound)
         }
       }

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -705,7 +705,7 @@ export default function useStreamingEvents({
         // Play review sound if not currently viewing this session
         if (!isCurrentlyViewing) {
           const reviewSound = preferences?.review_sound ?? 'none'
-          playNotificationSound(reviewSound)
+          void playNotificationSound(reviewSound)
         }
       }
 

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -495,7 +495,7 @@ export default function useStreamingEvents({
           // Play waiting sound if not currently viewing this session
           if (!isCurrentlyViewing) {
             const waitingSound = preferences?.waiting_sound ?? 'none'
-            playNotificationSound(waitingSound)
+            void playNotificationSound(waitingSound)
           }
         }
       } else if (event.payload.waiting_for_plan && !isCurrentlyViewing) {

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -3,7 +3,7 @@ import { invoke } from '@/lib/transport'
 import { escapeCliCommand } from '@/lib/shell-escape'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { Loader2, ChevronDown, Check, ChevronsUpDown } from 'lucide-react'
+import { Loader2, ChevronDown, Check, ChevronsUpDown, X, Upload } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
@@ -47,7 +47,9 @@ import type { OpenCodeAuthStatus } from '@/types/opencode-cli'
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
@@ -81,7 +83,6 @@ import {
   remotePollIntervalOptions,
   archiveRetentionOptions,
   removalBehaviorOptions,
-  notificationSoundOptions,
   type RemovalBehavior,
   type ClaudeModel,
   type CodexModel,
@@ -89,13 +90,13 @@ import {
   type CliBackend,
   type TerminalApp,
   type EditorApp,
-  type NotificationSound,
   openInDefaultOptions,
   type OpenInDefault,
 } from '@/types/preferences'
 import { OPENCODE_MODEL_OPTIONS } from '@/components/chat/toolbar/toolbar-options'
 import { formatOpencodeModelLabel } from '@/components/chat/toolbar/toolbar-utils'
 import { playNotificationSound } from '@/lib/sounds'
+import { useNotificationSounds, notificationSoundsQueryKeys } from '@/services/preferences'
 import type { ThinkingLevel, EffortLevel } from '@/types/chat'
 import { isNativeApp } from '@/lib/environment'
 import { cn } from '@/lib/utils'
@@ -143,6 +144,62 @@ const InlineField: React.FC<{
     {children}
   </div>
 )
+
+import type { NotificationSoundEntry } from '@/types/preferences'
+
+const SoundSelectOptions: React.FC<{
+  sounds: NotificationSoundEntry[] | undefined
+  onDelete: (soundId: string) => void
+}> = ({ sounds, onDelete }) => {
+  if (!sounds) return <SelectItem value="none">None</SelectItem>
+
+  const defaultSounds = sounds.filter(s => s.category === 'default')
+  const systemSounds = sounds.filter(s => s.category === 'system')
+  const customSounds = sounds.filter(s => s.category === 'custom')
+
+  return (
+    <>
+      {defaultSounds.map(s => (
+        <SelectItem key={s.id} value={s.id}>
+          {s.label}
+        </SelectItem>
+      ))}
+      {systemSounds.length > 0 && (
+        <SelectGroup>
+          <SelectLabel>System</SelectLabel>
+          {systemSounds.map(s => (
+            <SelectItem key={s.id} value={s.id}>
+              {s.label}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      )}
+      {customSounds.length > 0 && (
+        <SelectGroup>
+          <SelectLabel>Custom</SelectLabel>
+          {customSounds.map(s => (
+            <SelectItem key={s.id} value={s.id}>
+              <span className="flex items-center gap-2">
+                {s.label}
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:text-destructive ml-auto"
+                  onPointerDown={e => {
+                    e.stopPropagation()
+                    e.preventDefault()
+                    onDelete(s.id)
+                  }}
+                >
+                  <X className="size-3" />
+                </button>
+              </span>
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      )}
+    </>
+  )
+}
 
 export const GeneralPane: React.FC = () => {
   const queryClient = useQueryClient()
@@ -443,19 +500,64 @@ export const GeneralPane: React.FC = () => {
     }
   }
 
-  const handleWaitingSoundChange = (value: NotificationSound) => {
+  const { data: notificationSounds } = useNotificationSounds()
+
+  const handleWaitingSoundChange = (value: string) => {
     if (preferences) {
       savePreferences.mutate({ ...preferences, waiting_sound: value })
-      // Play preview of the selected sound
       playNotificationSound(value)
     }
   }
 
-  const handleReviewSoundChange = (value: NotificationSound) => {
+  const handleReviewSoundChange = (value: string) => {
     if (preferences) {
       savePreferences.mutate({ ...preferences, review_sound: value })
-      // Play preview of the selected sound
       playNotificationSound(value)
+    }
+  }
+
+  const handleImportSound = async () => {
+    try {
+      const { open } = await import('@tauri-apps/plugin-dialog')
+      const selected = await open({
+        multiple: false,
+        title: 'Select a sound file',
+        filters: [
+          {
+            name: 'Audio',
+            extensions: ['m4r', 'mp3', 'wav', 'ogg', 'm4a', 'aac'],
+          },
+        ],
+      })
+      if (!selected) return
+      const sourcePath = typeof selected === 'string' ? selected : String(selected)
+      await invoke<string>('import_custom_sound', { sourcePath })
+      queryClient.invalidateQueries({
+        queryKey: notificationSoundsQueryKeys.all,
+      })
+      toast.success('Sound imported')
+    } catch (error) {
+      if (String(error).includes('cancel')) return
+      toast.error(`Failed to import sound: ${error}`)
+    }
+  }
+
+  const handleDeleteSound = async (soundId: string) => {
+    try {
+      await invoke('delete_custom_sound', { soundId })
+      queryClient.invalidateQueries({
+        queryKey: notificationSoundsQueryKeys.all,
+      })
+      // If the deleted sound was selected, reset to none
+      if (preferences?.waiting_sound === soundId) {
+        savePreferences.mutate({ ...preferences, waiting_sound: 'none' })
+      }
+      if (preferences?.review_sound === soundId) {
+        savePreferences.mutate({ ...preferences, review_sound: 'none' })
+      }
+      toast.success('Sound deleted')
+    } catch (error) {
+      toast.error(`Failed to delete sound: ${error}`)
     }
   }
 
@@ -1575,11 +1677,10 @@ export const GeneralPane: React.FC = () => {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {notificationSoundOptions.map(option => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
+                <SoundSelectOptions
+                  sounds={notificationSounds}
+                  onDelete={handleDeleteSound}
+                />
               </SelectContent>
             </Select>
           </InlineField>
@@ -1596,14 +1697,23 @@ export const GeneralPane: React.FC = () => {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {notificationSoundOptions.map(option => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
+                <SoundSelectOptions
+                  sounds={notificationSounds}
+                  onDelete={handleDeleteSound}
+                />
               </SelectContent>
             </Select>
           </InlineField>
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleImportSound}
+            className="gap-1.5"
+          >
+            <Upload className="size-3.5" />
+            Import Sound
+          </Button>
         </div>
       </SettingsSection>
 

--- a/src/lib/sounds.ts
+++ b/src/lib/sounds.ts
@@ -1,33 +1,21 @@
 /**
  * Sound notification utilities for session status events.
  * Plays sounds when sessions complete or need input.
+ *
+ * Sound IDs: "none" | "system:<name>" | "custom:<filename>"
  */
 
-export type NotificationSound = 'none' | 'ding' | 'chime' | 'pop' | 'choochoo'
-
-export const notificationSoundOptions: {
-  value: NotificationSound
-  label: string
-}[] = [
-  { value: 'none', label: 'None' },
-  { value: 'ding', label: 'Ding' },
-  { value: 'chime', label: 'Chime' },
-  { value: 'pop', label: 'Pop' },
-  { value: 'choochoo', label: 'Choo-choo' },
-]
+import { invoke, convertFileSrc } from '@/lib/transport'
 
 // Single audio instance to prevent overlapping sounds
 let currentAudio: HTMLAudioElement | null = null
 
-// Audio context for system beep fallback (reused to avoid creating many contexts)
-let audioContext: AudioContext | null = null
-
 /**
- * Play a notification sound. If a sound is already playing, it will be stopped first.
- * Falls back to a system beep if the audio file is not found or playback fails.
+ * Play a notification sound by its ID.
+ * Resolves the sound file path via the backend, then plays via asset protocol.
  */
-export function playNotificationSound(sound: NotificationSound): void {
-  if (sound === 'none') return
+export async function playNotificationSound(soundId: string): Promise<void> {
+  if (!soundId || soundId === 'none') return
 
   // Stop any currently playing sound to prevent overlap
   if (currentAudio) {
@@ -36,63 +24,17 @@ export function playNotificationSound(sound: NotificationSound): void {
     currentAudio = null
   }
 
-  const audio = new Audio(`/sounds/${sound}.mp3`)
-  currentAudio = audio
-
-  audio.play().catch(() => {
-    // File not found or autoplay blocked - fallback to system beep
-    playSystemBeep()
-  })
-}
-
-/**
- * Play a synthesized system beep as fallback when audio files are unavailable.
- * Uses Web Audio API to generate a short tone.
- */
-function playSystemBeep(): void {
   try {
-    // Reuse or create audio context
-    if (!audioContext) {
-      audioContext = new AudioContext()
-    }
+    const filePath = await invoke<string | null>('get_sound_file_path', {
+      soundId,
+    })
+    if (!filePath) return
 
-    // Resume context if it's suspended (browser autoplay policy)
-    if (audioContext.state === 'suspended') {
-      audioContext.resume()
-    }
-
-    const oscillator = audioContext.createOscillator()
-    const gain = audioContext.createGain()
-
-    oscillator.connect(gain)
-    gain.connect(audioContext.destination)
-
-    // Configure a pleasant notification tone
-    oscillator.frequency.value = 800
-    oscillator.type = 'sine'
-    gain.gain.value = 0.1
-
-    // Play for 150ms
-    oscillator.start()
-    oscillator.stop(audioContext.currentTime + 0.15)
+    const url = convertFileSrc(filePath)
+    const audio = new Audio(url)
+    currentAudio = audio
+    await audio.play()
   } catch {
-    // Silently fail if Web Audio API is unavailable
-  }
-}
-
-// Cache for preloaded audio elements
-const audioCache = new Map<NotificationSound, HTMLAudioElement>()
-
-/**
- * Preload all sound files to ensure instant playback.
- * Call this on app startup.
- */
-export function preloadAllSounds(): void {
-  for (const option of notificationSoundOptions) {
-    if (option.value !== 'none') {
-      const audio = new Audio(`/sounds/${option.value}.mp3`)
-      audio.preload = 'auto'
-      audioCache.set(option.value, audio)
-    }
+    // Sound file not found or playback failed — silent fail
   }
 }

--- a/src/services/preferences.ts
+++ b/src/services/preferences.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { invoke } from '@/lib/transport'
 import { toast } from 'sonner'
 import { logger } from '@/lib/logger'
-import type { AppPreferences } from '@/types/preferences'
+import type { AppPreferences, NotificationSoundEntry } from '@/types/preferences'
 import { defaultPreferences } from '@/types/preferences'
 import { DEFAULT_KEYBINDINGS, type KeybindingsMap } from '@/types/keybindings'
 
@@ -121,5 +121,27 @@ export function useSavePreferences() {
       })
       logger.info('Preferences cache updated')
     },
+  })
+}
+
+// =============================================================================
+// Notification Sounds
+// =============================================================================
+
+export const notificationSoundsQueryKeys = {
+  all: ['notification-sounds'] as const,
+  list: () => [...notificationSoundsQueryKeys.all, 'list'] as const,
+}
+
+export function useNotificationSounds() {
+  return useQuery({
+    queryKey: notificationSoundsQueryKeys.list(),
+    queryFn: async (): Promise<NotificationSoundEntry[]> => {
+      if (!isTauri()) {
+        return [{ id: 'none', label: 'None', category: 'default' }]
+      }
+      return invoke<NotificationSoundEntry[]>('list_notification_sounds')
+    },
+    staleTime: 1000 * 60 * 30, // 30 minutes — sound files rarely change
   })
 }

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -5,19 +5,14 @@ import { DEFAULT_KEYBINDINGS, type KeybindingsMap } from './keybindings'
 // Notification Sounds
 // =============================================================================
 
-export type NotificationSound = 'none' | 'ding' | 'chime' | 'pop' | 'choochoo'
+/** Sound ID format: "none" | "system:<name>" | "custom:<filename>" */
+export type NotificationSound = string
 
-export const notificationSoundOptions: {
-  value: NotificationSound
+export interface NotificationSoundEntry {
+  id: string
   label: string
-}[] = [
-  { value: 'none', label: 'None' },
-  // More sounds will be added later:
-  // { value: 'ding', label: 'Ding' },
-  // { value: 'chime', label: 'Chime' },
-  // { value: 'pop', label: 'Pop' },
-  // { value: 'choochoo', label: 'Choo-choo' },
-]
+  category: 'default' | 'system' | 'custom'
+}
 
 // =============================================================================
 // Magic Prompts - Customizable prompts for AI-powered features
@@ -810,8 +805,8 @@ export interface AppPreferences {
   file_edit_mode: FileEditMode // How to edit files: inline (CodeMirror) or external (VS Code, etc.)
   ai_language: string // Preferred language for AI responses (empty = default)
   allow_web_tools_in_plan_mode: boolean // Allow WebFetch/WebSearch in plan mode without prompts
-  waiting_sound: NotificationSound // Sound when session is waiting for input
-  review_sound: NotificationSound // Sound when session finishes reviewing
+  waiting_sound: string // Sound ID: "none" | "system:<name>" | "custom:<filename>"
+  review_sound: string // Sound ID: "none" | "system:<name>" | "custom:<filename>"
   http_server_enabled: boolean // Whether HTTP server is enabled
   http_server_port: number // HTTP server port (default 3456)
   http_server_token: string | null // Auth token for HTTP/WS access


### PR DESCRIPTION
## Summary

- **Replaced hardcoded sound options** with dynamic system that lists system sounds (macOS alert tones) and custom imported sounds
- **Added backend commands** to list, fetch, import, and delete notification sounds
- **Updated UI** to display sounds grouped by category (default, system, custom) with delete buttons for custom sounds
- **Made playback async** — now resolves sound paths via backend before playing
- **Removed preloading** — sounds load on-demand via asset protocol

## Breaking Changes

- `NotificationSound` type changed from union type (`'none' | 'ding' | 'chime' | 'pop' | 'choochoo'`) to `string` (ID-based: `"none"` | `"system:<name>"` | `"custom:<filename>"`)
- Removed `notificationSoundOptions` static array
- `playNotificationSound()` is now async