### PR TITLE
feat(chat): add session export to clipboard and file

### DIFF
--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -3312,6 +3312,12 @@ pub async fn read_file_content(path: String) -> Result<String, String> {
     std::fs::read_to_string(&file_path).map_err(|e| format!("Failed to read file: {e}"))
 }
 
+#[tauri::command]
+pub async fn create_dir_all(path: String) -> Result<(), String> {
+    log::trace!("Creating directory path: {path}");
+    std::fs::create_dir_all(&path).map_err(|e| format!("Failed to create directory: {e}"))
+}
+
 /// Write file content to disk
 ///
 /// Used to save file content when editing in the inline editor.

--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -1527,6 +1527,11 @@ pub async fn dispatch_command(
         // =====================================================================
         // File Operations (additional)
         // =====================================================================
+        "create_dir_all" => {
+            let path: String = from_field(&args, "path")?;
+            crate::chat::create_dir_all(path).await?;
+            Ok(Value::Null)
+        }
         "write_file_content" => {
             let path: String = from_field(&args, "path")?;
             let content: String = from_field(&args, "content")?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2419,6 +2419,7 @@ pub fn run() {
             chat::read_plan_file,
             // Chat commands - File content preview/edit
             chat::read_file_content,
+            chat::create_dir_all,
             chat::write_file_content,
             chat::open_file_in_default_app,
             // Chat commands - Saved context handling

--- a/src/components/chat/CanvasGrid.tsx
+++ b/src/components/chat/CanvasGrid.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
 import { useChatStore } from '@/store/chat-store'
 import { useProjectsStore } from '@/store/projects-store'
 import { useUIStore } from '@/store/ui-store'
@@ -13,6 +14,13 @@ import { useRenameSession } from '@/services/chat'
 import { useCanvasKeyboardNav } from './hooks/useCanvasKeyboardNav'
 import { useCanvasShortcutEvents } from './hooks/useCanvasShortcutEvents'
 import { type SessionCardData, groupCardsByStatus } from './session-card-utils'
+import {
+  copyTextToClipboard,
+  formatSessionToMarkdown,
+  generateExportFileName,
+  getSessionForExport,
+  writeSessionExportFile,
+} from '@/lib/session-export-utils'
 
 interface CanvasGridProps {
   cards: SessionCardData[]
@@ -295,6 +303,41 @@ export function CanvasGrid({
     setRenamingSessionId(null)
   }, [])
 
+  const handleExportClipboard = useCallback(
+    async (sessionId: string) => {
+      if (!worktreeId || !worktreePath) return
+      const session = await getSessionForExport(
+        worktreeId,
+        worktreePath,
+        sessionId
+      )
+      const markdown = formatSessionToMarkdown(session)
+      await copyTextToClipboard(markdown)
+      toast.success('Copied to clipboard')
+    },
+    [worktreeId, worktreePath]
+  )
+
+  const handleExportFile = useCallback(
+    async (sessionId: string, sessionName: string) => {
+      if (!worktreeId || !worktreePath) return
+      const session = await getSessionForExport(
+        worktreeId,
+        worktreePath,
+        sessionId
+      )
+      const markdown = formatSessionToMarkdown(session)
+      const fileName = generateExportFileName(sessionName)
+      const relativePath = await writeSessionExportFile(
+        worktreePath,
+        fileName,
+        markdown
+      )
+      toast.success(`Saved to ${relativePath}`)
+    },
+    [worktreeId, worktreePath]
+  )
+
   // Track cumulative index offset per group for correct keyboard nav indices
   let indexOffset = 0
 
@@ -352,6 +395,12 @@ export function CanvasGrid({
                       onRenameStart={handleStartRename}
                       onRenameSubmit={handleRenameSubmit}
                       onRenameCancel={handleRenameCancel}
+                      onExportClipboard={() =>
+                        handleExportClipboard(card.session.id)
+                      }
+                      onExportFile={() =>
+                        handleExportFile(card.session.id, card.session.name)
+                      }
                     />
                   )
                 })}

--- a/src/components/chat/ExportSessionModal.tsx
+++ b/src/components/chat/ExportSessionModal.tsx
@@ -1,0 +1,98 @@
+import { useState, useCallback } from 'react'
+import { Loader2, Clipboard, FileDown } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+interface ExportSessionModalProps {
+  isOpen: boolean
+  onClose: () => void
+  sessionName: string
+  onExportClipboard: () => Promise<void>
+  onExportFile: () => Promise<void>
+}
+
+export function ExportSessionModal({
+  isOpen,
+  onClose,
+  sessionName,
+  onExportClipboard,
+  onExportFile,
+}: ExportSessionModalProps) {
+  const [loading, setLoading] = useState<'clipboard' | 'file' | null>(null)
+
+  const handleClipboard = useCallback(async () => {
+    setLoading('clipboard')
+    try {
+      await onExportClipboard()
+      onClose()
+    } catch (err) {
+      toast.error(`Export failed: ${err}`)
+    } finally {
+      setLoading(null)
+    }
+  }, [onExportClipboard, onClose])
+
+  const handleFile = useCallback(async () => {
+    setLoading('file')
+    try {
+      await onExportFile()
+      onClose()
+    } catch (err) {
+      toast.error(`Export failed: ${err}`)
+    } finally {
+      setLoading(null)
+    }
+  }, [onExportFile, onClose])
+
+  const isLoading = loading !== null
+
+  return (
+    <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
+      <DialogContent className="w-auto">
+        <DialogHeader>
+          <DialogTitle>Export Session</DialogTitle>
+          <DialogDescription className="truncate">
+            {sessionName}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 pt-1">
+          <Button
+            onClick={handleClipboard}
+            disabled={isLoading}
+            className="justify-start gap-3"
+          >
+            {loading === 'clipboard' ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Clipboard className="h-4 w-4" />
+            )}
+            Copy to Clipboard
+          </Button>
+          <Button
+            variant="outline"
+            onClick={handleFile}
+            disabled={isLoading}
+            className="justify-start gap-3 overflow-hidden"
+          >
+            {loading === 'file' ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <FileDown className="h-4 w-4" />
+            )}
+            <span className="truncate">Save to File</span>
+            <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+              ./session-exports/
+            </span>
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/chat/MessageItem.test.tsx
+++ b/src/components/chat/MessageItem.test.tsx
@@ -1,0 +1,101 @@
+import type { ComponentProps } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@/test/test-utils'
+import type {
+  ChatMessage,
+  Question,
+  QuestionAnswer,
+  ReviewFinding,
+} from '@/types/chat'
+import { toast } from 'sonner'
+import { MessageItem } from './MessageItem'
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+  },
+}))
+
+type MessageItemProps = ComponentProps<typeof MessageItem>
+
+const createAssistantMessage = (content: string): ChatMessage => ({
+  id: 'msg-1',
+  session_id: 'session-1',
+  role: 'assistant',
+  content,
+  timestamp: Date.now(),
+  tool_calls: [],
+})
+
+const createProps = (
+  overrides: Partial<MessageItemProps> = {}
+): MessageItemProps => ({
+  message: createAssistantMessage('Assistant response text'),
+  messageIndex: 0,
+  totalMessages: 1,
+  lastPlanMessageIndex: -1,
+  hasFollowUpMessage: false,
+  sessionId: 'session-1',
+  worktreePath: '/tmp/worktree',
+  approveShortcut: 'Cmd+Enter',
+  isSending: false,
+  onPlanApproval: vi.fn(),
+  onQuestionAnswer: vi.fn<
+    (_toolCallId: string, _answers: QuestionAnswer[], _questions: Question[]) => void
+  >(),
+  onQuestionSkip: vi.fn<(_toolCallId: string) => void>(),
+  onFileClick: vi.fn<(_path: string) => void>(),
+  onEditedFileClick: vi.fn<(_path: string) => void>(),
+  onFixFinding: vi.fn<
+    (_finding: ReviewFinding, _suggestion?: string) => Promise<void>
+  >().mockResolvedValue(undefined),
+  onFixAllFindings: vi.fn<
+    (_findings: { finding: ReviewFinding; suggestion?: string }[]) => Promise<void>
+  >().mockResolvedValue(undefined),
+  isQuestionAnswered: (_sessionId: string, _toolCallId: string) => false,
+  getSubmittedAnswers: (_sessionId: string, _toolCallId: string) => undefined,
+  areQuestionsSkipped: (_sessionId: string) => false,
+  isFindingFixed: (_sessionId: string, _key: string) => false,
+  ...overrides,
+})
+
+describe('MessageItem assistant response copy button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a copy response button for assistant messages with content', () => {
+    render(<MessageItem {...createProps()} />)
+
+    expect(
+      screen.getByRole('button', { name: /copy response/i })
+    ).toBeInTheDocument()
+  })
+
+  it('copies assistant response text when copy response button is clicked', async () => {
+    const user = userEvent.setup()
+    const writeTextMock = vi
+      .spyOn(navigator.clipboard, 'writeText')
+      .mockResolvedValue(undefined)
+
+    render(<MessageItem {...createProps()} />)
+
+    await user.click(screen.getByRole('button', { name: /copy response/i }))
+
+    expect(writeTextMock).toHaveBeenCalledWith('Assistant response text')
+    expect(toast.success).toHaveBeenCalledWith('Copied to clipboard')
+  })
+
+  it('does not render copy response button when assistant content is empty', () => {
+    render(
+      <MessageItem
+        {...createProps({ message: createAssistantMessage('   ') })}
+      />
+    )
+
+    expect(
+      screen.queryByRole('button', { name: /copy response/i })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback } from 'react'
 import { Copy } from 'lucide-react'
+import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { normalizePath } from '@/lib/path-utils'
 import { Markdown } from '@/components/ui/markdown'
@@ -204,6 +205,20 @@ export const MessageItem = memo(function MessageItem({
   const handleCopyToInput = useCallback(() => {
     onCopyToInput?.(message)
   }, [onCopyToInput, message])
+
+  // Stable callback for copying assistant response text
+  const handleCopyAssistantResponse = useCallback(() => {
+    if (message.role !== 'assistant' || !showContent) return
+
+    void navigator.clipboard
+      .writeText(displayContent)
+      .then(() => {
+        toast.success('Copied to clipboard')
+      })
+      .catch(() => {
+        // noop
+      })
+  }, [message.role, showContent, displayContent])
 
   // Content for the message box (shared between user and assistant)
   const messageBoxContent = (
@@ -551,6 +566,25 @@ export const MessageItem = memo(function MessageItem({
           />
         )}
 
+      {/* Copy response button for assistant messages */}
+      {message.role === 'assistant' && showContent && (
+        <div className="mt-1 flex justify-end">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Copy response"
+                onClick={handleCopyAssistantResponse}
+                className="shrink-0 p-1 rounded cursor-pointer text-muted-foreground/0 group-hover:text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/50 focus-visible:text-muted-foreground focus-visible:bg-muted/50 transition-colors"
+              >
+                <Copy className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Copy response</TooltipContent>
+          </Tooltip>
+        </div>
+      )}
+
       {message.cancelled && (
         <span className="text-xs text-muted-foreground/50 italic">
           (cancelled)
@@ -595,7 +629,7 @@ export const MessageItem = memo(function MessageItem({
       ) : (
         <div
           className={cn(
-            'text-muted-foreground w-full min-w-0 break-words',
+            'group text-muted-foreground w-full min-w-0 break-words',
             message.cancelled && 'opacity-60'
           )}
         >

--- a/src/components/chat/SessionCard.tsx
+++ b/src/components/chat/SessionCard.tsx
@@ -1,6 +1,7 @@
-import { forwardRef, useCallback } from 'react'
+import { forwardRef, useCallback, useState } from 'react'
 import {
   Archive,
+  Download,
   Eye,
   EyeOff,
   FileText,
@@ -29,6 +30,7 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import { type SessionCardData, statusConfig } from './session-card-utils'
+import { ExportSessionModal } from './ExportSessionModal'
 
 export interface SessionCardProps {
   card: SessionCardData
@@ -51,6 +53,8 @@ export interface SessionCardProps {
   onRenameStart?: (sessionId: string, currentName: string) => void
   onRenameSubmit?: (sessionId: string) => void
   onRenameCancel?: () => void
+  onExportClipboard?: () => Promise<void>
+  onExportFile?: () => Promise<void>
 }
 
 export const SessionCard = forwardRef<HTMLDivElement, SessionCardProps>(
@@ -75,11 +79,14 @@ export const SessionCard = forwardRef<HTMLDivElement, SessionCardProps>(
       onRenameStart,
       onRenameSubmit,
       onRenameCancel,
+      onExportClipboard,
+      onExportFile,
     },
     ref
   ) {
     const config = statusConfig[card.status]
     const isRunning = card.status === 'planning' || card.status === 'vibing' || card.status === 'yoloing'
+    const [exportModalOpen, setExportModalOpen] = useState(false)
     const renameInputRef = useCallback((node: HTMLInputElement | null) => {
       if (node) {
         node.focus()
@@ -338,6 +345,12 @@ export const SessionCard = forwardRef<HTMLDivElement, SessionCardProps>(
               )}
             </ContextMenuItem>
           )}
+          {(onExportClipboard || onExportFile) && (
+            <ContextMenuItem onSelect={() => setExportModalOpen(true)}>
+              <Download className="mr-2 h-4 w-4" />
+              Export Session
+            </ContextMenuItem>
+          )}
           <ContextMenuItem onSelect={onArchive}>
             <Archive className="mr-2 h-4 w-4" />
             Archive Session
@@ -349,6 +362,15 @@ export const SessionCard = forwardRef<HTMLDivElement, SessionCardProps>(
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
+      {(onExportClipboard || onExportFile) && (
+        <ExportSessionModal
+          isOpen={exportModalOpen}
+          onClose={() => setExportModalOpen(false)}
+          sessionName={card.session.name}
+          onExportClipboard={onExportClipboard ?? (() => Promise.resolve())}
+          onExportFile={onExportFile ?? (() => Promise.resolve())}
+        />
+      )}
       </div>
     )
   }

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -13,6 +13,7 @@ import {
   Archive,
   ArrowLeft,
   Code,
+  Download,
   Eye,
   EyeOff,
   FileText,
@@ -96,7 +97,15 @@ import {
 } from '@/components/ui/context-menu'
 import { WorktreeDropdownMenu } from '@/components/projects/WorktreeDropdownMenu'
 import { LabelModal } from './LabelModal'
+import { ExportSessionModal } from './ExportSessionModal'
 import { useSessionArchive } from './hooks/useSessionArchive'
+import {
+  copyTextToClipboard,
+  formatSessionToMarkdown,
+  generateExportFileName,
+  getSessionForExport,
+  writeSessionExportFile,
+} from '@/lib/session-export-utils'
 
 /** Track whether any waiting tabs are off-screen to the left or right */
 function useOffScreenWaiting(
@@ -349,6 +358,9 @@ export function SessionChatModal({
     }
   }, [isOpen])
 
+  // Export modal state
+  const [exportModalSessionId, setExportModalSessionId] = useState<string | null>(null)
+
   // Label modal state
   const [labelModalOpen, setLabelModalOpen] = useState(false)
   const [labelTargetSessionId, setLabelTargetSessionId] = useState<
@@ -426,6 +438,41 @@ export function SessionChatModal({
     removalBehavior: preferences?.removal_behavior,
     onLastSessionDeleted: onCloseWorktree ? handleCloseWorktreeFromModal : undefined,
   })
+
+  const handleExportClipboard = useCallback(
+    async (sessionId: string) => {
+      if (!worktreeId || !worktreePath) return
+      const session = await getSessionForExport(
+        worktreeId,
+        worktreePath,
+        sessionId
+      )
+      const markdown = formatSessionToMarkdown(session)
+      await copyTextToClipboard(markdown)
+      toast.success('Copied to clipboard')
+    },
+    [worktreeId, worktreePath]
+  )
+
+  const handleExportFile = useCallback(
+    async (sessionId: string, sessionName: string) => {
+      if (!worktreeId || !worktreePath) return
+      const session = await getSessionForExport(
+        worktreeId,
+        worktreePath,
+        sessionId
+      )
+      const markdown = formatSessionToMarkdown(session)
+      const fileName = generateExportFileName(sessionName)
+      const relativePath = await writeSessionExportFile(
+        worktreePath,
+        fileName,
+        markdown
+      )
+      toast.success(`Saved to ${relativePath}`)
+    },
+    [worktreeId, worktreePath]
+  )
 
   // CMD+W: close the active session tab, or close modal if last tab
   const [closeConfirmOpen, setCloseConfirmOpen] = useState(false)
@@ -1112,6 +1159,12 @@ export function SessionChatModal({
                             <Archive className="mr-2 h-4 w-4" />
                             Archive Session
                           </ContextMenuItem>
+                          <ContextMenuItem
+                            onSelect={() => setExportModalSessionId(session.id)}
+                          >
+                            <Download className="mr-2 h-4 w-4" />
+                            Export Session
+                          </ContextMenuItem>
                           <ContextMenuSeparator />
                           <ContextMenuItem
                             variant="destructive"
@@ -1220,6 +1273,20 @@ export function SessionChatModal({
         }}
         sessionId={labelSessionId}
         currentLabel={currentLabel}
+      />
+      <ExportSessionModal
+        isOpen={exportModalSessionId !== null}
+        onClose={() => setExportModalSessionId(null)}
+        sessionName={sessions.find(s => s.id === exportModalSessionId)?.name ?? ''}
+        onExportClipboard={() => {
+          if (!exportModalSessionId) return Promise.resolve()
+          return handleExportClipboard(exportModalSessionId)
+        }}
+        onExportFile={() => {
+          if (!exportModalSessionId) return Promise.resolve()
+          const s = sessions.find(s => s.id === exportModalSessionId)
+          return handleExportFile(exportModalSessionId, s?.name ?? '')
+        }}
       />
       <CloseWorktreeDialog
         open={closeConfirmOpen}

--- a/src/components/chat/SessionListRow.test.tsx
+++ b/src/components/chat/SessionListRow.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@/test/test-utils'
+import type { SessionCardData } from './session-card-utils'
+import { SessionListRow } from './SessionListRow'
+
+const createCard = (): SessionCardData => ({
+  session: {
+    id: 'session-1',
+    name: 'Session 1',
+    order: 0,
+    created_at: Date.now(),
+    updated_at: Date.now(),
+    messages: [],
+    backend: 'claude',
+  },
+  status: 'idle',
+  executionMode: 'plan',
+  isSending: false,
+  isWaiting: false,
+  hasExitPlanMode: false,
+  hasQuestion: false,
+  hasPermissionDenials: false,
+  permissionDenialCount: 0,
+  planFilePath: null,
+  planContent: null,
+  pendingPlanMessageId: null,
+  hasRecap: false,
+  recapDigest: null,
+  label: null,
+})
+
+describe('SessionListRow context menu export session', () => {
+  it('renders Export Session menu item when export handlers are provided', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <SessionListRow
+        card={createCard()}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onArchive={vi.fn()}
+        onDelete={vi.fn()}
+        onPlanView={vi.fn()}
+        onRecapView={vi.fn()}
+        onExportClipboard={vi.fn().mockResolvedValue(undefined)}
+        onExportFile={vi.fn().mockResolvedValue(undefined)}
+      />
+    )
+
+    await user.pointer({
+      target: screen.getByRole('button', { name: 'Session 1' }),
+      keys: '[MouseRight]',
+    })
+
+    expect(await screen.findByText('Export Session')).toBeInTheDocument()
+  })
+})

--- a/src/components/chat/SessionListRow.tsx
+++ b/src/components/chat/SessionListRow.tsx
@@ -1,6 +1,7 @@
-import { forwardRef, useCallback } from 'react'
+import { forwardRef, useCallback, useState } from 'react'
 import {
   Archive,
+  Download,
   Eye,
   EyeOff,
   FileText,
@@ -29,6 +30,7 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import { statusConfig } from './session-card-utils'
+import { ExportSessionModal } from './ExportSessionModal'
 import type { SessionCardProps } from './SessionCard'
 
 export const SessionListRow = forwardRef<HTMLDivElement, SessionCardProps>(
@@ -52,10 +54,13 @@ export const SessionListRow = forwardRef<HTMLDivElement, SessionCardProps>(
       onRenameStart,
       onRenameSubmit,
       onRenameCancel,
+      onExportClipboard,
+      onExportFile,
     },
     ref
   ) {
     const config = statusConfig[card.status]
+    const [exportModalOpen, setExportModalOpen] = useState(false)
     const renameInputRef = useCallback((node: HTMLInputElement | null) => {
       if (node) {
         node.focus()
@@ -76,7 +81,8 @@ export const SessionListRow = forwardRef<HTMLDivElement, SessionCardProps>(
     )
 
     return (
-      <ContextMenu>
+      <>
+        <ContextMenu>
         <ContextMenuTrigger asChild>
           <div
             ref={ref}
@@ -270,6 +276,12 @@ export const SessionListRow = forwardRef<HTMLDivElement, SessionCardProps>(
               )}
             </ContextMenuItem>
           )}
+          {(onExportClipboard || onExportFile) && (
+            <ContextMenuItem onSelect={() => setExportModalOpen(true)}>
+              <Download className="mr-2 h-4 w-4" />
+              Export Session
+            </ContextMenuItem>
+          )}
           <ContextMenuItem onSelect={onArchive}>
             <Archive className="mr-2 h-4 w-4" />
             Archive Session
@@ -281,6 +293,16 @@ export const SessionListRow = forwardRef<HTMLDivElement, SessionCardProps>(
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
+      {(onExportClipboard || onExportFile) && (
+        <ExportSessionModal
+          isOpen={exportModalOpen}
+          onClose={() => setExportModalOpen(false)}
+          sessionName={card.session.name}
+          onExportClipboard={onExportClipboard ?? (() => Promise.resolve())}
+          onExportFile={onExportFile ?? (() => Promise.resolve())}
+        />
+      )}
+    </>
     )
   }
 )

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -67,6 +67,13 @@ import { useUIStore } from '@/store/ui-store'
 import { isBaseSession, type Worktree } from '@/types/projects'
 import { getEditorLabel, getTerminalLabel } from '@/types/preferences'
 import type { LabelData, Session, WorktreeSessions } from '@/types/chat'
+import {
+  copyTextToClipboard,
+  formatSessionToMarkdown,
+  generateExportFileName,
+  getSessionForExport,
+  writeSessionExportFile,
+} from '@/lib/session-export-utils'
 import { NewIssuesBadge } from '@/components/shared/NewIssuesBadge'
 import { OpenPRsBadge } from '@/components/shared/OpenPRsBadge'
 import { FailedRunsBadge } from '@/components/shared/FailedRunsBadge'
@@ -2102,6 +2109,36 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
                                   }
                                   onRenameSubmit={handleRenameSubmit}
                                   onRenameCancel={handleRenameCancel}
+                                  onExportClipboard={async () => {
+                                    const session = await getSessionForExport(
+                                      section.worktree.id,
+                                      section.worktree.path,
+                                      card.session.id
+                                    )
+                                    const markdown =
+                                      formatSessionToMarkdown(session)
+                                    await copyTextToClipboard(markdown)
+                                    toast.success('Copied to clipboard')
+                                  }}
+                                  onExportFile={async () => {
+                                    const session = await getSessionForExport(
+                                      section.worktree.id,
+                                      section.worktree.path,
+                                      card.session.id
+                                    )
+                                    const markdown =
+                                      formatSessionToMarkdown(session)
+                                    const fileName = generateExportFileName(
+                                      card.session.name
+                                    )
+                                    const relativePath =
+                                      await writeSessionExportFile(
+                                        section.worktree.path,
+                                        fileName,
+                                        markdown
+                                      )
+                                    toast.success(`Saved to ${relativePath}`)
+                                  }}
                                 />
                               )
                             })}

--- a/src/lib/session-export-utils.test.ts
+++ b/src/lib/session-export-utils.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { invoke } from '@/lib/transport'
+import { isNativeApp } from '@/lib/environment'
+import {
+  generateExportFileName,
+  getSessionForExport,
+  copyTextToClipboard,
+  writeSessionExportFile,
+} from './session-export-utils'
+
+vi.mock('@/lib/transport', () => ({
+  invoke: vi.fn(),
+}))
+
+vi.mock('@/lib/environment', () => ({
+  isNativeApp: vi.fn(),
+}))
+
+describe('session export utils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+      configurable: true,
+    })
+
+    Object.defineProperty(document, 'execCommand', {
+      value: vi.fn().mockReturnValue(true),
+      configurable: true,
+    })
+  })
+  it('fetches session for export using camelCase get_session args', async () => {
+    const mockSession = {
+      id: 'session-1',
+      name: 'Session 1',
+      order: 0,
+      created_at: Date.now() / 1000,
+      updated_at: Date.now() / 1000,
+      messages: [],
+      backend: 'claude',
+    }
+
+    vi.mocked(invoke).mockResolvedValueOnce(mockSession)
+
+    const result = await getSessionForExport('wt-1', '/tmp/wt', 'session-1')
+
+    expect(result).toEqual(mockSession)
+    expect(invoke).toHaveBeenCalledWith('get_session', {
+      worktreeId: 'wt-1',
+      worktreePath: '/tmp/wt',
+      sessionId: 'session-1',
+    })
+  })
+
+  it('writes export file into session-exports after ensuring directory exists', async () => {
+    vi.mocked(invoke)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+
+    const relativePath = await writeSessionExportFile(
+      '/tmp/worktree',
+      'session.md',
+      '# Session'
+    )
+
+    expect(relativePath).toBe('session-exports/session.md')
+    expect(invoke).toHaveBeenNthCalledWith(1, 'create_dir_all', {
+      path: '/tmp/worktree/session-exports',
+    })
+    expect(invoke).toHaveBeenNthCalledWith(2, 'write_file_content', {
+      path: '/tmp/worktree/session-exports/session.md',
+      content: '# Session',
+    })
+  })
+
+  it('falls back to document.execCommand when navigator clipboard is denied', async () => {
+    vi.mocked(isNativeApp).mockReturnValue(false)
+
+    const denied = new DOMException('Denied', 'NotAllowedError')
+    const writeTextMock = vi
+      .spyOn(navigator.clipboard, 'writeText')
+      .mockRejectedValueOnce(denied)
+
+    const execSpy = vi
+      .spyOn(document, 'execCommand')
+      .mockImplementation(() => true)
+
+    await copyTextToClipboard('hello')
+
+    expect(writeTextMock).toHaveBeenCalledWith('hello')
+    expect(execSpy).toHaveBeenCalledWith('copy')
+  })
+
+  it('throws when both browser clipboard and fallback copy fail', async () => {
+    vi.mocked(isNativeApp).mockReturnValue(false)
+
+    const denied = new DOMException('Denied', 'NotAllowedError')
+    vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValueOnce(denied)
+
+    vi.spyOn(document, 'execCommand').mockImplementation(() => false)
+
+    await expect(copyTextToClipboard('hello')).rejects.toThrowError(
+      /NotAllowedError|Denied/
+    )
+  })
+
+  it('creates a sanitized export file name with markdown extension', () => {
+    const fileName = generateExportFileName('My Session: test/export!')
+
+    expect(fileName).toMatch(/^my-session-test-export-\d{4}-\d{2}-\d{2}\.md$/)
+  })
+
+  it('falls back to date-only filename when session name sanitizes to empty', () => {
+    const fileName = generateExportFileName('!!!')
+
+    expect(fileName).toMatch(/^-\d{4}-\d{2}-\d{2}\.md$/)
+  })
+})

--- a/src/lib/session-export-utils.ts
+++ b/src/lib/session-export-utils.ts
@@ -1,0 +1,191 @@
+import { invoke } from '@/lib/transport'
+import { isNativeApp } from '@/lib/environment'
+import type { Session, ChatMessage, ContentBlock, ToolCall } from '@/types/chat'
+import { stripAllMarkers } from '@/components/chat/message-content-utils'
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp * 1000).toLocaleString()
+}
+
+function formatToolCall(toolCall: ToolCall): string {
+  const lines: string[] = []
+  lines.push(`### Tool: ${toolCall.name}`)
+  lines.push('')
+  lines.push('**Input:**')
+  lines.push('```json')
+  lines.push(JSON.stringify(toolCall.input, null, 2))
+  lines.push('```')
+  if (toolCall.output !== undefined && toolCall.output !== null) {
+    lines.push('')
+    lines.push('**Output:**')
+    lines.push('```')
+    lines.push(toolCall.output)
+    lines.push('```')
+  }
+  return lines.join('\n')
+}
+
+function formatAssistantMessage(message: ChatMessage): string {
+  const toolCallMap = new Map<string, ToolCall>()
+  for (const tc of message.tool_calls ?? []) {
+    toolCallMap.set(tc.id, tc)
+  }
+
+  const parts: string[] = []
+
+  if (message.content_blocks && message.content_blocks.length > 0) {
+    for (const block of message.content_blocks) {
+      const b = block as ContentBlock
+      if (b.type === 'text') {
+        if (b.text.trim()) {
+          parts.push(b.text.trim())
+        }
+      } else if (b.type === 'tool_use') {
+        const tc = toolCallMap.get(b.tool_call_id)
+        if (tc) {
+          parts.push(formatToolCall(tc))
+        }
+      } else if (b.type === 'thinking') {
+        if (b.thinking.trim()) {
+          parts.push(`### Thinking\n\n${b.thinking.trim()}`)
+        }
+      }
+    }
+  } else {
+    // Fallback: content then tool calls
+    if (message.content?.trim()) {
+      parts.push(message.content.trim())
+    }
+    for (const tc of message.tool_calls ?? []) {
+      parts.push(formatToolCall(tc))
+    }
+  }
+
+  return parts.join('\n\n')
+}
+
+export async function getSessionForExport(
+  worktreeId: string,
+  worktreePath: string,
+  sessionId: string
+): Promise<Session> {
+  return invoke<Session>('get_session', {
+    worktreeId,
+    worktreePath,
+    sessionId,
+  })
+}
+
+function copyTextWithExecCommand(text: string): boolean {
+  if (typeof document === 'undefined') return false
+
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  textarea.style.pointerEvents = 'none'
+
+  document.body.appendChild(textarea)
+  textarea.focus()
+  textarea.select()
+  textarea.setSelectionRange(0, textarea.value.length)
+
+  try {
+    return document.execCommand('copy')
+  } finally {
+    document.body.removeChild(textarea)
+  }
+}
+
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (isNativeApp()) {
+    const { writeText } = await import('@tauri-apps/plugin-clipboard-manager')
+    await writeText(text)
+    return
+  }
+
+  try {
+    await navigator.clipboard.writeText(text)
+  } catch (error) {
+    if (copyTextWithExecCommand(text)) return
+    throw error
+  }
+}
+
+export async function writeSessionExportFile(
+  worktreePath: string,
+  fileName: string,
+  content: string
+): Promise<string> {
+  const exportDir = `${worktreePath}/session-exports`
+  await invoke('create_dir_all', { path: exportDir })
+
+  const filePath = `${exportDir}/${fileName}`
+  await invoke('write_file_content', { path: filePath, content })
+
+  return `session-exports/${fileName}`
+}
+
+export function formatSessionToMarkdown(session: Session): string {
+  const lines: string[] = []
+
+  // Header
+  lines.push(`# Session: ${session.name}`)
+  lines.push('')
+  lines.push(`Date: ${formatDate(session.created_at)}`)
+  if (session.selected_model) {
+    lines.push(`Model: ${session.selected_model}`)
+  }
+  lines.push('')
+
+  for (const message of session.messages) {
+    lines.push('---')
+    lines.push('')
+
+    if (message.role === 'user') {
+      lines.push('## User')
+      lines.push('')
+      const clean = stripAllMarkers(message.content)
+      if (clean.trim()) {
+        lines.push(clean.trim())
+      }
+      if (message.execution_mode) {
+        lines.push('')
+        lines.push(`*Mode: ${message.execution_mode}*`)
+      }
+    } else {
+      lines.push('## Assistant')
+      lines.push('')
+      const body = formatAssistantMessage(message)
+      if (body.trim()) {
+        lines.push(body)
+      }
+      if (message.cancelled) {
+        lines.push('')
+        lines.push('*[Cancelled]*')
+      }
+      if (message.usage) {
+        const { input_tokens, output_tokens } = message.usage
+        lines.push('')
+        lines.push(
+          `*Tokens: ${input_tokens.toLocaleString()} in / ${output_tokens.toLocaleString()} out*`
+        )
+      }
+    }
+
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+export function generateExportFileName(sessionName: string): string {
+  const date = new Date().toISOString().slice(0, 10) // YYYY-MM-DD
+  const sanitized = sessionName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60)
+  return `${sanitized}-${date}.md`
+}


### PR DESCRIPTION
## Summary

- **Copy to clipboard**: Export sessions as formatted markdown via context menu
- **Save to file**: Export sessions to `session-exports/` directory with sanitized names
- **Copy response**: New button on assistant messages to quickly copy individual responses
- **Markdown format**: Structured export includes messages, tool calls, thinking blocks, and token usage
- **Fallback clipboard**: Gracefully falls back to `document.execCommand` if Clipboard API is denied
- **Tauri command**: New `create_dir_all` command for directory creation

## What's New

### Components
- `ExportSessionModal`: Modal for choosing between clipboard and file export
- Copy response button on `MessageItem` with hover reveal and tooltip

### Utilities (`session-export-utils.ts`)
- `formatSessionToMarkdown()`: Converts sessions to readable markdown with all content blocks
- `copyTextToClipboard()`: Browser + Tauri + fallback clipboard handling
- `writeSessionExportFile()`: Saves to `worktree/session-exports/` with auto-created directory
- `generateExportFileName()`: Sanitizes session names + date for file naming

### Updated Components
- `SessionCard`, `SessionListRow`: Export menu item
- `CanvasGrid`, `SessionChatModal`, `ProjectCanvasView`: Export handlers + toast feedback

### Tests
- `MessageItem.test.tsx`: Copy response button functionality
- `SessionListRow.test.tsx`: Export menu item rendering
- `session-export-utils.test.ts`: Markdown formatting, clipboard fallback, file I/O

## Technical Details
- Uses `#[serde(default)]` on new `create_dir_all` command for safety
- Session export queries use camelCase args (Pattern B serialization)
- Clipboard denied errors gracefully fallback before throwing
- Markdown preserves all message metadata (tokens, cancellation, mode)