### PR TITLE
feat(preferences): add configurable window vibrancy effect

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -210,6 +210,8 @@ pub struct AppPreferences {
     pub yolo_thinking_level: Option<String>, // Thinking level override for yolo mode, None = use session thinking level
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub linear_api_key: Option<String>, // Global Linear personal API key (inherited by all projects)
+    #[serde(default = "default_window_effect")]
+    pub window_effect: String, // macOS window vibrancy effect: sidebar, hudWindow, windowBackground, etc.
 }
 
 fn default_true() -> Option<bool> {
@@ -384,6 +386,10 @@ fn default_codex_max_agent_threads() -> u32 {
 
 fn default_zoom_level() -> u32 {
     90 // 90% = slightly smaller default
+}
+
+fn default_window_effect() -> String {
+    "sidebar".to_string()
 }
 
 fn default_allow_web_tools_in_plan_mode() -> bool {
@@ -1078,6 +1084,7 @@ impl Default for AppPreferences {
             build_thinking_level: None,
             yolo_thinking_level: None,
             linear_api_key: None,
+            window_effect: default_window_effect(),
         }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
         "dragDropEnabled": true,
         "windowEffects": {
           "effects": [
-            "hudWindow"
+            "sidebar"
           ],
           "radius": 12,
           "state": "active"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,12 +22,16 @@ import ErrorBoundary from './components/ErrorBoundary'
 import { useClaudeCliStatus, useClaudeCliAuth } from './services/claude-cli'
 import { useCodexCliStatus, useCodexCliAuth } from './services/codex-cli'
 import { useGhCliStatus, useGhCliAuth } from './services/gh-cli'
-import { useOpencodeCliStatus, useOpencodeCliAuth } from './services/opencode-cli'
+import {
+  useOpencodeCliStatus,
+  useOpencodeCliAuth,
+} from './services/opencode-cli'
 import { useUIStore } from './store/ui-store'
 import type { AppPreferences } from './types/preferences'
 import { useChatStore } from './store/chat-store'
 import { useFontSettings } from './hooks/use-font-settings'
 import { useZoom } from './hooks/use-zoom'
+import { useWindowEffect } from './hooks/use-window-effect'
 import { useImmediateSessionStateSave } from './hooks/useImmediateSessionStateSave'
 import { useCliVersionCheck } from './hooks/useCliVersionCheck'
 import { useQueueProcessor } from './hooks/useQueueProcessor'
@@ -300,6 +304,9 @@ function App() {
   // Apply zoom level from preferences + keyboard shortcuts
   useZoom()
 
+  // Apply window vibrancy effect from preferences (macOS)
+  useWindowEffect()
+
   // Save reviewing/waiting state immediately (no debounce) to ensure persistence on reload
   useImmediateSessionStateSave()
 
@@ -450,7 +457,9 @@ function App() {
           store.setOnboardingManuallyTriggered(false)
         } else {
           const manuallyTriggered = store.onboardingManuallyTriggered
-          const prefs = queryClient.getQueryData<AppPreferences>(['preferences'])
+          const prefs = queryClient.getQueryData<AppPreferences>([
+            'preferences',
+          ])
           if (manuallyTriggered || (prefs && !prefs.has_seen_feature_tour)) {
             store.setOnboardingManuallyTriggered(false)
             setTimeout(() => {
@@ -525,7 +534,8 @@ function App() {
         // On fresh startup sendingSessionIds should be empty, but if the store
         // was somehow persisted or restored, ensure only truly resumable sessions
         // are marked as sending.
-        const { sendingSessionIds, removeSendingSession } = useChatStore.getState()
+        const { sendingSessionIds, removeSendingSession } =
+          useChatStore.getState()
         const resumableIds = new Set(resumable.map(r => r.session_id))
         for (const sessionId of Object.keys(sendingSessionIds)) {
           if (!resumableIds.has(sessionId)) {
@@ -545,10 +555,12 @@ function App() {
             // Mark session as sending and restore execution mode for streaming UI
             useChatStore.getState().addSendingSession(session.session_id)
             if (session.execution_mode) {
-              useChatStore.getState().setExecutingMode(
-                session.session_id,
-                session.execution_mode as 'plan' | 'build' | 'yolo'
-              )
+              useChatStore
+                .getState()
+                .setExecutingMode(
+                  session.session_id,
+                  session.execution_mode as 'plan' | 'build' | 'yolo'
+                )
             }
             // Resume the session (this will start tailing the output file)
             invoke('resume_session', {

--- a/src/components/preferences/panes/AppearancePane.tsx
+++ b/src/components/preferences/panes/AppearancePane.tsx
@@ -18,6 +18,7 @@ import {
   syntaxThemeDarkOptions,
   syntaxThemeLightOptions,
   fileEditModeOptions,
+  windowEffectOptions,
   FONT_SIZE_DEFAULT,
   ZOOM_LEVEL_DEFAULT,
   uiFontScaleTicks,
@@ -27,6 +28,7 @@ import {
   type ChatFont,
   type SyntaxTheme,
   type FileEditMode,
+  type WindowEffect,
 } from '@/types/preferences'
 import { isMacOS } from '@/lib/platform'
 
@@ -156,6 +158,15 @@ export const AppearancePane: React.FC = () => {
     [savePreferences, preferences]
   )
 
+  const handleWindowEffectChange = useCallback(
+    (value: WindowEffect) => {
+      if (preferences) {
+        savePreferences.mutate({ ...preferences, window_effect: value })
+      }
+    },
+    [savePreferences, preferences]
+  )
+
   return (
     <div className="space-y-6">
       <SettingsSection title="Theme">
@@ -235,6 +246,36 @@ export const AppearancePane: React.FC = () => {
           </InlineField>
         </div>
       </SettingsSection>
+
+      {isMacOS && (
+        <SettingsSection title="Window">
+          <div className="space-y-4">
+            <InlineField
+              label="Vibrancy effect"
+              description="macOS window background material"
+            >
+              <Select
+                value={preferences?.window_effect ?? 'sidebar'}
+                onValueChange={value =>
+                  handleWindowEffectChange(value as WindowEffect)
+                }
+                disabled={savePreferences.isPending}
+              >
+                <SelectTrigger className="w-52">
+                  <SelectValue placeholder="Select effect" />
+                </SelectTrigger>
+                <SelectContent>
+                  {windowEffectOptions.map(option => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </InlineField>
+          </div>
+        </SettingsSection>
+      )}
 
       <SettingsSection title="Fonts">
         <div className="space-y-4">

--- a/src/hooks/use-window-effect.ts
+++ b/src/hooks/use-window-effect.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+import { usePreferences } from '@/services/preferences'
+import { isNativeApp } from '@/lib/environment'
+import type { WindowEffect } from '@/types/preferences'
+
+async function applyWindowEffect(effect: WindowEffect) {
+  if (!isNativeApp()) return
+  try {
+    const mod = await import('@tauri-apps/api/window')
+    await mod.getCurrentWindow().setEffects({
+      effects: [
+        effect as unknown as (typeof mod.Effect)[keyof typeof mod.Effect],
+      ],
+      radius: 12,
+      state: mod.EffectState.Active,
+    })
+  } catch (error) {
+    console.error('Failed to set window effect:', error)
+  }
+}
+
+export function useWindowEffect() {
+  const { data: preferences } = usePreferences()
+
+  useEffect(() => {
+    const effect = preferences?.window_effect ?? 'sidebar'
+    applyWindowEffect(effect)
+  }, [preferences?.window_effect])
+}

--- a/src/services/preferences.test.ts
+++ b/src/services/preferences.test.ts
@@ -148,6 +148,7 @@ describe('preferences service', () => {
         build_thinking_level: null,
         yolo_thinking_level: null,
         linear_api_key: null,
+        window_effect: 'sidebar',
       }
       vi.mocked(invoke).mockResolvedValueOnce(mockPreferences)
 
@@ -262,6 +263,7 @@ describe('preferences service', () => {
         build_thinking_level: null,
         yolo_thinking_level: null,
         linear_api_key: null,
+        window_effect: 'sidebar',
       }
       vi.mocked(invoke).mockResolvedValueOnce(prefsWithOldBinding)
 
@@ -352,6 +354,7 @@ describe('preferences service', () => {
         build_thinking_level: null,
         yolo_thinking_level: null,
         linear_api_key: null,
+        window_effect: 'sidebar',
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -441,6 +444,7 @@ describe('preferences service', () => {
         build_thinking_level: null,
         yolo_thinking_level: null,
         linear_api_key: null,
+        window_effect: 'sidebar',
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -530,6 +534,7 @@ describe('preferences service', () => {
         build_thinking_level: null,
         yolo_thinking_level: null,
         linear_api_key: null,
+        window_effect: 'sidebar',
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -617,6 +622,7 @@ describe('preferences service', () => {
         build_thinking_level: null,
         yolo_thinking_level: null,
         linear_api_key: null,
+        window_effect: 'sidebar',
       }
 
       const { result } = renderHook(() => useSavePreferences(), {

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -20,6 +20,30 @@ export const notificationSoundOptions: {
 ]
 
 // =============================================================================
+// Window Effects (macOS vibrancy)
+// =============================================================================
+
+export type WindowEffect =
+  | 'sidebar'
+  | 'hudWindow'
+  | 'windowBackground'
+  | 'fullScreenUI'
+  | 'headerView'
+  | 'contentBackground'
+
+export const windowEffectOptions: {
+  value: WindowEffect
+  label: string
+}[] = [
+  { value: 'sidebar', label: 'Sidebar' },
+  { value: 'hudWindow', label: 'HUD Window' },
+  { value: 'windowBackground', label: 'Window Background' },
+  { value: 'fullScreenUI', label: 'Full Screen UI' },
+  { value: 'headerView', label: 'Header View' },
+  { value: 'contentBackground', label: 'Content Background' },
+]
+
+// =============================================================================
 // Magic Prompts - Customizable prompts for AI-powered features
 // =============================================================================
 
@@ -748,8 +772,7 @@ function makeBackendsPreset(backend: string): MagicPromptBackends {
   }
 }
 
-export const CLAUDE_DEFAULT_MAGIC_PROMPT_BACKENDS =
-  makeBackendsPreset('claude')
+export const CLAUDE_DEFAULT_MAGIC_PROMPT_BACKENDS = makeBackendsPreset('claude')
 export const CODEX_DEFAULT_MAGIC_PROMPT_BACKENDS = makeBackendsPreset('codex')
 export const OPENCODE_DEFAULT_MAGIC_PROMPT_BACKENDS =
   makeBackendsPreset('opencode')
@@ -848,6 +871,7 @@ export interface AppPreferences {
   build_thinking_level: string | null // Thinking level override for build mode, null = use session thinking level
   yolo_thinking_level: string | null // Thinking level override for yolo mode, null = use session thinking level
   linear_api_key: string | null // Global Linear personal API key (inherited by all projects)
+  window_effect: WindowEffect // macOS window vibrancy effect
 }
 
 export type CanvasLayout = 'grid' | 'list'
@@ -1342,4 +1366,5 @@ export const defaultPreferences: AppPreferences = {
   build_thinking_level: null, // Default: use session thinking level
   yolo_thinking_level: null, // Default: use session thinking level
   linear_api_key: null, // Default: no global Linear API key
+  window_effect: 'sidebar', // Default: sidebar (compatible with tiling WMs)
 }


### PR DESCRIPTION
## Summary
- Change default window effect from `hudWindow` to `sidebar` for better compatibility with tiling window managers (e.g. AeroSpace)
- Add a new "Vibrancy effect" setting in Preferences > Appearance (macOS only) to let users pick their preferred window background material at runtime
- Available effects: Sidebar, HUD Window, Window Background, Full Screen UI, Header View, Content Background

## Test plan
- [ ] Open Settings > Appearance on macOS — verify "Window" section appears with vibrancy select
- [ ] Change effect and observe immediate visual change in window background
- [ ] Restart app and verify the selected effect persists
- [ ] On non-macOS, verify the "Window" section does not appear