### PR TITLE
fix(projects): prevent keyboard shortcuts from interfering with text input

### DIFF
--- a/src/components/projects/AddProjectDialog.tsx
+++ b/src/components/projects/AddProjectDialog.tsx
@@ -133,10 +133,22 @@ export function AddProjectDialog() {
     }
   }, [initProject, addProjectParentFolderId, setAddProjectDialogOpen])
 
-  // Keyboard shortcuts: A = add existing, I = initialize new
+  // Keyboard shortcuts: A = add existing, I = initialize new, C = clone
   useEffect(() => {
     if (!addProjectDialogOpen || isPending) return
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Don't intercept when another modal is on top
+      const { gitInitModalOpen, cloneModalOpen } = useProjectsStore.getState()
+      if (gitInitModalOpen || cloneModalOpen) return
+
+      // Don't intercept when typing in an input field
+      const target = e.target as HTMLElement
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable
+      ) return
+
       if (e.key === 'a' || e.key === 'A') {
         e.preventDefault()
         handleAddExisting()


### PR DESCRIPTION
## Summary

- Prevents keyboard shortcut handlers from triggering when modals are stacked (gitInitModalOpen, cloneModalOpen)
- Skips shortcut interception when the user is typing in input fields, textareas, or contenteditable elements
- Fixes issue where typing "c" triggered clone dialog and "i" triggered folder selection during git identity setup

## Details

The AddProjectDialog keyboard shortcuts for 'A' (add existing), 'I' (initialize new), and 'C' (clone) were firing even while users typed in input fields. This prevented typing certain characters in the Git identity dialog.

The fix adds two checks before processing shortcuts:
1. Modal state check - ignores shortcuts if another modal is already open
2. Input focus check - ignores shortcuts if the active element is a text input or editable field

Fixes #169

---

Fixes #169