### PR TITLE
fix(transport): use Tauri's native path encoding for cross-platform compatibility

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,7 +32,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost data: blob: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'",
+      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' ipc: http://ipc.localhost https://ipc.localhost; img-src 'self' asset: http://asset.localhost https://asset.localhost data: blob: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'",
       "assetProtocol": {
         "enable": true,
         "scope": {

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -34,6 +34,15 @@ export function setAppDataDir(dir: string): void {
  */
 export function convertFileSrc(filePath: string, protocol = 'asset'): string {
   if (isNativeApp()) {
+    // Use Tauri's native implementation which correctly percent-encodes paths
+    // on all platforms (JS encodeURIComponent misses dots/hyphens/underscores
+    // that Tauri's Rust encoder expects on Windows).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = (window as any).__TAURI_INTERNALS__
+    if (internals?.convertFileSrc) {
+      return internals.convertFileSrc(filePath, protocol)
+    }
+    // Fallback (should not reach in native app)
     const path = encodeURIComponent(filePath)
     return navigator.userAgent.includes('Windows')
       ? `https://${protocol}.localhost/${path}`


### PR DESCRIPTION
## Summary

- Replace custom `encodeURIComponent()` path encoding with Tauri's native `__TAURI_INTERNALS__.convertFileSrc()` implementation
- Add HTTPS variants (`https://asset.localhost` and `https://ipc.localhost`) to CSP headers for Windows compatibility
- Fixes image preview rendering failure on Windows while maintaining compatibility with macOS/Linux

## Problem

On Windows, pasted/dropped images displayed as broken image icons because `convertFileSrc()` used JavaScript's `encodeURIComponent()` to encode file paths. However, Tauri's asset protocol handler on Windows uses Rust's `percent_encode()`, which encodes a different character set (dots, hyphens, underscores).

This mismatch caused the asset protocol handler to fail decoding the URL on Windows, while the same code worked correctly on macOS/Linux.

## Solution

- Use Tauri's native implementation via `__TAURI_INTERNALS__.convertFileSrc()` which correctly handles platform-specific encoding requirements
- Fallback to previous behavior if native implementation unavailable (shouldn't occur in native app)
- Update CSP to allow HTTPS variants of Tauri's virtual hosts on Windows, which uses HTTPS instead of HTTP

Fixes #185

---

Fixes #185