### PR TITLE
feat(preferences): add default execution mode setting

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -182,6 +182,8 @@ pub struct AppPreferences {
     pub canvas_layout: String, // Canvas display mode: grid or list
     #[serde(default = "default_confirm_session_close")]
     pub confirm_session_close: bool, // Show confirmation dialog before closing sessions/worktrees
+    #[serde(default = "default_execution_mode")]
+    pub default_execution_mode: String, // Default execution mode: "plan", "build", or "yolo"
     #[serde(default = "default_backend")]
     pub default_backend: String, // Default CLI backend: "claude", "codex", or "opencode"
     #[serde(default = "default_codex_model")]
@@ -362,6 +364,10 @@ fn default_canvas_layout() -> String {
 
 fn default_confirm_session_close() -> bool {
     true // Enabled by default
+}
+
+fn default_execution_mode() -> String {
+    "plan".to_string()
 }
 
 fn default_backend() -> String {
@@ -1095,6 +1101,7 @@ impl Default for AppPreferences {
             default_provider: None,
             canvas_layout: default_canvas_layout(),
             confirm_session_close: default_confirm_session_close(),
+            default_execution_mode: default_execution_mode(),
             default_backend: default_backend(),
             selected_codex_model: default_codex_model(),
             selected_opencode_model: default_opencode_model(),

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -566,14 +566,15 @@ export function ChatWindow({
   // PERFORMANCE: Track hasValue via callback from ChatInput instead of store subscription
   // ChatInput notifies on mount, session change, and empty/non-empty boundary changes
   const [hasInputValue, setHasInputValue] = useState(false)
-  // Per-session execution mode (defaults to 'plan' for new sessions)
+  // Per-session execution mode (defaults to preference or 'plan' for new sessions)
   // Uses deferredSessionId for display consistency with other content
+  const defaultExecutionMode = preferences?.default_execution_mode ?? 'plan'
   const executionMode = useChatStore(state =>
     deferredSessionId
       ? (state.executionModes[deferredSessionId] ??
         session?.selected_execution_mode ??
-        'plan')
-      : 'plan'
+        defaultExecutionMode)
+      : defaultExecutionMode
   )
   // Executing mode - the mode the currently-running prompt was sent with
   // Uses activeSessionId for immediate status feedback (not deferred)

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -931,6 +931,27 @@ export const GeneralPane: React.FC = () => {
           </InlineField>
 
           <InlineField
+            label="Default mode"
+            description="Permission mode for new sessions"
+          >
+            <Select
+              value={preferences?.default_execution_mode ?? 'plan'}
+              onValueChange={(value: 'plan' | 'build' | 'yolo') => {
+                patchPreferences.mutate({ default_execution_mode: value })
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="plan">Plan</SelectItem>
+                <SelectItem value="build">Build</SelectItem>
+                <SelectItem value="yolo">Yolo</SelectItem>
+              </SelectContent>
+            </Select>
+          </InlineField>
+
+          <InlineField
             label="Build execution"
             description="Backend, model, and thinking/effort override when approving plans"
           >

--- a/src/services/preferences.test.ts
+++ b/src/services/preferences.test.ts
@@ -134,6 +134,7 @@ describe('preferences service', () => {
 
         auto_pull_base_branch: true,
         confirm_session_close: true,
+        default_execution_mode: 'plan',
         default_backend: 'claude',
         selected_codex_model: 'gpt-5.4',
         selected_opencode_model: 'opencode/gpt-5.3-codex',
@@ -249,6 +250,7 @@ describe('preferences service', () => {
 
         auto_pull_base_branch: true,
         confirm_session_close: true,
+        default_execution_mode: 'plan',
         default_backend: 'claude',
         selected_codex_model: 'gpt-5.4',
         selected_opencode_model: 'opencode/gpt-5.3-codex',
@@ -336,6 +338,7 @@ describe('preferences service', () => {
 
         auto_pull_base_branch: true,
         confirm_session_close: true,
+        default_execution_mode: 'plan',
         default_backend: 'claude',
         selected_codex_model: 'gpt-5.3-fast' as AppPreferences['selected_codex_model'],
         selected_opencode_model: 'opencode/gpt-5.3-codex',
@@ -424,6 +427,7 @@ describe('preferences service', () => {
 
         auto_pull_base_branch: true,
         confirm_session_close: true,
+        default_execution_mode: 'plan',
         default_backend: 'claude',
         selected_codex_model: 'gpt-5.4',
         selected_opencode_model: 'opencode/gpt-5.3-codex',
@@ -514,6 +518,7 @@ describe('preferences service', () => {
 
         auto_pull_base_branch: true,
         confirm_session_close: true,
+        default_execution_mode: 'plan',
         default_backend: 'claude',
         selected_codex_model: 'gpt-5.4',
         selected_opencode_model: 'opencode/gpt-5.3-codex',
@@ -604,6 +609,7 @@ describe('preferences service', () => {
 
         auto_pull_base_branch: true,
         confirm_session_close: true,
+        default_execution_mode: 'plan',
         default_backend: 'claude',
         selected_codex_model: 'gpt-5.4',
         selected_opencode_model: 'opencode/gpt-5.3-codex',
@@ -692,6 +698,7 @@ describe('preferences service', () => {
 
         auto_pull_base_branch: true,
         confirm_session_close: true,
+        default_execution_mode: 'plan',
         default_backend: 'claude',
         selected_codex_model: 'gpt-5.4',
         selected_opencode_model: 'opencode/gpt-5.3-codex',

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1,4 +1,4 @@
-import type { ThinkingLevel, EffortLevel } from './chat'
+import type { ThinkingLevel, EffortLevel, ExecutionMode } from './chat'
 import { DEFAULT_KEYBINDINGS, type KeybindingsMap } from './keybindings'
 
 // =============================================================================
@@ -895,6 +895,7 @@ export interface AppPreferences {
   default_provider: string | null // Default provider profile name (null = Anthropic direct)
 
   confirm_session_close: boolean // Show confirmation dialog before closing sessions/worktrees
+  default_execution_mode: ExecutionMode // Default execution mode for new sessions: 'plan', 'build', or 'yolo'
   default_backend: CliBackend // Default CLI backend for new sessions: 'claude', 'codex', or 'opencode'
   selected_codex_model: CodexModel // Default Codex model
   selected_opencode_model: string // Default OpenCode model (provider/model)
@@ -1414,6 +1415,7 @@ export const defaultPreferences: AppPreferences = {
   custom_cli_profiles: [],
   default_provider: null,
   confirm_session_close: true, // Default: enabled (show confirmation)
+  default_execution_mode: 'plan', // Default: plan mode
   default_backend: 'claude', // Default: Claude
   selected_codex_model: 'gpt-5.4', // Default: latest Codex model
   selected_opencode_model: 'opencode/gpt-5.3-codex', // Default OpenCode model


### PR DESCRIPTION
## Summary

- Adds a **Default mode** preference (`default_execution_mode`) so users can choose whether new sessions start in Plan, Build, or Yolo mode
- Previously hardcoded to Plan; now configurable via **Settings > Defaults** dropdown
- Applies to all new sessions that don't already have a persisted execution mode

## Changes

- **`src/types/preferences.ts`** — Added `ExecutionMode` import and `default_execution_mode` field to `AppPreferences` interface + defaults
- **`src-tauri/src/lib.rs`** — Added `default_execution_mode` field to Rust `AppPreferences` struct with `"plan"` default, plus `Default` impl
- **`src/components/chat/ChatWindow.tsx`** — Replaced hardcoded `'plan'` fallback with preference-based default
- **`src/components/preferences/panes/GeneralPane.tsx`** — Added "Default mode" dropdown (Plan/Build/Yolo) in the Defaults settings section
- **`src/services/preferences.test.ts`** — Added `default_execution_mode` field to all test fixtures

## Test plan

- [x] TypeScript typecheck passes (`bun run typecheck`)
- [x] All 235 frontend tests pass (`bun run test:run`)
- [x] All 111 Rust tests pass (`bun run rust:test`)
- [x] Rust compiles without errors related to this change
- [ ] Manual: Open Settings > Defaults, verify "Default mode" dropdown appears below "Default backend"
- [ ] Manual: Set default mode to Yolo, create a new session, verify it starts in Yolo mode
- [ ] Manual: Existing sessions with a persisted mode should keep their mode (not overridden by new default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)