### PR TITLE
fix(ui): enable text selection in ReviewResultsPanel

### DIFF
--- a/src/components/chat/ReviewResultsPanel.tsx
+++ b/src/components/chat/ReviewResultsPanel.tsx
@@ -207,7 +207,7 @@ const FindingCard = memo(function FindingCard({
         <CollapsibleContent>
           <div className="px-4 pb-4 pt-3 space-y-3 border-t border-border/50">
             {/* File location */}
-            <p className="text-xs font-mono">
+            <p className="text-xs font-mono select-text cursor-text">
               <span className="text-muted-foreground">Affected code: </span>
               <span className="text-foreground">
                 {finding.file}
@@ -216,7 +216,7 @@ const FindingCard = memo(function FindingCard({
             </p>
 
             {/* Description */}
-            <p className="text-sm text-muted-foreground">
+            <p className="text-sm text-muted-foreground select-text cursor-text">
               {finding.description}
             </p>
 
@@ -227,7 +227,7 @@ const FindingCard = memo(function FindingCard({
                   Suggested fix:
                 </p>
                 <div className="rounded-md bg-muted/50 p-2 border">
-                  <pre className="text-xs font-mono whitespace-pre-wrap text-foreground/80">
+                  <pre className="text-xs font-mono whitespace-pre-wrap text-foreground/80 select-text cursor-text">
                     {finding.suggestion}
                   </pre>
                 </div>
@@ -498,7 +498,7 @@ Please apply all these fixes to the codebase.`
                 </Badge>
               )}
             </div>
-            <p className="text-sm leading-6 text-muted-foreground">
+            <p className="text-sm leading-6 text-muted-foreground select-text cursor-text">
               {reviewResults.summary}
             </p>
           </div>


### PR DESCRIPTION
## Summary

- Adds `select-text cursor-text` classes to ReviewResultsPanel content areas (summary, finding descriptions, file locations, suggested fixes) so users can select and copy review findings for pasting into GitHub PR reviews
- The global `body.native-app` rule disables text selection; the existing `select-text` class is the opt-in override used elsewhere in the codebase

> Note: I made this change as I usually see the review comments in the review panel copy and paste them on github PR review as inline comments. I have tested it locally and it works, I understand that this might be too specific for me , if it is I am open to closing this as Id rather not bother maintainers with unnesesary PR's.  

## Changes

- **`src/components/chat/ReviewResultsPanel.tsx`** — Added `select-text cursor-text` to 4 content elements:
  - Review summary text (line 501)
  - Finding file location (line 210)
  - Finding description (line 219)
  - Suggested fix `<pre>` block (line 230)

## Test plan

- [x] TypeScript typecheck passes
- [x] All frontend tests pass (253/254 — 1 pre-existing failure in `StreamingMessage.test.tsx` on `main`)
- [x] No new lint or format warnings introduced (all pre-existing on `main`)
- [ ] Manual: Open a review in the sidebar, verify text in summary, descriptions, and suggested fixes is selectable and copyable

🤖 Generated with [Claude Code](https://claude.com/claude-code)