### PR TITLE
perf(chat): batch thinking deltas via rAF to reduce re-renders

### DIFF
--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -232,10 +232,28 @@ export default function useStreamingEvents({
       }
     )
 
-    // Handle thinking content blocks (extended thinking)
+    // Buffer thinking deltas and flush on animation frames (same pattern as chunks).
+    // OpenCode/Codex stream thinking as frequent small deltas; without batching,
+    // each delta triggers a store mutation + re-render.
+    const thinkingBuffer: Record<string, string> = {}
+    let thinkingRafId: number | null = null
+
+    function flushThinkingBuffer() {
+      thinkingRafId = null
+      for (const [sid, buffered] of Object.entries(thinkingBuffer)) {
+        addThinkingBlock(sid, buffered)
+      }
+      for (const key of Object.keys(thinkingBuffer)) {
+        delete thinkingBuffer[key]
+      }
+    }
+
     const unlistenThinking = listen<ThinkingEvent>('chat:thinking', event => {
       const { session_id, content } = event.payload
-      addThinkingBlock(session_id, content)
+      thinkingBuffer[session_id] = (thinkingBuffer[session_id] ?? '') + content
+      if (thinkingRafId === null) {
+        thinkingRafId = requestAnimationFrame(flushThinkingBuffer)
+      }
     })
 
     // Handle tool result events (tool execution output)
@@ -304,10 +322,14 @@ export default function useStreamingEvents({
       const sessionId = event.payload.session_id
       const worktreeId = event.payload.worktree_id
 
-      // Flush any buffered chunks so streamingContents is up to date
+      // Flush any buffered chunks/thinking so streaming state is up to date
       if (chunkRafId !== null) {
         cancelAnimationFrame(chunkRafId)
         flushChunkBuffer()
+      }
+      if (thinkingRafId !== null) {
+        cancelAnimationFrame(thinkingRafId)
+        flushThinkingBuffer()
       }
 
       console.log(`[Done] chat:done received session=${sessionId}`, { currentSending: Object.keys(useChatStore.getState().sendingSessionIds) })
@@ -1055,10 +1077,14 @@ export default function useStreamingEvents({
           emitted_at_ms,
         } = event.payload
 
-        // Flush any buffered chunks so streamingContents is up to date
+        // Flush any buffered chunks/thinking so streaming state is up to date
         if (chunkRafId !== null) {
           cancelAnimationFrame(chunkRafId)
           flushChunkBuffer()
+        }
+        if (thinkingRafId !== null) {
+          cancelAnimationFrame(thinkingRafId)
+          flushThinkingBuffer()
         }
 
         console.log(`[Cancelled] chat:cancelled received session=${session_id} undo_send=${undo_send}`, { currentSending: Object.keys(useChatStore.getState().sendingSessionIds) })
@@ -1425,10 +1451,14 @@ export default function useStreamingEvents({
     })
 
     return () => {
-      // Flush any buffered chunks before tearing down
+      // Flush any buffered chunks/thinking before tearing down
       if (chunkRafId !== null) {
         cancelAnimationFrame(chunkRafId)
         flushChunkBuffer()
+      }
+      if (thinkingRafId !== null) {
+        cancelAnimationFrame(thinkingRafId)
+        flushThinkingBuffer()
       }
       unlistenSending.then(f => f())
       unlistenChunk.then(f => f())

--- a/src/store/chat-store.ts
+++ b/src/store/chat-store.ts
@@ -1147,7 +1147,7 @@ export const useChatStore = create<ChatUIState>()(
               const newBlocks = [...blocks]
               newBlocks[newBlocks.length - 1] = {
                 type: 'thinking',
-                thinking: lastBlock.thinking + '\n\n---\n\n' + thinking,
+                thinking: lastBlock.thinking + thinking,
               }
               return {
                 streamingContentBlocks: {


### PR DESCRIPTION
## Summary

- Batch thinking content deltas using `requestAnimationFrame` to prevent excessive re-renders from frequent small streaming updates
- Remove `\n\n---\n\n` separator that was being inserted between thinking blocks
- Ensure thinking buffer is flushed on stream completion (`chat:done`, `chat:cancelled`) and hook cleanup
- Aligns thinking delta handling with existing chunk batching pattern

## Details

OpenCode/Codex stream thinking blocks as frequent small deltas. Previously, each delta triggered a store mutation and re-render, causing performance degradation and excessive newline breaks in the UI.

This change buffers thinking deltas and flushes them on animation frames, matching the proven pattern used for regular message chunks. The unwanted `\n\n---\n\n` separator has been removed to fix the visual line-splitting issue.

Fixes #192

---

Fixes #192