### PR TITLE
fix(chat): centralize session completion state persistence to backend

### DIFF
--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -2529,8 +2529,22 @@ pub async fn send_chat_message(
         });
     }
 
-    // Create assistant message with tool calls and content blocks
+    // Pre-compute completion state flags before moving unified_response fields
     let has_content = !unified_response.content.is_empty();
+    let was_cancelled = unified_response.cancelled;
+    let has_blocking_tool = unified_response
+        .tool_calls
+        .iter()
+        .any(|tc| tc.name == "AskUserQuestion" || tc.name == "ExitPlanMode");
+    let has_question_tool = unified_response
+        .tool_calls
+        .iter()
+        .any(|tc| tc.name == "AskUserQuestion");
+    let is_plan_mode_with_content = matches!(response_backend, Backend::Codex | Backend::Opencode)
+        && execution_mode.as_deref() == Some("plan")
+        && has_content;
+
+    // Create assistant message with tool calls and content blocks
     let assistant_msg_id = Uuid::new_v4().to_string();
     let assistant_msg = ChatMessage {
         id: assistant_msg_id.clone(),
@@ -2553,7 +2567,7 @@ pub async fn send_chat_message(
     // Messages are loaded from NDJSON on demand via load_session_messages().
 
     // Finalize run log (complete or cancel based on response status)
-    if unified_response.cancelled {
+    if was_cancelled {
         let cancel_resume_sid =
             if response_backend != Backend::Claude || resume_id_for_log.is_empty() {
                 None
@@ -2594,16 +2608,43 @@ pub async fn send_chat_message(
                     }
                 }
             }
+
+            // Persist completion state (single authoritative write).
+            // This eliminates the dual-client race where both native and web frontends
+            // independently call update_session_state with conflicting decisions.
+            // Flags are pre-computed above before unified_response fields are moved.
+            if was_cancelled {
+                // Cancelled: don't change waiting/reviewing state
+            } else if has_blocking_tool {
+                session.waiting_for_input = true;
+                session.is_reviewing = false;
+                session.waiting_for_input_type = Some(
+                    if has_question_tool {
+                        "question"
+                    } else {
+                        "plan"
+                    }
+                    .to_string(),
+                );
+            } else if is_plan_mode_with_content {
+                // Codex/OpenCode plan-mode with content → waiting for plan approval
+                session.waiting_for_input = true;
+                session.is_reviewing = false;
+                session.waiting_for_input_type = Some("plan".to_string());
+            } else {
+                // Normal completion
+                session.waiting_for_input = false;
+                session.is_reviewing = true;
+                session.waiting_for_input_type = None;
+            }
         }
         Ok(())
     })?;
 
-    // NOTE: Plan-waiting state for Codex/Opencode is now signaled via the
-    // `waiting_for_plan` field in the chat:done event, and persisted by the
-    // frontend's chat:done handler. The previous approach of setting it here
-    // raced with the frontend (chat:done fires before this code runs).
+    // Emit cache invalidation so all clients (native + web) refetch authoritative state
+    emit_sessions_cache_invalidation(&app);
 
-    if unified_response.cancelled {
+    if was_cancelled {
         log::info!("[SendChat] EXIT session={session_id} reason=cancelled_with_content");
     } else {
         log::info!("[SendChat] EXIT session={session_id} reason=success");

--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -241,7 +241,9 @@ pub async fn dispatch_command(
         "detect_and_link_pr" => {
             let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
             let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
-            let result = crate::projects::detect_and_link_pr(app.clone(), worktree_id, worktree_path).await?;
+            let result =
+                crate::projects::detect_and_link_pr(app.clone(), worktree_id, worktree_path)
+                    .await?;
             if result.is_some() {
                 emit_cache_invalidation(app, &["projects"]);
             }

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -4494,9 +4494,7 @@ pub async fn detect_and_link_pr(
 
     if let Ok(view_out) = view_output {
         if view_out.status.success() {
-            if let Ok(view_json) =
-                serde_json::from_slice::<serde_json::Value>(&view_out.stdout)
-            {
+            if let Ok(view_json) = serde_json::from_slice::<serde_json::Value>(&view_out.stdout) {
                 let pr_number = view_json["number"].as_u64().unwrap_or(0) as u32;
                 let pr_url = view_json["url"].as_str().unwrap_or("").to_string();
                 let title = view_json["title"].as_str().unwrap_or("").to_string();
@@ -4506,9 +4504,7 @@ pub async fn detect_and_link_pr(
 
                     // Save PR info to worktree
                     if let Ok(mut data) = load_projects_data(&app) {
-                        if let Some(wt) =
-                            data.worktrees.iter_mut().find(|w| w.id == worktree_id)
-                        {
+                        if let Some(wt) = data.worktrees.iter_mut().find(|w| w.id == worktree_id) {
                             wt.pr_number = Some(pr_number);
                             wt.pr_url = Some(pr_url.clone());
                             let _ = save_projects_data(&app, &data);

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -15,6 +15,10 @@ import { isAskUserQuestion, isExitPlanMode } from '@/types/chat'
 import { playNotificationSound } from '@/lib/sounds'
 import { findPlanFilePath } from '@/components/chat/tool-call-utils'
 import { generateId } from '@/lib/uuid'
+import {
+  markBackendPersisting,
+  clearBackendPersisting,
+} from '@/lib/backend-persist-guard'
 import type {
   ChunkEvent,
   ToolUseEvent,
@@ -453,10 +457,11 @@ export default function useStreamingEvents({
       clearLastSentMessage(sessionId)
       useChatStore.getState().clearLastSentAttachments(sessionId)
 
-      // Track disk persistence promise so invalidateQueries waits for it.
-      // Without this, stale data is refetched before the write completes,
-      // causing waiting↔review oscillation via useSessionStatePersistence.
-      let persistencePromise: Promise<unknown> | null = null
+      // Completion state is now persisted by the backend (single authoritative write).
+      // Frontend only updates in-memory state (Zustand + TanStack Query caches).
+      // Guard: prevent useImmediateSessionStateSave from racing with backend write.
+      markBackendPersisting(sessionId)
+      setTimeout(() => clearBackendPersisting(sessionId), 2000)
 
       if (hasUnansweredBlockingTool) {
         // YOLO mode auto-continue: automatically answer blocking tools and continue
@@ -584,20 +589,6 @@ export default function useStreamingEvents({
           // Batch-clear text content, executing mode, sending — set waiting state
           pauseSession(sessionId)
 
-          // Determine waiting type: question or plan
-          const hasUnansweredQuestion = effectiveToolCalls?.some(
-            tc => isAskUserQuestion(tc) && !isQuestionAnswered(sessionId, tc.id)
-          )
-          const hasUnansweredPlan = effectiveToolCalls?.some(
-            tc => isExitPlanMode(tc) && !isQuestionAnswered(sessionId, tc.id)
-          )
-          // Questions take priority over plans for the type indicator
-          const waitingType: 'question' | 'plan' | null = hasUnansweredQuestion
-            ? 'question'
-            : hasUnansweredPlan
-              ? 'plan'
-              : null
-
           // Persist plan file path and pending message ID for ExitPlanMode
           if (effectiveToolCalls) {
             const planPath = findPlanFilePath(effectiveToolCalls)
@@ -617,44 +608,26 @@ export default function useStreamingEvents({
                 .getState()
                 .setPendingPlanMessageId(sessionId, pendingMessageId)
 
-              // Persist to disk BEFORE invalidateQueries (prevent stale refetch)
+              // Persist plan file path + pending message ID (non-state metadata).
+              // Completion state (waitingForInput) is persisted by the backend.
               const { worktreePaths } = useChatStore.getState()
               const wtPath = worktreePaths[worktreeId]
               if (wtPath) {
-                persistencePromise = invoke('update_session_state', {
+                invoke('update_session_state', {
                   worktreeId,
                   worktreePath: wtPath,
                   sessionId,
                   planFilePath: planPath ?? undefined,
                   pendingPlanMessageId: pendingMessageId,
-                  waitingForInput: true,
-                  waitingForInputType: waitingType,
                 }).catch(err => {
                   console.error(
-                    '[useStreamingEvents] Failed to persist plan state:',
-                    err
-                  )
-                })
-              }
-            } else if (waitingType === 'question') {
-              // Persist to disk BEFORE invalidateQueries (prevent stale refetch)
-              const { worktreePaths } = useChatStore.getState()
-              const wtPath = worktreePaths[worktreeId]
-              if (wtPath) {
-                persistencePromise = invoke('update_session_state', {
-                  worktreeId,
-                  worktreePath: wtPath,
-                  sessionId,
-                  waitingForInput: true,
-                  waitingForInputType: waitingType,
-                }).catch(err => {
-                  console.error(
-                    '[useStreamingEvents] Failed to persist question state:',
+                    '[useStreamingEvents] Failed to persist plan metadata:',
                     err
                   )
                 })
               }
             }
+            // Question waiting state is persisted by the backend — no frontend persist needed.
           }
 
           // Play waiting sound if not currently viewing this session
@@ -748,24 +721,24 @@ export default function useStreamingEvents({
             .setPendingPlanMessageId(sessionId, planMessageId)
         }
 
-        // 4. Persist to disk BEFORE invalidating queries
-        const { worktreePaths: wtPaths2 } = useChatStore.getState()
-        const wtPath2 = wtPaths2[worktreeId]
-        if (wtPath2) {
-          persistencePromise = invoke('update_session_state', {
-            worktreeId,
-            worktreePath: wtPath2,
-            sessionId,
-            isReviewing: false,
-            waitingForInput: true,
-            waitingForInputType: 'plan',
-            pendingPlanMessageId: planMessageId ?? null,
-          }).catch(err =>
-            console.error(
-              '[useStreamingEvents] Failed to persist plan-waiting state:',
-              err
+        // Plan-waiting state is persisted by the backend.
+        // Persist plan metadata (pendingPlanMessageId) only.
+        if (planMessageId) {
+          const { worktreePaths: wtPaths2 } = useChatStore.getState()
+          const wtPath2 = wtPaths2[worktreeId]
+          if (wtPath2) {
+            invoke('update_session_state', {
+              worktreeId,
+              worktreePath: wtPath2,
+              sessionId,
+              pendingPlanMessageId: planMessageId,
+            }).catch(err =>
+              console.error(
+                '[useStreamingEvents] Failed to persist plan metadata:',
+                err
+              )
             )
-          )
+          }
         }
 
         // Play waiting sound if not currently viewing this session
@@ -856,25 +829,7 @@ export default function useStreamingEvents({
         console.log(`[Done] about to completeSession session=${sessionId}`, { currentSending: Object.keys(useChatStore.getState().sendingSessionIds) })
         completeSession(sessionId)
 
-        // Persist reviewing state to disk BEFORE invalidating queries.
-        // Without this, invalidateQueries can refetch stale is_reviewing: false
-        // and useSessionStatePersistence overwrites Zustand, causing idle↔review oscillation.
-        const { worktreePaths: wtPaths } = useChatStore.getState()
-        const wtPath = wtPaths[worktreeId]
-        if (wtPath) {
-          persistencePromise = invoke('update_session_state', {
-            worktreeId,
-            worktreePath: wtPath,
-            sessionId,
-            isReviewing: true,
-            waitingForInput: false,
-          }).catch(err =>
-            console.error(
-              '[useStreamingEvents] Failed to persist reviewing state:',
-              err
-            )
-          )
-        }
+        // Reviewing state is persisted by the backend — no frontend persist needed.
 
         // Play review sound if not currently viewing this session
         if (!isCurrentlyViewing) {
@@ -949,26 +904,17 @@ export default function useStreamingEvents({
       )
 
       // Invalidate sessions list to update metadata.
-      // Wait for disk persistence (if any) to complete first — otherwise
-      // invalidateQueries refetches stale data and useSessionStatePersistence
-      // overwrites Zustand, causing waiting↔review oscillation.
-      const invalidateSessions = () => {
-        queryClient.invalidateQueries({
-          queryKey: chatQueryKeys.sessions(worktreeId),
-        })
-        queryClient.invalidateQueries({ queryKey: ['all-sessions'] })
-        // Invalidate individual session so cross-client viewers get the
-        // complete conversation (user message + assistant response).
-        queryClient.invalidateQueries({
-          queryKey: chatQueryKeys.session(sessionId),
-        })
-      }
-
-      if (persistencePromise) {
-        persistencePromise.finally(invalidateSessions)
-      } else {
-        invalidateSessions()
-      }
+      // Backend persists completion state and emits cache:invalidate, but we also
+      // invalidate here for optimistic cache consistency on the local client.
+      queryClient.invalidateQueries({
+        queryKey: chatQueryKeys.sessions(worktreeId),
+      })
+      queryClient.invalidateQueries({ queryKey: ['all-sessions'] })
+      // Invalidate individual session so cross-client viewers get the
+      // complete conversation (user message + assistant response).
+      queryClient.invalidateQueries({
+        queryKey: chatQueryKeys.session(sessionId),
+      })
     })
 
     // Handle errors from Claude CLI

--- a/src/hooks/useImmediateSessionStateSave.ts
+++ b/src/hooks/useImmediateSessionStateSave.ts
@@ -4,6 +4,7 @@ import { invoke } from '@/lib/transport'
 import { logger } from '@/lib/logger'
 import type { LabelData } from '@/types/chat'
 import { isSessionStateHydrating } from '@/lib/session-state-hydration'
+import { isBackendPersisting } from '@/lib/backend-persist-guard'
 
 /**
  * Saves reviewing/waiting state immediately when it changes.
@@ -53,16 +54,21 @@ export function useImmediateSessionStateSave() {
           reviewingSessions
         )) {
           if (prevReviewingRef.current[sessionId] !== isReviewing) {
-            saveSessionStatus(sessionId, sessionWorktreeMap, worktreePaths, {
-              isReviewing,
-            })
+            // Skip if backend is persisting completion state for this session
+            if (!isBackendPersisting(sessionId)) {
+              saveSessionStatus(sessionId, sessionWorktreeMap, worktreePaths, {
+                isReviewing,
+              })
+            }
           }
         }
         for (const sessionId of Object.keys(prevReviewingRef.current)) {
           if (!(sessionId in reviewingSessions)) {
-            saveSessionStatus(sessionId, sessionWorktreeMap, worktreePaths, {
-              isReviewing: false,
-            })
+            if (!isBackendPersisting(sessionId)) {
+              saveSessionStatus(sessionId, sessionWorktreeMap, worktreePaths, {
+                isReviewing: false,
+              })
+            }
           }
         }
         prevReviewingRef.current = reviewingSessions
@@ -73,16 +79,21 @@ export function useImmediateSessionStateSave() {
           waitingForInputSessionIds
         )) {
           if (prevWaitingRef.current[sessionId] !== isWaiting) {
-            saveSessionStatus(sessionId, sessionWorktreeMap, worktreePaths, {
-              waitingForInput: isWaiting,
-            })
+            // Skip if backend is persisting completion state for this session
+            if (!isBackendPersisting(sessionId)) {
+              saveSessionStatus(sessionId, sessionWorktreeMap, worktreePaths, {
+                waitingForInput: isWaiting,
+              })
+            }
           }
         }
         for (const sessionId of Object.keys(prevWaitingRef.current)) {
           if (!(sessionId in waitingForInputSessionIds)) {
-            saveSessionStatus(sessionId, sessionWorktreeMap, worktreePaths, {
-              waitingForInput: false,
-            })
+            if (!isBackendPersisting(sessionId)) {
+              saveSessionStatus(sessionId, sessionWorktreeMap, worktreePaths, {
+                waitingForInput: false,
+              })
+            }
           }
         }
         prevWaitingRef.current = waitingForInputSessionIds

--- a/src/lib/backend-persist-guard.ts
+++ b/src/lib/backend-persist-guard.ts
@@ -1,0 +1,23 @@
+/**
+ * Guards against useImmediateSessionStateSave racing with backend completion state writes.
+ *
+ * When chat:done fires, the backend persists completion state (waitingForInput, isReviewing)
+ * authoritatively. The frontend updates Zustand in-memory, which triggers
+ * useImmediateSessionStateSave to also write to disk — creating a race.
+ *
+ * This guard prevents the frontend's immediate-save from writing completion state
+ * while the backend write is in flight.
+ */
+const pendingSessions = new Set<string>()
+
+export function markBackendPersisting(sessionId: string) {
+  pendingSessions.add(sessionId)
+}
+
+export function clearBackendPersisting(sessionId: string) {
+  pendingSessions.delete(sessionId)
+}
+
+export function isBackendPersisting(sessionId: string) {
+  return pendingSessions.has(sessionId)
+}


### PR DESCRIPTION
## Summary

- Moves completion state persistence (`waiting_for_input`, `is_reviewing`, `waiting_for_input_type`) from frontend to backend as the single authoritative source
- Eliminates race condition where native and web frontends independently wrote conflicting state after chat completion
- Backend pre-computes completion flags before moving unified_response fields, then persists in a single write
- Frontend guards against racing with backend writes using a 2-second fence during cache invalidation
- Frontend continues to persist non-state metadata (plan file path, pending message ID)
- Emits cache invalidation event so all connected clients refetch authoritative state from backend

## Problem

When `chat:done` fires, both the native and web frontends independently call `update_session_state` to persist completion state. This caused:
- "Waiting ↔ review oscillation" where rapid cache refetches and frontend overwrites triggered state-dependent hooks repeatedly
- Flaky session state when multiple clients competed to persist conflicting decisions
- Difficult debugging due to non-deterministic ordering of frontend writes vs. cache refetches

## Solution

**Backend now owns completion state persistence:**
- Pre-computes completion flags (`was_cancelled`, `has_blocking_tool`, `is_plan_mode_with_content`) immediately after response processing
- Persists waiting/reviewing state to disk in a single authoritative write within the session update block
- Emits `cache:invalidate` so all clients refetch authoritative state

**Frontend stops racing on completion state:**
- Removes frontend persistence of `waiting_for_input` and `is_reviewing`
- Guards `useImmediateSessionStateSave` with `isBackendPersisting()` to skip writes during backend flight window (2s)
- Still persists plan metadata (non-state) for ExitPlanMode UX

**Result:** Single source of truth, no dual-client races, and better consistency across native + web frontends.