### PR TITLE
fix(commands): fix visibility on Windows and support project-level commands

### DIFF
--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -1315,11 +1315,13 @@ pub async fn dispatch_command(
         // Skills & Search
         // =====================================================================
         "list_claude_skills" => {
-            let result = crate::projects::list_claude_skills().await?;
+            let worktree_path: Option<String> = field_opt(&args, "worktreePath", "worktree_path")?;
+            let result = crate::projects::list_claude_skills(worktree_path).await?;
             to_value(result)
         }
         "list_claude_commands" => {
-            let result = crate::projects::list_claude_commands().await?;
+            let worktree_path: Option<String> = field_opt(&args, "worktreePath", "worktree_path")?;
+            let result = crate::projects::list_claude_commands(worktree_path).await?;
             to_value(result)
         }
         "search_github_issues" => {

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -8351,24 +8351,27 @@ fn resolve_command_interpolations(content: &str, working_dir: &str) -> String {
     resolved
 }
 
-/// List Claude CLI skills from ~/.claude/skills/
-/// Skills are directories containing a SKILL.md file
-#[tauri::command]
-pub async fn list_claude_skills() -> Result<Vec<ClaudeSkill>, String> {
-    log::trace!("Listing Claude CLI skills");
+/// Get home directory with Windows USERPROFILE fallback
+fn get_home_dir() -> Option<std::path::PathBuf> {
+    dirs::home_dir().or_else(|| std::env::var("USERPROFILE").ok().map(std::path::PathBuf::from))
+}
 
-    let home = dirs::home_dir().ok_or_else(|| "Failed to get home directory".to_string())?;
-    let skills_dir = home.join(".claude").join("skills");
-
-    if !skills_dir.exists() {
-        log::trace!("Skills directory does not exist: {:?}", skills_dir);
-        return Ok(Vec::new());
+/// Collect skills from a directory into a map (later inserts override earlier ones)
+fn collect_skills_from_dir(
+    dir: &std::path::Path,
+    skills: &mut std::collections::HashMap<String, ClaudeSkill>,
+) {
+    if !dir.exists() {
+        return;
     }
 
-    let mut skills = Vec::new();
-
-    let entries = std::fs::read_dir(&skills_dir)
-        .map_err(|e| format!("Failed to read skills directory: {e}"))?;
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            log::warn!("Failed to read skills directory {dir:?}: {e}");
+            return;
+        }
+    };
 
     for entry in entries {
         let entry = match entry {
@@ -8380,13 +8383,10 @@ pub async fn list_claude_skills() -> Result<Vec<ClaudeSkill>, String> {
         };
 
         let path = entry.path();
-
-        // Only process directories
         if !path.is_dir() {
             continue;
         }
 
-        // Check for SKILL.md inside the directory
         let skill_file = path.join("SKILL.md");
         if !skill_file.exists() {
             continue;
@@ -8402,7 +8402,6 @@ pub async fn list_claude_skills() -> Result<Vec<ClaudeSkill>, String> {
             continue;
         }
 
-        // Try to extract description from first line of SKILL.md (if starts with #)
         let description = std::fs::read_to_string(&skill_file)
             .ok()
             .and_then(|content| {
@@ -8412,35 +8411,33 @@ pub async fn list_claude_skills() -> Result<Vec<ClaudeSkill>, String> {
                     .and_then(|line| line.strip_prefix("# ").map(|s| s.to_string()))
             });
 
-        skills.push(ClaudeSkill {
-            name,
-            path: skill_file.to_string_lossy().to_string(),
-            description,
-        });
+        skills.insert(
+            name.clone(),
+            ClaudeSkill {
+                name,
+                path: skill_file.to_string_lossy().to_string(),
+                description,
+            },
+        );
     }
-
-    skills.sort_by(|a, b| a.name.cmp(&b.name));
-    log::trace!("Found {} Claude CLI skills", skills.len());
-    Ok(skills)
 }
 
-/// List Claude CLI custom commands from ~/.claude/commands/
-#[tauri::command]
-pub async fn list_claude_commands() -> Result<Vec<ClaudeCommand>, String> {
-    log::trace!("Listing Claude CLI custom commands");
-
-    let home = dirs::home_dir().ok_or_else(|| "Failed to get home directory".to_string())?;
-    let commands_dir = home.join(".claude").join("commands");
-
-    if !commands_dir.exists() {
-        log::trace!("Commands directory does not exist: {:?}", commands_dir);
-        return Ok(Vec::new());
+/// Collect commands from a directory into a map (later inserts override earlier ones)
+fn collect_commands_from_dir(
+    dir: &std::path::Path,
+    commands: &mut std::collections::HashMap<String, ClaudeCommand>,
+) {
+    if !dir.exists() {
+        return;
     }
 
-    let mut commands = Vec::new();
-
-    let entries = std::fs::read_dir(&commands_dir)
-        .map_err(|e| format!("Failed to read commands directory: {e}"))?;
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            log::warn!("Failed to read commands directory {dir:?}: {e}");
+            return;
+        }
+    };
 
     for entry in entries {
         let entry = match entry {
@@ -8452,8 +8449,6 @@ pub async fn list_claude_commands() -> Result<Vec<ClaudeCommand>, String> {
         };
 
         let path = entry.path();
-
-        // Only process .md files
         if path.extension().is_none_or(|ext| ext != "md") {
             continue;
         }
@@ -8473,13 +8468,65 @@ pub async fn list_claude_commands() -> Result<Vec<ClaudeCommand>, String> {
             description
         });
 
-        commands.push(ClaudeCommand {
-            name,
-            path: path.to_string_lossy().to_string(),
-            description,
-        });
+        commands.insert(
+            name.clone(),
+            ClaudeCommand {
+                name,
+                path: path.to_string_lossy().to_string(),
+                description,
+            },
+        );
+    }
+}
+
+/// List Claude CLI skills from ~/.claude/skills/ and optionally <worktree>/.claude/skills/
+/// Skills are directories containing a SKILL.md file
+#[tauri::command]
+pub async fn list_claude_skills(
+    worktree_path: Option<String>,
+) -> Result<Vec<ClaudeSkill>, String> {
+    log::trace!("Listing Claude CLI skills (worktree: {worktree_path:?})");
+
+    let mut skills_map = std::collections::HashMap::new();
+
+    // Global skills (~/.claude/skills/)
+    if let Some(home) = get_home_dir() {
+        collect_skills_from_dir(&home.join(".claude").join("skills"), &mut skills_map);
     }
 
+    // Project-level skills (<worktree>/.claude/skills/)
+    if let Some(ref wt) = worktree_path {
+        let project_skills_dir = Path::new(wt).join(".claude").join("skills");
+        collect_skills_from_dir(&project_skills_dir, &mut skills_map);
+    }
+
+    let mut skills: Vec<ClaudeSkill> = skills_map.into_values().collect();
+    skills.sort_by(|a, b| a.name.cmp(&b.name));
+    log::trace!("Found {} Claude CLI skills", skills.len());
+    Ok(skills)
+}
+
+/// List Claude CLI custom commands from ~/.claude/commands/ and optionally <worktree>/.claude/commands/
+#[tauri::command]
+pub async fn list_claude_commands(
+    worktree_path: Option<String>,
+) -> Result<Vec<ClaudeCommand>, String> {
+    log::trace!("Listing Claude CLI custom commands (worktree: {worktree_path:?})");
+
+    let mut commands_map = std::collections::HashMap::new();
+
+    // Global commands (~/.claude/commands/)
+    if let Some(home) = get_home_dir() {
+        collect_commands_from_dir(&home.join(".claude").join("commands"), &mut commands_map);
+    }
+
+    // Project-level commands (<worktree>/.claude/commands/)
+    if let Some(ref wt) = worktree_path {
+        let project_commands_dir = Path::new(wt).join(".claude").join("commands");
+        collect_commands_from_dir(&project_commands_dir, &mut commands_map);
+    }
+
+    let mut commands: Vec<ClaudeCommand> = commands_map.into_values().collect();
     commands.sort_by(|a, b| a.name.cmp(&b.name));
     log::trace!("Found {} Claude CLI custom commands", commands.len());
     Ok(commands)

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -987,6 +987,7 @@ export const ChatInput = memo(function ChatInput({
         anchorPosition={slashAnchor}
         containerRef={formRef}
         isAtPromptStart={isSlashAtPromptStart}
+        worktreePath={activeWorktreePath}
         handleRef={slashPopoverHandleRef}
       />
     </div>

--- a/src/components/chat/SlashPopover.tsx
+++ b/src/components/chat/SlashPopover.tsx
@@ -44,6 +44,8 @@ interface SlashPopoverProps {
   containerRef?: React.RefObject<HTMLElement | null>
   /** Whether slash is at prompt start (enables commands) */
   isAtPromptStart: boolean
+  /** Worktree path for loading project-level commands/skills */
+  worktreePath?: string | null
   /** Ref to expose navigation methods to parent */
   handleRef?: React.RefObject<SlashPopoverHandle | null>
 }
@@ -61,10 +63,11 @@ export function SlashPopover({
   anchorPosition,
   containerRef,
   isAtPromptStart,
+  worktreePath,
   handleRef,
 }: SlashPopoverProps) {
-  const { data: skills = [] } = useClaudeSkills()
-  const { data: commands = [] } = useClaudeCommands()
+  const { data: skills = [] } = useClaudeSkills(worktreePath)
+  const { data: commands = [] } = useClaudeCommands(worktreePath)
   const listRef = useRef<HTMLDivElement>(null)
   const [selectedIndex, setSelectedIndex] = useState(0)
 

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -7,18 +7,20 @@ import { isTauri } from '@/services/projects'
 // Query keys for Claude CLI skills and commands
 export const skillQueryKeys = {
   all: ['claude-cli'] as const,
-  skills: () => [...skillQueryKeys.all, 'skills'] as const,
-  commands: () => [...skillQueryKeys.all, 'commands'] as const,
+  skills: (worktreePath?: string | null) =>
+    [...skillQueryKeys.all, 'skills', worktreePath ?? 'global'] as const,
+  commands: (worktreePath?: string | null) =>
+    [...skillQueryKeys.all, 'commands', worktreePath ?? 'global'] as const,
 }
 
 /**
- * Hook to get Claude CLI skills from ~/.claude/skills/
+ * Hook to get Claude CLI skills from ~/.claude/skills/ and <project>/.claude/skills/
  * Skills can be attached anywhere in a prompt as context
  * Results are cached for 5 minutes (skills rarely change)
  */
-export function useClaudeSkills() {
+export function useClaudeSkills(worktreePath?: string | null) {
   return useQuery({
-    queryKey: skillQueryKeys.skills(),
+    queryKey: skillQueryKeys.skills(worktreePath),
     queryFn: async (): Promise<ClaudeSkill[]> => {
       if (!isTauri()) {
         return []
@@ -26,7 +28,9 @@ export function useClaudeSkills() {
 
       try {
         logger.debug('Loading Claude CLI skills')
-        const skills = await invoke<ClaudeSkill[]>('list_claude_skills')
+        const skills = await invoke<ClaudeSkill[]>('list_claude_skills', {
+          worktreePath: worktreePath ?? undefined,
+        })
         logger.info('Claude CLI skills loaded', { count: skills.length })
         return skills
       } catch (error) {
@@ -40,13 +44,13 @@ export function useClaudeSkills() {
 }
 
 /**
- * Hook to get Claude CLI custom commands from ~/.claude/commands/
+ * Hook to get Claude CLI custom commands from ~/.claude/commands/ and <project>/.claude/commands/
  * Commands can only be executed at the start of an empty prompt
  * Results are cached for 5 minutes (commands rarely change)
  */
-export function useClaudeCommands() {
+export function useClaudeCommands(worktreePath?: string | null) {
   return useQuery({
-    queryKey: skillQueryKeys.commands(),
+    queryKey: skillQueryKeys.commands(worktreePath),
     queryFn: async (): Promise<ClaudeCommand[]> => {
       if (!isTauri()) {
         return []
@@ -54,7 +58,9 @@ export function useClaudeCommands() {
 
       try {
         logger.debug('Loading Claude CLI custom commands')
-        const commands = await invoke<ClaudeCommand[]>('list_claude_commands')
+        const commands = await invoke<ClaudeCommand[]>('list_claude_commands', {
+          worktreePath: worktreePath ?? undefined,
+        })
         logger.info('Claude CLI custom commands loaded', {
           count: commands.length,
         })


### PR DESCRIPTION
## Summary

- **Fixes Windows command visibility** by adding `USERPROFILE` environment variable fallback for home directory resolution (issue #177)
- **Adds project-level support** for Claude CLI skills and commands in `<project>/.claude/skills/` and `<project>/.claude/commands/`
- Project-level commands/skills override global ones when both exist
- Passes worktree path through the skill/command loading pipeline

## Changes

- Modified `list_claude_skills()` and `list_claude_commands()` to accept optional `worktree_path` parameter
- Added `get_home_dir()` helper with Windows `USERPROFILE` fallback for reliable home directory detection
- Refactored skill/command loading into reusable `collect_skills_from_dir()` and `collect_commands_from_dir()` helpers
- Updated frontend components to pass active worktree path when loading skills/commands
- Query hooks now include worktree path in cache keys for proper isolation

## Fixes

Resolves #177 - Commands not showing on Windows 11

---

Fixes #177