### PR TITLE
feat(chat): insert file path into input on non-image drag-and-drop

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -48,6 +48,10 @@ interface ChatInputProps {
   onRegisterClearHandler?: (clearHandler: (() => void) | null) => void
   formRef: React.RefObject<HTMLFormElement | null>
   inputRef: React.RefObject<HTMLTextAreaElement | null>
+  /** Non-image file paths dropped into the window */
+  droppedFilePaths?: string[]
+  /** Called after dropped file paths have been inserted into the input */
+  onDroppedFilePathsConsumed?: () => void
 }
 
 export const ChatInput = memo(function ChatInput({
@@ -65,6 +69,8 @@ export const ChatInput = memo(function ChatInput({
   onRegisterClearHandler,
   formRef,
   inputRef,
+  droppedFilePaths,
+  onDroppedFilePathsConsumed,
 }: ChatInputProps) {
   const isMobile = useIsMobile()
 
@@ -151,6 +157,30 @@ export const ChatInput = memo(function ChatInput({
         handleFocusChatInput
       )
   }, [inputRef])
+
+  // Insert dropped non-image file paths into the textarea
+  useEffect(() => {
+    if (!droppedFilePaths?.length) return
+    const textarea = inputRef.current
+    if (!textarea) return
+
+    const paths = droppedFilePaths.map(p => `"${p}"`).join(' ')
+    const current = valueRef.current
+    const newValue = current ? `${current} ${paths}` : paths
+    textarea.value = newValue
+    valueRef.current = newValue
+    textarea.selectionStart = textarea.selectionEnd = newValue.length
+    textarea.focus()
+
+    // Update draft and hint state
+    if (activeSessionId) {
+      useChatStore.getState().setInputDraft(activeSessionId, newValue)
+    }
+    setShowHint(false)
+    onHasValueChangeRef.current?.(true)
+
+    onDroppedFilePathsConsumed?.()
+  }, [droppedFilePaths, onDroppedFilePathsConsumed, activeSessionId, inputRef])
 
   // Sync DOM when store draft is cleared or restored externally
   useEffect(() => {

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -826,7 +826,7 @@ export function ChatWindow({
   })
 
   // Drag and drop images into chat input
-  const { isDragging } = useDragAndDropImages(activeSessionId)
+  const { isDragging, droppedFilePaths, clearDroppedFilePaths } = useDragAndDropImages(activeSessionId)
 
   // State for file content modal (opened by clicking filenames in tool calls)
   const [viewingFilePath, setViewingFilePath] = useState<string | null>(null)
@@ -2380,6 +2380,8 @@ export function ChatWindow({
                                 }}
                                 formRef={formRef}
                                 inputRef={inputRef}
+                                droppedFilePaths={droppedFilePaths}
+                                onDroppedFilePathsConsumed={clearDroppedFilePaths}
                               />
                             </div>
 

--- a/src/components/chat/hooks/useDragAndDropImages.ts
+++ b/src/components/chat/hooks/useDragAndDropImages.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { invoke } from '@/lib/transport'
 import { toast } from 'sonner'
 import { useChatStore } from '@/store/chat-store'
@@ -20,6 +20,10 @@ interface UseDragAndDropImagesOptions {
 interface UseDragAndDropImagesResult {
   /** Whether files are currently being dragged over the window */
   isDragging: boolean
+  /** Absolute paths of non-image files that were just dropped */
+  droppedFilePaths: string[]
+  /** Clear the dropped file paths after they've been consumed */
+  clearDroppedFilePaths: () => void
 }
 
 /**
@@ -33,6 +37,8 @@ export function useDragAndDropImages(
   options?: UseDragAndDropImagesOptions
 ): UseDragAndDropImagesResult {
   const [isDragging, setIsDragging] = useState(false)
+  const [droppedFilePaths, setDroppedFilePaths] = useState<string[]>([])
+  const clearDroppedFilePaths = useCallback(() => setDroppedFilePaths([]), [])
 
   useEffect(() => {
     if (options?.disabled || !isNativeApp()) return
@@ -63,18 +69,12 @@ export function useDragAndDropImages(
           const paths = event.payload.paths
           const imagePaths: string[] = []
           const svgPaths: string[] = []
+          const otherPaths: string[] = []
           for (const path of paths) {
             const ext = path.split('.').pop()?.toLowerCase() ?? ''
             if (ALLOWED_EXTENSIONS.includes(ext)) imagePaths.push(path)
             else if (TEXT_IMAGE_EXTENSIONS.includes(ext)) svgPaths.push(path)
-          }
-
-          if (imagePaths.length === 0 && svgPaths.length === 0) {
-            toast.error('No image detected', {
-              description:
-                'Only PNG, JPEG, GIF, WebP, SVG files are accepted',
-            })
-            return
+            else otherPaths.push(path)
           }
 
           // Process raster images
@@ -87,13 +87,9 @@ export function useDragAndDropImages(
             processDroppedSvg(sourcePath, sessionId)
           }
 
-          // Notify if some files were skipped
-          const skippedCount =
-            paths.length - imagePaths.length - svgPaths.length
-          if (skippedCount > 0) {
-            toast.warning(`${skippedCount} file(s) skipped`, {
-              description: 'Only images are accepted',
-            })
+          // Insert non-image file paths into chat input
+          if (otherPaths.length > 0) {
+            setDroppedFilePaths(otherPaths)
           }
         } else if (event.payload.type === 'leave') {
           // Files left the window
@@ -116,7 +112,7 @@ export function useDragAndDropImages(
     }
   }, [sessionId, options?.disabled])
 
-  return { isDragging }
+  return { isDragging, droppedFilePaths, clearDroppedFilePaths }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Previously, dropping non-image files into the chat window showed an error toast ("Only images are accepted")
- Now, non-image file paths are inserted (double-quoted) directly into the chat input, so Claude can reference them
- Images continue to be processed as attachments as before

## Changes
- **`useDragAndDropImages.ts`** — Collect non-image paths in `otherPaths` array instead of showing error/warning toasts; expose `droppedFilePaths` and `clearDroppedFilePaths`
- **`ChatWindow.tsx`** — Wire new props from the hook to `ChatInput`
- **`ChatInput.tsx`** — New `droppedFilePaths` prop + `useEffect` that inserts quoted paths into the textarea and updates draft state

## Test plan
- [x] Drop a non-image file (e.g. `.rs`, `.txt`, `.json`) → its absolute path appears quoted in the input
- [x] Drop an image (PNG, JPEG, etc.) → still processed as image attachment
- [x] Drop a mix of images and non-images → images attached, non-image paths inserted
- [x] Drop multiple non-image files → all paths inserted space-separated