### PR TITLE
fix(terminal): use Warp URL scheme to open new tabs

### DIFF
--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -3250,19 +3250,14 @@ pub async fn open_worktree_in_terminal(
 
         let script = match terminal_app.as_str() {
             "warp" => {
-                // Warp uses a different AppleScript approach
-                format!(
-                    r#"tell application "Warp"
-                        activate
-                        tell application "System Events"
-                            keystroke "t" using command down
-                            delay 0.3
-                            keystroke "cd '{}' && clear"
-                            keystroke return
-                        end tell
-                    end tell"#,
-                    escaped_path
-                )
+                let output = std::process::Command::new("open")
+                    .arg(format!("warp://action/new_tab?path={escaped_path}"))
+                    .spawn();
+
+                match output {
+                    Ok(_) => return Ok(()),
+                    Err(e) => return Err(format_open_error("Warp", &e)),
+                }
             }
             "ghostty" => {
                 // Opening a directory path with Ghostty creates a new tab


### PR DESCRIPTION
Generated by AI with human oversight. I tested manually the fix. I didn't find any automatic tests for this.

## Summary
- Replace fragile AppleScript keystroke automation with Warp's native URL scheme (`warp://action/new_tab?path=<path>`)
- Follows the same pattern already used for Ghostty (early return with `open` command)

Fixes https://github.com/coollabsio/jean/issues/220

## Test plan
- [x] Set Warp as terminal in preferences
- [x] Click "Open in Terminal" on a worktree
- [x] Verify a new Warp tab opens at the correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)