### PR TITLE
feat(sessions): add ability to move chat sessions between worktrees

### DIFF
--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -832,6 +832,101 @@ pub async fn archive_session(
     Ok(new_active)
 }
 
+/// Move a session from one worktree to another, optionally migrating uncommitted changes
+#[tauri::command]
+pub async fn move_session_to_worktree(
+    app: AppHandle,
+    session_id: String,
+    from_worktree_id: String,
+    to_worktree_id: String,
+    migrate_changes: bool,
+    from_worktree_path: String,
+    to_worktree_path: String,
+) -> Result<(), String> {
+    log::trace!(
+        "Moving session {session_id} from {from_worktree_id} to {to_worktree_id} (migrate_changes: {migrate_changes})"
+    );
+
+    // Stash changes from source worktree if requested
+    let stashed = if migrate_changes {
+        match crate::projects::git::git_stash(&from_worktree_path) {
+            Ok(msg) => {
+                // "No local changes to save" means nothing was stashed
+                !msg.contains("No local changes to save")
+            }
+            Err(e) => {
+                log::warn!("Failed to stash changes: {e}");
+                return Err(format!("Failed to stash changes from source worktree: {e}"));
+            }
+        }
+    } else {
+        false
+    };
+
+    // Build a conversation transcript from run logs before the move,
+    // so the new CLI session has context of the prior conversation.
+    // The claude_session_id is cleared during move, so without this transcript
+    // Claude CLI would start a completely fresh conversation.
+    if let Ok(messages) = super::run_log::load_session_messages(&app, &session_id) {
+        if !messages.is_empty() {
+            let mut transcript = String::from(
+                "# Previous Conversation (migrated session)\n\n\
+                 This session was moved from another worktree. Below is the conversation history.\n\n"
+            );
+            for msg in &messages {
+                match msg.role {
+                    super::types::MessageRole::User => {
+                        transcript.push_str("## User\n\n");
+                        transcript.push_str(&msg.content);
+                        transcript.push_str("\n\n");
+                    }
+                    super::types::MessageRole::Assistant => {
+                        transcript.push_str("## Assistant\n\n");
+                        // Include text content only (tool calls are noise)
+                        if !msg.content.is_empty() {
+                            transcript.push_str(&msg.content);
+                        } else {
+                            transcript.push_str("*(tool use only)*");
+                        }
+                        transcript.push_str("\n\n");
+                    }
+                }
+            }
+
+            // Save as a per-session context file that gets auto-loaded
+            if let Ok(contexts_dir) = super::storage::get_saved_contexts_dir(&app) {
+                let context_filename = format!("{session_id}-context-migration-transcript.md");
+                let context_path = contexts_dir.join(&context_filename);
+                if let Err(e) = std::fs::write(&context_path, &transcript) {
+                    log::warn!("Failed to write migration transcript: {e}");
+                } else {
+                    log::info!("Saved migration transcript for session {session_id} ({} messages)", messages.len());
+                }
+            }
+        }
+    }
+
+    // Move the session in storage
+    super::storage::move_session_to_worktree(&app, &session_id, &from_worktree_id, &to_worktree_id)?;
+
+    // Apply stashed changes to target worktree
+    if stashed {
+        match crate::projects::git::git_stash_pop(&to_worktree_path) {
+            Ok(_) => {
+                log::trace!("Successfully applied stashed changes to target worktree");
+            }
+            Err(e) => {
+                // Don't fail the move — changes are safely in the stash
+                log::warn!("Failed to apply stashed changes to target worktree: {e}. Changes remain in git stash.");
+                // We still emit success but the frontend will show a warning
+            }
+        }
+    }
+
+    emit_sessions_cache_invalidation(&app);
+    Ok(())
+}
+
 /// Unarchive a session (restore it to the session list)
 #[tauri::command]
 pub async fn unarchive_session(

--- a/src-tauri/src/chat/storage.rs
+++ b/src-tauri/src/chat/storage.rs
@@ -936,6 +936,83 @@ pub fn restore_base_sessions(
 }
 
 // ============================================================================
+// Move Session Between Worktrees
+// ============================================================================
+
+/// Move a session from one worktree to another.
+/// Updates both worktree indices and the session metadata atomically.
+pub fn move_session_to_worktree(
+    app: &AppHandle,
+    session_id: &str,
+    from_worktree_id: &str,
+    to_worktree_id: &str,
+) -> Result<(), String> {
+    if from_worktree_id == to_worktree_id {
+        return Ok(());
+    }
+
+    // Lock both indices in alphabetical order to prevent deadlocks
+    let (first_id, second_id) = if from_worktree_id < to_worktree_id {
+        (from_worktree_id, to_worktree_id)
+    } else {
+        (to_worktree_id, from_worktree_id)
+    };
+
+    let first_lock = get_index_lock(first_id);
+    let _first_guard = first_lock.lock().unwrap();
+    let second_lock = get_index_lock(second_id);
+    let _second_guard = second_lock.lock().unwrap();
+
+    // Load both indices
+    let mut from_index = load_index_internal(app, from_worktree_id)?;
+    let mut to_index = load_index_internal(app, to_worktree_id)?;
+
+    // Find and remove the session entry from source
+    let entry_pos = from_index
+        .sessions
+        .iter()
+        .position(|e| e.id == session_id)
+        .ok_or_else(|| format!("Session {session_id} not found in worktree {from_worktree_id}"))?;
+    let mut entry = from_index.sessions.remove(entry_pos);
+
+    // Set order to append at end of target
+    let max_order = to_index.sessions.iter().map(|e| e.order).max().unwrap_or(0);
+    entry.order = max_order + 1;
+
+    // Add to target index
+    to_index.sessions.push(entry);
+
+    // If the moved session was the active one in source, pick next available
+    if from_index.active_session_id.as_deref() == Some(session_id) {
+        from_index.active_session_id = from_index.sessions.first().map(|e| e.id.clone());
+    }
+
+    // Save both indices
+    save_index_internal(app, &from_index)?;
+    save_index_internal(app, &to_index)?;
+
+    // Update session metadata: worktree_id + clear CLI session IDs
+    // CLI session IDs are tied to the original worktree's working directory
+    // and cannot be resumed from a different worktree, so we must clear them.
+    // The message history is preserved in the NDJSON run logs.
+    let metadata_lock = get_metadata_lock(session_id);
+    let _metadata_guard = metadata_lock.lock().unwrap();
+    if let Some(mut metadata) = load_metadata_internal(app, session_id)? {
+        metadata.worktree_id = to_worktree_id.to_string();
+        metadata.claude_session_id = None;
+        metadata.codex_thread_id = None;
+        metadata.opencode_session_id = None;
+        save_metadata_internal(app, &metadata)?;
+    }
+
+    log::info!(
+        "Moved session {session_id} from worktree {from_worktree_id} to {to_worktree_id}"
+    );
+
+    Ok(())
+}
+
+// ============================================================================
 // Saved Contexts (unchanged from original)
 // ============================================================================
 

--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -1524,6 +1524,27 @@ pub async fn dispatch_command(
                     .await?;
             to_value(result)
         }
+        "move_session_to_worktree" => {
+            let session_id: String = field(&args, "sessionId", "session_id")?;
+            let from_worktree_id: String = field(&args, "fromWorktreeId", "from_worktree_id")?;
+            let to_worktree_id: String = field(&args, "toWorktreeId", "to_worktree_id")?;
+            let migrate_changes: bool = from_field(&args, "migrateChanges").unwrap_or(false);
+            let from_worktree_path: String =
+                field(&args, "fromWorktreePath", "from_worktree_path")?;
+            let to_worktree_path: String = field(&args, "toWorktreePath", "to_worktree_path")?;
+            crate::chat::move_session_to_worktree(
+                app.clone(),
+                session_id,
+                from_worktree_id,
+                to_worktree_id,
+                migrate_changes,
+                from_worktree_path,
+                to_worktree_path,
+            )
+            .await?;
+            emit_cache_invalidation(app, &["sessions"]);
+            Ok(Value::Null)
+        }
         "unarchive_session" => {
             let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
             let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2758,6 +2758,7 @@ pub fn run() {
             chat::update_session_state,
             chat::close_session,
             chat::archive_session,
+            chat::move_session_to_worktree,
             chat::unarchive_session,
             chat::restore_session_with_base,
             chat::delete_archived_session,

--- a/src/components/chat/MoveSessionDialog.tsx
+++ b/src/components/chat/MoveSessionDialog.tsx
@@ -1,0 +1,65 @@
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+
+interface MoveSessionDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  sourceWorktreeName: string
+  targetWorktreeName: string
+  onMoveWithChanges: () => void
+  onMoveWithoutChanges: () => void
+}
+
+export function MoveSessionDialog({
+  open,
+  onOpenChange,
+  sourceWorktreeName,
+  targetWorktreeName,
+  onMoveWithChanges,
+  onMoveWithoutChanges,
+}: MoveSessionDialogProps) {
+  if (!open) return null
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent onEscapeKeyDown={e => e.stopPropagation()}>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Migrate uncommitted changes?</AlertDialogTitle>
+          <AlertDialogDescription>
+            <strong>{sourceWorktreeName}</strong> has uncommitted changes. Do
+            you want to move them to <strong>{targetWorktreeName}</strong>?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <Button
+            variant="outline"
+            onClick={() => {
+              onMoveWithoutChanges()
+              onOpenChange(false)
+            }}
+          >
+            Move without changes
+          </Button>
+          <Button
+            autoFocus
+            onClick={() => {
+              onMoveWithChanges()
+              onOpenChange(false)
+            }}
+          >
+            Move with changes
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react'
 import {
   Archive,
+  ArrowRightLeft,
   Code,
   Eye,
   EyeOff,
@@ -24,6 +25,8 @@ import {
   Plus,
   Trash2,
 } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { invoke } from '@/lib/transport'
 import { ModalCloseButton } from '@/components/ui/modal-close-button'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -45,11 +48,12 @@ import { useTerminalStore } from '@/store/terminal-store'
 import { useUIStore } from '@/store/ui-store'
 import {
   useSessions,
+  chatQueryKeys,
   useCreateSession,
   useRenameSession,
 } from '@/services/chat'
 import { usePreferences } from '@/services/preferences'
-import { useWorktree, useProjects, useRunScript } from '@/services/projects'
+import { useWorktree, useWorktrees, useProjects, useRunScript } from '@/services/projects'
 import {
   useGitStatus,
   gitPush,
@@ -90,10 +94,14 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import { WorktreeDropdownMenu } from '@/components/projects/WorktreeDropdownMenu'
 import { LabelModal } from './LabelModal'
+import { MoveSessionDialog } from './MoveSessionDialog'
 import { useSessionArchive } from './hooks/useSessionArchive'
 import { useIsMobile } from '@/hooks/use-mobile'
 
@@ -160,6 +168,7 @@ interface SessionChatModalProps {
   worktreePath: string
   isOpen: boolean
   onClose: () => void
+  onNavigateToWorktree?: (worktreeId: string, worktreePath: string) => void
 }
 
 function getSessionStatus(
@@ -216,6 +225,7 @@ export function SessionChatModal({
   worktreePath,
   isOpen,
   onClose,
+  onNavigateToWorktree,
 }: SessionChatModalProps) {
   const isMobile = useIsMobile()
   const { data: sessionsData } = useSessions(
@@ -329,6 +339,59 @@ export function SessionChatModal({
   const branchDiffRemoved =
     gitStatus?.branch_diff_removed ?? worktree?.cached_branch_diff_removed ?? 0
   const defaultBranch = project?.default_branch ?? 'main'
+
+  // Move session to worktree
+  const queryClient = useQueryClient()
+  const { data: allWorktrees } = useWorktrees(project?.id ?? null)
+  const otherWorktrees = useMemo(
+    () =>
+      (allWorktrees ?? [])
+        .filter(wt => wt.id !== worktreeId && !wt.archived_at)
+        .map(wt => ({ id: wt.id, name: wt.name, path: wt.path, branch: wt.branch })),
+    [allWorktrees, worktreeId]
+  )
+  const hasUncommittedChanges = (uncommittedAdded + uncommittedRemoved) > 0
+  const [moveSessionState, setMoveSessionState] = useState<{
+    sessionId: string
+    targetWorktree: { id: string; name: string; path: string }
+  } | null>(null)
+
+  const handleMoveSession = useCallback(
+    async (sessionId: string, targetWt: { id: string; name: string; path: string }, migrateChanges: boolean) => {
+      const toastId = toast.loading(`Moving session to ${targetWt.name}...`)
+      try {
+        await invoke('move_session_to_worktree', {
+          sessionId,
+          fromWorktreeId: worktreeId,
+          toWorktreeId: targetWt.id,
+          migrateChanges,
+          fromWorktreePath: worktreePath,
+          toWorktreePath: targetWt.path,
+        })
+        queryClient.invalidateQueries({ queryKey: chatQueryKeys.sessions(worktreeId) })
+        queryClient.invalidateQueries({ queryKey: chatQueryKeys.sessions(targetWt.id) })
+        toast.success(`Session moved to ${targetWt.name}`, { id: toastId })
+
+        // Navigate to the target worktree to follow the moved session
+        useChatStore.getState().setActiveSession(targetWt.id, sessionId)
+        onNavigateToWorktree?.(targetWt.id, targetWt.path)
+      } catch (error) {
+        toast.error(`Failed to move session: ${error}`, { id: toastId })
+      }
+    },
+    [worktreeId, worktreePath, queryClient, onNavigateToWorktree]
+  )
+
+  const handleMoveSessionClick = useCallback(
+    (sessionId: string, targetWt: { id: string; name: string; path: string }) => {
+      if (hasUncommittedChanges) {
+        setMoveSessionState({ sessionId, targetWorktree: targetWt })
+      } else {
+        void handleMoveSession(sessionId, targetWt, false)
+      }
+    },
+    [hasUncommittedChanges, handleMoveSession]
+  )
 
   // Open-in actions for mobile overflow menu
   const openInEditor = useOpenWorktreeInEditor()
@@ -1123,6 +1186,27 @@ export function SessionChatModal({
                           <Archive className="mr-2 h-4 w-4" />
                           Archive Session
                         </ContextMenuItem>
+                        {otherWorktrees.length > 0 && (
+                          <ContextMenuSub>
+                            <ContextMenuSubTrigger>
+                              <ArrowRightLeft className="mr-2 h-4 w-4" />
+                              Move to Worktree
+                            </ContextMenuSubTrigger>
+                            <ContextMenuSubContent className="w-48">
+                              {otherWorktrees.map(wt => (
+                                <ContextMenuItem
+                                  key={wt.id}
+                                  onSelect={() => handleMoveSessionClick(session.id, wt)}
+                                >
+                                  <span className="truncate">{wt.name}</span>
+                                  <span className="ml-auto text-xs text-muted-foreground truncate max-w-[100px]">
+                                    {wt.branch}
+                                  </span>
+                                </ContextMenuItem>
+                              ))}
+                            </ContextMenuSubContent>
+                          </ContextMenuSub>
+                        )}
                         <ContextMenuSeparator />
                         <ContextMenuItem
                           variant="destructive"
@@ -1188,6 +1272,26 @@ export function SessionChatModal({
         onConfirm={executeCloseAction}
         branchName={worktree?.branch}
         mode="session"
+      />
+      <MoveSessionDialog
+        open={!!moveSessionState}
+        onOpenChange={open => {
+          if (!open) setMoveSessionState(null)
+        }}
+        sourceWorktreeName={worktree?.name ?? 'source'}
+        targetWorktreeName={moveSessionState?.targetWorktree.name ?? ''}
+        onMoveWithChanges={() => {
+          if (moveSessionState) {
+            void handleMoveSession(moveSessionState.sessionId, moveSessionState.targetWorktree, true)
+            setMoveSessionState(null)
+          }
+        }}
+        onMoveWithoutChanges={() => {
+          if (moveSessionState) {
+            void handleMoveSession(moveSessionState.sessionId, moveSessionState.targetWorktree, false)
+            setMoveSessionState(null)
+          }
+        }}
       />
     </>
   )

--- a/src/components/chat/SessionListRow.tsx
+++ b/src/components/chat/SessionListRow.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useCallback } from 'react'
 import {
   Archive,
+  ArrowRightLeft,
   Eye,
   EyeOff,
   FileText,
@@ -24,6 +25,9 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import { getResumeCommand, statusConfig, type SessionCardProps } from './session-card-utils'
@@ -51,6 +55,8 @@ export const SessionListRow = forwardRef<HTMLDivElement, SessionCardProps>(
       onRenameStart,
       onRenameSubmit,
       onRenameCancel,
+      otherWorktrees,
+      onMoveToWorktree,
     },
     ref
   ) {
@@ -272,6 +278,27 @@ export const SessionListRow = forwardRef<HTMLDivElement, SessionCardProps>(
             <Archive className="mr-2 h-4 w-4" />
             Archive Session
           </ContextMenuItem>
+          {onMoveToWorktree && otherWorktrees && otherWorktrees.length > 0 && (
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>
+                <ArrowRightLeft className="mr-2 h-4 w-4" />
+                Move to Worktree
+              </ContextMenuSubTrigger>
+              <ContextMenuSubContent className="w-48">
+                {otherWorktrees.map(wt => (
+                  <ContextMenuItem
+                    key={wt.id}
+                    onSelect={() => onMoveToWorktree(wt.id, wt.name, wt.path)}
+                  >
+                    <span className="truncate">{wt.name}</span>
+                    <span className="ml-auto text-xs text-muted-foreground truncate max-w-[100px]">
+                      {wt.branch}
+                    </span>
+                  </ContextMenuItem>
+                ))}
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+          )}
           {resumeCommand && (
             <ContextMenuItem
               onSelect={() => {

--- a/src/components/chat/session-card-utils.tsx
+++ b/src/components/chat/session-card-utils.tsx
@@ -65,6 +65,8 @@ export interface SessionCardProps {
   onRenameStart?: (sessionId: string, currentName: string) => void
   onRenameSubmit?: (sessionId: string) => void
   onRenameCancel?: () => void
+  otherWorktrees?: { id: string; name: string; path: string; branch: string }[]
+  onMoveToWorktree?: (targetWorktreeId: string, targetWorktreeName: string, targetWorktreePath: string) => void
 }
 
 export const statusConfig: Record<

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -1993,6 +1993,7 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
         worktreePath={selectedWorktreeModal?.worktreePath ?? ''}
         isOpen={!!selectedWorktreeModal}
         onClose={() => setSelectedWorktreeModal(null)}
+        onNavigateToWorktree={(wtId, wtPath) => setSelectedWorktreeModal({ worktreeId: wtId, worktreePath: wtPath })}
       />
 
       {/* Git Diff Modal (CMD+G on canvas) */}


### PR DESCRIPTION
## Summary

- Add "Move to Worktree" context menu option on session tabs (right-click) to move a session from one worktree to another within the same project
- When the source worktree has uncommitted changes, a confirmation dialog asks whether to migrate them (via git stash/pop) or move the session only
- Automatically navigates to the target worktree after a successful move
- Clears CLI session IDs on move (they're tied to the original working directory) and saves a conversation transcript as a per-session context file so Claude retains conversation history in the new worktree

## Changes

**Backend (Rust):**
- `storage.rs`: New `move_session_to_worktree()` — atomically moves session between worktree indices with deadlock-safe locking, clears CLI session IDs, updates metadata
- `commands.rs`: New Tauri command with optional git stash/pop for uncommitted changes migration + conversation transcript generation
- `lib.rs`: Register command
- `dispatch.rs`: Web access dispatch match arm

**Frontend (React):**
- `MoveSessionDialog.tsx`: New AlertDialog with 3 options (move with changes / without / cancel)
- `SessionChatModal.tsx`: Full integration — fetches sibling worktrees, handles move logic, uncommitted changes detection, navigation after move
- `SessionListRow.tsx`: "Move to Worktree" submenu in context menu
- `session-card-utils.tsx`: New props for worktree list and move handler
- `ProjectCanvasView.tsx`: Wire up `onNavigateToWorktree` callback

## Test plan

- [ ] Open a project with 2+ worktrees
- [ ] Right-click a session tab → "Move to Worktree" → pick a target
- [ ] On clean worktree: session moves immediately with toast
- [ ] On dirty worktree: dialog appears with 3 options
- [ ] After move: modal navigates to target worktree with moved session selected
- [ ] Send a message referencing prior conversation → Claude has context via transcript
- [ ] Move last session from a worktree → source shows empty session list