### PR TITLE
style(chat): improve message text contrast

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -621,7 +621,7 @@ export const MessageItem = memo(function MessageItem({
         </div>
       ) : (
         <div
-          className="text-muted-foreground w-full min-w-0 break-words"
+          className="text-foreground/90 w-full min-w-0 break-words"
         >
           {messageBoxContent}
         </div>

--- a/src/components/chat/StreamingMessage.tsx
+++ b/src/components/chat/StreamingMessage.tsx
@@ -106,7 +106,7 @@ export const StreamingMessage = memo(function StreamingMessage({
   hideApproveButtons,
 }: StreamingMessageProps) {
   return (
-    <div className="text-muted-foreground">
+    <div className="text-foreground/90">
       {/* Render streaming content blocks inline if available */}
       {contentBlocks.length > 0 ? (
         (() => {


### PR DESCRIPTION
## Summary

- Update chat message text color from `text-muted-foreground` to `text-foreground/90` in both `MessageItem` and `StreamingMessage` components
- Improves text contrast in both light and dark mode, addressing accessibility concerns
- Resolves issue #221

## Changes

- `src/components/chat/MessageItem.tsx`: Update user message text color
- `src/components/chat/StreamingMessage.tsx`: Update streaming message text color

---

Fixes #221