### PR TITLE
fix(worktree): improve deletion reliability with manual cleanup fallback

### DIFF
--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -2489,6 +2489,20 @@ pub async fn delete_worktree(app: AppHandle, worktree_id: String) -> Result<(), 
         // Remove the git worktree (this can be slow for large repos)
         if let Err(e) = git::remove_worktree(&project_path, &worktree_path) {
             log::error!("Background: Failed to remove worktree: {e}");
+
+            // Re-add worktree to storage since deletion failed
+            match load_projects_data(&app_clone) {
+                Ok(mut data) => {
+                    data.add_worktree(worktree_for_restore);
+                    if let Err(save_err) = save_projects_data(&app_clone, &data) {
+                        log::error!("Failed to restore worktree in storage: {save_err}");
+                    }
+                }
+                Err(load_err) => {
+                    log::error!("Failed to load projects data for restore: {load_err}");
+                }
+            }
+
             let error_event = WorktreeDeleteErrorEvent {
                 id: worktree_id_clone,
                 project_id: project_id_clone,

--- a/src-tauri/src/projects/git.rs
+++ b/src-tauri/src/projects/git.rs
@@ -1296,8 +1296,29 @@ pub fn remove_worktree(repo_path: &str, worktree_path: &str) -> Result<(), Strin
                 .current_dir(repo_path)
                 .output();
         } else {
-            return Err(format!("Failed to remove worktree: {stderr}"));
+            // git worktree remove failed (e.g. file locks on Windows)
+            // Try manual directory removal as fallback
+            if Path::new(worktree_path).exists() {
+                log::warn!("git worktree remove failed ({stderr}), attempting manual directory removal");
+                if let Err(rm_err) = std::fs::remove_dir_all(worktree_path) {
+                    return Err(format!("Failed to remove worktree: {stderr} (manual cleanup also failed: {rm_err})"));
+                }
+                log::info!("Manually removed worktree directory at {worktree_path}");
+                // Prune the now-stale git worktree entry
+                let _ = silent_command("git")
+                    .args(["worktree", "prune"])
+                    .current_dir(repo_path)
+                    .output();
+            } else {
+                return Err(format!("Failed to remove worktree: {stderr}"));
+            }
         }
+    }
+
+    // Safety net: if git reported success but directory still exists, clean it up
+    if Path::new(worktree_path).exists() {
+        log::warn!("Worktree directory still exists after git worktree remove, cleaning up manually");
+        let _ = std::fs::remove_dir_all(worktree_path);
     }
 
     log::trace!("Successfully removed worktree at {worktree_path}");


### PR DESCRIPTION
## Summary
- Added manual directory removal fallback in `remove_worktree()` when `git worktree remove` fails, handling Windows file lock issues
- Added safety check to clean up worktree directories that persist after git reports success
- Improved error recovery by re-adding worktree to storage if deletion fails, preventing data loss from the sidebar

Fixes #224

---

Fixes #224