### PR TITLE
feat(worktree): defer setup script execution for immediate ui opening

### DIFF
--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -38,7 +38,8 @@ use super::types::{
     JeanConfig, MergeType, Project, SessionType, Worktree, WorktreeArchivedEvent,
     WorktreeBranchExistsEvent, WorktreeCreateErrorEvent, WorktreeCreatedEvent,
     WorktreeCreatingEvent, WorktreeDeleteErrorEvent, WorktreeDeletedEvent, WorktreeDeletingEvent,
-    WorktreePathExistsEvent, WorktreePermanentlyDeletedEvent, WorktreeUnarchivedEvent,
+    WorktreePathExistsEvent, WorktreePermanentlyDeletedEvent, WorktreeSetupCompleteEvent,
+    WorktreeUnarchivedEvent,
 };
 use crate::claude_cli::resolve_cli_binary;
 use crate::codex_cli::resolve_cli_binary as resolve_codex_cli_binary;
@@ -1203,31 +1204,14 @@ pub async fn create_worktree(
                 }
             }
 
-            // Check for jean.json and run setup script
-            let (setup_output, setup_script, setup_success) =
-                if let Some(config) = git::read_jean_config(&project_path) {
-                    if let Some(script) = config.scripts.setup {
-                        log::trace!("Background: Found jean.json with setup script, executing...");
-                        match git::run_setup_script(
-                            &worktree_path_clone,
-                            &project_path,
-                            &final_branch,
-                            &script,
-                        ) {
-                            Ok(output) => (Some(output), Some(script), Some(true)),
-                            Err(e) => {
-                                log::warn!("Background: Setup script failed (continuing): {e}");
-                                (Some(e), Some(script), Some(false))
-                            }
-                        }
-                    } else {
-                        (None, None, None)
-                    }
-                } else {
-                    (None, None, None)
-                };
+            // Check for jean.json setup script upfront so we can include it in the
+            // initial worktree record. This lets the frontend know a setup script
+            // will run (setup_script is set, but setup_output is still None).
+            let pending_setup_script = git::read_jean_config(&project_path)
+                .and_then(|config| config.scripts.setup);
 
-            // Save to storage
+            // Save to storage and emit worktree:created BEFORE running setup script
+            // so the UI can open immediately and the user can start typing.
             if let Ok(mut data) = load_projects_data(&app_clone) {
                 // Get max order for worktrees in this project
                 let max_order = data
@@ -1238,17 +1222,18 @@ pub async fn create_worktree(
                     .max()
                     .unwrap_or(0);
 
-                // Create the final worktree record
+                // Create the worktree record (setup_script set if jean.json has one,
+                // but setup_output is None — signals "setup pending" to frontend)
                 let worktree = Worktree {
                     id: worktree_id_clone.clone(),
                     project_id: project_id_clone.clone(),
                     name: name_clone.clone(),
                     path: worktree_path_clone.clone(),
-                    branch: final_branch,
+                    branch: final_branch.clone(),
                     created_at,
-                    setup_output,
-                    setup_script,
-                    setup_success,
+                    setup_output: None,
+                    setup_script: pending_setup_script.clone(),
+                    setup_success: None,
                     session_type: SessionType::Worktree,
                     pr_number: pr_context_clone.as_ref().map(|ctx| ctx.number),
                     pr_url: None,
@@ -1289,7 +1274,7 @@ pub async fn create_worktree(
                     return;
                 }
 
-                // Emit success event
+                // Emit success event — UI opens immediately
                 log::trace!(
                     "Background: Worktree created successfully: {}",
                     worktree.name
@@ -1307,6 +1292,52 @@ pub async fn create_worktree(
                 };
                 if let Err(emit_err) = app_clone.emit_all("worktree:error", &error_event) {
                     log::error!("Failed to emit worktree:error event: {emit_err}");
+                }
+                return;
+            }
+
+            // Run setup script AFTER emitting worktree:created (user can already type)
+            if let Some(script) = pending_setup_script {
+                log::trace!("Background: Found jean.json with setup script, executing...");
+                let (setup_output, setup_success) = match git::run_setup_script(
+                    &worktree_path_clone,
+                    &project_path,
+                    &final_branch,
+                    &script,
+                ) {
+                    Ok(output) => (output, true),
+                    Err(e) => {
+                        log::warn!("Background: Setup script failed (continuing): {e}");
+                        (e, false)
+                    }
+                };
+
+                // Update worktree in storage with setup results
+                if let Ok(mut data) = load_projects_data(&app_clone) {
+                    if let Some(wt) = data
+                        .worktrees
+                        .iter_mut()
+                        .find(|w| w.id == worktree_id_clone)
+                    {
+                        wt.setup_output = Some(setup_output.clone());
+                        wt.setup_script = Some(script.clone());
+                        wt.setup_success = Some(setup_success);
+                    }
+                    if let Err(e) = save_projects_data(&app_clone, &data) {
+                        log::warn!("Background: Failed to save setup results: {e}");
+                    }
+                }
+
+                // Emit setup complete event
+                let setup_event = WorktreeSetupCompleteEvent {
+                    id: worktree_id_clone,
+                    project_id: project_id_clone,
+                    setup_output,
+                    setup_script: script,
+                    setup_success,
+                };
+                if let Err(e) = app_clone.emit_all("worktree:setup_complete", &setup_event) {
+                    log::error!("Failed to emit worktree:setup_complete event: {e}");
                 }
             }
         })); // end catch_unwind

--- a/src-tauri/src/projects/types.rs
+++ b/src-tauri/src/projects/types.rs
@@ -440,6 +440,21 @@ pub struct WorktreeCreatedEvent {
     pub worktree: Worktree,
 }
 
+/// Event emitted when worktree setup script completes (after worktree:created)
+#[derive(Clone, Serialize)]
+pub struct WorktreeSetupCompleteEvent {
+    /// The worktree ID
+    pub id: String,
+    /// The project ID
+    pub project_id: String,
+    /// Output from the setup script (stdout + stderr)
+    pub setup_output: String,
+    /// The setup script command that was executed
+    pub setup_script: String,
+    /// Whether the setup script succeeded
+    pub setup_success: bool,
+}
+
 /// Event emitted when worktree creation fails
 #[derive(Clone, Serialize)]
 pub struct WorktreeCreateErrorEvent {

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary'
 import { invoke, listen } from '@/lib/transport'
-import { GitBranch, GitMerge, Layers } from 'lucide-react'
+import { GitBranch, GitMerge, Layers, Loader2 } from 'lucide-react'
 import {
   useSession,
   useSessions,
@@ -2078,6 +2078,19 @@ export function ChatWindow({
                                     selectedBackend={selectedBackend}
                                     onFileClick={setViewingFilePath}
                                   />
+                                </div>
+                              )}
+                            {/* Setup script running indicator */}
+                            {worktree?.setup_script &&
+                              !setupScriptResult && (
+                                <div className="my-2 flex items-center gap-2 rounded border border-muted bg-muted/30 px-3 py-2 font-mono text-sm text-muted-foreground">
+                                  <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+                                  <span>
+                                    Running setup script:{' '}
+                                    <code className="rounded bg-muted px-1 py-0.5">
+                                      {worktree.setup_script}
+                                    </code>
+                                  </span>
                                 </div>
                               )}
                             {/* Setup script output from jean.json */}

--- a/src/components/chat/WorktreeSetupCard.tsx
+++ b/src/components/chat/WorktreeSetupCard.tsx
@@ -13,7 +13,7 @@ export interface WorktreeSetupCardProps {
 function getStatusText(worktree: Worktree): string {
   if (worktree.pr_number) return `Checking out PR #${worktree.pr_number}...`
   if (worktree.issue_number) return 'Setting up branch...'
-  return 'Running setup script...'
+  return 'Creating worktree...'
 }
 
 /**

--- a/src/services/projects.ts
+++ b/src/services/projects.ts
@@ -20,6 +20,7 @@ import type {
   WorktreePermanentlyDeletedEvent,
   WorktreePathExistsEvent,
   WorktreeBranchExistsEvent,
+  WorktreeSetupCompleteEvent,
 } from '@/types/projects'
 import { useProjectsStore } from '@/store/projects-store'
 import { useChatStore } from '@/store/chat-store'
@@ -951,7 +952,7 @@ export function useWorktreeEvents() {
       })
     )
 
-    // Listen for successful creation
+    // Listen for successful creation (fires before setup script runs)
     unlistenPromises.push(
       listen<WorktreeCreatedEvent>('worktree:created', event => {
         const { worktree } = event.payload
@@ -961,9 +962,6 @@ export function useWorktreeEvents() {
         })
 
         clearPendingTimeout(worktree.id)
-
-        const setupFailed =
-          worktree.setup_output && worktree.setup_success === false
 
         const openWorktreeAction = {
           label: 'Open',
@@ -993,30 +991,60 @@ export function useWorktreeEvents() {
           },
         }
 
-        if (setupFailed) {
-          toast.error('Setup script failed', {
-            id: `worktree-creating-${worktree.id}`,
-            description: 'Worktree was created but the setup script exited with an error.',
-            action: openWorktreeAction,
-          })
-        } else {
-          toast.success('Worktree ready', {
-            id: `worktree-creating-${worktree.id}`,
-            action: openWorktreeAction,
-          })
-        }
+        toast.success('Worktree ready', {
+          id: `worktree-creating-${worktree.id}`,
+          action: openWorktreeAction,
+        })
 
         handleWorktreeReady(worktree, queryClient)
+      })
+    )
 
-        // Add setup script output to chat store if present
-        if (worktree.setup_output) {
-          const { addSetupScriptResult } = useChatStore.getState()
-          addSetupScriptResult(worktree.id, {
-            worktreeName: worktree.name,
-            worktreePath: worktree.path,
-            script: worktree.setup_script ?? '',
-            output: worktree.setup_output,
-            success: worktree.setup_success !== false,
+    // Listen for setup script completion (fires after worktree:created)
+    unlistenPromises.push(
+      listen<WorktreeSetupCompleteEvent>('worktree:setup_complete', event => {
+        const { id, project_id, setup_output, setup_script, setup_success } =
+          event.payload
+        logger.info('Worktree setup script complete', {
+          id,
+          success: setup_success,
+        })
+
+        // Update worktree in query cache with setup results
+        const updateWorktree = (worktree: Worktree): Worktree => ({
+          ...worktree,
+          setup_output,
+          setup_script,
+          setup_success,
+        })
+        queryClient.setQueryData<Worktree[]>(
+          projectsQueryKeys.worktrees(project_id),
+          old => old?.map(w => (w.id === id ? updateWorktree(w) : w))
+        )
+        queryClient.setQueryData<Worktree>(
+          [...projectsQueryKeys.all, 'worktree', id],
+          old => (old ? updateWorktree(old) : old)
+        )
+
+        // Get worktree info from cache for the setup result display
+        const cachedWorktree = queryClient
+          .getQueryData<Worktree[]>(projectsQueryKeys.worktrees(project_id))
+          ?.find(w => w.id === id)
+
+        // Add setup script output to chat store
+        const { addSetupScriptResult } = useChatStore.getState()
+        addSetupScriptResult(id, {
+          worktreeName: cachedWorktree?.name ?? id,
+          worktreePath: cachedWorktree?.path ?? '',
+          script: setup_script,
+          output: setup_output,
+          success: setup_success,
+        })
+
+        if (!setup_success) {
+          toast.error('Setup script failed', {
+            description:
+              'Worktree is ready but the setup script exited with an error.',
           })
         }
       })

--- a/src/types/projects.ts
+++ b/src/types/projects.ts
@@ -156,6 +156,15 @@ export interface WorktreeCreatedEvent {
   worktree: Worktree
 }
 
+/** Event payload when worktree setup script completes (after worktree:created) */
+export interface WorktreeSetupCompleteEvent {
+  id: string
+  project_id: string
+  setup_output: string
+  setup_script: string
+  setup_success: boolean
+}
+
 /** Event payload when worktree creation fails */
 export interface WorktreeCreateErrorEvent {
   id: string


### PR DESCRIPTION
## Summary

- Defer jean.json setup script execution until after worktree creation, allowing the UI to open immediately
- Emit `worktree:created` event before running setup so users can start typing while setup completes in the background
- Add new `worktree:setup_complete` event that fires when the setup script finishes
- Display "Running setup script" indicator in the UI while setup is in progress
- Update worktree cache when setup completes with final results

## Changes

**Backend (Rust):**
- Move setup script execution to run asynchronously after emitting `worktree:created`
- Create new `WorktreeSetupCompleteEvent` type to signal setup completion
- Update storage and emit setup event with output, script, and success status after setup runs

**Frontend (React):**
- Add listener for `worktree:setup_complete` event to update worktree state
- Show spinning loader with setup command while script is running
- Display setup script output card when setup completes (success or failure)
- Update setup status text from "Running setup script..." to "Creating worktree..."

## User Experience

Users can now start typing their initial message into the chat while the jean.json setup script runs in the background. The setup status is clearly indicated with a loading state, and results are displayed when complete. This resolves the issue where the UI would be blocked for seconds or minutes during long setup operations.

---

Fixes #208