### PR TITLE
fix(chat): preserve conversations on CLI completion despite thread errors

### DIFF
--- a/src-tauri/src/chat/claude.rs
+++ b/src-tauri/src/chat/claude.rs
@@ -959,6 +959,7 @@ pub fn tail_claude_output(
     let mut content_blocks: Vec<ContentBlock> = Vec::new();
     let mut completed = false;
     let mut cancelled = false;
+    let mut user_cancelled = false; // True only for explicit user cancel (not process death)
     let mut usage: Option<UsageData> = None;
     let mut error_lines: Vec<String> = Vec::new();
 
@@ -1381,6 +1382,7 @@ pub fn tail_claude_output(
         // for the dead_process_timeout
         if !super::registry::is_process_running(session_id) {
             log::trace!("Session {session_id} cancelled externally, stopping tail");
+            user_cancelled = true;
             cancelled = true;
             break;
         }
@@ -1472,9 +1474,12 @@ pub fn tail_claude_output(
         );
     }
 
-    // Emit done event only if not cancelled
-    // (cancel_process already emitted chat:cancelled, avoid double event)
-    if !cancelled {
+    // Emit done event unless the user explicitly cancelled (cancel_process
+    // already emitted chat:cancelled in that case, avoid double event).
+    // When the process died naturally (not user cancel) but produced content,
+    // we still emit chat:done so the frontend properly transitions from
+    // streaming to persisted state (#209).
+    if !user_cancelled {
         let done_event = DoneEvent {
             session_id: session_id.to_string(),
             worktree_id: worktree_id.to_string(),

--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -2390,9 +2390,52 @@ pub async fn send_chat_message(
                 }
                 // If the flag was set, the cancel_process path already marked the run as Cancelled
             } else {
-                // Non-OpenCode error: mark as crashed too
-                if let Err(mark_err) = run_log_writer.mark_crashed() {
-                    log::warn!("Failed to mark run as crashed after thread error: {mark_err}");
+                // Non-OpenCode error: check if CLI actually completed despite the
+                // thread error (e.g. tailing timed out but CLI finished). If so,
+                // salvage the run as Completed with the resume ID (#209).
+                if run_log::jsonl_has_result_line(&app, &session_id, &run_id) {
+                    log::info!(
+                        "[SendChat] CLI completed despite thread error for session={session_id}, salvaging run"
+                    );
+                    let resume_sid =
+                        run_log::extract_session_id_from_jsonl(&app, &session_id, &run_id);
+                    let salvage_msg_id = Uuid::new_v4().to_string();
+                    if let Err(complete_err) = run_log_writer.complete(
+                        &salvage_msg_id,
+                        resume_sid.as_deref(),
+                        None,
+                    ) {
+                        log::warn!("Failed to complete salvaged run: {complete_err}");
+                    }
+                    // Also persist resume ID to session index so --resume works
+                    if let Some(ref sid) = resume_sid {
+                        if let Err(save_err) = with_sessions_mut(
+                            &app,
+                            &worktree_path,
+                            &worktree_id,
+                            |sessions| {
+                                if let Some(session) =
+                                    sessions.find_session_mut(&session_id)
+                                {
+                                    session.claude_session_id = Some(sid.clone());
+                                    session.is_reviewing = true;
+                                    session.waiting_for_input = false;
+                                }
+                                Ok(())
+                            },
+                        ) {
+                            log::warn!(
+                                "Failed to save salvaged resume ID (will recover on restart): {save_err}"
+                            );
+                        }
+                    }
+                    emit_sessions_cache_invalidation(&app);
+                } else {
+                    if let Err(mark_err) = run_log_writer.mark_crashed() {
+                        log::warn!(
+                            "Failed to mark run as crashed after thread error: {mark_err}"
+                        );
+                    }
                 }
             }
             return Err(e);
@@ -2400,8 +2443,24 @@ pub async fn send_chat_message(
         Err(_) => {
             log::info!("[SendChat] EXIT session={session_id} reason=thread_panic");
             super::registry::cleanup_session_registrations(&session_id);
-            if let Err(mark_err) = run_log_writer.mark_crashed() {
-                log::warn!("Failed to mark run as crashed after thread panic: {mark_err}");
+            // Check if CLI completed despite thread panic (#209)
+            if run_log::jsonl_has_result_line(&app, &session_id, &run_id) {
+                log::info!(
+                    "[SendChat] CLI completed despite thread panic for session={session_id}, salvaging run"
+                );
+                let resume_sid =
+                    run_log::extract_session_id_from_jsonl(&app, &session_id, &run_id);
+                let salvage_msg_id = Uuid::new_v4().to_string();
+                if let Err(complete_err) =
+                    run_log_writer.complete(&salvage_msg_id, resume_sid.as_deref(), None)
+                {
+                    log::warn!("Failed to complete salvaged run after panic: {complete_err}");
+                }
+                emit_sessions_cache_invalidation(&app);
+            } else {
+                if let Err(mark_err) = run_log_writer.mark_crashed() {
+                    log::warn!("Failed to mark run as crashed after thread panic: {mark_err}");
+                }
             }
             return Err(
                 "CLI execution thread closed unexpectedly (possible crash or panic)".to_string(),
@@ -2599,8 +2658,13 @@ pub async fn send_chat_message(
 
     // Atomically save session metadata (resume ID for session continuity)
     // Note: Messages are NOT saved here - they're in NDJSON only
-    // Only persist if the run produced meaningful content
-    with_sessions_mut(&app, &worktree_path, &worktree_id, |sessions| {
+    // Only persist if the run produced meaningful content.
+    // IMPORTANT: This is non-fatal — the critical data (run completion, JSONL content)
+    // is already persisted by run_log_writer.complete() above. If this fails, the
+    // resume ID and completion state will be recovered on next app startup via
+    // recover_incomplete_runs(). Making this fatal would cause the frontend to roll
+    // back the conversation cache even though the CLI ran successfully (#209).
+    if let Err(e) = with_sessions_mut(&app, &worktree_path, &worktree_id, |sessions| {
         if let Some(session) = sessions.find_session_mut(&session_id) {
             if !resume_id_for_log.is_empty() && has_content {
                 match response_backend {
@@ -2646,7 +2710,11 @@ pub async fn send_chat_message(
             }
         }
         Ok(())
-    })?;
+    }) {
+        log::error!(
+            "[SendChat] Failed to save session state for session={session_id} (non-fatal, will recover on restart): {e}"
+        );
+    }
 
     // Emit cache invalidation so all clients (native + web) refetch authoritative state
     emit_sessions_cache_invalidation(&app);

--- a/src-tauri/src/chat/run_log.rs
+++ b/src-tauri/src/chat/run_log.rs
@@ -1041,6 +1041,24 @@ pub fn recover_incomplete_runs(app: &tauri::AppHandle) -> Result<Vec<RecoveredRu
                     if completed {
                         run.status = RunStatus::Completed;
                         metadata.is_reviewing = true;
+
+                        // Recover claude_session_id from JSONL so the session can
+                        // resume with full context (#209). This handles the case
+                        // where send_chat_message errored before persisting the
+                        // resume ID to the session index.
+                        if run.claude_session_id.is_none() {
+                            if let Some(sid) =
+                                extract_session_id_from_jsonl(app, &session_id, &run.run_id)
+                            {
+                                log::trace!(
+                                    "Recovered claude_session_id from JSONL for run {} in session {}",
+                                    run.run_id,
+                                    session_id
+                                );
+                                run.claude_session_id = Some(sid.clone());
+                                metadata.claude_session_id = Some(sid);
+                            }
+                        }
                     } else {
                         run.status = RunStatus::Crashed;
                     }
@@ -1088,7 +1106,7 @@ pub fn recover_incomplete_runs(app: &tauri::AppHandle) -> Result<Vec<RecoveredRu
 
 /// Check if a run's JSONL file contains a "type":"result" line,
 /// indicating the CLI process completed successfully (vs crashing).
-fn jsonl_has_result_line(app: &tauri::AppHandle, session_id: &str, run_id: &str) -> bool {
+pub fn jsonl_has_result_line(app: &tauri::AppHandle, session_id: &str, run_id: &str) -> bool {
     let session_dir = match get_session_dir(app, session_id) {
         Ok(d) => d,
         Err(_) => return false,
@@ -1119,6 +1137,44 @@ fn jsonl_has_result_line(app: &tauri::AppHandle, session_id: &str, run_id: &str)
         }
     }
     false
+}
+
+/// Extract the Claude session ID from a run's JSONL file.
+/// Looks for the `"session_id"` field in the result line (last ~8KB of file).
+/// Returns None if the file doesn't exist, can't be read, or has no session ID.
+pub fn extract_session_id_from_jsonl(
+    app: &tauri::AppHandle,
+    session_id: &str,
+    run_id: &str,
+) -> Option<String> {
+    let session_dir = get_session_dir(app, session_id).ok()?;
+    let jsonl_path = session_dir.join(format!("{run_id}.jsonl"));
+    let file = File::open(&jsonl_path).ok()?;
+
+    // Read from the end — the session_id is typically in the result line near EOF.
+    let file_len = file.metadata().map(|m| m.len()).unwrap_or(0);
+    let reader = if file_len > 8192 {
+        use std::io::{Seek, SeekFrom};
+        let mut f = file;
+        let _ = f.seek(SeekFrom::End(-8192));
+        BufReader::new(f)
+    } else {
+        BufReader::new(file)
+    };
+
+    let mut last_session_id = None;
+    for line in reader.lines().flatten() {
+        // Look for session_id in JSON lines (typically in result or system lines)
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&line) {
+            if let Some(sid) = val.get("session_id").and_then(|v| v.as_str()) {
+                if !sid.is_empty() {
+                    last_session_id = Some(sid.to_string());
+                }
+            }
+        }
+    }
+
+    last_session_id
 }
 
 /// Find all runs with status = Running (incomplete runs that need recovery)

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -1011,6 +1011,7 @@ export default function useStreamingEvents({
       // Store error for inline display and restore input
       const {
         lastSentMessages,
+        streamingContents,
         setInputDraft,
         clearLastSentMessage,
         setError,
@@ -1095,9 +1096,14 @@ export default function useStreamingEvents({
       // Set error state for inline display
       setError(session_id, error)
 
+      // Check if CLI produced streaming content BEFORE clearing state.
+      // If content was streamed, the CLI ran — don't remove the user message
+      // or rollback, as the conversation is persisted in JSONL on disk (#209).
+      const hasStreamedContent = !!streamingContents[session_id]
+
       // Restore the input that failed so user can retry
       const lastMessage = lastSentMessages[session_id]
-      if (lastMessage) {
+      if (lastMessage && !hasStreamedContent) {
         setInputDraft(session_id, lastMessage)
         clearLastSentMessage(session_id)
 
@@ -1124,6 +1130,9 @@ export default function useStreamingEvents({
           }
         )
 
+      } else if (lastMessage) {
+        // Had streaming content — don't restore to input, just clear tracking
+        clearLastSentMessage(session_id)
       }
 
       // Restore attachments that were cleared on send

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -1417,7 +1417,29 @@ export function useSendMessage() {
         return
       }
 
-      // Real errors — rollback to previous state
+      // Check if CLI produced streaming content before the error.
+      // If so, the CLI likely ran — don't destroy the conversation by
+      // rolling back to pre-send state. Instead, refetch from disk (#209).
+      const hasStreamedContent = !!useChatStore.getState().streamingContents[sessionId]
+      if (hasStreamedContent) {
+        logger.warn('Error after CLI produced content, refetching instead of rollback', {
+          sessionId,
+          error: errorMessage,
+        })
+        setError(sessionId, errorMessage || 'Unknown error occurred')
+        queryClient.invalidateQueries({
+          queryKey: chatQueryKeys.session(sessionId),
+        })
+        queryClient.invalidateQueries({
+          queryKey: chatQueryKeys.sessions(worktreeId),
+        })
+        toast.error('An error occurred, but your conversation was preserved.', {
+          description: errorMessage,
+        })
+        return
+      }
+
+      // Real errors with no streamed content — rollback to previous state
       setError(sessionId, errorMessage || 'Unknown error occurred')
 
       if (context?.previous) {


### PR DESCRIPTION
## Summary

- Detect when CLI successfully completes despite thread errors or panics by checking JSONL output for result lines
- Salvage completed runs and recover resume IDs from JSONL when session state wasn't persisted due to thread failure
- Distinguish between explicit user cancellation and natural process death to preserve frontend state appropriately
- Prevent conversation rollback in error handlers when streaming content was produced — refetch from disk instead
- Make session state persistence non-fatal to avoid rolling back successfully completed conversations

## Fixes

Resolves #209: Conversation disappearing after first message when CLI thread encounters an error.

Previously, if the CLI process completed successfully but the Rust thread handling the completion encountered an error (timeout, panic, etc.), the system would:
1. Mark the run as crashed
2. Rollback the frontend conversation state
3. Lose the conversation data despite it being written to disk

Now, the system checks if the CLI actually produced results in JSONL before deciding to destroy the conversation. If results exist, the run is salvaged, resume IDs are recovered, and the frontend is instructed to refetch rather than rollback.

---

Fixes #209