### PR TITLE
refactor(chat): consolidate slash command execution into message pipeline

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "jean"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "arboard",
  "axum",

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -22,6 +22,7 @@ import {
 } from './FileMentionPopover'
 import { queryClient } from '@/lib/query-client'
 import { fileQueryKeys } from '@/services/files'
+import { skillQueryKeys } from '@/services/skills'
 import type { WorktreeFile } from '@/types/chat'
 import { SlashPopover, type SlashPopoverHandle } from './SlashPopover'
 
@@ -43,7 +44,6 @@ interface ChatInputProps {
   onSubmit: (e: React.FormEvent) => void
   onCancel: () => void
   onSwitchBackendWithTab?: () => void
-  onCommandExecute?: (command: ClaudeCommand) => void
   onHasValueChange?: (hasValue: boolean) => void
   onRegisterClearHandler?: (clearHandler: (() => void) | null) => void
   formRef: React.RefObject<HTMLFormElement | null>
@@ -60,7 +60,6 @@ export const ChatInput = memo(function ChatInput({
   onSubmit,
   onCancel,
   onSwitchBackendWithTab,
-  onCommandExecute,
   onHasValueChange,
   onRegisterClearHandler,
   formRef,
@@ -187,7 +186,11 @@ export const ChatInput = memo(function ChatInput({
     valueRef.current = ''
     setShowHint(true)
     onHasValueChangeRef.current?.(false)
-  }, [inputRef])
+    // Clear any pending command for the active session
+    if (activeSessionId) {
+      useChatStore.getState().setPendingCommand(activeSessionId, null)
+    }
+  }, [inputRef, activeSessionId])
 
   useEffect(() => {
     onRegisterClearHandler?.(clearInputState)
@@ -214,6 +217,13 @@ export const ChatInput = memo(function ChatInput({
       setShowHint(prev => (prev !== isEmpty ? isEmpty : prev))
       // Notify parent of hasValue change for send button styling
       onHasValueChangeRef.current?.(!isEmpty)
+
+      // Clear pending command if input no longer starts with /commandname
+      const { pendingCommands, setPendingCommand } = useChatStore.getState()
+      const pendingCmd = pendingCommands[activeSessionId]
+      if (pendingCmd && !value.startsWith(`/${pendingCmd.name}`)) {
+        setPendingCommand(activeSessionId, null)
+      }
 
       // Sync pending files with @mentions in input
       // Remove any pending files whose @filename is no longer in the text
@@ -323,6 +333,20 @@ export const ChatInput = memo(function ChatInput({
             query.includes('\n') ||
             cursorPos <= slashTriggerIndex
           ) {
+            // If closing due to space, check if the query (before space) exactly matches a command
+            // Auto-set pending command so the user can type args after the command name
+            if (query.includes(' ') && activeSessionId) {
+              const commandName = query.split(' ')[0]
+              if (commandName) {
+                const commands = queryClient.getQueryData<ClaudeCommand[]>(
+                  skillQueryKeys.commands(activeWorktreePath)
+                )
+                const matched = commands?.find(c => c.name === commandName)
+                if (matched) {
+                  useChatStore.getState().setPendingCommand(activeSessionId, matched)
+                }
+              }
+            }
             setSlashPopoverOpen(false)
             setSlashTriggerIndex(null)
             setSlashQuery('')
@@ -896,31 +920,41 @@ export const ChatInput = memo(function ChatInput({
     [activeSessionId, slashTriggerIndex, inputRef]
   )
 
-  // Handle command selection from / mention popover (executes immediately)
+  // Handle command selection from / mention popover (inserts into input for user to add args)
   const handleCommandSelect = useCallback(
     (command: ClaudeCommand) => {
+      if (!activeSessionId) return
+
       // Cancel pending debounced save (it still has the old "/command" value)
       clearTimeout(debouncedSaveRef.current)
 
-      // Clear input
+      // Store the pending command in the store
+      useChatStore.getState().setPendingCommand(activeSessionId, command)
+
+      // Replace input with /commandname + trailing space for args
+      const newValue = `/${command.name} `
       if (inputRef.current) {
-        inputRef.current.value = ''
-        valueRef.current = ''
+        inputRef.current.value = newValue
+        valueRef.current = newValue
+        // Place cursor at end
+        requestAnimationFrame(() => {
+          const pos = newValue.length
+          inputRef.current?.setSelectionRange(pos, pos)
+        })
       }
-      if (activeSessionId) {
-        useChatStore.getState().setInputDraft(activeSessionId, '')
-      }
+      useChatStore.getState().setInputDraft(activeSessionId, newValue)
+      onHasValueChangeRef.current?.(true)
 
       // Reset slash popover state
       setSlashPopoverOpen(false)
       setSlashTriggerIndex(null)
       setSlashQuery('')
-      setShowHint(true)
+      setShowHint(false)
 
-      // Notify parent to execute command
-      onCommandExecute?.(command)
+      // Refocus input
+      inputRef.current?.focus()
     },
-    [activeSessionId, inputRef, onCommandExecute]
+    [activeSessionId, inputRef]
   )
 
   // Determine if slash is at prompt start (for enabling commands)

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -1497,7 +1497,6 @@ export function ChatWindow({
   // Message sending pipeline: resolveCustomProfile, sendMessageNow, handleSubmit, git diff handlers
   const {
     resolveCustomProfile,
-    sendMessageNow,
     handleSubmit,
     handleCancel,
     handleGitDiffAddToPrompt,
@@ -1910,31 +1909,17 @@ export function ChatWindow({
     else if (pendingPlanMessage) handleWorktreeYoloApproval(pendingPlanMessage.id)
   }, [hasStreamingPlan, handleStreamingWorktreeYoloApproval, pendingPlanMessage, handleWorktreeYoloApproval])
 
-  // Pending attachment removal, slash command execution, queue management
+  // Pending attachment removal, queue management
   const {
     handleRemovePendingImage,
     handleRemovePendingTextFile,
     handleRemovePendingSkill,
     handleRemovePendingFile,
-    handleCommandExecute,
     handleRemoveQueuedMessage,
     handleForceSendQueued,
   } = usePendingAttachments({
     activeSessionId,
-    activeWorktreeId,
-    activeWorktreePath,
-    selectedModelRef,
-    selectedProviderRef,
-    executionModeRef,
-    selectedThinkingLevelRef,
-    selectedEffortLevelRef,
-    useAdaptiveThinkingRef,
-    isCodexBackendRef,
-    mcpServersDataRef,
-    enabledMcpServersRef,
-    selectedBackendRef,
     setInputDraft,
-    sendMessageNow,
   })
 
   // Pre-calculate last plan message index for approve button logic
@@ -2384,7 +2369,6 @@ export function ChatWindow({
                                 onSubmit={handleSubmit}
                                 onCancel={handleCancel}
                                 onSwitchBackendWithTab={handleTabBackendSwitch}
-                                onCommandExecute={handleCommandExecute}
                                 onHasValueChange={setHasInputValue}
                                 onRegisterClearHandler={(
                                   handler: (() => void) | null

--- a/src/components/chat/hooks/useMessageSending.ts
+++ b/src/components/chat/hooks/useMessageSending.ts
@@ -7,12 +7,14 @@ import { buildMcpConfigJson } from '@/services/mcp'
 import { DEFAULT_PARALLEL_EXECUTION_PROMPT } from '@/types/preferences'
 import type {
   QueuedMessage,
+  ResolvedCommand,
   ExecutionMode,
   ThinkingLevel,
   EffortLevel,
   McpServerInfo,
   Session,
 } from '@/types/chat'
+import { invoke } from '@/lib/transport'
 import type { QueryClient } from '@tanstack/react-query'
 import { GIT_ALLOWED_TOOLS } from './useMessageHandlers'
 
@@ -335,6 +337,8 @@ export function useMessageSending({
 
       const {
         inputDrafts,
+        pendingCommands,
+        setPendingCommand,
         getPendingImages,
         clearPendingImages,
         getPendingFiles,
@@ -351,6 +355,7 @@ export function useMessageSending({
       const textMessage = (
         liveInputValue ?? inputDrafts[activeSessionId ?? ''] ?? ''
       ).trim()
+      const pendingCommand = activeSessionId ? pendingCommands[activeSessionId] : undefined
       const images = getPendingImages(activeSessionId ?? '')
       const files = getPendingFiles(activeSessionId ?? '')
       const skills = getPendingSkills(activeSessionId ?? '')
@@ -358,6 +363,7 @@ export function useMessageSending({
 
       if (
         !textMessage &&
+        !pendingCommand &&
         images.length === 0 &&
         files.length === 0 &&
         textFiles.length === 0 &&
@@ -377,8 +383,6 @@ export function useMessageSending({
         )
         return
       }
-
-      const message = textMessage
 
       if (
         images.length > 0 ||
@@ -408,6 +412,85 @@ export function useMessageSending({
         useChatStore.getState()
       setQuestionsSkipped(activeSessionId, false)
       setWaitingForInput(activeSessionId, false)
+
+      // If there's a pending command, resolve it asynchronously then send
+      if (pendingCommand) {
+        setPendingCommand(activeSessionId, null)
+
+        // Extract user args: strip /commandname prefix
+        const prefix = `/${pendingCommand.name}`
+        const userArgs = textMessage.startsWith(prefix)
+          ? textMessage.slice(prefix.length).trim()
+          : textMessage
+
+        const toastId = toast.loading(`Resolving /${pendingCommand.name}...`)
+
+        void (async () => {
+          try {
+            const resolved = await invoke<ResolvedCommand>(
+              'resolve_claude_command',
+              {
+                commandPath: pendingCommand.path,
+                workingDir: activeWorktreePath,
+              }
+            )
+
+            const resolvedMessage = userArgs
+              ? `${resolved.content}\n\nArguments are: ${userArgs}`
+              : resolved.content
+
+            const mode = executionModeRef.current
+            const thinkingLvl = selectedThinkingLevelRef.current
+            const queuedMessage: QueuedMessage = {
+              id: generateId(),
+              message: resolvedMessage,
+              pendingImages: images,
+              pendingFiles: files,
+              pendingSkills: skills,
+              pendingTextFiles: textFiles,
+              model: selectedModelRef.current,
+              provider: selectedProviderRef.current,
+              executionMode: mode,
+              thinkingLevel: thinkingLvl,
+              effortLevel:
+                useAdaptiveThinkingRef.current || isCodexBackendRef.current
+                  ? selectedEffortLevelRef.current
+                  : undefined,
+              mcpConfig: buildMcpConfigJson(
+                mcpServersDataRef.current ?? [],
+                enabledMcpServersRef.current,
+                selectedBackendRef.current
+              ),
+              commandAllowedTools: resolved.allowed_tools,
+              backend:
+                selectedBackendRef.current !== 'claude'
+                  ? selectedBackendRef.current
+                  : undefined,
+              queuedAt: Date.now(),
+            }
+
+            toast.dismiss(toastId)
+            markAtBottom()
+
+            const { isSending: recheckSending, enqueueMessage: reEnqueue } =
+              useChatStore.getState()
+            if (recheckSending(activeSessionId)) {
+              reEnqueue(activeSessionId, queuedMessage)
+              persistEnqueue(activeWorktreeId, activeWorktreePath, activeSessionId, queuedMessage)
+            } else {
+              sendMessageNow(queuedMessage)
+            }
+          } catch (error) {
+            toast.error(
+              `Failed to resolve /${pendingCommand.name}: ${error instanceof Error ? error.message : String(error)}`,
+              { id: toastId }
+            )
+          }
+        })()
+        return
+      }
+
+      const message = textMessage
 
       const mode = executionModeRef.current
       const thinkingLvl = selectedThinkingLevelRef.current

--- a/src/components/chat/hooks/usePendingAttachments.ts
+++ b/src/components/chat/hooks/usePendingAttachments.ts
@@ -1,58 +1,19 @@
-import { useCallback, type RefObject } from 'react'
-import { invoke } from '@/lib/transport'
-import { generateId } from '@/lib/uuid'
-import { toast } from 'sonner'
-import { persistEnqueue, persistRemoveQueued } from '@/services/chat'
+import { useCallback } from 'react'
+import { persistRemoveQueued } from '@/services/chat'
 import { useChatStore } from '@/store/chat-store'
-import { buildMcpConfigJson } from '@/services/mcp'
 import { getFilename } from '@/lib/path-utils'
-import type {
-  QueuedMessage,
-  ClaudeCommand,
-  ResolvedCommand,
-  ExecutionMode,
-  ThinkingLevel,
-  EffortLevel,
-  McpServerInfo,
-} from '@/types/chat'
 
 interface UsePendingAttachmentsParams {
   activeSessionId: string | null | undefined
-  activeWorktreeId: string | null | undefined
-  activeWorktreePath: string | null | undefined
-  selectedModelRef: RefObject<string>
-  selectedProviderRef: RefObject<string | null>
-  executionModeRef: RefObject<ExecutionMode>
-  selectedThinkingLevelRef: RefObject<ThinkingLevel>
-  selectedEffortLevelRef: RefObject<EffortLevel>
-  useAdaptiveThinkingRef: RefObject<boolean>
-  isCodexBackendRef: RefObject<boolean>
-  mcpServersDataRef: RefObject<McpServerInfo[] | undefined>
-  enabledMcpServersRef: RefObject<string[]>
-  selectedBackendRef: RefObject<'claude' | 'codex' | 'opencode'>
   setInputDraft: (sessionId: string, draft: string) => void
-  sendMessageNow: (queuedMsg: QueuedMessage) => void
 }
 
 /**
- * Handlers for removing pending attachments and executing slash commands.
+ * Handlers for removing pending attachments and queue management.
  */
 export function usePendingAttachments({
   activeSessionId,
-  activeWorktreeId,
-  activeWorktreePath,
-  selectedModelRef,
-  selectedProviderRef,
-  executionModeRef,
-  selectedThinkingLevelRef,
-  selectedEffortLevelRef,
-  useAdaptiveThinkingRef,
-  isCodexBackendRef,
-  mcpServersDataRef,
-  enabledMcpServersRef,
-  selectedBackendRef,
   setInputDraft,
-  sendMessageNow,
 }: UsePendingAttachmentsParams) {
   const handleRemovePendingImage = useCallback(
     (imageId: string) => {
@@ -105,69 +66,6 @@ export function usePendingAttachments({
     [activeSessionId, setInputDraft]
   )
 
-  const handleCommandExecute = useCallback(
-    (command: ClaudeCommand) => {
-      if (!activeSessionId || !activeWorktreeId || !activeWorktreePath) return
-
-      void (async () => {
-        const toastId = toast.loading(`Resolving /${command.name}...`)
-
-        try {
-          const resolved = await invoke<ResolvedCommand>(
-            'resolve_claude_command',
-            {
-              commandPath: command.path,
-              workingDir: activeWorktreePath,
-            }
-          )
-
-          const queuedMessage: QueuedMessage = {
-            id: generateId(),
-            message: resolved.content,
-            pendingImages: [],
-            pendingFiles: [],
-            pendingSkills: [],
-            pendingTextFiles: [],
-            model: selectedModelRef.current,
-            provider: selectedProviderRef.current,
-            executionMode: executionModeRef.current,
-            thinkingLevel: selectedThinkingLevelRef.current,
-            effortLevel:
-              useAdaptiveThinkingRef.current || isCodexBackendRef.current
-                ? selectedEffortLevelRef.current
-                : undefined,
-            mcpConfig: buildMcpConfigJson(
-              mcpServersDataRef.current ?? [],
-              enabledMcpServersRef.current,
-              selectedBackendRef.current
-            ),
-            commandAllowedTools: resolved.allowed_tools,
-            queuedAt: Date.now(),
-          }
-
-          const { isSending: checkIsSendingNow, enqueueMessage } =
-            useChatStore.getState()
-          if (checkIsSendingNow(activeSessionId)) {
-            enqueueMessage(activeSessionId, queuedMessage)
-            if (activeWorktreeId && activeWorktreePath) {
-              persistEnqueue(activeWorktreeId, activeWorktreePath, activeSessionId, queuedMessage)
-            }
-          } else {
-            sendMessageNow(queuedMessage)
-          }
-
-          toast.dismiss(toastId)
-        } catch (error) {
-          toast.error(
-            `Failed to resolve /${command.name}: ${error instanceof Error ? error.message : String(error)}`,
-            { id: toastId }
-          )
-        }
-      })()
-    },
-    [activeSessionId, activeWorktreeId, activeWorktreePath, sendMessageNow]
-  )
-
   const handleRemoveQueuedMessage = useCallback(
     (sessionId: string, messageId: string) => {
       useChatStore.getState().removeQueuedMessage(sessionId, messageId)
@@ -191,7 +89,6 @@ export function usePendingAttachments({
     handleRemovePendingTextFile,
     handleRemovePendingSkill,
     handleRemovePendingFile,
-    handleCommandExecute,
     handleRemoveQueuedMessage,
     handleForceSendQueued,
   }

--- a/src/store/chat-store.ts
+++ b/src/store/chat-store.ts
@@ -18,6 +18,7 @@ import {
   type ExecutionMode,
   type SessionDigest,
   type LabelData,
+  type ClaudeCommand,
   EXECUTION_MODE_CYCLE,
   isExitPlanMode,
 } from '@/types/chat'
@@ -111,6 +112,9 @@ interface ChatUIState {
 
   // Draft input per session (preserves text when switching tabs)
   inputDrafts: Record<string, string>
+
+  // Pending slash command per session (set when user selects from popover, resolved on submit)
+  pendingCommands: Record<string, ClaudeCommand>
 
   // Execution mode per session (defaults to 'plan' for new sessions)
   executionModes: Record<string, ExecutionMode>
@@ -332,6 +336,9 @@ interface ChatUIState {
   // Actions - Input drafts (session-based)
   setInputDraft: (sessionId: string, value: string) => void
   clearInputDraft: (sessionId: string) => void
+
+  // Actions - Pending command (session-based)
+  setPendingCommand: (sessionId: string, command: ClaudeCommand | null) => void
 
   // Actions - Execution mode (session-based)
   cycleExecutionMode: (sessionId: string) => void
@@ -570,6 +577,7 @@ export const useChatStore = create<ChatUIState>()(
       streamingContentBlocks: {},
       streamingThinkingContent: {},
       inputDrafts: {},
+      pendingCommands: {},
       executionModes: {},
       thinkingLevels: {},
       effortLevels: {},
@@ -1226,6 +1234,21 @@ export const useChatStore = create<ChatUIState>()(
           },
           undefined,
           'clearInputDraft'
+        ),
+
+      setPendingCommand: (sessionId, command) =>
+        set(
+          state => {
+            if (command === null) {
+              if (!(sessionId in state.pendingCommands)) return state
+              const { [sessionId]: _, ...rest } = state.pendingCommands
+              return { pendingCommands: rest }
+            }
+            if (state.pendingCommands[sessionId]?.path === command.path) return state
+            return { pendingCommands: { ...state.pendingCommands, [sessionId]: command } }
+          },
+          undefined,
+          'setPendingCommand'
         ),
 
       // Execution mode (session-based)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,26 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
+import { writeFileSync, mkdirSync } from 'fs'
+
+/** Recreate dist/.gitkeep after Vite clears the output directory */
+function gitkeepPlugin(): Plugin {
+  return {
+    name: 'gitkeep',
+    writeBundle() {
+      const distDir = path.resolve(__dirname, 'dist')
+      mkdirSync(distDir, { recursive: true })
+      writeFileSync(path.join(distDir, '.gitkeep'), '')
+    },
+  }
+}
 
 const host = process.env.TAURI_DEV_HOST
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), gitkeepPlugin()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary

- Move slash command execution from immediate handler to message sending pipeline
- Commands now insert into chat input as `/commandname ` instead of executing immediately, allowing users to provide arguments
- Auto-detect and set pending command when user types space after a command name
- Clear pending commands when input is edited or form is submitted
- Add `pendingCommands` state to chat store to track selected command per session
- Simplify `usePendingAttachments` hook by removing command execution logic
- Update version to 0.1.31

## Changes by File

**ChatInput.tsx**: Refactor command selection to insert into input rather than execute; auto-detect command when user types space after command name; clear pending command when input changes.

**useMessageSending.ts**: Add command resolution logic to `handleSubmit`; when a pending command exists, resolve it asynchronously and send resolved content plus user arguments as the message.

**usePendingAttachments.ts**: Remove `handleCommandExecute` and associated parameters; simplify to only handle attachment removal and queue management.

**ChatWindow.tsx**: Remove `onCommandExecute` prop from ChatInput; pass only essential parameters to `usePendingAttachments`.

**chat-store.ts**: Add `pendingCommands` state and `setPendingCommand` action to track slash commands per session.
