### PR TITLE
feat(chat): enable spellcheck on chat input

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,6 +172,8 @@ pub struct AppPreferences {
     pub has_seen_feature_tour: bool, // Whether user has seen the feature tour onboarding
     #[serde(default)]
     pub has_seen_jean_config_wizard: bool, // Whether user has seen the jean.json setup wizard
+    #[serde(default = "default_spellcheck_enabled")]
+    pub spellcheck_enabled: bool, // Enable spellcheck in the chat input
     #[serde(default = "default_chrome_enabled")]
     pub chrome_enabled: bool, // Enable browser automation via Chrome extension
     #[serde(default = "default_zoom_level")]
@@ -366,6 +368,10 @@ fn default_session_recap_enabled() -> bool {
 
 fn default_parallel_execution_prompt_enabled() -> bool {
     false // Disabled by default (experimental)
+}
+
+fn default_spellcheck_enabled() -> bool {
+    true // Enabled by default
 }
 
 fn default_chrome_enabled() -> bool {
@@ -1120,6 +1126,7 @@ impl Default for AppPreferences {
             known_mcp_servers: Vec::new(),
             has_seen_feature_tour: false,
             has_seen_jean_config_wizard: false,
+            spellcheck_enabled: default_spellcheck_enabled(),
             chrome_enabled: default_chrome_enabled(),
             zoom_level: default_zoom_level(),
             custom_cli_profiles: Vec::new(),

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -4,6 +4,7 @@ import { invoke } from '@/lib/transport'
 import { generateId } from '@/lib/uuid'
 import { toast } from 'sonner'
 import { Textarea } from '@/components/ui/textarea'
+import { usePreferences } from '@/services/preferences'
 import { Kbd } from '@/components/ui/kbd'
 import { useChatStore } from '@/store/chat-store'
 import { getFilename, getExtension } from '@/lib/path-utils'
@@ -67,6 +68,7 @@ export const ChatInput = memo(function ChatInput({
   inputRef,
 }: ChatInputProps) {
   const isMobile = useIsMobile()
+  const { data: preferences } = usePreferences()
 
   // PERFORMANCE: Use uncontrolled input pattern - track value in ref, not state
   // This avoids React re-renders on every keystroke
@@ -934,7 +936,7 @@ export const ChatInput = memo(function ChatInput({
     <div className="relative">
       <Textarea
         ref={inputRef}
-        spellCheck
+        spellCheck={preferences?.spellcheck_enabled ?? true}
         placeholder={
           isSending
             ? executionMode === 'yolo'

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -2000,6 +2000,26 @@ export const GeneralPane: React.FC = () => {
         </div>
       </SettingsSection>
 
+      <SettingsSection title="Chat">
+        <div className="space-y-4">
+          <InlineField
+            label="Spellcheck"
+            description="Enable spellcheck in the chat input"
+          >
+            <Switch
+              checked={preferences?.spellcheck_enabled ?? true}
+              onCheckedChange={checked => {
+                if (preferences) {
+                  patchPreferences.mutate({
+                    spellcheck_enabled: checked,
+                  })
+                }
+              }}
+            />
+          </InlineField>
+        </div>
+      </SettingsSection>
+
       <SettingsSection title="Auto-generate">
         <div className="space-y-4">
           <InlineField

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -934,6 +934,7 @@ export interface AppPreferences {
   known_mcp_servers: string[] // All MCP server names ever seen (prevents re-enabling user-disabled servers)
   has_seen_feature_tour: boolean // Whether user has seen the feature tour onboarding
   has_seen_jean_config_wizard: boolean // Whether user has seen the jean.json setup wizard
+  spellcheck_enabled: boolean // Enable spellcheck in the chat input
   chrome_enabled: boolean // Enable browser automation via Chrome extension
   zoom_level: number // Zoom level percentage (50-200, default 100)
   custom_cli_profiles: CustomCliProfile[] // Custom CLI settings profiles (e.g., OpenRouter, MiniMax)
@@ -1504,6 +1505,7 @@ export const defaultPreferences: AppPreferences = {
   known_mcp_servers: [], // Default: no known servers
   has_seen_feature_tour: false, // Default: not seen
   has_seen_jean_config_wizard: false, // Default: not seen
+  spellcheck_enabled: true, // Default: enabled
   chrome_enabled: true, // Default: enabled
   zoom_level: ZOOM_LEVEL_DEFAULT,
   custom_cli_profiles: [],


### PR DESCRIPTION
## Summary
- Enables spellcheck on the chat textarea with a **configurable toggle** under **Settings > General > Chat**
- Enabled by default — OS-native spellchecker highlights misspelled words and offers right-click corrections
- Can be disabled via the toggle for users who prefer no spellcheck
- Works cross-platform: macOS (WKWebView), Windows (WebView2), and Linux (WebKitGTK) all respect the HTML `spellcheck` attribute
- Zero new dependencies

## Changes
| File | Change |
|------|--------|
| `src/types/preferences.ts` | Add `spellcheck_enabled: boolean` field + default (`true`) |
| `src-tauri/src/lib.rs` | Add field to Rust `AppPreferences` struct |
| `src/components/chat/ChatInput.tsx` | Read preference, conditionally set `spellCheck` prop |
| `src/components/preferences/panes/GeneralPane.tsx` | New "Chat" settings section with spellcheck toggle |

## Test plan
- [ ] Open Settings > General, find the new "Chat" section
- [ ] Verify "Spellcheck" toggle is ON by default
- [ ] Type misspelled words in the chat input — red underlines should appear
- [ ] Right-click a misspelled word to confirm correction suggestions
- [ ] Toggle OFF — spellcheck underlines should disappear
- [ ] Toggle ON again — underlines should reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)