### PR TITLE
feat(chat): add toggle to show full file paths in mention badges

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,6 +172,8 @@ pub struct AppPreferences {
     pub has_seen_feature_tour: bool, // Whether user has seen the feature tour onboarding
     #[serde(default)]
     pub has_seen_jean_config_wizard: bool, // Whether user has seen the jean.json setup wizard
+    #[serde(default)]
+    pub show_full_file_path: bool, // Show full relative path in file mention badges
     #[serde(default = "default_chrome_enabled")]
     pub chrome_enabled: bool, // Enable browser automation via Chrome extension
     #[serde(default = "default_zoom_level")]
@@ -1120,6 +1122,7 @@ impl Default for AppPreferences {
             known_mcp_servers: Vec::new(),
             has_seen_feature_tour: false,
             has_seen_jean_config_wizard: false,
+            show_full_file_path: false,
             chrome_enabled: default_chrome_enabled(),
             zoom_level: default_zoom_level(),
             custom_cli_profiles: Vec::new(),

--- a/src/components/chat/FileMentionBadge.tsx
+++ b/src/components/chat/FileMentionBadge.tsx
@@ -12,6 +12,7 @@ import { Markdown } from '@/components/ui/markdown'
 import { cn } from '@/lib/utils'
 import { getExtension, getExtensionColor } from '@/lib/file-colors'
 import { getFilename } from '@/lib/path-utils'
+import { usePreferences } from '@/services/preferences'
 import {
   Tooltip,
   TooltipTrigger,
@@ -45,8 +46,11 @@ export function FileMentionBadge({
   const [content, setContent] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { data: preferences } = usePreferences()
+  const showFullPath = preferences?.show_full_file_path ?? false
 
   const filename = getFilename(path)
+  const displayName = showFullPath ? path : filename
   const extension = getExtension(path)
 
   const handleOpen = useCallback(async () => {
@@ -96,8 +100,8 @@ export function FileMentionBadge({
                 )}
               />
             )}
-            <span className="text-xs font-medium truncate max-w-[120px]">
-              {isDirectory ? `${filename}/` : filename}
+            <span className={cn('text-xs font-medium truncate', showFullPath ? 'max-w-[240px]' : 'max-w-[120px]')}>
+              {isDirectory ? `${displayName}/` : displayName}
             </span>
           </button>
         </TooltipTrigger>

--- a/src/components/chat/FilePreview.tsx
+++ b/src/components/chat/FilePreview.tsx
@@ -5,6 +5,7 @@ import type { PendingFile } from '@/types/chat'
 import { cn } from '@/lib/utils'
 import { getExtensionColor } from '@/lib/file-colors'
 import { getFilename } from '@/lib/path-utils'
+import { usePreferences } from '@/services/preferences'
 import {
   Tooltip,
   TooltipTrigger,
@@ -25,6 +26,17 @@ interface FilePreviewProps {
  * Renders above the chat input area
  */
 export function FilePreview({ files, onRemove, disabled }: FilePreviewProps) {
+  const { data: preferences } = usePreferences()
+  const showFullPath = preferences?.show_full_file_path ?? false
+
+  const getDisplayName = useCallback(
+    (file: PendingFile) => {
+      const name = showFullPath ? file.relativePath : getFilename(file.relativePath)
+      return file.isDirectory ? `${name}/` : name
+    },
+    [showFullPath]
+  )
+
   const handleRemove = useCallback(
     (e: React.MouseEvent, file: PendingFile) => {
       e.stopPropagation()
@@ -52,10 +64,8 @@ export function FilePreview({ files, onRemove, disabled }: FilePreviewProps) {
                   )}
                 />
               )}
-              <span className="max-w-32 truncate">
-                {file.isDirectory
-                  ? `${getFilename(file.relativePath)}/`
-                  : getFilename(file.relativePath)}
+              <span className={cn('truncate', showFullPath ? 'max-w-64' : 'max-w-32')}>
+                {getDisplayName(file)}
               </span>
               {!disabled && (
                 <DismissButton

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -2000,6 +2000,26 @@ export const GeneralPane: React.FC = () => {
         </div>
       </SettingsSection>
 
+      <SettingsSection title="Chat">
+        <div className="space-y-4">
+          <InlineField
+            label="Show full file paths"
+            description="Display full relative paths in file mention badges instead of just filenames (useful for monorepos)"
+          >
+            <Switch
+              checked={preferences?.show_full_file_path ?? false}
+              onCheckedChange={checked => {
+                if (preferences) {
+                  patchPreferences.mutate({
+                    show_full_file_path: checked,
+                  })
+                }
+              }}
+            />
+          </InlineField>
+        </div>
+      </SettingsSection>
+
       <SettingsSection title="Auto-generate">
         <div className="space-y-4">
           <InlineField

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -934,6 +934,7 @@ export interface AppPreferences {
   known_mcp_servers: string[] // All MCP server names ever seen (prevents re-enabling user-disabled servers)
   has_seen_feature_tour: boolean // Whether user has seen the feature tour onboarding
   has_seen_jean_config_wizard: boolean // Whether user has seen the jean.json setup wizard
+  show_full_file_path: boolean // Show full relative path in file mention badges instead of just filename
   chrome_enabled: boolean // Enable browser automation via Chrome extension
   zoom_level: number // Zoom level percentage (50-200, default 100)
   custom_cli_profiles: CustomCliProfile[] // Custom CLI settings profiles (e.g., OpenRouter, MiniMax)
@@ -1504,6 +1505,7 @@ export const defaultPreferences: AppPreferences = {
   known_mcp_servers: [], // Default: no known servers
   has_seen_feature_tour: false, // Default: not seen
   has_seen_jean_config_wizard: false, // Default: not seen
+  show_full_file_path: false, // Default: show filename only
   chrome_enabled: true, // Default: enabled
   zoom_level: ZOOM_LEVEL_DEFAULT,
   custom_cli_profiles: [],


### PR DESCRIPTION
## Summary
- Adds a **"Show full file paths"** toggle under **Settings > General > Chat**
- When enabled, file mention badges display the full relative path (e.g. `src/components/Button.tsx`) instead of just the filename (`Button.tsx`)
- Applies to both the input area badges (FilePreview) and in-message badges (FileMentionBadge)
- Tooltip still shows the full path regardless of the setting

## Motivation
In **monorepos** with multiple packages (e.g. web + mobile), files often share the same name (`Button.tsx`, `index.ts`, `config.json`). Showing only the filename makes it impossible to tell which package's file was mentioned. This toggle lets users opt into full paths for disambiguation.

## Changes
| File | Change |
|------|--------|
| `src/types/preferences.ts` | Add `show_full_file_path: boolean` field + default |
| `src-tauri/src/lib.rs` | Add field to Rust `AppPreferences` struct |
| `src/components/preferences/panes/GeneralPane.tsx` | New "Chat" settings section with toggle |
| `src/components/chat/FilePreview.tsx` | Use setting for badge display (input area) |
| `src/components/chat/FileMentionBadge.tsx` | Use setting for badge display (messages) |

## Test plan
- [ ] Open Settings > General, find the new "Chat" section
- [ ] Toggle "Show full file paths" ON
- [ ] Type `@` in chat, select a file — badge should show full relative path
- [ ] Send a message with a file mention — in-message badge should show full path
- [ ] Toggle OFF — badges should revert to filename only
- [ ] Hover over badges — tooltip should always show full path regardless of toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)