### PR TITLE
feat(ui): add settings link to Open In dropdown

### DIFF
--- a/src/components/open-in/OpenInButton.tsx
+++ b/src/components/open-in/OpenInButton.tsx
@@ -1,10 +1,11 @@
 import { useCallback } from 'react'
-import { Code, Terminal, FolderOpen, Github, ChevronDown } from 'lucide-react'
+import { Code, Terminal, FolderOpen, Github, ChevronDown, Settings } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import {
@@ -21,6 +22,7 @@ import {
 import { usePreferences } from '@/services/preferences'
 import { getOpenInDefaultLabel } from '@/types/preferences'
 import { isNativeApp } from '@/lib/environment'
+import { useUIStore } from '@/store/ui-store'
 
 interface OpenInButtonProps {
   worktreePath: string
@@ -34,6 +36,7 @@ export function OpenInButton({
   className,
 }: OpenInButtonProps) {
   const { data: preferences } = usePreferences()
+  const openPreferencesPane = useUIStore(state => state.openPreferencesPane)
   const openInEditor = useOpenWorktreeInEditor()
   const openInTerminal = useOpenWorktreeInTerminal()
   const openInFinder = useOpenWorktreeInFinder()
@@ -134,6 +137,11 @@ export function OpenInButton({
               GitHub
             </DropdownMenuItem>
           )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => openPreferencesPane('general')}>
+            <Settings className="h-4 w-4" />
+            Change default...
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
     </div>


### PR DESCRIPTION
## Summary
- Adds a **"Change default..."** menu item to the bottom of the "Open in" dropdown (separated by a divider)
- Clicking it opens **Settings > General** where the Editor, Terminal, and Open In preferences live
- Improves discoverability — new users seeing "Open in Zed" can immediately find how to switch to VS Code, Cursor, etc.

## Motivation
The "Open in" button defaults to whatever editor is configured in settings, but there's no indication *from the button itself* how to change it. Users unfamiliar with the settings layout may not realize they can switch editors. This mirrors the existing "Change defaults in Settings" link already present in the `OpenInModal` component.

## Changes
| File | Change |
|------|--------|
| `src/components/open-in/OpenInButton.tsx` | Add `DropdownMenuSeparator` + "Change default..." item that calls `openPreferencesPane('general')` |

## Test plan
- [ ] Click the dropdown chevron on the "Open in" button
- [ ] Verify "Change default..." appears below a separator after the existing options
- [ ] Click it — Settings dialog should open on the General pane
- [ ] Scroll to the Editor/Terminal/Open In fields and verify they're visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)