### PR TITLE
fix(process): use atomic rename on all platforms to prevent macOS inode taint

### DIFF
--- a/src-tauri/src/claude_cli/commands.rs
+++ b/src-tauri/src/claude_cli/commands.rs
@@ -450,8 +450,9 @@ pub async fn install_claude_cli(app: AppHandle, version: Option<String>) -> Resu
     emit_progress(&app, "installing", "Installing Claude CLI...", 65);
 
     // Write the binary to the target path
-    // Uses platform::write_binary_file which handles Windows file-locking (OS error 32)
-    // via a rename strategy when the existing binary is in use by another process.
+    // Uses platform::write_binary_file which writes to a temp file then atomically renames.
+    // This handles Windows file-locking (OS error 32) and macOS code-signing inode taint
+    // (SIGKILL) when the existing binary is in use by another process.
     log::trace!("Creating binary file at {:?}", binary_path);
     crate::platform::write_binary_file(&binary_path, &binary_content)
         .map_err(|e| format!("Failed to create binary file: {e}"))?;

--- a/src-tauri/src/platform/process.rs
+++ b/src-tauri/src/platform/process.rs
@@ -186,16 +186,20 @@ pub fn kill_process_tree(pid: u32) -> Result<(), String> {
 /// 3. Renaming the `.tmp` file to the target path
 /// 4. Best-effort cleanup of the `.old` file
 ///
-/// On Unix, this simply writes directly (overwriting is safe even for running binaries).
+/// On macOS, overwriting a running binary in-place (same inode) causes the kernel's code-signing
+/// enforcement to taint the inode, resulting in SIGKILL for all subsequent executions from that
+/// path. To avoid this, we always write to a temp file and atomically rename it into place,
+/// which allocates a new inode while the old one stays alive for any running process.
 pub fn write_binary_file(path: &std::path::Path, content: &[u8]) -> Result<(), String> {
+    let temp_path = path.with_extension("tmp");
+
+    // Write new binary to temp file (always a new inode)
+    std::fs::write(&temp_path, content)
+        .map_err(|e| format!("Failed to write temp file: {e}"))?;
+
     #[cfg(windows)]
     {
-        let temp_path = path.with_extension("tmp");
         let old_path = path.with_extension("old");
-
-        // Write new binary to temp file
-        std::fs::write(&temp_path, content)
-            .map_err(|e| format!("Failed to write temp file: {e}"))?;
 
         // Move existing file out of the way (Windows allows renaming locked files)
         if path.exists() {
@@ -219,7 +223,13 @@ pub fn write_binary_file(path: &std::path::Path, content: &[u8]) -> Result<(), S
 
     #[cfg(not(windows))]
     {
-        std::fs::write(path, content).map_err(|e| format!("Failed to write file: {e}"))
+        // Atomic rename: replaces the directory entry so `path` points to the new inode.
+        // The old inode (if any running process has it mapped) stays alive until that process exits.
+        if let Err(e) = std::fs::rename(&temp_path, path) {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(format!("Failed to install new file: {e}"));
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

- Changes `write_binary_file()` to always write to a temp file and atomically rename into place
- Prevents macOS kernel from tainting the inode when overwriting a running binary
- Resolves SIGKILL failures when reinstalling Claude CLI while a previous instance is running
- Simplifies cross-platform code by using the same robust strategy everywhere

## Problem

When reinstalling Claude CLI on macOS while a previous process is still running, the kernel's code-signing enforcement marks the inode as tainted after in-place overwrite, causing all subsequent executions to be immediately SIGKILL'd—even after a successful reinstall.

## Solution

Use atomic file operations (write to temp, then rename) on all platforms, not just Windows. This allocates a new inode for the binary while allowing any running process to continue using the old one until it exits. The atomic rename ensures the path always points to a working binary.

This approach was already necessary on Windows to handle locked files; extending it to Unix/macOS solves the taint problem universally.

---

Fixes #231