### PR TITLE
feat(chat): unify cross-backend model switching

### DIFF
--- a/src/components/chat/ChatToolbar.tsx
+++ b/src/components/chat/ChatToolbar.tsx
@@ -9,7 +9,6 @@ import {
 import { useChatStore } from '@/store/chat-store'
 import { useRemotePicker } from '@/hooks/useRemotePicker'
 import { useAllBackendsMcpHealth } from '@/services/mcp'
-import type { ClaudeModel } from '@/types/preferences'
 import type { EffortLevel, ThinkingLevel } from '@/types/chat'
 import type { ChatToolbarProps } from '@/components/chat/toolbar/types'
 import { MobileToolbarMenu } from '@/components/chat/toolbar/MobileToolbarMenu'
@@ -22,6 +21,7 @@ import {
   MODEL_OPTIONS,
   OPENCODE_MODEL_OPTIONS,
   THINKING_LEVEL_OPTIONS,
+  type ModelOption,
 } from '@/components/chat/toolbar/toolbar-options'
 import { useToolbarDropdownShortcuts } from '@/components/chat/toolbar/useToolbarDropdownShortcuts'
 import { useToolbarDerivedState } from '@/components/chat/toolbar/useToolbarDerivedState'
@@ -131,12 +131,13 @@ export const ChatToolbar = memo(function ChatToolbar({
   })
 
   const { data: availableOpencodeModels } = useAvailableOpencodeModels({
-    enabled: selectedBackend === 'opencode',
+    enabled: installedBackends.includes('opencode'),
   })
-  const opencodeModelOptions =
+  const opencodeModelOptions: ModelOption[] =
     availableOpencodeModels?.map(model => ({
       value: model,
       label: formatOpencodeModelLabel(model),
+      backend: 'opencode',
     })) ?? OPENCODE_MODEL_OPTIONS
 
   const { isCodex, activeMcpCount, filteredModelOptions, selectedModelLabel } =
@@ -145,6 +146,7 @@ export const ChatToolbar = memo(function ChatToolbar({
       selectedProvider,
       selectedModel,
       opencodeModelOptions,
+      installedBackends,
       customCliProfiles,
       availableMcpServers,
       enabledMcpServers,
@@ -163,7 +165,7 @@ export const ChatToolbar = memo(function ChatToolbar({
 
   const handleModelChange = useCallback(
     (value: string) => {
-      onModelChange(value as ClaudeModel)
+      onModelChange(value)
     },
     [onModelChange]
   )
@@ -181,7 +183,7 @@ export const ChatToolbar = memo(function ChatToolbar({
           selectedModel === 'opus-fast' ||
           selectedModel === 'claude-opus-4-6[1m]-fast')
       ) {
-        onModelChange('opus' as ClaudeModel)
+        onModelChange('opus')
       }
     },
     [onProviderChange, onModelChange, selectedModel]

--- a/src/components/chat/QueuedMessageItem.tsx
+++ b/src/components/chat/QueuedMessageItem.tsx
@@ -17,10 +17,10 @@ import { SkillBadge } from '@/components/chat/SkillBadge'
 import { normalizePath } from '@/lib/path-utils'
 import type { QueuedMessage } from '@/types/chat'
 import {
-  MODEL_OPTIONS,
   THINKING_LEVEL_OPTIONS,
   EFFORT_LEVEL_OPTIONS,
 } from '@/components/chat/ChatToolbar'
+import { getModelOptionLabel } from '@/components/chat/toolbar/toolbar-options'
 import {
   Tooltip,
   TooltipTrigger,
@@ -165,8 +165,7 @@ export const QueuedMessageItem = memo(function QueuedMessageItem({
           {/* Model badge */}
           <span className="inline-flex items-center gap-1 rounded bg-muted/80 px-1.5 py-0.5 text-[10px] text-muted-foreground">
             <Sparkles className="h-2.5 w-2.5" />
-            {MODEL_OPTIONS.find(o => o.value === message.model)?.label ??
-              message.model}
+            {getModelOptionLabel(message.model)}
           </span>
           {/* Mode badge */}
           <span

--- a/src/components/chat/approval-label-utils.ts
+++ b/src/components/chat/approval-label-utils.ts
@@ -1,6 +1,4 @@
-import { MODEL_OPTIONS, CODEX_MODEL_OPTIONS, OPENCODE_MODEL_OPTIONS } from './toolbar/toolbar-options'
-
-const ALL_MODEL_OPTIONS = [...MODEL_OPTIONS, ...CODEX_MODEL_OPTIONS, ...OPENCODE_MODEL_OPTIONS]
+import { getModelOptionLabel } from './toolbar/toolbar-options'
 
 /**
  * Resolves a human-readable label for the backend + model that will be used
@@ -30,9 +28,7 @@ export function resolveApprovalLabel(
       : (preferences.selected_model ?? null)
   const resolvedModel = model ?? backendDefaultModel
   if (!resolvedModel && !resolvedBackend) return null
-  const modelLabel = resolvedModel
-    ? (ALL_MODEL_OPTIONS.find(o => o.value === resolvedModel)?.label ?? resolvedModel)
-    : null
+  const modelLabel = resolvedModel ? getModelOptionLabel(resolvedModel) : null
   const parts: string[] = []
   if (resolvedBackend && resolvedBackend !== 'claude') parts.push(resolvedBackend)
   if (modelLabel) parts.push(modelLabel)

--- a/src/components/chat/hooks/session-setting-sync.test.ts
+++ b/src/components/chat/hooks/session-setting-sync.test.ts
@@ -25,8 +25,21 @@ describe('applySessionSettingToSession', () => {
 
   it('updates model', () => {
     expect(applySessionSettingToSession(baseSession, 'model', 'gpt-5.4')).toMatchObject({
-      backend: 'claude',
+      backend: 'codex',
       selected_model: 'gpt-5.4',
+    })
+  })
+
+  it('infers opencode backend from model changes', () => {
+    expect(
+      applySessionSettingToSession(
+        baseSession,
+        'model',
+        'opencode/gpt-5.3-codex'
+      )
+    ).toMatchObject({
+      backend: 'opencode',
+      selected_model: 'opencode/gpt-5.3-codex',
     })
   })
 

--- a/src/components/chat/hooks/session-setting-sync.ts
+++ b/src/components/chat/hooks/session-setting-sync.ts
@@ -1,4 +1,5 @@
 import type { Backend, ExecutionMode, Session, ThinkingLevel } from '@/types/chat'
+import { resolveBackend } from '@/lib/model-utils'
 
 export type SessionSettingKey =
   | 'backend'
@@ -21,6 +22,7 @@ export function applySessionSettingToSession(
     case 'model':
       return {
         ...session,
+        backend: resolveBackend(value) as Backend,
         selected_model: value,
       }
     case 'thinkingLevel':

--- a/src/components/chat/hooks/useToolbarHandlers.ts
+++ b/src/components/chat/hooks/useToolbarHandlers.ts
@@ -4,6 +4,7 @@ import { useChatStore, DEFAULT_MODEL } from '@/store/chat-store'
 import { useUIStore } from '@/store/ui-store'
 import { useProjectsStore } from '@/store/projects-store'
 import { chatQueryKeys } from '@/services/chat'
+import { resolveBackend } from '@/lib/model-utils'
 import type { QueryClient } from '@tanstack/react-query'
 import type {
   ThinkingLevel,
@@ -76,23 +77,42 @@ export function useToolbarHandlers({
   const handleToolbarModelChange = useCallback(
     (model: string) => {
       if (activeSessionId && activeWorktreeId && activeWorktreePath) {
+        const backend = resolveBackend(model)
+        useChatStore.getState().setSelectedBackend(activeSessionId, backend)
         useChatStore.getState().setSelectedModel(activeSessionId, model)
         queryClient.setQueryData(
           chatQueryKeys.session(activeSessionId),
           (old: Session | null | undefined) =>
             old ? applySessionSettingToSession(old, 'model', model) : old
         )
-        setSessionModel.mutate({
+        invoke('broadcast_session_setting', {
           sessionId: activeSessionId,
-          worktreeId: activeWorktreeId,
-          worktreePath: activeWorktreePath,
-          model,
-        })
+          key: 'backend',
+          value: backend,
+        }).catch(() => undefined)
         invoke('broadcast_session_setting', {
           sessionId: activeSessionId,
           key: 'model',
           value: model,
         }).catch(() => undefined)
+        setSessionBackend.mutate(
+          {
+            sessionId: activeSessionId,
+            worktreeId: activeWorktreeId,
+            worktreePath: activeWorktreePath,
+            backend,
+          },
+          {
+            onSuccess: () => {
+              setSessionModel.mutate({
+                sessionId: activeSessionId,
+                worktreeId: activeWorktreeId,
+                worktreePath: activeWorktreePath,
+                model,
+              })
+            },
+          }
+        )
       }
       window.dispatchEvent(new CustomEvent('focus-chat-input'))
     },
@@ -101,6 +121,7 @@ export function useToolbarHandlers({
       activeWorktreeId,
       activeWorktreePath,
       queryClient,
+      setSessionBackend,
       setSessionModel,
     ]
   )

--- a/src/components/chat/toolbar/DesktopToolbarControls.tsx
+++ b/src/components/chat/toolbar/DesktopToolbarControls.tsx
@@ -69,6 +69,7 @@ import type { CliBackend } from '@/types/preferences'
 import {
   EFFORT_LEVEL_OPTIONS,
   THINKING_LEVEL_OPTIONS,
+  type ModelOption,
 } from '@/components/chat/toolbar/toolbar-options'
 import {
   getPrStatusDisplay,
@@ -88,7 +89,7 @@ interface DesktopToolbarControlsProps {
   sessionHasMessages?: boolean
   providerLocked?: boolean
   customCliProfiles: CustomCliProfile[]
-  filteredModelOptions: { value: string; label: string }[]
+  filteredModelOptions: ModelOption[]
   selectedModelLabel: string
   isCodex: boolean
 
@@ -226,6 +227,18 @@ export function DesktopToolbarControls({
         option.value.toLowerCase().includes(query)
     )
   }, [filteredModelOptions, modelSearchQuery])
+  const groupedModelOptions = useMemo(() => {
+    const groups: { backend: CliBackend; options: ModelOption[] }[] = []
+    for (const option of visibleModelOptions) {
+      const group = groups.find(entry => entry.backend === option.backend)
+      if (group) {
+        group.options.push(option)
+      } else {
+        groups.push({ backend: option.backend, options: [option] })
+      }
+    }
+    return groups
+  }, [visibleModelOptions])
 
   useEffect(() => {
     if (!modelDropdownOpen) return
@@ -791,7 +804,9 @@ export function DesktopToolbarControls({
           onEscapeKeyDown={e => e.stopPropagation()}
           onCloseAutoFocus={focusChatInput}
         >
-          {providerLocked && customCliProfiles.length > 0 && (
+          {providerLocked &&
+            selectedBackend === 'claude' &&
+            customCliProfiles.length > 0 && (
             <>
               <DropdownMenuLabel className="text-xs text-muted-foreground">
                 Provider: {providerDisplayName}
@@ -819,8 +834,9 @@ export function DesktopToolbarControls({
                 } else if (event.key === 'Enter') {
                   event.preventDefault()
                   event.stopPropagation()
-                  if (visibleModelOptions.length > 0) {
-                    handleModelChange(visibleModelOptions[0]!.value)
+                  const firstOption = visibleModelOptions[0]
+                  if (firstOption) {
+                    handleModelChange(firstOption.value)
                   }
                 } else {
                   event.stopPropagation()
@@ -831,21 +847,29 @@ export function DesktopToolbarControls({
             />
           </div>
           <DropdownMenuSeparator />
-          <DropdownMenuRadioGroup
-            className="max-h-[19rem] overflow-y-auto"
-            value={selectedModel}
-            onValueChange={handleModelChange}
-          >
-            {visibleModelOptions.length > 0 ? (
-              visibleModelOptions.map(option => (
-                <DropdownMenuRadioItem key={option.value} value={option.value}>
-                  {option.label}
-                </DropdownMenuRadioItem>
-              ))
-            ) : (
-              <DropdownMenuItem disabled>No models found</DropdownMenuItem>
-            )}
-          </DropdownMenuRadioGroup>
+          {visibleModelOptions.length > 0 ? (
+            <DropdownMenuRadioGroup
+              className="max-h-[19rem] overflow-y-auto"
+              value={selectedModel}
+              onValueChange={handleModelChange}
+            >
+              {groupedModelOptions.map((group, index) => (
+                <div key={group.backend}>
+                  {index > 0 && <DropdownMenuSeparator />}
+                  <DropdownMenuLabel className="text-xs text-muted-foreground">
+                    {BACKEND_LABELS[group.backend]}
+                  </DropdownMenuLabel>
+                  {group.options.map(option => (
+                    <DropdownMenuRadioItem key={option.value} value={option.value}>
+                      {option.label}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </div>
+              ))}
+            </DropdownMenuRadioGroup>
+          ) : (
+            <DropdownMenuItem disabled>No models found</DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/src/components/chat/toolbar/MobileToolbarMenu.tsx
+++ b/src/components/chat/toolbar/MobileToolbarMenu.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
   ArrowDownToLine,
   ArrowUpToLine,
@@ -69,6 +69,7 @@ import { openExternal } from '@/lib/platform'
 import {
   EFFORT_LEVEL_OPTIONS,
   THINKING_LEVEL_OPTIONS,
+  type ModelOption,
 } from '@/components/chat/toolbar/toolbar-options'
 import {
   getPrStatusDisplay,
@@ -93,7 +94,7 @@ interface MobileToolbarMenuProps {
   isCodex: boolean
   executionMode: ExecutionMode
   customCliProfiles: CustomCliProfile[]
-  filteredModelOptions: { value: string; label: string }[]
+  filteredModelOptions: ModelOption[]
 
   uncommittedAdded: number
   uncommittedRemoved: number
@@ -231,6 +232,18 @@ export function MobileToolbarMenu({
         )
       })
     : filteredModelOptions
+  const groupedModelOptions = useMemo(() => {
+    const groups: { backend: CliBackend; options: ModelOption[] }[] = []
+    for (const option of visibleModelOptions) {
+      const group = groups.find(entry => entry.backend === option.backend)
+      if (group) {
+        group.options.push(option)
+      } else {
+        groups.push({ backend: option.backend, options: [option] })
+      }
+    }
+    return groups
+  }, [visibleModelOptions])
 
   return (
     <>
@@ -780,7 +793,9 @@ export function MobileToolbarMenu({
                 </span>
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
-                {providerLocked && customCliProfiles.length > 0 && (
+                {providerLocked &&
+                  selectedBackend === 'claude' &&
+                  customCliProfiles.length > 0 && (
                   <>
                     <DropdownMenuLabel className="text-xs text-muted-foreground">
                       Provider: {providerDisplayName}
@@ -792,10 +807,18 @@ export function MobileToolbarMenu({
                   value={selectedModel}
                   onValueChange={handleModelChange}
                 >
-                  {filteredModelOptions.map(option => (
-                    <DropdownMenuRadioItem key={option.value} value={option.value}>
-                      {option.label}
-                    </DropdownMenuRadioItem>
+                  {groupedModelOptions.map((group, index) => (
+                    <div key={group.backend}>
+                      {index > 0 && <DropdownMenuSeparator />}
+                      <DropdownMenuLabel className="text-xs text-muted-foreground">
+                        {BACKEND_LABELS[group.backend]}
+                      </DropdownMenuLabel>
+                      {group.options.map(option => (
+                        <DropdownMenuRadioItem key={option.value} value={option.value}>
+                          {option.label}
+                        </DropdownMenuRadioItem>
+                      ))}
+                    </div>
                   ))}
                 </DropdownMenuRadioGroup>
               </DropdownMenuSubContent>
@@ -972,27 +995,36 @@ export function MobileToolbarMenu({
                 autoFocus
               />
             </div>
-            {providerLocked && customCliProfiles.length > 0 && (
+            {providerLocked &&
+              selectedBackend === 'claude' &&
+              customCliProfiles.length > 0 && (
               <div className="px-2 pb-1 text-xs text-muted-foreground">
                 Provider: {providerDisplayName}
               </div>
             )}
-            {visibleModelOptions.map(option => (
-              <button
-                key={option.value}
-                type="button"
-                className={cn(
-                  'flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground',
-                  selectedModel === option.value && 'bg-accent text-accent-foreground'
-                )}
-                onClick={() => {
-                  handleModelChange(option.value)
-                  setModelSheetOpen(false)
-                }}
-              >
-                <span className="flex-1">{option.label}</span>
-                {selectedModel === option.value && <Check className="h-4 w-4" />}
-              </button>
+            {groupedModelOptions.map(group => (
+              <div key={group.backend} className="pb-2">
+                <div className="px-2 pb-1 text-xs text-muted-foreground">
+                  {BACKEND_LABELS[group.backend]}
+                </div>
+                {group.options.map(option => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={cn(
+                      'flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground',
+                      selectedModel === option.value && 'bg-accent text-accent-foreground'
+                    )}
+                    onClick={() => {
+                      handleModelChange(option.value)
+                      setModelSheetOpen(false)
+                    }}
+                  >
+                    <span className="flex-1">{option.label}</span>
+                    {selectedModel === option.value && <Check className="h-4 w-4" />}
+                  </button>
+                ))}
+              </div>
             ))}
             {visibleModelOptions.length === 0 && (
               <div className="px-3 py-4 text-sm text-muted-foreground">

--- a/src/components/chat/toolbar/toolbar-options.test.ts
+++ b/src/components/chat/toolbar/toolbar-options.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { buildUnifiedModelOptions, getModelOptionLabel } from './toolbar-options'
+
+describe('buildUnifiedModelOptions', () => {
+  it('includes installed backends in order with backend metadata', () => {
+    const options = buildUnifiedModelOptions({
+      installedBackends: ['claude', 'codex', 'opencode'],
+      selectedProvider: null,
+      customCliProfiles: [],
+      opencodeModelOptions: [
+        {
+          value: 'opencode/custom-model',
+          label: 'Custom Model (OpenCode)',
+          backend: 'opencode',
+        },
+      ],
+    })
+
+    expect(options.slice(0, 9).every(option => option.backend === 'claude')).toBe(
+      true
+    )
+    expect(
+      options.slice(9, options.length - 1).every(option => option.backend === 'codex')
+    ).toBe(true)
+    expect(options[options.length - 1]).toEqual({
+      value: 'opencode/custom-model',
+      label: 'Custom Model (OpenCode)',
+      backend: 'opencode',
+    })
+  })
+
+  it('uses custom provider labels for claude options without removing codex', () => {
+    const options = buildUnifiedModelOptions({
+      installedBackends: ['claude', 'codex'],
+      selectedProvider: 'OpenAI',
+      customCliProfiles: [
+        {
+          name: 'OpenAI',
+          settings_json: JSON.stringify({
+            env: {
+              ANTHROPIC_DEFAULT_OPUS_MODEL: 'gpt-5.4',
+            },
+          }),
+        },
+      ],
+    })
+
+    expect(options.find(option => option.value === 'opus')?.label).toBe(
+      'Opus (gpt-5.4)'
+    )
+    expect(options.some(option => option.backend === 'codex')).toBe(true)
+  })
+})
+
+describe('getModelOptionLabel', () => {
+  it('returns a readable label for known models', () => {
+    expect(getModelOptionLabel('gpt-5.4')).toBe('GPT 5.4')
+  })
+})

--- a/src/components/chat/toolbar/toolbar-options.ts
+++ b/src/components/chat/toolbar/toolbar-options.ts
@@ -1,26 +1,130 @@
-import { codexModelOptions, type ClaudeModel } from '@/types/preferences'
+import {
+  codexModelOptions,
+  type ClaudeModel,
+  type CliBackend,
+  type CustomCliProfile,
+} from '@/types/preferences'
 import type { EffortLevel, ThinkingLevel } from '@/types/chat'
 
-export const MODEL_OPTIONS: { value: ClaudeModel; label: string }[] = [
-  { value: 'opus', label: 'Opus 4.6' },
-  { value: 'claude-opus-4-6[1m]', label: 'Opus 4.6 (1M)' },
-  { value: 'opus-fast', label: 'Opus 4.6 Fast' },
-  { value: 'claude-opus-4-6[1m]-fast', label: 'Opus 4.6 (1M) Fast' },
-  { value: 'opus-4.5', label: 'Opus 4.5' },
-  { value: 'sonnet', label: 'Sonnet 4.6' },
-  { value: 'claude-sonnet-4-6[1m]', label: 'Sonnet 4.6 (1M)' },
-  { value: 'sonnet-4.5', label: 'Sonnet 4.5' },
-  { value: 'haiku', label: 'Haiku' },
-]
-
-export const CODEX_MODEL_OPTIONS = codexModelOptions as {
+export interface ModelOption {
   value: string
   label: string
-}[]
+  backend: CliBackend
+}
 
-export const OPENCODE_MODEL_OPTIONS: { value: string; label: string }[] = [
-  { value: 'opencode/gpt-5.3-codex', label: 'GPT-5.3 Codex (OpenCode)' },
+export const MODEL_OPTIONS: ModelOption[] = [
+  { value: 'opus', label: 'Opus 4.6', backend: 'claude' },
+  { value: 'claude-opus-4-6[1m]', label: 'Opus 4.6 (1M)', backend: 'claude' },
+  { value: 'opus-fast', label: 'Opus 4.6 Fast', backend: 'claude' },
+  {
+    value: 'claude-opus-4-6[1m]-fast',
+    label: 'Opus 4.6 (1M) Fast',
+    backend: 'claude',
+  },
+  { value: 'opus-4.5', label: 'Opus 4.5', backend: 'claude' },
+  { value: 'sonnet', label: 'Sonnet 4.6', backend: 'claude' },
+  {
+    value: 'claude-sonnet-4-6[1m]',
+    label: 'Sonnet 4.6 (1M)',
+    backend: 'claude',
+  },
+  { value: 'sonnet-4.5', label: 'Sonnet 4.5', backend: 'claude' },
+  { value: 'haiku', label: 'Haiku', backend: 'claude' },
 ]
+
+export const CODEX_MODEL_OPTIONS: ModelOption[] = codexModelOptions.map(option => ({
+  ...option,
+  backend: 'codex',
+}))
+
+export const OPENCODE_MODEL_OPTIONS: ModelOption[] = [
+  {
+    value: 'opencode/gpt-5.3-codex',
+    label: 'GPT-5.3 Codex (OpenCode)',
+    backend: 'opencode',
+  },
+]
+
+export const ALL_MODEL_OPTIONS: ModelOption[] = [
+  ...MODEL_OPTIONS,
+  ...CODEX_MODEL_OPTIONS,
+  ...OPENCODE_MODEL_OPTIONS,
+]
+
+export function getClaudeModelOptions(
+  selectedProvider: string | null,
+  customCliProfiles: CustomCliProfile[]
+): ModelOption[] {
+  if (!selectedProvider || selectedProvider === '__anthropic__') {
+    return MODEL_OPTIONS
+  }
+
+  const profile = customCliProfiles.find(p => p.name === selectedProvider)
+  let opusModel: string | undefined
+  let sonnetModel: string | undefined
+  let haikuModel: string | undefined
+  if (profile?.settings_json) {
+    try {
+      const settings = JSON.parse(profile.settings_json)
+      const env = settings?.env
+      if (env) {
+        opusModel = env.ANTHROPIC_DEFAULT_OPUS_MODEL || env.ANTHROPIC_MODEL
+        sonnetModel =
+          env.ANTHROPIC_DEFAULT_SONNET_MODEL || env.ANTHROPIC_MODEL
+        haikuModel = env.ANTHROPIC_DEFAULT_HAIKU_MODEL || env.ANTHROPIC_MODEL
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  const suffix = (model?: string) => (model ? ` (${model})` : '')
+  return [
+    {
+      value: 'opus' as ClaudeModel,
+      label: `Opus${suffix(opusModel)}`,
+      backend: 'claude',
+    },
+    {
+      value: 'sonnet' as ClaudeModel,
+      label: `Sonnet${suffix(sonnetModel)}`,
+      backend: 'claude',
+    },
+    {
+      value: 'haiku' as ClaudeModel,
+      label: `Haiku${suffix(haikuModel)}`,
+      backend: 'claude',
+    },
+  ]
+}
+
+export function buildUnifiedModelOptions({
+  installedBackends,
+  selectedProvider,
+  customCliProfiles,
+  opencodeModelOptions,
+}: {
+  installedBackends: CliBackend[]
+  selectedProvider: string | null
+  customCliProfiles: CustomCliProfile[]
+  opencodeModelOptions?: ModelOption[]
+}): ModelOption[] {
+  const claudeOptions = getClaudeModelOptions(selectedProvider, customCliProfiles)
+  const perBackend: Record<CliBackend, ModelOption[]> = {
+    claude: claudeOptions,
+    codex: CODEX_MODEL_OPTIONS,
+    opencode: opencodeModelOptions ?? OPENCODE_MODEL_OPTIONS,
+  }
+
+  return installedBackends.flatMap(backend => perBackend[backend] ?? [])
+}
+
+export function getModelOptionLabel(
+  value: string,
+  options: ModelOption[] = ALL_MODEL_OPTIONS
+): string {
+  return options.find(option => option.value === value)?.label ?? value
+}
 
 export const THINKING_LEVEL_OPTIONS: {
   value: ThinkingLevel

--- a/src/components/chat/toolbar/types.ts
+++ b/src/components/chat/toolbar/types.ts
@@ -1,4 +1,4 @@
-import type { ClaudeModel, CustomCliProfile } from '@/types/preferences'
+import type { CustomCliProfile } from '@/types/preferences'
 import type { ThinkingLevel, EffortLevel, ExecutionMode } from '@/types/chat'
 import type { McpServerInfo } from '@/types/chat'
 import type {
@@ -80,7 +80,7 @@ export interface ChatToolbarProps {
   onSetDiffRequest: (request: DiffRequest) => void
   installedBackends: ('claude' | 'codex' | 'opencode')[]
   onBackendChange: (backend: 'claude' | 'codex' | 'opencode') => void
-  onModelChange: (model: ClaudeModel) => void
+  onModelChange: (model: string) => void
   onProviderChange: (provider: string | null) => void
   customCliProfiles: CustomCliProfile[]
   onThinkingLevelChange: (level: ThinkingLevel) => void

--- a/src/components/chat/toolbar/useToolbarDerivedState.ts
+++ b/src/components/chat/toolbar/useToolbarDerivedState.ts
@@ -1,16 +1,16 @@
 import { useMemo } from 'react'
-import type { ClaudeModel, CustomCliProfile } from '@/types/preferences'
+import type { CustomCliProfile } from '@/types/preferences'
 import {
-  CODEX_MODEL_OPTIONS,
-  MODEL_OPTIONS,
-  OPENCODE_MODEL_OPTIONS,
+  buildUnifiedModelOptions,
+  type ModelOption,
 } from '@/components/chat/toolbar/toolbar-options'
 
 interface UseToolbarDerivedStateArgs {
   selectedBackend: 'claude' | 'codex' | 'opencode'
   selectedProvider: string | null
   selectedModel: string
-  opencodeModelOptions?: { value: string; label: string }[]
+  opencodeModelOptions?: ModelOption[]
+  installedBackends: ('claude' | 'codex' | 'opencode')[]
   customCliProfiles: CustomCliProfile[]
   availableMcpServers: { name: string; disabled?: boolean }[]
   enabledMcpServers: string[]
@@ -21,6 +21,7 @@ export function useToolbarDerivedState({
   selectedProvider,
   selectedModel,
   opencodeModelOptions,
+  installedBackends,
   customCliProfiles,
   availableMcpServers,
   enabledMcpServers,
@@ -36,43 +37,16 @@ export function useToolbarDerivedState({
   }, [availableMcpServers, enabledMcpServers])
 
   const filteredModelOptions = useMemo(() => {
-    if (isCodex)
-      return CODEX_MODEL_OPTIONS as { value: string; label: string }[]
-    if (isOpencode) return opencodeModelOptions ?? OPENCODE_MODEL_OPTIONS
-    if (!selectedProvider || selectedProvider === '__anthropic__') {
-      return MODEL_OPTIONS
-    }
-
-    const profile = customCliProfiles.find(p => p.name === selectedProvider)
-    let opusModel: string | undefined
-    let sonnetModel: string | undefined
-    let haikuModel: string | undefined
-    if (profile?.settings_json) {
-      try {
-        const settings = JSON.parse(profile.settings_json)
-        const env = settings?.env
-        if (env) {
-          opusModel = env.ANTHROPIC_DEFAULT_OPUS_MODEL || env.ANTHROPIC_MODEL
-          sonnetModel =
-            env.ANTHROPIC_DEFAULT_SONNET_MODEL || env.ANTHROPIC_MODEL
-          haikuModel = env.ANTHROPIC_DEFAULT_HAIKU_MODEL || env.ANTHROPIC_MODEL
-        }
-      } catch {
-        // ignore parse errors
-      }
-    }
-
-    const suffix = (model?: string) => (model ? ` (${model})` : '')
-    return [
-      { value: 'opus' as ClaudeModel, label: `Opus${suffix(opusModel)}` },
-      { value: 'sonnet' as ClaudeModel, label: `Sonnet${suffix(sonnetModel)}` },
-      { value: 'haiku' as ClaudeModel, label: `Haiku${suffix(haikuModel)}` },
-    ]
+    return buildUnifiedModelOptions({
+      installedBackends,
+      selectedProvider,
+      customCliProfiles,
+      opencodeModelOptions,
+    })
   }, [
+    installedBackends,
     selectedProvider,
     customCliProfiles,
-    isCodex,
-    isOpencode,
     opencodeModelOptions,
   ])
 

--- a/src/lib/model-utils.ts
+++ b/src/lib/model-utils.ts
@@ -8,6 +8,7 @@
  */
 
 import { compareVersions } from './version-utils'
+import { isCodexModel, isOpenCodeModel } from '@/types/preferences'
 
 /** Minimum CLI version that supports Claude 4.6 adaptive thinking */
 const ADAPTIVE_THINKING_MIN_CLI_VERSION = '2.1.32'
@@ -16,8 +17,8 @@ const ADAPTIVE_THINKING_MIN_CLI_VERSION = '2.1.32'
  * Resolve which CLI backend to use based on the model string.
  */
 export function resolveBackend(model: string): 'claude' | 'codex' | 'opencode' {
-  if (model.startsWith('opencode/')) return 'opencode'
-  if (model.startsWith('codex') || model.includes('codex')) return 'codex'
+  if (isOpenCodeModel(model)) return 'opencode'
+  if (isCodexModel(model)) return 'codex'
   return 'claude'
 }
 


### PR DESCRIPTION
## Summary
- unify the chat model picker across Claude, Codex, and OpenCode with backend-grouped options
- infer and persist session backend from the selected model so users can switch models mid-session
- update model labels and tests to use shared backend-aware model metadata

## Testing
- bun run typecheck
- bun run vitest run src/components/chat/hooks/session-setting-sync.test.ts src/components/chat/toolbar/toolbar-options.test.ts
- bun run eslint src/components/chat/ChatToolbar.tsx src/components/chat/QueuedMessageItem.tsx src/components/chat/approval-label-utils.ts src/components/chat/hooks/session-setting-sync.ts src/components/chat/hooks/session-setting-sync.test.ts src/components/chat/hooks/useToolbarHandlers.ts src/components/chat/toolbar/DesktopToolbarControls.tsx src/components/chat/toolbar/MobileToolbarMenu.tsx src/components/chat/toolbar/toolbar-options.ts src/components/chat/toolbar/toolbar-options.test.ts src/components/chat/toolbar/types.ts src/components/chat/toolbar/useToolbarDerivedState.ts src/lib/model-utils.ts

current: 
<img width="830" height="351" alt="image" src="https://github.com/user-attachments/assets/9885817a-1d88-4de7-b462-e578f48568d3" />


this branch: 
<img width="564" height="108" alt="image" src="https://github.com/user-attachments/assets/a3ff0f19-54ee-4fc5-8263-23eb434581c3" />
-----------
<img width="564" height="297" alt="image" src="https://github.com/user-attachments/assets/634cec19-7cc4-419a-9c28-884b21ecdcc2" />
