### PR TITLE
feat: add per-CLI auto-update on app launch

### DIFF
--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -34,7 +34,7 @@ fi
 
 echo "==> Building AppImage via Tauri..."
 cd "$PROJECT_DIR"
-NO_STRIP=true bun run tauri build --bundles appimage 2>&1 || {
+NO_STRIP=true ./node_modules/.bin/tauri build --bundles appimage 2>&1 || {
     echo "Tauri build failed, trying manual linuxdeploy fallback..."
     if [ ! -x "$LINUXDEPLOY_BIN" ]; then
         echo "ERROR: linuxdeploy not found/executable at $LINUXDEPLOY_BIN"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -224,6 +224,14 @@ pub struct AppPreferences {
     pub opencode_cli_source: String, // OpenCode CLI source: "jean" (managed) or "path" (system PATH)
     #[serde(default = "default_cli_source")]
     pub gh_cli_source: String, // GitHub CLI source: "jean" (managed) or "path" (system PATH)
+    #[serde(default)]
+    pub auto_update_claude_cli: bool, // Auto-update Claude CLI on app launch
+    #[serde(default)]
+    pub auto_update_codex_cli: bool, // Auto-update Codex CLI on app launch
+    #[serde(default)]
+    pub auto_update_opencode_cli: bool, // Auto-update OpenCode CLI on app launch
+    #[serde(default)]
+    pub auto_update_gh_cli: bool, // Auto-update GitHub CLI on app launch
 }
 
 fn default_true() -> Option<bool> {
@@ -1146,6 +1154,10 @@ impl Default for AppPreferences {
             codex_cli_source: default_cli_source(),
             opencode_cli_source: default_cli_source(),
             gh_cli_source: default_cli_source(),
+            auto_update_claude_cli: false,
+            auto_update_codex_cli: false,
+            auto_update_opencode_cli: false,
+            auto_update_gh_cli: false,
         }
     }
 }

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -858,6 +858,19 @@ export const GeneralPane: React.FC = () => {
                 </Select>
               </InlineField>
             )}
+            {preferences?.claude_cli_source === 'jean' && cliStatus?.installed && (
+              <InlineField
+                label="Auto-update on launch"
+                description="Automatically install latest version when Jean starts"
+              >
+                <Switch
+                  checked={preferences?.auto_update_claude_cli ?? false}
+                  onCheckedChange={(checked) =>
+                    patchPreferences.mutate({ auto_update_claude_cli: checked })
+                  }
+                />
+              </InlineField>
+            )}
           </div>
         </SettingsSection>
       )}
@@ -982,6 +995,19 @@ export const GeneralPane: React.FC = () => {
                     </SelectItem>
                   </SelectContent>
                 </Select>
+              </InlineField>
+            )}
+            {preferences?.gh_cli_source === 'jean' && ghStatus?.installed && (
+              <InlineField
+                label="Auto-update on launch"
+                description="Automatically install latest version when Jean starts"
+              >
+                <Switch
+                  checked={preferences?.auto_update_gh_cli ?? false}
+                  onCheckedChange={(checked) =>
+                    patchPreferences.mutate({ auto_update_gh_cli: checked })
+                  }
+                />
               </InlineField>
             )}
           </div>
@@ -1117,6 +1143,19 @@ export const GeneralPane: React.FC = () => {
                 </Select>
               </InlineField>
             )}
+            {preferences?.codex_cli_source === 'jean' && codexStatus?.installed && (
+              <InlineField
+                label="Auto-update on launch"
+                description="Automatically install latest version when Jean starts"
+              >
+                <Switch
+                  checked={preferences?.auto_update_codex_cli ?? false}
+                  onCheckedChange={(checked) =>
+                    patchPreferences.mutate({ auto_update_codex_cli: checked })
+                  }
+                />
+              </InlineField>
+            )}
           </div>
         </SettingsSection>
       )}
@@ -1248,6 +1287,19 @@ export const GeneralPane: React.FC = () => {
                     </SelectItem>
                   </SelectContent>
                 </Select>
+              </InlineField>
+            )}
+            {preferences?.opencode_cli_source === 'jean' && opencodeStatus?.installed && (
+              <InlineField
+                label="Auto-update on launch"
+                description="Automatically install latest version when Jean starts"
+              >
+                <Switch
+                  checked={preferences?.auto_update_opencode_cli ?? false}
+                  onCheckedChange={(checked) =>
+                    patchPreferences.mutate({ auto_update_opencode_cli: checked })
+                  }
+                />
               </InlineField>
             )}
           </div>

--- a/src/hooks/useCliVersionCheck.ts
+++ b/src/hooks/useCliVersionCheck.ts
@@ -7,27 +7,37 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   useClaudeCliStatus,
   useAvailableCliVersions,
   useClaudePathDetection,
+  claudeCliQueryKeys,
 } from '@/services/claude-cli'
-import { useGhCliStatus, useAvailableGhVersions, useGhPathDetection } from '@/services/gh-cli'
+import {
+  useGhCliStatus,
+  useAvailableGhVersions,
+  useGhPathDetection,
+  ghCliQueryKeys,
+} from '@/services/gh-cli'
 import {
   useCodexCliStatus,
   useAvailableCodexVersions,
   useCodexPathDetection,
+  codexCliQueryKeys,
 } from '@/services/codex-cli'
 import {
   useOpencodeCliStatus,
   useAvailableOpencodeVersions,
   useOpencodePathDetection,
+  opencodeCliQueryKeys,
 } from '@/services/opencode-cli'
 import { useUIStore } from '@/store/ui-store'
 import { isNewerVersion } from '@/lib/version-utils'
 import { logger } from '@/lib/logger'
 import { isNativeApp } from '@/lib/environment'
 import { usePreferences } from '@/services/preferences'
+import { invoke } from '@/lib/transport'
 
 interface CliUpdateInfo {
   type: 'claude' | 'gh' | 'codex' | 'opencode'
@@ -53,14 +63,40 @@ const CLI_DISPLAY_NAMES: Record<CliUpdateInfo['type'], string> = {
   opencode: 'OpenCode CLI',
 }
 
+/** Map CLI type to its Tauri install command name */
+const CLI_INSTALL_COMMANDS: Record<CliUpdateInfo['type'], string> = {
+  claude: 'install_claude_cli',
+  gh: 'install_gh_cli',
+  codex: 'install_codex_cli',
+  opencode: 'install_opencode_cli',
+}
+
+/** Map CLI type to its query keys for cache invalidation */
+const CLI_STATUS_QUERY_KEYS: Record<CliUpdateInfo['type'], readonly string[]> = {
+  claude: claudeCliQueryKeys.status(),
+  gh: ghCliQueryKeys.status(),
+  codex: codexCliQueryKeys.status(),
+  opencode: opencodeCliQueryKeys.status(),
+}
+
+/** Map CLI type to its auto-update preference key */
+const CLI_AUTO_UPDATE_PREF_KEYS: Record<CliUpdateInfo['type'], string> = {
+  claude: 'auto_update_claude_cli',
+  gh: 'auto_update_gh_cli',
+  codex: 'auto_update_codex_cli',
+  opencode: 'auto_update_opencode_cli',
+}
+
 /**
  * Hook that checks for CLI updates on startup and periodically (every hour).
  * Shows toast notifications when updates are detected.
+ * When auto-update is enabled for a CLI (jean-managed only), silently installs the latest version.
  * Should be called once in App.tsx.
  */
 export function useCliVersionCheck() {
   const shouldCheck = isNativeApp()
   const { data: preferences } = usePreferences()
+  const queryClient = useQueryClient()
   const { data: claudePathInfo } = useClaudePathDetection({ enabled: shouldCheck })
   const { data: ghPathInfo } = useGhPathDetection({ enabled: shouldCheck })
   const { data: codexPathInfo } = useCodexPathDetection({ enabled: shouldCheck })
@@ -92,7 +128,7 @@ export function useCliVersionCheck() {
   const { data: opencodeVersions, isLoading: opencodeVersionsLoading } =
     useAvailableOpencodeVersions({ enabled: shouldCheck && versionCheckReady })
 
-  // Track which update pairs we've already shown notifications for
+  // Track which update pairs we've already shown notifications for or auto-installed
   // Format: "type:currentVersion→latestVersion"
   const notifiedRef = useRef<Set<string>>(new Set())
   const isInitialCheckRef = useRef(true)
@@ -215,13 +251,36 @@ export function useCliVersionCheck() {
     if (updates.length > 0) {
       logger.info('CLI updates available', { updates })
 
-      if (isInitialCheckRef.current) {
-        // Delay initial notification to let the app settle
-        setTimeout(() => {
-          showUpdateToasts(updates)
-        }, 5000)
-      } else {
-        showUpdateToasts(updates)
+      // Split updates into auto-install (jean-managed + auto-update enabled) vs manual toast
+      const autoInstallUpdates: CliUpdateInfo[] = []
+      const manualUpdates: CliUpdateInfo[] = []
+
+      for (const update of updates) {
+        const prefKey = CLI_AUTO_UPDATE_PREF_KEYS[update.type] as keyof typeof preferences
+        const isAutoUpdate = preferences?.[prefKey] === true
+        const isJeanManaged = update.cliSource === 'jean'
+
+        if (isAutoUpdate && isJeanManaged) {
+          autoInstallUpdates.push(update)
+        } else {
+          manualUpdates.push(update)
+        }
+      }
+
+      // Auto-install: fire all in parallel with loading toasts
+      for (const update of autoInstallUpdates) {
+        autoInstallCli(update, queryClient)
+      }
+
+      // Manual: show interactive toasts (with delay on initial check)
+      if (manualUpdates.length > 0) {
+        if (isInitialCheckRef.current) {
+          setTimeout(() => {
+            showUpdateToasts(manualUpdates)
+          }, 5000)
+        } else {
+          showUpdateToasts(manualUpdates)
+        }
       }
     }
 
@@ -247,7 +306,51 @@ export function useCliVersionCheck() {
     preferences?.codex_cli_source,
     preferences?.opencode_cli_source,
     preferences?.gh_cli_source,
+    preferences?.auto_update_claude_cli,
+    preferences?.auto_update_codex_cli,
+    preferences?.auto_update_opencode_cli,
+    preferences?.auto_update_gh_cli,
+    queryClient,
   ])
+}
+
+/**
+ * Silently auto-install a CLI update. Shows a loading toast that transitions
+ * to success/error. Each CLI gets its own stacked toast.
+ */
+async function autoInstallCli(
+  update: CliUpdateInfo,
+  queryClient: ReturnType<typeof import('@tanstack/react-query').useQueryClient>
+) {
+  const cliName = CLI_DISPLAY_NAMES[update.type]
+  const toastId = `cli-auto-update-${update.type}`
+  const command = CLI_INSTALL_COMMANDS[update.type]
+  const statusQueryKey = CLI_STATUS_QUERY_KEYS[update.type]
+
+  toast.loading(`Updating ${cliName}...`, {
+    id: toastId,
+    description: `v${update.currentVersion} → v${update.latestVersion}`,
+  })
+
+  try {
+    await invoke(command, { version: null })
+    queryClient.invalidateQueries({ queryKey: statusQueryKey })
+    toast.success(`${cliName} updated`, {
+      id: toastId,
+      description: `v${update.currentVersion} → v${update.latestVersion}`,
+    })
+    logger.info(`[CliVersionCheck] Auto-updated ${cliName}`, {
+      from: update.currentVersion,
+      to: update.latestVersion,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    toast.error(`Failed to update ${cliName}`, {
+      id: toastId,
+      description: message,
+    })
+    logger.error(`[CliVersionCheck] Auto-update failed for ${cliName}`, { error: message })
+  }
 }
 
 /** Get the correct self-update args for each CLI type, or null if no built-in update */

--- a/src/hooks/useCliVersionCheck.ts
+++ b/src/hooks/useCliVersionCheck.ts
@@ -53,6 +53,29 @@ interface PendingCliUpdate extends CliUpdateInfo {
   key: string
 }
 
+interface CliStatusSnapshot {
+  installed?: boolean
+  version?: string | null
+  path?: string | null
+}
+
+interface CliVersionSnapshot {
+  version: string
+  prerelease: boolean
+}
+
+interface CliPathInfoSnapshot {
+  package_manager?: string | null
+}
+
+interface CliUpdateCandidate {
+  type: CliUpdateInfo['type']
+  status: CliStatusSnapshot | undefined
+  versions: CliVersionSnapshot[] | undefined
+  cliSource: CliUpdateInfo['cliSource']
+  pathInfo: CliPathInfoSnapshot | undefined
+}
+
 /** Map CLI type to the binary name used by the package manager */
 const CLI_BINARY_NAMES: Record<CliUpdateInfo['type'], string> = {
   claude: 'claude-code',
@@ -111,6 +134,61 @@ function canAutoInstallCli(
   return preferences?.[prefKey] === true && update.cliSource === 'jean'
 }
 
+function collectPendingUpdates(
+  candidates: CliUpdateCandidate[],
+  handledKeys: Set<string>,
+  autoInstallInFlightKeys: Set<string>
+): PendingCliUpdate[] {
+  const updates: PendingCliUpdate[] = []
+
+  for (const candidate of candidates) {
+    const { type, status, versions, cliSource, pathInfo } = candidate
+    if (!status?.installed || !status.version || !versions?.length) {
+      continue
+    }
+
+    const latestStable = versions.find(version => !version.prerelease)
+    if (!latestStable || !isNewerVersion(latestStable.version, status.version)) {
+      continue
+    }
+
+    const key = getCliUpdateKey(type, status.version, latestStable.version)
+    if (handledKeys.has(key) || autoInstallInFlightKeys.has(key)) {
+      continue
+    }
+
+    updates.push({
+      key,
+      type,
+      currentVersion: status.version,
+      latestVersion: latestStable.version,
+      cliSource,
+      cliPath: status.path,
+      packageManager: pathInfo?.package_manager,
+    })
+  }
+
+  return updates
+}
+
+function splitUpdatesByInstallMode(
+  updates: PendingCliUpdate[],
+  preferences: AppPreferences | undefined
+) {
+  const autoInstallUpdates: PendingCliUpdate[] = []
+  const manualUpdates: PendingCliUpdate[] = []
+
+  for (const update of updates) {
+    if (canAutoInstallCli(update, preferences)) {
+      autoInstallUpdates.push(update)
+    } else {
+      manualUpdates.push(update)
+    }
+  }
+
+  return { autoInstallUpdates, manualUpdates }
+}
+
 /**
  * Hook that checks for CLI updates on startup and periodically (every hour).
  * Shows toast notifications when updates are detected.
@@ -160,157 +238,61 @@ export function useCliVersionCheck() {
 
   useEffect(() => {
     // Wait until all data is loaded
-    const isLoading =
-      claudeLoading ||
-      ghLoading ||
-      codexLoading ||
-      opencodeLoading ||
-      claudeVersionsLoading ||
-      ghVersionsLoading ||
-      codexVersionsLoading ||
-      opencodeVersionsLoading
+    const isLoading = [
+      claudeLoading,
+      ghLoading,
+      codexLoading,
+      opencodeLoading,
+      claudeVersionsLoading,
+      ghVersionsLoading,
+      codexVersionsLoading,
+      opencodeVersionsLoading,
+    ].some(Boolean)
     if (isLoading) return
 
-    const updates: PendingCliUpdate[] = []
-
-    // Check Claude CLI
-    if (
-      claudeStatus?.installed &&
-      claudeStatus.version &&
-      claudeVersions?.length
-    ) {
-      const latestStable = claudeVersions.find(v => !v.prerelease)
-      if (
-        latestStable &&
-        isNewerVersion(latestStable.version, claudeStatus.version)
-      ) {
-        const key = getCliUpdateKey(
-          'claude',
-          claudeStatus.version,
-          latestStable.version
-        )
-        if (
-          !handledRef.current.has(key) &&
-          !autoInstallInFlightRef.current.has(key)
-        ) {
-          updates.push({
-            key,
-            type: 'claude',
-            currentVersion: claudeStatus.version,
-            latestVersion: latestStable.version,
-            cliSource: preferences?.claude_cli_source,
-            cliPath: claudeStatus.path,
-            packageManager: claudePathInfo?.package_manager,
-          })
-        }
-      }
-    }
-
-    // Check GitHub CLI
-    if (ghStatus?.installed && ghStatus.version && ghVersions?.length) {
-      const latestStable = ghVersions.find(v => !v.prerelease)
-      if (
-        latestStable &&
-        isNewerVersion(latestStable.version, ghStatus.version)
-      ) {
-        const key = getCliUpdateKey('gh', ghStatus.version, latestStable.version)
-        if (
-          !handledRef.current.has(key) &&
-          !autoInstallInFlightRef.current.has(key)
-        ) {
-          updates.push({
-            key,
-            type: 'gh',
-            currentVersion: ghStatus.version,
-            latestVersion: latestStable.version,
-            cliSource: preferences?.gh_cli_source,
-            cliPath: ghStatus.path,
-            packageManager: ghPathInfo?.package_manager,
-          })
-        }
-      }
-    }
-
-    // Check Codex CLI
-    if (
-      codexStatus?.installed &&
-      codexStatus.version &&
-      codexVersions?.length
-    ) {
-      const latestStable = codexVersions.find(v => !v.prerelease)
-      if (
-        latestStable &&
-        isNewerVersion(latestStable.version, codexStatus.version)
-      ) {
-        const key = getCliUpdateKey(
-          'codex',
-          codexStatus.version,
-          latestStable.version
-        )
-        if (
-          !handledRef.current.has(key) &&
-          !autoInstallInFlightRef.current.has(key)
-        ) {
-          updates.push({
-            key,
-            type: 'codex',
-            currentVersion: codexStatus.version,
-            latestVersion: latestStable.version,
-            cliSource: preferences?.codex_cli_source,
-            cliPath: codexStatus.path,
-            packageManager: codexPathInfo?.package_manager,
-          })
-        }
-      }
-    }
-
-    // Check OpenCode CLI
-    if (
-      opencodeStatus?.installed &&
-      opencodeStatus.version &&
-      opencodeVersions?.length
-    ) {
-      const latestStable = opencodeVersions.find(v => !v.prerelease)
-      if (
-        latestStable &&
-        isNewerVersion(latestStable.version, opencodeStatus.version)
-      ) {
-        const key = getCliUpdateKey(
-          'opencode',
-          opencodeStatus.version,
-          latestStable.version
-        )
-        if (
-          !handledRef.current.has(key) &&
-          !autoInstallInFlightRef.current.has(key)
-        ) {
-          updates.push({
-            key,
-            type: 'opencode',
-            currentVersion: opencodeStatus.version,
-            latestVersion: latestStable.version,
-            cliSource: preferences?.opencode_cli_source,
-            cliPath: opencodeStatus.path,
-            packageManager: opencodePathInfo?.package_manager,
-          })
-        }
-      }
-    }
+    const updates = collectPendingUpdates(
+      [
+        {
+          type: 'claude',
+          status: claudeStatus,
+          versions: claudeVersions,
+          cliSource: preferences?.claude_cli_source,
+          pathInfo: claudePathInfo,
+        },
+        {
+          type: 'gh',
+          status: ghStatus,
+          versions: ghVersions,
+          cliSource: preferences?.gh_cli_source,
+          pathInfo: ghPathInfo,
+        },
+        {
+          type: 'codex',
+          status: codexStatus,
+          versions: codexVersions,
+          cliSource: preferences?.codex_cli_source,
+          pathInfo: codexPathInfo,
+        },
+        {
+          type: 'opencode',
+          status: opencodeStatus,
+          versions: opencodeVersions,
+          cliSource: preferences?.opencode_cli_source,
+          pathInfo: opencodePathInfo,
+        },
+      ],
+      handledRef.current,
+      autoInstallInFlightRef.current
+    )
 
     if (updates.length > 0) {
       logger.info('CLI updates available', { updates })
 
       // Split updates into silent auto-install (Jean-managed + auto-update enabled) vs manual toast.
-      const autoInstallUpdates: PendingCliUpdate[] = []
-      const manualUpdates: PendingCliUpdate[] = []
-
-      for (const update of updates) {
-        if (canAutoInstallCli(update, preferences)) {
-          autoInstallUpdates.push(update)
-        } else {
-          manualUpdates.push(update)
-        }
-      }
+      const { autoInstallUpdates, manualUpdates } = splitUpdatesByInstallMode(
+        updates,
+        preferences
+      )
 
       const isInitialCheck = isInitialCheckRef.current
 

--- a/src/hooks/useCliVersionCheck.ts
+++ b/src/hooks/useCliVersionCheck.ts
@@ -7,7 +7,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { useQueryClient } from '@tanstack/react-query'
+import { useQueryClient, type QueryClient } from '@tanstack/react-query'
 import {
   useClaudeCliStatus,
   useAvailableCliVersions,
@@ -37,6 +37,7 @@ import { isNewerVersion } from '@/lib/version-utils'
 import { logger } from '@/lib/logger'
 import { isNativeApp } from '@/lib/environment'
 import { usePreferences } from '@/services/preferences'
+import type { AppPreferences } from '@/types/preferences'
 import { invoke } from '@/lib/transport'
 
 interface CliUpdateInfo {
@@ -46,6 +47,10 @@ interface CliUpdateInfo {
   cliSource?: 'jean' | 'path'
   cliPath?: string | null
   packageManager?: string | null
+}
+
+interface PendingCliUpdate extends CliUpdateInfo {
+  key: string
 }
 
 /** Map CLI type to the binary name used by the package manager */
@@ -80,17 +85,36 @@ const CLI_STATUS_QUERY_KEYS: Record<CliUpdateInfo['type'], readonly string[]> = 
 }
 
 /** Map CLI type to its auto-update preference key */
-const CLI_AUTO_UPDATE_PREF_KEYS: Record<CliUpdateInfo['type'], string> = {
+const CLI_AUTO_UPDATE_PREF_KEYS: Record<
+  CliUpdateInfo['type'],
+  keyof AppPreferences
+> = {
   claude: 'auto_update_claude_cli',
   gh: 'auto_update_gh_cli',
   codex: 'auto_update_codex_cli',
   opencode: 'auto_update_opencode_cli',
 }
 
+function getCliUpdateKey(
+  type: CliUpdateInfo['type'],
+  currentVersion: string,
+  latestVersion: string
+) {
+  return `${type}:${currentVersion}→${latestVersion}`
+}
+
+function canAutoInstallCli(
+  update: CliUpdateInfo,
+  preferences: AppPreferences | undefined
+) {
+  const prefKey = CLI_AUTO_UPDATE_PREF_KEYS[update.type]
+  return preferences?.[prefKey] === true && update.cliSource === 'jean'
+}
+
 /**
  * Hook that checks for CLI updates on startup and periodically (every hour).
  * Shows toast notifications when updates are detected.
- * When auto-update is enabled for a CLI (jean-managed only), silently installs the latest version.
+ * When auto-update is enabled for a Jean-managed installer, silently installs the pinned version.
  * Should be called once in App.tsx.
  */
 export function useCliVersionCheck() {
@@ -130,7 +154,8 @@ export function useCliVersionCheck() {
 
   // Track which update pairs we've already shown notifications for or auto-installed
   // Format: "type:currentVersion→latestVersion"
-  const notifiedRef = useRef<Set<string>>(new Set())
+  const handledRef = useRef<Set<string>>(new Set())
+  const autoInstallInFlightRef = useRef<Set<string>>(new Set())
   const isInitialCheckRef = useRef(true)
 
   useEffect(() => {
@@ -146,7 +171,7 @@ export function useCliVersionCheck() {
       opencodeVersionsLoading
     if (isLoading) return
 
-    const updates: CliUpdateInfo[] = []
+    const updates: PendingCliUpdate[] = []
 
     // Check Claude CLI
     if (
@@ -159,10 +184,17 @@ export function useCliVersionCheck() {
         latestStable &&
         isNewerVersion(latestStable.version, claudeStatus.version)
       ) {
-        const key = `claude:${claudeStatus.version}→${latestStable.version}`
-        if (!notifiedRef.current.has(key)) {
-          notifiedRef.current.add(key)
+        const key = getCliUpdateKey(
+          'claude',
+          claudeStatus.version,
+          latestStable.version
+        )
+        if (
+          !handledRef.current.has(key) &&
+          !autoInstallInFlightRef.current.has(key)
+        ) {
           updates.push({
+            key,
             type: 'claude',
             currentVersion: claudeStatus.version,
             latestVersion: latestStable.version,
@@ -181,10 +213,13 @@ export function useCliVersionCheck() {
         latestStable &&
         isNewerVersion(latestStable.version, ghStatus.version)
       ) {
-        const key = `gh:${ghStatus.version}→${latestStable.version}`
-        if (!notifiedRef.current.has(key)) {
-          notifiedRef.current.add(key)
+        const key = getCliUpdateKey('gh', ghStatus.version, latestStable.version)
+        if (
+          !handledRef.current.has(key) &&
+          !autoInstallInFlightRef.current.has(key)
+        ) {
           updates.push({
+            key,
             type: 'gh',
             currentVersion: ghStatus.version,
             latestVersion: latestStable.version,
@@ -207,10 +242,17 @@ export function useCliVersionCheck() {
         latestStable &&
         isNewerVersion(latestStable.version, codexStatus.version)
       ) {
-        const key = `codex:${codexStatus.version}→${latestStable.version}`
-        if (!notifiedRef.current.has(key)) {
-          notifiedRef.current.add(key)
+        const key = getCliUpdateKey(
+          'codex',
+          codexStatus.version,
+          latestStable.version
+        )
+        if (
+          !handledRef.current.has(key) &&
+          !autoInstallInFlightRef.current.has(key)
+        ) {
           updates.push({
+            key,
             type: 'codex',
             currentVersion: codexStatus.version,
             latestVersion: latestStable.version,
@@ -233,10 +275,17 @@ export function useCliVersionCheck() {
         latestStable &&
         isNewerVersion(latestStable.version, opencodeStatus.version)
       ) {
-        const key = `opencode:${opencodeStatus.version}→${latestStable.version}`
-        if (!notifiedRef.current.has(key)) {
-          notifiedRef.current.add(key)
+        const key = getCliUpdateKey(
+          'opencode',
+          opencodeStatus.version,
+          latestStable.version
+        )
+        if (
+          !handledRef.current.has(key) &&
+          !autoInstallInFlightRef.current.has(key)
+        ) {
           updates.push({
+            key,
             type: 'opencode',
             currentVersion: opencodeStatus.version,
             latestVersion: latestStable.version,
@@ -251,30 +300,41 @@ export function useCliVersionCheck() {
     if (updates.length > 0) {
       logger.info('CLI updates available', { updates })
 
-      // Split updates into auto-install (jean-managed + auto-update enabled) vs manual toast
-      const autoInstallUpdates: CliUpdateInfo[] = []
-      const manualUpdates: CliUpdateInfo[] = []
+      // Split updates into silent auto-install (Jean-managed + auto-update enabled) vs manual toast.
+      const autoInstallUpdates: PendingCliUpdate[] = []
+      const manualUpdates: PendingCliUpdate[] = []
 
       for (const update of updates) {
-        const prefKey = CLI_AUTO_UPDATE_PREF_KEYS[update.type] as keyof typeof preferences
-        const isAutoUpdate = preferences?.[prefKey] === true
-        const isJeanManaged = update.cliSource === 'jean'
-
-        if (isAutoUpdate && isJeanManaged) {
+        if (canAutoInstallCli(update, preferences)) {
           autoInstallUpdates.push(update)
         } else {
           manualUpdates.push(update)
         }
       }
 
-      // Auto-install: fire all in parallel with loading toasts
-      for (const update of autoInstallUpdates) {
-        autoInstallCli(update, queryClient)
+      const isInitialCheck = isInitialCheckRef.current
+
+      for (const update of manualUpdates) {
+        handledRef.current.add(update.key)
+      }
+
+      // Auto-install: keep launch-time work serialized to avoid startup contention.
+      if (autoInstallUpdates.length > 0) {
+        for (const update of autoInstallUpdates) {
+          autoInstallInFlightRef.current.add(update.key)
+        }
+
+        void processAutoInstallQueue(
+          autoInstallUpdates,
+          queryClient,
+          handledRef.current,
+          autoInstallInFlightRef.current
+        )
       }
 
       // Manual: show interactive toasts (with delay on initial check)
       if (manualUpdates.length > 0) {
-        if (isInitialCheckRef.current) {
+        if (isInitialCheck) {
           setTimeout(() => {
             showUpdateToasts(manualUpdates)
           }, 5000)
@@ -320,8 +380,8 @@ export function useCliVersionCheck() {
  */
 async function autoInstallCli(
   update: CliUpdateInfo,
-  queryClient: ReturnType<typeof import('@tanstack/react-query').useQueryClient>
-) {
+  queryClient: QueryClient
+): Promise<boolean> {
   const cliName = CLI_DISPLAY_NAMES[update.type]
   const toastId = `cli-auto-update-${update.type}`
   const command = CLI_INSTALL_COMMANDS[update.type]
@@ -333,8 +393,8 @@ async function autoInstallCli(
   })
 
   try {
-    await invoke(command, { version: null })
-    queryClient.invalidateQueries({ queryKey: statusQueryKey })
+    await invoke(command, { version: update.latestVersion })
+    await queryClient.invalidateQueries({ queryKey: statusQueryKey })
     toast.success(`${cliName} updated`, {
       id: toastId,
       description: `v${update.currentVersion} → v${update.latestVersion}`,
@@ -343,6 +403,7 @@ async function autoInstallCli(
       from: update.currentVersion,
       to: update.latestVersion,
     })
+    return true
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     toast.error(`Failed to update ${cliName}`, {
@@ -350,6 +411,30 @@ async function autoInstallCli(
       description: message,
     })
     logger.error(`[CliVersionCheck] Auto-update failed for ${cliName}`, { error: message })
+    return false
+  }
+}
+
+async function processAutoInstallQueue(
+  updates: PendingCliUpdate[],
+  queryClient: QueryClient,
+  handledKeys: Set<string>,
+  autoInstallInFlightKeys: Set<string>
+) {
+  for (const update of updates) {
+    let didInstall = false
+
+    try {
+      didInstall = await autoInstallCli(update, queryClient)
+    } finally {
+      autoInstallInFlightKeys.delete(update.key)
+    }
+
+    handledKeys.add(update.key)
+
+    if (!didInstall) {
+      showUpdateToasts([update])
+    }
   }
 }
 

--- a/src/services/preferences.test.ts
+++ b/src/services/preferences.test.ts
@@ -156,6 +156,10 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        auto_update_claude_cli: false,
+        auto_update_codex_cli: false,
+        auto_update_opencode_cli: false,
+        auto_update_gh_cli: false,
       }
       vi.mocked(invoke).mockResolvedValueOnce(mockPreferences)
 
@@ -277,6 +281,10 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        auto_update_claude_cli: false,
+        auto_update_codex_cli: false,
+        auto_update_opencode_cli: false,
+        auto_update_gh_cli: false,
       }
       vi.mocked(invoke).mockResolvedValueOnce(prefsWithOldBinding)
 
@@ -370,6 +378,10 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        auto_update_claude_cli: false,
+        auto_update_codex_cli: false,
+        auto_update_opencode_cli: false,
+        auto_update_gh_cli: false,
       }
       vi.mocked(invoke).mockResolvedValueOnce(prefsWithDeprecatedFastModel)
 
@@ -464,6 +476,10 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        auto_update_claude_cli: false,
+        auto_update_codex_cli: false,
+        auto_update_opencode_cli: false,
+        auto_update_gh_cli: false,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -560,6 +576,10 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        auto_update_claude_cli: false,
+        auto_update_codex_cli: false,
+        auto_update_opencode_cli: false,
+        auto_update_gh_cli: false,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -656,6 +676,10 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        auto_update_claude_cli: false,
+        auto_update_codex_cli: false,
+        auto_update_opencode_cli: false,
+        auto_update_gh_cli: false,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -750,6 +774,10 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        auto_update_claude_cli: false,
+        auto_update_codex_cli: false,
+        auto_update_opencode_cli: false,
+        auto_update_gh_cli: false,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -961,6 +961,10 @@ export interface AppPreferences {
   codex_cli_source: 'jean' | 'path' // Codex CLI source: 'jean' (managed) or 'path' (system PATH)
   opencode_cli_source: 'jean' | 'path' // OpenCode CLI source: 'jean' (managed) or 'path' (system PATH)
   gh_cli_source: 'jean' | 'path' // GitHub CLI source: 'jean' (managed) or 'path' (system PATH)
+  auto_update_claude_cli: boolean // Auto-update Claude CLI on app launch
+  auto_update_codex_cli: boolean // Auto-update Codex CLI on app launch
+  auto_update_opencode_cli: boolean // Auto-update OpenCode CLI on app launch
+  auto_update_gh_cli: boolean // Auto-update GitHub CLI on app launch
 }
 
 export interface CustomCliProfile {
@@ -1530,4 +1534,8 @@ export const defaultPreferences: AppPreferences = {
   codex_cli_source: 'jean', // Default: Jean-managed
   opencode_cli_source: 'jean', // Default: Jean-managed
   gh_cli_source: 'jean', // Default: Jean-managed
+  auto_update_claude_cli: false, // Default: no auto-update
+  auto_update_codex_cli: false, // Default: no auto-update
+  auto_update_opencode_cli: false, // Default: no auto-update
+  auto_update_gh_cli: false, // Default: no auto-update
 }


### PR DESCRIPTION
## Summary
- add per-CLI auto-update preferences for Jean-managed Claude, GitHub CLI, Codex, and OpenCode installs
- run launch-time CLI updates with pinned versions, serialized background installs, and manual-toast fallback on failure
- refactor the CLI version check hook to reduce duplication while keeping the launch-time update flow explicit

## Validation
- bunx eslint src/hooks/useCliVersionCheck.ts
- bun run typecheck