### PR TITLE
fix(chat): prevent WebKit blank-screen bug on rapid scroll during animations

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -308,6 +308,14 @@
   animation: collapsible-up 150ms ease-out;
 }
 
+/* Force GPU compositing layer on scroll viewport to prevent WebKit blank-screen bug.
+   Without this, rapid programmatic scrollTop changes during CSS collapse animations
+   can leave the viewport visually blank until a user scroll gesture forces a repaint. */
+.will-change-scroll {
+  will-change: scroll-position;
+  -webkit-transform: translateZ(0);
+}
+
 /* Bell ring animation for unread notifications */
 @keyframes bell-ring {
   0%, 70%, 100% {

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -2060,6 +2060,7 @@ export function ChatWindow({
                       <ScrollArea
                         className="h-full w-full"
                         viewportRef={scrollViewportRef}
+                        viewportClassName="will-change-scroll"
                         onScroll={handleScroll}
                       >
                         <div className="mx-auto max-w-7xl px-4 pt-4 pb-6 md:px-6 min-w-0 w-full">


### PR DESCRIPTION
## Summary

Fixes the blank-screen bug where the chat window goes visually empty after sending a message when a plan is expanded — especially with long sessions containing lots of content. The content was still in the DOM at the correct scroll position, but WebKit failed to repaint the viewport.

## Root Cause

When a plan is expanded and the user sends a new message:

1. `hasFollowUpMessage` becomes `true` → PlanDisplay's `defaultCollapsed` transitions to `true` → plan collapses
2. This removes **thousands of pixels** of content height instantly (we measured 1600–6800px drops)
3. The `ResizeObserver` in `useScrollManagement` fires repeatedly (up to 9 times), setting `scrollTop = scrollHeight` each frame to keep the viewport at the bottom
4. The scroll position ends up **correct** (`gap: 0`, `isAtBottom: true`) — but WebKit doesn't visually repaint the viewport after these rapid programmatic `scrollTop` changes during CSS animations
5. **Result**: blank screen until the user scrolls manually (which forces a repaint)

We confirmed this with debug instrumentation: the `+300ms` and `+1000ms` snapshots after sending showed `gap: 0` and `isAtBottom: true` — the scroll system was working perfectly, but the pixels on screen were stale.

## Changes

### 1. Eliminate CSS animation on programmatic plan collapse (`PlanFileDisplay.tsx`)

- Replaced `CollapsibleContent` (which uses a 150ms CSS `collapsible-up` animation) with conditional rendering (`{isOpen && <div>...</div>}`)
- Plan content is now removed from the DOM instantly when collapsed programmatically, eliminating the frame-by-frame height changes that trigger rapid ResizeObserver callbacks
- User-initiated toggle (clicking the plan header) still works smoothly via the Collapsible open/close state
- Switched from `useEffect` to render-time sync pattern (`useState` + conditional set during render) for `defaultCollapsed` tracking — collapses in the same render frame instead of a delayed effect

### 2. Simplify scroll timing (`useScrollManagement.ts`)

- Reduced double-rAF to single rAF in the send-start scroll handler — no longer needed since PlanDisplay collapses instantly (no second layout shift to wait for)

### 3. Force GPU compositing on scroll viewport (`App.css` + `ChatWindow.tsx`)

- Added `.will-change-scroll` class with `will-change: scroll-position` and `-webkit-transform: translateZ(0)` to the chat ScrollArea viewport
- Forces WebKit to create a GPU compositing layer, ensuring visual repaints happen on programmatic scroll position changes
- This is a standard fix for WebKit rendering issues and acts as a safety net even if future code introduces rapid scroll changes

## Demo

https://github.com/user-attachments/assets/7ccc1fea-7b17-4c9d-a4f4-8211ef817022

## Test Plan

- [ ] Open a session with an expanded plan and lots of chat content, send a new message → chat should scroll to bottom normally (no blank screen)
- [ ] Verify plan still collapses when user clicks the plan header toggle
- [ ] Verify plan collapses when approved (approve button)
- [ ] Send a message without any expanded plan → should work as before
- [ ] During streaming, scroll up with mouse wheel → auto-scroll should stop
- [ ] Switch between worktrees → should scroll to bottom instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)