### PR TITLE
fix(chat): prevent WebKit blank-screen bug on rapid scroll during animations

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -308,6 +308,14 @@
   animation: collapsible-up 150ms ease-out;
 }
 
+/* Force GPU compositing layer on scroll viewport to prevent WebKit blank-screen bug.
+   Without this, rapid programmatic scrollTop changes during CSS collapse animations
+   can leave the viewport visually blank until a user scroll gesture forces a repaint. */
+.will-change-scroll {
+  will-change: scroll-position;
+  -webkit-transform: translateZ(0);
+}
+
 /* Bell ring animation for unread notifications */
 @keyframes bell-ring {
   0%, 70%, 100% {

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -2060,6 +2060,7 @@ export function ChatWindow({
                       <ScrollArea
                         className="h-full w-full"
                         viewportRef={scrollViewportRef}
+                        viewportClassName="will-change-scroll"
                         onScroll={handleScroll}
                       >
                         <div className="mx-auto max-w-7xl px-4 pt-4 pb-6 md:px-6 min-w-0 w-full">


### PR DESCRIPTION
## Summary

Fixes a WebKit rendering bug where the chat window goes visually blank after sending a message when a plan is expanded, despite content being correctly positioned in the DOM.

### Key Changes

- **Instant plan collapse**: Removed CSS animation on programmatic plan collapse in `PlanFileDisplay.tsx` to prevent rapid ResizeObserver callbacks that trigger the rendering issue
- **Simplified scroll timing**: Reduced unnecessary double-rAF to single rAF in send-start scroll handler
- **GPU compositing safety net**: Added `will-change: scroll-position` and `-webkit-transform: translateZ(0)` to chat viewport to force GPU compositing layer and ensure repaints during programmatic scroll changes

### Root Cause

Expanding a plan then sending a message caused the plan to collapse, removing thousands of pixels of content height instantly. This triggered repeated ResizeObserver callbacks that set `scrollTop` multiple times during CSS animations. While scroll positioning was correct, WebKit failed to visually repaint the viewport after these rapid programmatic changes.

### Testing

- Verify no blank screen when sending messages with expanded plans
- Confirm plan still collapses on user toggle and approval
- Test streaming, manual scrolling, and worktree switching still work normally

---

Related to #253