### PR TITLE
feat(ui): allow minimizing CLI upgrade modals to run in background

### DIFF
--- a/docs/developer/auto-updates.md
+++ b/docs/developer/auto-updates.md
@@ -333,6 +333,52 @@ All updates are cryptographically signed:
 3. **Antivirus software**: Check if antivirus is blocking installation
 4. **System updates**: Ensure system is compatible with new version
 
+## CLI Upgrade Minimization
+
+Separate from the app auto-update system, Jean manages CLI tools (Claude CLI, GitHub CLI, Codex CLI, OpenCode CLI) that can be upgraded via toast notifications. These upgrades run through two modal types:
+
+- **CliReinstallModal**: Progress-bar dialog for jean-managed installs (download binary from GitHub)
+- **CliLoginModal**: Full-screen xterm terminal for Homebrew/PATH-based upgrades (`brew upgrade`, `claude update`)
+
+Both modals support **minimization** — clicking the Minus button in the modal header closes the modal but keeps the upgrade running in the background. A small indicator pill appears in the titlebar (top-right, next to the app update indicator) showing:
+
+- CLI name and progress percentage (for reinstall mode)
+- CLI name and "updating..." (for terminal/login mode)
+
+On completion, the indicator auto-clears and shows a success/error toast. Users can also dismiss the indicator with the X button.
+
+### Minimize Button Positioning
+
+The minimize button (Minus icon) is positioned absolutely (`absolute top-4 right-14`) to sit to the left of the Dialog's built-in close (X) button (`absolute top-4 right-5`). Both use identical styling for visual consistency. The minimize button is rendered outside `DialogHeader` as a sibling of the dialog content.
+
+### CLI Usage Guard During Updates
+
+When a CLI is being updated (minimized, reinstall modal open, or login modal open), message sending is blocked for that CLI's backend. The guard lives in `useMessageSending.ts`:
+
+```typescript
+const cliType = (queuedMsg.backend ?? 'claude') as 'claude' | 'codex' | 'opencode'
+const uiState = useUIStore.getState()
+const isUpdating =
+  uiState.minimizedCliUpdate?.type === cliType ||
+  (uiState.cliUpdateModalOpen && uiState.cliUpdateModalType === cliType) ||
+  (uiState.cliLoginModalOpen && uiState.cliLoginModalType === cliType)
+```
+
+If the CLI is updating, the user sees an error toast: *"[CLI Name] is currently being updated. Please wait for the update to complete."*
+
+### Restore from Minimized State
+
+- **Reinstall mode**: Clicking the titlebar indicator re-opens the `CliUpdateModal`, which picks up fresh progress events
+- **Login mode**: The PTY terminal UI was detached on minimize and cannot be re-attached, so clicking does nothing — the user can only dismiss with the X button or wait for completion
+
+### Implementation
+
+- **State**: `minimizedCliUpdate` in `ui-store.ts` tracks the minimized upgrade
+- **Indicator**: `MinimizedCliUpdate` component in `src/components/titlebar/MinimizedCliUpdate.tsx`
+- **Event listeners**: Reinstall mode listens to `${type}-cli:install-progress`, login mode uses `setOnStopped()` on the terminal instance
+- **PTY safety**: `CliLoginModal` uses a `minimizingRef` to skip PTY cleanup on minimize (the `MinimizedCliUpdate` component handles cleanup on completion)
+- **Send guard**: `useMessageSending.ts` checks `minimizedCliUpdate`, `cliUpdateModalOpen`, and `cliLoginModalOpen` before sending messages
+
 ## Future Enhancements
 
 ### Planned Improvements

--- a/docs/developer/notifications.md
+++ b/docs/developer/notifications.md
@@ -138,6 +138,38 @@ Native notifications require the `notification:default` permission in `src-tauri
 }
 ```
 
+## Titlebar Progress Indicators
+
+For long-running background operations that the user has minimized, Jean uses inline titlebar indicators instead of toasts. These appear as small pills in the top-right of the titlebar, next to the app version.
+
+### MinimizedCliUpdate
+
+**Location**: `src/components/titlebar/MinimizedCliUpdate.tsx`
+
+Shows progress for CLI upgrades that have been minimized from their modal. Displays a spinner, CLI name, and progress percentage (or "updating..."). Auto-clears on completion with a success/error toast.
+
+```typescript
+// Rendered directly in TitleBar.tsx (not lazy — titlebar is always mounted)
+<MinimizedCliUpdate />
+```
+
+The component self-guards — returns `null` when no minimized update is active. State is managed via `minimizedCliUpdate` in `ui-store.ts`.
+
+**Interactions:**
+- **Reinstall mode**: Clicking the indicator re-opens the upgrade modal (restorable)
+- **Login mode**: Not restorable (PTY detached) — user waits for completion or dismisses with X
+- **Dismiss (X)**: For login mode, also stops the PTY and disposes the terminal instance
+
+**CLI usage guard**: While a CLI is being updated, sending messages with that backend is blocked and an error toast is shown. See `auto-updates.md` for details.
+
+### When to Use Each Pattern
+
+| Pattern | Use Case |
+|---------|----------|
+| **Toast** (`sonner`) | Short-lived feedback (save, copy, quick action result) |
+| **Native notification** | System-level alerts when app may not be focused |
+| **Titlebar indicator** | Long-running background operations the user has minimized |
+
 ## Best Practices
 
 1. **Choose the right type**: Use toast for in-app feedback, native for system-level alerts

--- a/src/components/chat/hooks/useMessageSending.ts
+++ b/src/components/chat/hooks/useMessageSending.ts
@@ -2,6 +2,7 @@ import { useCallback, type RefObject } from 'react'
 import { generateId } from '@/lib/uuid'
 import { toast } from 'sonner'
 import { useChatStore } from '@/store/chat-store'
+import { useUIStore } from '@/store/ui-store'
 import { chatQueryKeys, cancelChatMessage, persistEnqueue } from '@/services/chat'
 import { buildMcpConfigJson } from '@/services/mcp'
 import { DEFAULT_PARALLEL_EXECUTION_PROMPT } from '@/types/preferences'
@@ -150,6 +151,23 @@ export function useMessageSending({
   const sendMessageNow = useCallback(
     (queuedMsg: QueuedMessage) => {
       if (!activeSessionId || !activeWorktreeId || !activeWorktreePath) return
+
+      // Block sending if the CLI for this backend is being updated
+      const cliType = (queuedMsg.backend ?? 'claude') as 'claude' | 'codex' | 'opencode'
+      const uiState = useUIStore.getState()
+      const isUpdating =
+        uiState.minimizedCliUpdate?.type === cliType ||
+        (uiState.cliUpdateModalOpen && uiState.cliUpdateModalType === cliType) ||
+        (uiState.cliLoginModalOpen && uiState.cliLoginModalType === cliType)
+      if (isUpdating) {
+        const cliNames: Record<string, string> = {
+          claude: 'Claude CLI',
+          codex: 'Codex CLI',
+          opencode: 'OpenCode CLI',
+        }
+        toast.error(`${cliNames[cliType]} is currently being updated. Please wait for the update to complete.`)
+        return
+      }
 
       console.log(`[Send] sendMessageNow sessionId=${activeSessionId} worktreeId=${activeWorktreeId}`)
 

--- a/src/components/layout/CliUpdateModal.tsx
+++ b/src/components/layout/CliUpdateModal.tsx
@@ -8,6 +8,7 @@
  * open one will have hooks running (prevents duplicate event listeners).
  */
 
+import { useCallback } from 'react'
 import { useUIStore } from '@/store/ui-store'
 import {
   ClaudeCliReinstallModal,
@@ -27,6 +28,16 @@ export function CliUpdateModal() {
     }
   }
 
+  const handleMinimize = useCallback(() => {
+    const { minimizeCliUpdate, closeCliUpdateModal: close } =
+      useUIStore.getState()
+    const type = useUIStore.getState().cliUpdateModalType
+    if (type) {
+      minimizeCliUpdate({ type, mode: 'reinstall' })
+    }
+    close()
+  }, [])
+
   // Render both modals - each has lazy mounting (returns null when closed)
   // Only the one matching cliUpdateModalType will actually render hooks
   return (
@@ -34,18 +45,22 @@ export function CliUpdateModal() {
       <ClaudeCliReinstallModal
         open={cliUpdateModalOpen && cliUpdateModalType === 'claude'}
         onOpenChange={handleOpenChange}
+        onMinimize={handleMinimize}
       />
       <GhCliReinstallModal
         open={cliUpdateModalOpen && cliUpdateModalType === 'gh'}
         onOpenChange={handleOpenChange}
+        onMinimize={handleMinimize}
       />
       <CodexCliReinstallModal
         open={cliUpdateModalOpen && cliUpdateModalType === 'codex'}
         onOpenChange={handleOpenChange}
+        onMinimize={handleMinimize}
       />
       <OpenCodeCliReinstallModal
         open={cliUpdateModalOpen && cliUpdateModalType === 'opencode'}
         onOpenChange={handleOpenChange}
+        onMinimize={handleMinimize}
       />
     </>
   )

--- a/src/components/preferences/CliLoginModal.tsx
+++ b/src/components/preferences/CliLoginModal.tsx
@@ -4,6 +4,9 @@
  * Modal with embedded xterm terminal for CLI login flows.
  * Used for `claude` and `gh auth login` commands that require
  * interactive terminal access.
+ *
+ * Supports minimizing to a titlebar indicator so upgrades
+ * can run in the background while the user continues working.
  */
 
 import { useCallback, useEffect, useRef, useMemo, useState } from 'react'
@@ -27,6 +30,7 @@ import { useUIStore } from '@/store/ui-store'
 import { useShallow } from 'zustand/react/shallow'
 import { useTerminal } from '@/hooks/useTerminal'
 import { disposeTerminal, setOnStopped } from '@/lib/terminal-instances'
+import { Minus } from 'lucide-react'
 
 export function CliLoginModal() {
   const [retryKey, setRetryKey] = useState(0)
@@ -73,6 +77,7 @@ function CliLoginModalContent({
   const queryClient = useQueryClient()
   const initialized = useRef(false)
   const observerRef = useRef<ResizeObserver | null>(null)
+  const minimizingRef = useRef(false)
   const [exitStatus, setExitStatus] = useState<{
     exitCode: number | null
     signal: string | null
@@ -167,6 +172,8 @@ function CliLoginModalContent({
       if (observerRef.current) {
         observerRef.current.disconnect()
       }
+      // When minimizing, keep PTY alive — MinimizedCliUpdate handles cleanup
+      if (minimizingRef.current) return
       invoke('stop_terminal', { terminalId }).catch(() => {
         // Terminal may already be stopped
       })
@@ -178,6 +185,12 @@ function CliLoginModalContent({
   const handleOpenChange = useCallback(
     async (open: boolean) => {
       if (!open) {
+        // When minimizing, skip PTY cleanup — MinimizedCliUpdate handles it
+        if (minimizingRef.current) {
+          onClose()
+          return
+        }
+
         // Stop PTY process
         try {
           await invoke('stop_terminal', { terminalId })
@@ -205,6 +218,18 @@ function CliLoginModalContent({
     [terminalId, onClose, cliType, queryClient]
   )
 
+  // Minimize to titlebar indicator — PTY keeps running in background
+  const handleMinimize = useCallback(() => {
+    minimizingRef.current = true
+    // Clear the onStopped callback — MinimizedCliUpdate will register its own
+    setOnStopped(terminalId, undefined)
+    const { minimizeCliUpdate, closeCliLoginModal } = useUIStore.getState()
+    if (cliType) {
+      minimizeCliUpdate({ type: cliType, mode: 'login', terminalId })
+    }
+    closeCliLoginModal()
+  }, [cliType, terminalId])
+
   // Auto-close modal on success, show error on failure
   useEffect(() => {
     setOnStopped(terminalId, (exitCode, signal) => {
@@ -230,6 +255,14 @@ function CliLoginModalContent({
   return (
     <Dialog open={true} onOpenChange={handleOpenChange}>
       <DialogContent className="!w-screen !h-dvh !max-w-screen !rounded-none sm:!w-[calc(100vw-64px)] sm:!max-w-[calc(100vw-64px)] sm:!h-[calc(100vh-64px)] sm:!rounded-lg flex flex-col">
+        {/* Minimize button positioned to the left of the Dialog close (X) button */}
+        <button
+          onClick={handleMinimize}
+          title="Minimize to background"
+          className="ring-offset-background focus:ring-ring absolute top-4 right-14 inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 focus:ring-2 focus:ring-offset-2 focus:outline-hidden cursor-pointer"
+        >
+          <Minus className="size-4" />
+        </button>
         <DialogHeader>
           <DialogTitle>{cliName} Login</DialogTitle>
           <DialogDescription>

--- a/src/components/preferences/CliReinstallModal.tsx
+++ b/src/components/preferences/CliReinstallModal.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { CheckCircle2 } from 'lucide-react'
+import { CheckCircle2, Minus } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -52,6 +52,7 @@ interface CliSetupInterface {
 interface ModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  onMinimize?: () => void
 }
 
 type ModalStep = 'setup' | 'installing' | 'complete'
@@ -60,14 +61,14 @@ type ModalStep = 'setup' | 'installing' | 'complete'
  * Claude CLI specific modal - calls ONLY useClaudeCliSetup
  * This ensures only one event listener is active
  */
-export function ClaudeCliReinstallModal({ open, onOpenChange }: ModalProps) {
+export function ClaudeCliReinstallModal({ open, onOpenChange, onMinimize }: ModalProps) {
   if (!open) return null
   return (
-    <ClaudeCliReinstallModalContent open={open} onOpenChange={onOpenChange} />
+    <ClaudeCliReinstallModalContent open={open} onOpenChange={onOpenChange} onMinimize={onMinimize} />
   )
 }
 
-function ClaudeCliReinstallModalContent({ open, onOpenChange }: ModalProps) {
+function ClaudeCliReinstallModalContent({ open, onOpenChange, onMinimize }: ModalProps) {
   const setup = useClaudeCliSetup()
   return (
     <CliReinstallModalUI
@@ -75,6 +76,7 @@ function ClaudeCliReinstallModalContent({ open, onOpenChange }: ModalProps) {
       cliType="claude"
       open={open}
       onOpenChange={onOpenChange}
+      onMinimize={onMinimize}
     />
   )
 }
@@ -83,12 +85,12 @@ function ClaudeCliReinstallModalContent({ open, onOpenChange }: ModalProps) {
  * GitHub CLI specific modal - calls ONLY useGhCliSetup
  * This ensures only one event listener is active
  */
-export function GhCliReinstallModal({ open, onOpenChange }: ModalProps) {
+export function GhCliReinstallModal({ open, onOpenChange, onMinimize }: ModalProps) {
   if (!open) return null
-  return <GhCliReinstallModalContent open={open} onOpenChange={onOpenChange} />
+  return <GhCliReinstallModalContent open={open} onOpenChange={onOpenChange} onMinimize={onMinimize} />
 }
 
-function GhCliReinstallModalContent({ open, onOpenChange }: ModalProps) {
+function GhCliReinstallModalContent({ open, onOpenChange, onMinimize }: ModalProps) {
   const setup = useGhCliSetup()
   return (
     <CliReinstallModalUI
@@ -96,6 +98,7 @@ function GhCliReinstallModalContent({ open, onOpenChange }: ModalProps) {
       cliType="gh"
       open={open}
       onOpenChange={onOpenChange}
+      onMinimize={onMinimize}
     />
   )
 }
@@ -104,14 +107,14 @@ function GhCliReinstallModalContent({ open, onOpenChange }: ModalProps) {
  * Codex CLI specific modal - calls ONLY useCodexCliSetup
  * This ensures only one event listener is active
  */
-export function CodexCliReinstallModal({ open, onOpenChange }: ModalProps) {
+export function CodexCliReinstallModal({ open, onOpenChange, onMinimize }: ModalProps) {
   if (!open) return null
   return (
-    <CodexCliReinstallModalContent open={open} onOpenChange={onOpenChange} />
+    <CodexCliReinstallModalContent open={open} onOpenChange={onOpenChange} onMinimize={onMinimize} />
   )
 }
 
-function CodexCliReinstallModalContent({ open, onOpenChange }: ModalProps) {
+function CodexCliReinstallModalContent({ open, onOpenChange, onMinimize }: ModalProps) {
   const setup = useCodexCliSetup()
   return (
     <CliReinstallModalUI
@@ -119,6 +122,7 @@ function CodexCliReinstallModalContent({ open, onOpenChange }: ModalProps) {
       cliType="codex"
       open={open}
       onOpenChange={onOpenChange}
+      onMinimize={onMinimize}
     />
   )
 }
@@ -127,14 +131,14 @@ function CodexCliReinstallModalContent({ open, onOpenChange }: ModalProps) {
  * OpenCode CLI specific modal - calls ONLY useOpenCodeCliSetup
  * This ensures only one event listener is active
  */
-export function OpenCodeCliReinstallModal({ open, onOpenChange }: ModalProps) {
+export function OpenCodeCliReinstallModal({ open, onOpenChange, onMinimize }: ModalProps) {
   if (!open) return null
   return (
-    <OpenCodeCliReinstallModalContent open={open} onOpenChange={onOpenChange} />
+    <OpenCodeCliReinstallModalContent open={open} onOpenChange={onOpenChange} onMinimize={onMinimize} />
   )
 }
 
-function OpenCodeCliReinstallModalContent({ open, onOpenChange }: ModalProps) {
+function OpenCodeCliReinstallModalContent({ open, onOpenChange, onMinimize }: ModalProps) {
   const setup = useOpenCodeCliSetup()
   return (
     <CliReinstallModalUI
@@ -142,6 +146,7 @@ function OpenCodeCliReinstallModalContent({ open, onOpenChange }: ModalProps) {
       cliType="opencode"
       open={open}
       onOpenChange={onOpenChange}
+      onMinimize={onMinimize}
     />
   )
 }
@@ -154,6 +159,7 @@ interface CliReinstallModalUIProps {
   cliType: 'claude' | 'gh' | 'codex' | 'opencode'
   open: boolean
   onOpenChange: (open: boolean) => void
+  onMinimize?: () => void
 }
 
 function CliReinstallModalUI({
@@ -161,6 +167,7 @@ function CliReinstallModalUI({
   cliType,
   open,
   onOpenChange,
+  onMinimize,
 }: CliReinstallModalUIProps) {
   const cliName =
     cliType === 'claude'
@@ -268,6 +275,16 @@ function CliReinstallModalUI({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[450px]" preventClose>
+        {/* Minimize button positioned to the left of the Dialog close (X) button */}
+        {step === 'installing' && onMinimize && (
+          <button
+            onClick={onMinimize}
+            title="Minimize to background"
+            className="ring-offset-background focus:ring-ring absolute top-4 right-14 inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 focus:ring-2 focus:ring-offset-2 focus:outline-hidden cursor-pointer"
+          >
+            <Minus className="size-4" />
+          </button>
+        )}
         <DialogHeader>
           <DialogTitle>
             {step === 'complete'

--- a/src/components/titlebar/MinimizedCliUpdate.tsx
+++ b/src/components/titlebar/MinimizedCliUpdate.tsx
@@ -1,0 +1,196 @@
+/**
+ * Minimized CLI Update Indicator
+ *
+ * Inline titlebar indicator shown when a CLI upgrade modal is minimized.
+ * Tracks progress via Tauri events and auto-clears on completion.
+ * Clicking the indicator re-opens the upgrade modal.
+ */
+
+import { useEffect, useState, useCallback } from 'react'
+import { listen, invoke } from '@/lib/transport'
+import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { Loader2, X } from 'lucide-react'
+import { useUIStore } from '@/store/ui-store'
+import { claudeCliQueryKeys } from '@/services/claude-cli'
+import { ghCliQueryKeys } from '@/services/gh-cli'
+import { codexCliQueryKeys } from '@/services/codex-cli'
+import { opencodeCliQueryKeys } from '@/services/opencode-cli'
+import { githubQueryKeys } from '@/services/github'
+import { disposeTerminal, setOnStopped } from '@/lib/terminal-instances'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+const CLI_NAMES: Record<string, string> = {
+  claude: 'Claude CLI',
+  gh: 'GitHub CLI',
+  codex: 'Codex CLI',
+  opencode: 'OpenCode CLI',
+}
+
+function invalidateCliQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  type: string
+) {
+  if (type === 'claude') {
+    queryClient.invalidateQueries({ queryKey: claudeCliQueryKeys.all })
+  } else if (type === 'gh') {
+    queryClient.invalidateQueries({ queryKey: ghCliQueryKeys.all })
+    queryClient.invalidateQueries({ queryKey: githubQueryKeys.all })
+  } else if (type === 'codex') {
+    queryClient.invalidateQueries({ queryKey: codexCliQueryKeys.all })
+  } else if (type === 'opencode') {
+    queryClient.invalidateQueries({ queryKey: opencodeCliQueryKeys.all })
+  }
+}
+
+export function MinimizedCliUpdate() {
+  const minimized = useUIStore(state => state.minimizedCliUpdate)
+  const clearMinimizedCliUpdate = useUIStore(
+    state => state.clearMinimizedCliUpdate
+  )
+  const queryClient = useQueryClient()
+  const [progress, setProgress] = useState<{
+    stage: string
+    message: string
+    percent: number
+  } | null>(null)
+
+  const handleComplete = useCallback(
+    (success: boolean) => {
+      if (!minimized) return
+      const cliName = CLI_NAMES[minimized.type] ?? minimized.type
+      if (success) {
+        toast.success(`${cliName} updated successfully`)
+      } else {
+        toast.error(`${cliName} update failed`)
+      }
+      invalidateCliQueries(queryClient, minimized.type)
+      clearMinimizedCliUpdate()
+    },
+    [minimized, queryClient, clearMinimizedCliUpdate]
+  )
+
+  // Reinstall mode: listen to install-progress events
+  useEffect(() => {
+    if (!minimized || minimized.mode !== 'reinstall') return
+
+    const eventName = `${minimized.type}-cli:install-progress`
+    const unlisten = listen<{
+      stage: string
+      message: string
+      percent: number
+    }>(eventName, event => {
+      setProgress(event.payload)
+      if (event.payload.stage === 'complete') {
+        handleComplete(true)
+      }
+    })
+    return () => {
+      unlisten.then(fn => fn())
+    }
+  }, [minimized?.type, minimized?.mode, handleComplete])
+
+  // Login mode: listen to terminal stopped
+  useEffect(() => {
+    if (!minimized || minimized.mode !== 'login' || !minimized.terminalId)
+      return
+
+    const terminalId = minimized.terminalId
+    setOnStopped(terminalId, (exitCode: number | null) => {
+      const success = exitCode === 0
+      handleComplete(success)
+      // Cleanup the PTY
+      invoke('stop_terminal', { terminalId }).catch(() => {
+        // Terminal may already be stopped
+      })
+      disposeTerminal(terminalId)
+    })
+    return () => setOnStopped(terminalId, undefined)
+  }, [minimized?.terminalId, minimized?.mode, handleComplete])
+
+  // Reset progress when minimized state changes
+  useEffect(() => {
+    setProgress(null)
+  }, [minimized?.type, minimized?.mode])
+
+  // Restore: re-open the upgrade modal
+  const handleRestore = useCallback(() => {
+    if (!minimized) return
+    const { openCliUpdateModal } = useUIStore.getState()
+
+    if (minimized.mode === 'reinstall') {
+      // Re-open reinstall modal — it will pick up fresh progress events
+      clearMinimizedCliUpdate()
+      openCliUpdateModal(minimized.type)
+    } else if (minimized.mode === 'login') {
+      // For login mode, the PTY is still running but the terminal UI was detached.
+      // Re-opening would create a new terminal, so we just keep showing the indicator.
+      // User can dismiss with X when done.
+    }
+  }, [minimized, clearMinimizedCliUpdate])
+
+  const handleDismiss = useCallback(() => {
+    if (!minimized) return
+    // For login mode, stop PTY and dispose terminal
+    if (minimized.mode === 'login' && minimized.terminalId) {
+      setOnStopped(minimized.terminalId, undefined)
+      invoke('stop_terminal', { terminalId: minimized.terminalId }).catch(
+        () => {
+          // Terminal may already be stopped
+        }
+      )
+      disposeTerminal(minimized.terminalId)
+    }
+    clearMinimizedCliUpdate()
+  }, [minimized, clearMinimizedCliUpdate])
+
+  if (!minimized) return null
+
+  const cliName = CLI_NAMES[minimized.type] ?? minimized.type
+  const progressPercent =
+    minimized.mode === 'reinstall' && progress ? `${progress.percent}%` : null
+  const isRestorable = minimized.mode === 'reinstall'
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          role={isRestorable ? 'button' : undefined}
+          tabIndex={isRestorable ? 0 : undefined}
+          onClick={isRestorable ? handleRestore : undefined}
+          onKeyDown={
+            isRestorable
+              ? e => {
+                  if (e.key === 'Enter') handleRestore()
+                }
+              : undefined
+          }
+          className={`mr-1.5 flex items-center gap-1.5 rounded-md bg-primary/15 px-1.5 py-0.5 text-[0.625rem] font-medium text-primary ${isRestorable ? 'cursor-pointer hover:bg-primary/25' : ''}`}
+        >
+          <Loader2 className="size-3 animate-spin" />
+          <span className="truncate max-w-[120px]">
+            {cliName} {progressPercent ?? 'updating...'}
+          </span>
+          <button
+            onClick={e => {
+              e.stopPropagation()
+              handleDismiss()
+            }}
+            className="ml-0.5 rounded-sm hover:bg-primary/20 transition-colors cursor-pointer"
+          >
+            <X className="size-3" />
+          </button>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        {isRestorable
+          ? 'Click to restore upgrade dialog'
+          : (progress?.message ?? `Updating ${cliName} in background`)}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/components/titlebar/TitleBar.tsx
+++ b/src/components/titlebar/TitleBar.tsx
@@ -23,6 +23,7 @@ import { usePreferences } from '@/services/preferences'
 import { formatShortcutDisplay, DEFAULT_KEYBINDINGS } from '@/types/keybindings'
 import { isNativeApp } from '@/lib/environment'
 import { UnreadBell } from '@/components/unread/UnreadBell'
+import { MinimizedCliUpdate } from '@/components/titlebar/MinimizedCliUpdate'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { FALLBACK_APP_VERSION } from '@/lib/app-version'
 
@@ -186,6 +187,7 @@ export function TitleBar({
             <TooltipContent>GitHub</TooltipContent>
           </Tooltip>
         )}
+        <MinimizedCliUpdate />
         {appVersion && <UpdateIndicator />}
         {appVersion && (
           <button

--- a/src/store/ui-store.ts
+++ b/src/store/ui-store.ts
@@ -19,6 +19,12 @@ export type CliUpdateModalType = 'claude' | 'gh' | 'codex' | 'opencode' | null
 
 export type CliLoginModalType = 'claude' | 'gh' | 'codex' | 'opencode' | null
 
+export interface MinimizedCliUpdate {
+  type: 'claude' | 'gh' | 'codex' | 'opencode'
+  mode: 'reinstall' | 'login'
+  terminalId?: string
+}
+
 interface UIState {
   leftSidebarVisible: boolean
   leftSidebarSize: number // Width in pixels, persisted across sessions
@@ -79,6 +85,8 @@ interface UIState {
   featureTourOpen: boolean
   /** Whether UI state has been restored from persisted storage */
   uiStateInitialized: boolean
+  /** Minimized CLI update running in background — shown as indicator in title bar */
+  minimizedCliUpdate: MinimizedCliUpdate | null
   /** Pending app update that user skipped — shown as indicator in title bar */
   pendingUpdateVersion: string | null
   /** When non-null, shows the update available modal */
@@ -151,6 +159,8 @@ interface UIState {
   setPlanDialogOpen: (open: boolean) => void
   setFeatureTourOpen: (open: boolean) => void
   setUIStateInitialized: (initialized: boolean) => void
+  minimizeCliUpdate: (info: MinimizedCliUpdate) => void
+  clearMinimizedCliUpdate: () => void
   setPendingUpdateVersion: (version: string | null) => void
   setUpdateModalVersion: (version: string | null) => void
   githubDashboardOpen: boolean
@@ -213,6 +223,7 @@ export const useUIStore = create<UIState>()(
       planDialogOpen: false,
       featureTourOpen: false,
       uiStateInitialized: false,
+      minimizedCliUpdate: null,
       pendingUpdateVersion: null,
       updateModalVersion: null,
       githubDashboardOpen: false,
@@ -637,6 +648,19 @@ export const useUIStore = create<UIState>()(
           { uiStateInitialized: initialized },
           undefined,
           'setUIStateInitialized'
+        ),
+
+      minimizeCliUpdate: (info: MinimizedCliUpdate) =>
+        set({ minimizedCliUpdate: info }, undefined, 'minimizeCliUpdate'),
+
+      clearMinimizedCliUpdate: () =>
+        set(
+          state => {
+            if (!state.minimizedCliUpdate) return state
+            return { minimizedCliUpdate: null }
+          },
+          undefined,
+          'clearMinimizedCliUpdate'
         ),
 
       setPendingUpdateVersion: (version: string | null) =>


### PR DESCRIPTION
## Summary

- CLI upgrade modals (Codex, Claude, GH, OpenCode) now have a **minimize button** so upgrades can run in the background
- Minimized upgrades show as a **titlebar indicator pill** (top-right, next to app update indicator) with spinner, CLI name, and progress
- Indicator **auto-clears on completion** with a success/error toast
- **Blocks message sending** for a CLI backend while it's being updated, showing an error toast
- Reinstall mode indicator is clickable to **restore the modal**

Closes #257

## Changes

| File | Change |
|------|--------|
| `src/store/ui-store.ts` | Add `MinimizedCliUpdate` interface, state, and actions |
| `src/components/titlebar/MinimizedCliUpdate.tsx` | **New** - Titlebar indicator with progress tracking and event listeners |
| `src/components/preferences/CliReinstallModal.tsx` | Add `onMinimize` prop and minimize button during install step |
| `src/components/layout/CliUpdateModal.tsx` | Wire minimize handler to store actions |
| `src/components/preferences/CliLoginModal.tsx` | Add minimize with PTY-safe cleanup (`minimizingRef`) |
| `src/components/titlebar/TitleBar.tsx` | Render `MinimizedCliUpdate` in right section |
| `src/components/chat/hooks/useMessageSending.ts` | Guard against sending while CLI is updating |
| `docs/developer/auto-updates.md` | Document minimize feature, button positioning, CLI guard, restore |
| `docs/developer/notifications.md` | Document titlebar indicator pattern |

## Test plan

- [ ] Trigger a CLI update toast (or open update modal from Settings)
- [ ] Click Update, then click minimize (Minus icon to the left of X)
- [ ] Verify modal closes and pill indicator appears in titlebar
- [ ] Verify you can use the app normally while upgrade runs
- [ ] Verify success/error toast shows on completion and indicator auto-clears
- [ ] Verify normal close (X) on modal still stops the process
- [ ] Try sending a message with the updating CLI's backend - should show error toast
- [ ] For reinstall mode: click the indicator to restore the modal

<img width="1562" height="416" alt="image" src="https://github.com/user-attachments/assets/ceff70ae-472d-4ef0-8d0c-d2fba5e6bb29" />

<img width="1866" height="1302" alt="image" src="https://github.com/user-attachments/assets/2ffcfc1e-e3ab-4a63-8421-881109a4656a" />


