### PR TITLE
fix(terminal): restore full PATH and consistent shell init for PTY sessions

### DIFF
--- a/src-tauri/src/terminal/pty.rs
+++ b/src-tauri/src/terminal/pty.rs
@@ -33,6 +33,10 @@ pub fn spawn_terminal(
         command, command_args
     );
 
+    // Ensure the full user PATH is available (macOS GUI apps inherit a minimal PATH)
+    #[cfg(target_os = "macos")]
+    crate::platform::ensure_macos_path();
+
     let pty_system = native_pty_system();
 
     // Guard against degenerate dimensions that crash portable_pty
@@ -88,7 +92,10 @@ pub fn spawn_terminal(
             c
         }
     } else {
-        CommandBuilder::new(&shell)
+        let mut c = CommandBuilder::new(&shell);
+        #[cfg(not(windows))]
+        c.arg("-l");
+        c
     };
     // Use the requested working directory if it exists, otherwise fall back to
     // the system temp directory. This is critical on Windows where `/tmp` doesn't

--- a/src-tauri/src/terminal/pty.rs
+++ b/src-tauri/src/terminal/pty.rs
@@ -86,7 +86,7 @@ pub fn spawn_terminal(
             }
             #[cfg(not(windows))]
             {
-                c.arg("-c");
+                c.arg("-lc");
                 c.arg(run_command);
             }
             c


### PR DESCRIPTION
## Summary

- ensure PTY sessions on macOS inherit the user's full shell-derived `PATH`, including tools installed via Homebrew, bun, nvm, and similar setups
- start interactive PTY shells as login shells and run shell-wrapped PTY commands with `-lc` for more consistent environment initialization
- keep direct binary execution with `command_args` unchanged while reducing cases where commands work in an opened terminal but fail in a PTY-launched command


## Problem

macOS GUI apps launched outside a terminal can inherit a minimal `PATH`, which caused PTY sessions to miss user-installed binaries. interactive PTY shells using login-shell behavior should also be aligned with shell-wrapped PTY commands.


## Approach

- call `ensure_macos_path()` before spawning PTY processes so terminal sessions inherit the corrected process environment
- use `-l` for interactive Unix PTY shells
- use `-lc` for Unix shell-wrapped PTY commands to align command execution with interactive terminal environment setup


## Notes

- this intentionally relies on the user's shell configuration to derive `PATH` on macOS, matching expected terminal behavior
- direct binary invocation via `command_args` remains the preferred path when exact argument handling is needed