### PR TITLE
feat(nightshift): single-check runs, setup script integration, and UI improvements

### DIFF
--- a/.strajk/customizations.yml
+++ b/.strajk/customizations.yml
@@ -1,0 +1,139 @@
+# Customization re-implementation tracking
+# Status: done | in-progress | todo
+
+customizations:
+  - spec: xx-active-session-highlight.md
+    status: done
+    commit: 92f414ae75f562bfa291d53e64decf889e948b04
+    pr: 286
+    jean_deep_link: null
+
+  - spec: xx-chat-text-search.md
+    status: done
+    commit: 92c5bc475f8a385f6d8e7ec9a8001368c31e44e2
+    pr: 287
+    jean_deep_link: "jean:///show?session=58eae522-8a2c-4fd3-ae45-3ba044c74f3b"
+
+  - spec: xx-ui-tweaks.md
+    status: done
+    commit: 69f2f6d
+
+  - spec: xx-direct-model-and-mode-shortcuts.md
+    status: done
+    commit: f8115b1
+    pr: null
+    jean_deep_link: null
+  
+  - spec: xx-go-to-session.md
+    status: done
+    commit: f5f0886
+    pr: null
+    jean_deep_link: null
+
+  - spec: xx-rename-session-shortcut.md
+    status: done
+    commit: 1166584
+    pr: null
+    jean_deep_link: null
+    
+  - spec: xx-indicator-hover-titles.md
+    status: done
+    commit: 1009bfd
+    pr: null
+    jean_deep_link: null
+
+  - spec: xx-navigation-history.md
+    status: done
+    commit: 8c9ea16
+    pr: null
+    jean_deep_link: null
+
+  - spec: xx-selectable-text.md
+    status: done
+    commit: b50ada9
+
+  - spec: xx-sidebar-disable-status-grouping.md
+    status: done
+    commit: cd3e63d
+    pr: null
+    jean_deep_link: null
+
+  - spec: xx-toggle-all-worktrees-expanded.md
+    status: done
+    commit: fb79175
+    pr: null
+    jean_deep_link: null
+
+  - spec: xx-sidebar-session-labels.md
+    status: done
+    commit: fc4277a
+    pr: null
+    jean_deep_link: null
+
+  - spec: xx-session-history-and-notification-center.md
+    status: done
+    commit: b4c61ed
+    pr: null
+    jean_deep_link: null
+    
+
+  - spec: xx-git-diff-tree-view.md
+    status: done
+    commit: da5d26e
+  
+  - spec: xx-push-tooltip-commit-list.md
+    status: done
+    commit: b4aa00a
+    pr: null
+    jean_deep_link: null
+
+  - spec: xx-recap-banner.md
+    status: done
+    commit: aac36a1
+
+
+  - spec: xx-sidebar-pr-badge.md
+    status: done
+    commit: 60ec8ed
+    pr: null
+    jean_deep_link: null
+
+  - spec: xx-terminal-word-wrap-toggle.md
+    status: done
+    commit: 9e1868c
+    pr: null
+    jean_deep_link: null
+
+  - spec: xx-text-highlights.md
+    status: done
+    commit: 338c38f
+    pr: null
+    jean_deep_link: null
+
+  - spec: xx-terminal-status-indicator.md
+    status: in-progress
+    commit: null
+    pr: 285 # not mine
+    jean_deep_link: null
+    note: "Based on upstream PR #285 with tweaks: icon moved right of title, clickable to open terminal"
+
+  # TODO
+
+  - spec: xx-deep-links.md
+    status: todo
+  
+
+  
+  
+  
+  
+  # SKIP
+  - spec: xx-fork-session.md
+    status: todo
+
+
+  - spec: xx-project-index-switching.md
+    status: not-needed-anymore
+
+  - spec: xx-fix-json-schema-max-turns.md
+    status: maybe-not-needed-anymore

--- a/.strajk/customizations.yml
+++ b/.strajk/customizations.yml
@@ -117,6 +117,13 @@ customizations:
     jean_deep_link: null
     note: "Based on upstream PR #285 with tweaks: icon moved right of title, clickable to open terminal"
 
+  - spec: xx-nightshift.md
+    status: in-progress
+    commit: null
+    pr: 122 # not mine
+    jean_deep_link: null
+    note: "Based on upstream PR #122. Tweaks: merged storage.rs conflict with text-highlights, added missing Worktree fields to engine.rs"
+
   # TODO
 
   - spec: xx-deep-links.md

--- a/.strajk/customizations/xx-nightshift.md
+++ b/.strajk/customizations/xx-nightshift.md
@@ -1,0 +1,63 @@
+# Nightshift — Automated Codebase Maintenance
+
+Based on upstream PR #122 (`feat(nightshift): add automated codebase maintenance system`).
+
+## What
+
+Background maintenance system that runs configurable code-quality checks using real Claude CLI sessions. A project-level "Nightshift" tab in settings lets you enable/configure checks, and a "Run Now" button triggers them manually. Results are viewable in a runs history modal.
+
+## Why
+
+Codebases accumulate lint issues, dead code, stale docs, security vulnerabilities, and test gaps over time. Nightshift automates these maintenance tasks on a schedule (or on-demand), each running as a real Claude CLI session in a dedicated worktree so it doesn't interfere with active work.
+
+## What's included
+
+### Rust backend (`src-tauri/src/nightshift/` — 6 new files)
+
+- **`types.rs`** — Data models: `NightshiftConfig`, `NightshiftRun`, `CheckResult`, `SessionSource` enum, per-check settings (enable/disable, cooldown, custom prompts, post-action)
+- **`checks.rs`** — 10 built-in checks with default prompts: lint-fix, dead-code removal, doc-drift, security audit, test gaps, dependency audit, type safety, error handling, performance review, config hygiene
+- **`engine.rs`** — Core orchestrator: sequential checks per project, concurrent across projects. Creates a dedicated "nightshift" worktree, spawns Claude CLI sessions per check, tracks cooldowns, handles post-actions (nothing / commit / commit+PR). `RUNNING_PROJECTS` guard prevents double-runs
+- **`storage.rs`** — Atomic JSON persistence with file locking, max 50 runs per project
+- **`commands.rs`** — Tauri commands: `get_nightshift_config`, `update_nightshift_config`, `get_nightshift_runs`, `trigger_nightshift_run`, `nightshift_check_completed`
+- **`mod.rs`** — Module re-exports
+
+### Modified Rust files
+
+- **`chat/codex.rs`** — Adds `tail_codex_output()` for tailing detached Codex CLI JSONL output files
+- **`chat/types.rs`** — Adds `SessionSource` enum and nightshift metadata fields (`source`, `nightshift_check_id`, `nightshift_run_id`) to `Session`
+- **`chat/storage.rs`** — Adds nightshift fields to session hydration defaults
+- **`lib.rs`** — Registers nightshift module, commands, and `NightshiftEngine` as managed state
+- **`projects/commands.rs`** — Adds `save_empty_index()` call for nightshift worktree setup
+- **`projects/types.rs`** — Adds nightshift-related project type fields
+
+### Frontend (7 new files)
+
+- **`src/types/nightshift.ts`** — TypeScript types mirroring Rust structs
+- **`src/store/nightshift-store.ts`** — Zustand store for UI state (active sessions, modal visibility)
+- **`src/services/nightshift.ts`** — TanStack Query hooks for config/runs CRUD
+- **`src/lib/commands/nightshift-commands.ts`** — Typed `invoke()` wrappers for all nightshift Tauri commands
+- **`src/components/projects/panes/NightshiftPane.tsx`** — Settings UI: experimental banner, enable toggle, schedule time, post-action selector, per-check config with custom prompts and cooldown overrides
+- **`src/components/nightshift/NightshiftRunsModal.tsx`** — Run history viewer with collapsible check results
+- **`src/hooks/useNightshiftEvents.ts`** — Event bridge: listens for `nightshift:execute-check`, sends messages to CLI sessions, reports completion back to engine
+
+### Modified frontend files
+
+- **`MainWindow.tsx`** — Mounts `useNightshiftEvents` hook
+- **`ProjectSettingsDialog.tsx`** — Adds "Nightshift" tab to project settings dialog
+- **`lib/commands/index.ts`** — Re-exports nightshift commands
+- **`types/chat.ts`** — Adds `source`, `nightshift_check_id`, `nightshift_run_id` to Session type
+
+## Tweaks on top of upstream PR
+
+1. **Merge conflict resolution**: `chat/storage.rs` session hydration — merged nightshift fields alongside our existing `highlights` field from the text-highlights customization.
+2. **Missing Worktree fields**: Added `linear_issue_identifier`, `security_alert_number`, `security_alert_url`, `advisory_ghsa_id`, `advisory_url` (all `None`) to `engine.rs:269` Worktree constructor — these fields were added to the `Worktree` struct after the PR was authored.
+
+## Dependencies
+
+- Upstream PR #120 (worktree refactor) for `save_empty_index()` and `worktrees:changed` event — appears to already be merged into main.
+- No dependency on other customizations (but conflicts with xx-text-highlights on `storage.rs` field list — resolved).
+
+## Not yet implemented (upstream)
+
+- Token usage / cost tracking and budget limits
+- Inspiration: [marcus/nightshift](https://github.com/marcus/nightshift)

--- a/.strajk/customizations/xx-terminal-status-indicator.md
+++ b/.strajk/customizations/xx-terminal-status-indicator.md
@@ -1,0 +1,29 @@
+# Terminal Status Indicator
+
+Based on upstream PR #285 (`feat(terminal): live process & port detection in sidebar`).
+
+## What
+
+Show a play icon next to each worktree name when a terminal has a running process. Hovering shows the command and detected TCP ports (e.g. `bun run dev (:3000)`). If the process crashes (non-zero exit), the icon turns red with "(crashed)". Clicking the icon opens the terminal.
+
+## Why
+
+Before, there was no way to know at a glance if a dev server was running in a worktree's terminal, which port it was on, or if it had crashed. The only indicator was a generic spinner that didn't distinguish running vs. crashed and showed no port info.
+
+## Tweaks on top of upstream PR
+
+1. **Icon position**: Moved from the left side (before the title) to directly after the worktree name text. Keeps it close to the name but out of the leading indicator area.
+2. **Clickable**: Clicking the play icon opens the terminal for that worktree. In both canvas view and sidebar, this opens the session chat modal with the terminal drawer visible. Click uses `stopPropagation` to avoid triggering the parent row's click handler.
+
+## Upstream scope (PR #285)
+
+- **Rust**: New `get_terminal_listening_ports` command that uses `lsof` + process tree walking (`ps -eo pid=,ppid=`) to find TCP LISTEN ports belonging to terminal child processes. Unix-only; returns empty on Windows and web access.
+- **Terminal store**: Added `failedTerminals: Set<string>` tracking terminals that exited with non-zero code. All mutations guarded against no-op updates.
+- **Terminal exit handling**: Reworked to distinguish clean exits (code 0, SIGINT, SIGTERM) from crashes. Crashes set `failedTerminals`; clean exits auto-close the terminal tab.
+- **Hook + component**: `useWorktreeTerminalStatus` hook reads running/failed state and polls for listening ports (every 5s, only when active). `TerminalStatusIndicator` renders the play icon with tooltip.
+- **Port polling**: `useTerminalListeningPorts` TanStack Query hook, enabled only when terminals are running.
+
+## Dependencies
+
+- No dependency on other customizations.
+- Depends on upstream terminal store having `runningTerminals` set (already present).

--- a/.strajk/customizations/xx-ui-tweaks.md
+++ b/.strajk/customizations/xx-ui-tweaks.md
@@ -1,0 +1,30 @@
+# UI Tweaks
+
+## What
+- Always use the narrow/compact indentation for sidebar worktree items, regardless of sidebar width. The default indentation feels too generous.
+- Remove background "pill" styling from all sidebar badges (issues, PRs, workflow runs, security alerts, push/pull commits). Keep the colored text and icons, just drop the rounded background, padding, and hover-background. The pills take up too much visual space in the sidebar.
+- Remove aggressive JS hard-truncation on collapsed tool call rows, letting CSS handle responsive truncation instead. The JS truncation cuts text at 50-60 chars regardless of available width, wasting space on wide windows.
+
+## Why
+- **Compact indentation**: The wide padding mode wastes horizontal space, causing worktree names and badges to truncate unnecessarily.
+- **Badge de-pilling**: With pill backgrounds removed, badges become lightweight colored text that blends into the sidebar row without dominating it. The color and icon are already enough to communicate meaning.
+
+## Scope
+
+### Compact sidebar indentation
+- `WorktreeList.tsx`: Reduce left margin from `ml-4` to `ml-2`
+- `WorktreeItem.tsx`: Force narrow padding (`pl-3`) instead of conditional `pl-4`/`pl-7`; force narrow session list margin (`ml-4`) instead of conditional `ml-6`/`ml-9`
+- `WorktreeItem.tsx`: Reduce worktree row vertical padding from `py-1.5` to `py-1` so worktree rows are closer in height to session rows
+
+### Badge de-pilling
+- Strip `rounded bg-COLOR/10 px-1.5 py-0.5` and `hover:bg-COLOR/20` from all sidebar badge buttons
+- Replace with `transition-opacity hover:opacity-70`
+- Affected components: `NewIssuesBadge`, `OpenPRsBadge`, `FailedRunsBadge`, `SecurityAlertsBadge`, `WorktreeItem` (push/pull), `ProjectTreeItem` (base branch push/pull), `git-status-badges` (shared component)
+- Bump project-level badge container gap from `gap-1` to `gap-2` to compensate for removed padding
+
+### Tool call truncation removal
+- In `ToolCallInline.tsx`, remove JS `substring()` truncation — CSS `truncate` on the `<code>` element adapts to available width
+- **Bash commands**: Remove `command.substring(0, 50)`, pass raw `command` as `detail`
+- **SpawnAgent prompts**: Remove `prompt.substring(0, 60)`, pass raw `prompt` as `detail`
+- **SubToolItem / SubThinkingItem**: Add `min-w-0` to their `CollapsibleTrigger` so flex children can shrink and CSS truncation takes effect
+

--- a/src-tauri/src/chat/codex.rs
+++ b/src-tauri/src/chat/codex.rs
@@ -2422,6 +2422,237 @@ fn process_codex_event(
 }
 
 // =============================================================================
+// File-based tailing for detached Codex CLI
+// =============================================================================
+
+/// Tail a Codex JSONL output file and emit events as new lines appear.
+///
+/// Maps Codex events to the same Tauri events used by Claude, so the
+/// frontend streaming infrastructure works unchanged.
+pub fn tail_codex_output(
+    app: &tauri::AppHandle,
+    session_id: &str,
+    worktree_id: &str,
+    output_file: &std::path::Path,
+    pid: u32,
+    is_plan_mode: bool,
+) -> Result<CodexResponse, String> {
+    use super::detached::is_process_alive;
+    use super::tail::{NdjsonTailer, POLL_INTERVAL, POLL_INTERVAL_FAST};
+    use std::time::{Duration, Instant};
+
+    log::trace!("Starting to tail Codex NDJSON output for session: {session_id}");
+
+    let mut tailer = NdjsonTailer::new_from_start(output_file)?;
+
+    let mut full_content = String::new();
+    let mut thread_id = String::new();
+    let mut tool_calls: Vec<ToolCall> = Vec::new();
+    let mut content_blocks: Vec<ContentBlock> = Vec::new();
+    let mut completed = false;
+    let mut cancelled = false;
+    let mut error_emitted = false;
+    let mut usage: Option<UsageData> = None;
+    let mut error_lines: Vec<String> = Vec::new();
+
+    // Track tool IDs for matching started/completed pairs
+    let mut pending_tool_ids: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+
+    let startup_timeout = Duration::from_secs(120);
+    let dead_process_timeout = Duration::from_secs(2);
+    let started_at = Instant::now();
+    let mut last_output_time = Instant::now();
+    let mut received_codex_output = false;
+
+    loop {
+        let lines = tailer.poll()?;
+        let had_data = !lines.is_empty();
+
+        if had_data {
+            last_output_time = Instant::now();
+        }
+
+        for line in lines {
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            // Skip our metadata header
+            if line.contains("\"_run_meta\"") {
+                continue;
+            }
+
+            if !received_codex_output {
+                log::trace!("Received first Codex output for session: {session_id}");
+                received_codex_output = true;
+            }
+
+            let msg: serde_json::Value = match serde_json::from_str(&line) {
+                Ok(m) => m,
+                Err(e) => {
+                    log::trace!("Failed to parse Codex line as JSON: {e}");
+                    let trimmed = line.trim().to_string();
+                    if !trimmed.is_empty() {
+                        error_lines.push(trimmed);
+                    }
+                    continue;
+                }
+            };
+
+            let event_type = msg.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+            process_codex_event(
+                app,
+                session_id,
+                worktree_id,
+                &msg,
+                event_type,
+                &mut full_content,
+                &mut thread_id,
+                &mut tool_calls,
+                &mut content_blocks,
+                &mut pending_tool_ids,
+                &mut completed,
+                &mut usage,
+                &mut error_emitted,
+            );
+        }
+
+        if completed {
+            break;
+        }
+
+        // Check if externally cancelled
+        if !super::registry::is_process_running(session_id) {
+            log::trace!("Session {session_id} cancelled externally, stopping Codex tail");
+            cancelled = true;
+            break;
+        }
+
+        // Timeout logic
+        let process_alive = is_process_alive(pid);
+
+        if received_codex_output {
+            if !process_alive && last_output_time.elapsed() > dead_process_timeout {
+                log::trace!("Codex process {pid} is no longer running and no new output");
+                // If we got content, treat as completed (Codex yolo mode may
+                // not emit turn.completed before exiting)
+                if full_content.is_empty() && content_blocks.is_empty() && tool_calls.is_empty() {
+                    cancelled = true;
+                }
+                break;
+            }
+        } else {
+            let elapsed = started_at.elapsed();
+
+            if !process_alive && elapsed > Duration::from_secs(5) {
+                log::warn!(
+                    "Codex process {pid} died during startup after {:.1}s with no output",
+                    elapsed.as_secs_f64()
+                );
+                cancelled = true;
+                break;
+            }
+
+            if elapsed > startup_timeout {
+                log::warn!("Startup timeout exceeded waiting for Codex output");
+                cancelled = true;
+                break;
+            }
+        }
+
+        // Adaptive sleep: poll faster when actively receiving data (5ms)
+        // to reduce per-event latency, back off to 50ms when idle.
+        std::thread::sleep(if had_data {
+            POLL_INTERVAL_FAST
+        } else {
+            POLL_INTERVAL
+        });
+    }
+
+    // Surface errors
+    if cancelled || (full_content.is_empty() && !received_codex_output) {
+        if let Ok(remaining) = tailer.poll() {
+            for line in remaining {
+                let trimmed = line.trim();
+                if !trimmed.is_empty()
+                    && !trimmed.contains("\"_run_meta\"")
+                    && serde_json::from_str::<serde_json::Value>(trimmed).is_err()
+                {
+                    error_lines.push(trimmed.to_string());
+                }
+            }
+        }
+        let drained = tailer.drain_buffer();
+        if !drained.trim().is_empty() {
+            error_lines.push(drained.trim().to_string());
+        }
+    }
+
+    let has_content = !full_content.is_empty() || !content_blocks.is_empty() || !tool_calls.is_empty();
+
+    if !error_emitted && !error_lines.is_empty() && !has_content {
+        let error_text = error_lines.join("\n");
+        log::warn!("Codex CLI error output for session {session_id}: {error_text}");
+
+        let user_error = format_codex_user_error(&error_text);
+        let _ = app.emit_all(
+            "chat:error",
+            &ErrorEvent {
+                session_id: session_id.to_string(),
+                worktree_id: worktree_id.to_string(),
+                error: user_error,
+            },
+        );
+        error_emitted = true;
+    }
+
+    // Fallback: process died silently with no content and no error emitted
+    if !error_emitted && !completed && !has_content && cancelled {
+        log::warn!("Codex process died silently for session {session_id} with no output");
+        let _ = app.emit_all(
+            "chat:error",
+            &ErrorEvent {
+                session_id: session_id.to_string(),
+                worktree_id: worktree_id.to_string(),
+                error: "Codex CLI exited unexpectedly without producing output. Check your API key and usage limits.".to_string(),
+            },
+        );
+        error_emitted = true;
+    }
+
+    // Don't emit chat:done if an error was emitted — the frontend chat:done
+    // handler clears errors, which would hide the error message from the user
+    if !cancelled && !error_emitted {
+        let _ = app.emit_all(
+            "chat:done",
+            &DoneEvent {
+                session_id: session_id.to_string(),
+                worktree_id: worktree_id.to_string(),
+                waiting_for_plan: is_plan_mode && !full_content.is_empty(),
+            },
+        );
+    }
+
+    log::trace!(
+        "Codex tailing complete: {} chars, {} tool calls, cancelled: {cancelled}",
+        full_content.len(),
+        tool_calls.len()
+    );
+
+    Ok(CodexResponse {
+        content: full_content,
+        thread_id,
+        tool_calls,
+        content_blocks,
+        cancelled,
+        error_emitted,
+        usage,
+    })
+}
+
+// =============================================================================
 // JSONL history parser (for loading saved sessions)
 // =============================================================================
 

--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -510,6 +510,7 @@ pub async fn update_session_state(
     review_results: Option<Option<serde_json::Value>>,
     enabled_mcp_servers: Option<Option<Vec<String>>>,
     selected_execution_mode: Option<Option<String>>,
+    highlights: Option<Vec<super::types::TextHighlight>>,
 ) -> Result<(), String> {
     log::trace!("Updating session state for: {session_id}");
 
@@ -577,6 +578,9 @@ pub async fn update_session_state(
             }
             if let Some(v) = selected_execution_mode {
                 session.selected_execution_mode = v;
+            }
+            if let Some(v) = highlights {
+                session.highlights = v;
             }
             Ok(())
         } else {

--- a/src-tauri/src/chat/storage.rs
+++ b/src-tauri/src/chat/storage.rs
@@ -671,6 +671,9 @@ pub fn load_sessions(
                 archived_at: entry.archived_at,
                 archived_by_base_close: None,
                 last_opened_at: None,
+                source: None,
+                nightshift_check_id: None,
+                nightshift_run_id: None,
                 answered_questions: vec![],
                 submitted_answers: std::collections::HashMap::new(),
                 fixed_findings: vec![],
@@ -784,6 +787,9 @@ where
                 label: None,
                 queued_messages: vec![],
                 highlights: vec![],
+                source: None,
+                nightshift_check_id: None,
+                nightshift_run_id: None,
             }
         };
         hydrated_sessions.push(session);

--- a/src-tauri/src/chat/storage.rs
+++ b/src-tauri/src/chat/storage.rs
@@ -694,6 +694,7 @@ pub fn load_sessions(
                 last_run_execution_mode: None,
                 label: None,
                 queued_messages: vec![],
+                highlights: vec![],
             }
         };
         sessions.push(session);
@@ -782,6 +783,7 @@ where
                 last_run_execution_mode: None,
                 label: None,
                 queued_messages: vec![],
+                highlights: vec![],
             }
         };
         hydrated_sessions.push(session);

--- a/src-tauri/src/chat/types.rs
+++ b/src-tauri/src/chat/types.rs
@@ -553,6 +553,19 @@ pub struct Session {
     pub last_opened_at: Option<u64>,
 
     // ========================================================================
+    // Nightshift metadata
+    // ========================================================================
+    /// Source of session creation (None = user-created, "nightshift" = nightshift)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Nightshift check ID that created this session
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nightshift_check_id: Option<String>,
+    /// Nightshift run ID (links session to a run)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nightshift_run_id: Option<String>,
+
+    // ========================================================================
     // Session-specific UI state (moved from ui-state.json)
     // ========================================================================
     /// Tool call IDs that have been answered (for AskUserQuestion)
@@ -672,6 +685,10 @@ impl Session {
             archived_at: None,
             archived_by_base_close: None,
             last_opened_at: None,
+            // Nightshift metadata
+            source: None,
+            nightshift_check_id: None,
+            nightshift_run_id: None,
             // Session-specific UI state
             answered_questions: vec![],
             submitted_answers: HashMap::new(),
@@ -861,6 +878,9 @@ impl SessionMetadata {
             archived_at: self.archived_at,
             archived_by_base_close: self.archived_by_base_close,
             last_opened_at: self.last_opened_at,
+            source: self.source.clone(),
+            nightshift_check_id: self.nightshift_check_id.clone(),
+            nightshift_run_id: self.nightshift_run_id.clone(),
             answered_questions: self.answered_questions.clone(),
             submitted_answers: self.submitted_answers.clone(),
             fixed_findings: self.fixed_findings.clone(),
@@ -910,6 +930,9 @@ impl SessionMetadata {
         self.session_naming_completed = session.session_naming_completed;
         self.archived_at = session.archived_at;
         self.archived_by_base_close = session.archived_by_base_close;
+        self.source = session.source.clone();
+        self.nightshift_check_id = session.nightshift_check_id.clone();
+        self.nightshift_run_id = session.nightshift_run_id.clone();
         self.answered_questions = session.answered_questions.clone();
         self.submitted_answers = session.submitted_answers.clone();
         self.fixed_findings = session.fixed_findings.clone();
@@ -1200,6 +1223,17 @@ pub struct SessionMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub archived_by_base_close: Option<bool>,
 
+    // Nightshift metadata
+    /// Source of session creation (None = user-created, "nightshift" = nightshift)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Nightshift check ID that created this session
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nightshift_check_id: Option<String>,
+    /// Nightshift run ID (links session to a run)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nightshift_run_id: Option<String>,
+
     // Session-specific UI state
     /// Tool call IDs that have been answered (for AskUserQuestion)
     #[serde(default)]
@@ -1356,6 +1390,9 @@ impl SessionMetadata {
             session_naming_completed: false,
             archived_at: None,
             archived_by_base_close: None,
+            source: None,
+            nightshift_check_id: None,
+            nightshift_run_id: None,
             answered_questions: vec![],
             submitted_answers: HashMap::new(),
             fixed_findings: vec![],

--- a/src-tauri/src/chat/types.rs
+++ b/src-tauri/src/chat/types.rs
@@ -35,6 +35,15 @@ pub struct LabelData {
     pub color: String,
 }
 
+/// A persistent text highlight within a chat message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextHighlight {
+    pub id: String,
+    pub message_id: String,
+    pub text: String,
+    pub start_offset: u64,
+}
+
 /// Deserializes label from either a plain string (old format) or a LabelData object (new format).
 fn deserialize_label_compat<'de, D>(deserializer: D) -> Result<Option<LabelData>, D::Error>
 where
@@ -627,6 +636,10 @@ pub struct Session {
     /// Messages queued for sending (persisted so they survive page refresh / sync across clients)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub queued_messages: Vec<serde_json::Value>,
+
+    /// User-created text highlights (persistent annotations)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub highlights: Vec<TextHighlight>,
 }
 
 impl Session {
@@ -683,6 +696,7 @@ impl Session {
             last_run_execution_mode: None,
             label: None,
             queued_messages: vec![],
+            highlights: vec![],
         }
     }
 
@@ -877,6 +891,7 @@ impl SessionMetadata {
             last_run_execution_mode: last_run.and_then(|r| r.execution_mode.clone()),
             label: self.label.clone(),
             queued_messages: self.queued_messages.clone(),
+            highlights: self.highlights.clone(),
         }
     }
 
@@ -917,6 +932,7 @@ impl SessionMetadata {
         self.pending_plan_message_id = session.pending_plan_message_id.clone();
         self.enabled_mcp_servers = session.enabled_mcp_servers.clone();
         self.label = session.label.clone();
+        self.highlights = session.highlights.clone();
         // NOTE: Do NOT overwrite queued_messages here. Queue state is managed
         // exclusively by enqueue/dequeue/remove/clear operations which use
         // atomic read-modify-write via with_existing_metadata_mut. Overwriting
@@ -1254,6 +1270,10 @@ pub struct SessionMetadata {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub queued_messages: Vec<serde_json::Value>,
 
+    /// User-created text highlights (persistent annotations)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub highlights: Vec<TextHighlight>,
+
     /// Unix timestamp when session was last opened/viewed by the user
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_opened_at: Option<u64>,
@@ -1357,6 +1377,7 @@ impl SessionMetadata {
             digest: None,
             label: None,
             queued_messages: vec![],
+            highlights: vec![],
             last_opened_at: None,
             runs: vec![],
             version: 1,

--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -1460,6 +1460,10 @@ pub async fn dispatch_command(
             let result = crate::terminal::get_ports(worktree_path).await;
             to_value(result)
         }
+        "get_terminal_listening_ports" => {
+            // NATIVE ONLY: lsof not available in browser mode
+            Ok(Value::Array(vec![]))
+        }
 
         // =====================================================================
         // Session Management (additional)

--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -1546,6 +1546,8 @@ pub async fn dispatch_command(
                 field_opt(&args, "enabledMcpServers", "enabled_mcp_servers")?;
             let selected_execution_mode: Option<Option<String>> =
                 field_opt(&args, "selectedExecutionMode", "selected_execution_mode")?;
+            let highlights: Option<Vec<crate::chat::types::TextHighlight>> =
+                field_opt(&args, "highlights", "highlights")?;
             crate::chat::update_session_state(
                 app.clone(),
                 worktree_id,
@@ -1571,6 +1573,7 @@ pub async fn dispatch_command(
                 review_results,
                 enabled_mcp_servers,
                 selected_execution_mode,
+                highlights,
             )
             .await?;
             emit_cache_invalidation(app, &["sessions"]);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -226,6 +226,12 @@ pub struct AppPreferences {
     pub opencode_cli_source: String, // OpenCode CLI source: "jean" (managed) or "path" (system PATH)
     #[serde(default = "default_cli_source")]
     pub gh_cli_source: String, // GitHub CLI source: "jean" (managed) or "path" (system PATH)
+    #[serde(default = "default_sidebar_group_by_status")]
+    pub sidebar_group_by_status: bool, // Group sidebar sessions by status headers (default: true)
+}
+
+fn default_sidebar_group_by_status() -> bool {
+    true
 }
 
 fn default_true() -> Option<bool> {
@@ -1191,6 +1197,7 @@ impl Default for AppPreferences {
             codex_cli_source: default_cli_source(),
             opencode_cli_source: default_cli_source(),
             gh_cli_source: default_cli_source(),
+            sidebar_group_by_status: default_sidebar_group_by_status(),
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -233,6 +233,8 @@ pub struct AppPreferences {
     pub sidebar_group_by_status: bool, // Group sidebar sessions by status headers (default: true)
     #[serde(default = "default_terminal_word_wrap")]
     pub terminal_word_wrap: bool, // Terminal word wrap (default: true, false = horizontal scroll with wide cols)
+    #[serde(default)]
+    pub expand_tool_calls: bool, // Expand tool call groups by default in chat (default: false)
 }
 
 fn default_sidebar_group_by_status() -> bool {
@@ -1213,6 +1215,7 @@ impl Default for AppPreferences {
             gh_cli_source: default_cli_source(),
             sidebar_group_by_status: default_sidebar_group_by_status(),
             terminal_word_wrap: default_terminal_word_wrap(),
+            expand_tool_calls: false,
         }
     }
 }
@@ -2984,6 +2987,7 @@ pub fn run() {
             nightshift::nightshift_get_config,
             nightshift::nightshift_save_config,
             nightshift::nightshift_start_run,
+            nightshift::nightshift_start_check,
             nightshift::nightshift_cancel_run,
             nightshift::nightshift_get_runs,
             nightshift::nightshift_get_run,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2839,6 +2839,7 @@ pub fn run() {
             terminal::has_active_terminal,
             terminal::get_run_scripts,
             terminal::get_ports,
+            terminal::get_terminal_listening_ports,
             terminal::kill_all_terminals,
             // Chat commands - Session management
             chat::get_sessions,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod claude_cli;
 mod codex_cli;
 mod gh_cli;
 pub mod http_server;
+mod nightshift;
 mod opencode_cli;
 mod opencode_server;
 mod platform;
@@ -2668,6 +2669,9 @@ pub fn run() {
                 }
             });
 
+            // Start the nightshift scheduler (checks every minute)
+            nightshift::engine::start_scheduler(app.handle().clone());
+
             log::info!("Startup: setup() completed in {:?}", setup_start.elapsed());
             Ok(())
         })
@@ -2968,6 +2972,16 @@ pub fn run() {
             opencode_server::start_opencode_server,
             opencode_server::stop_opencode_server,
             opencode_server::get_opencode_server_status,
+            // Nightshift commands
+            nightshift::nightshift_list_checks,
+            nightshift::nightshift_get_config,
+            nightshift::nightshift_save_config,
+            nightshift::nightshift_start_run,
+            nightshift::nightshift_cancel_run,
+            nightshift::nightshift_get_runs,
+            nightshift::nightshift_get_run,
+            nightshift::nightshift_report_check_done,
+            nightshift::nightshift_get_default_prompt,
         ])
         .build(tauri::generate_context!())
         .expect("error building tauri application")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -228,9 +228,15 @@ pub struct AppPreferences {
     pub gh_cli_source: String, // GitHub CLI source: "jean" (managed) or "path" (system PATH)
     #[serde(default = "default_sidebar_group_by_status")]
     pub sidebar_group_by_status: bool, // Group sidebar sessions by status headers (default: true)
+    #[serde(default = "default_terminal_word_wrap")]
+    pub terminal_word_wrap: bool, // Terminal word wrap (default: true, false = horizontal scroll with wide cols)
 }
 
 fn default_sidebar_group_by_status() -> bool {
+    true
+}
+
+fn default_terminal_word_wrap() -> bool {
     true
 }
 
@@ -1198,6 +1204,7 @@ impl Default for AppPreferences {
             opencode_cli_source: default_cli_source(),
             gh_cli_source: default_cli_source(),
             sidebar_group_by_status: default_sidebar_group_by_status(),
+            terminal_word_wrap: default_terminal_word_wrap(),
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -187,6 +187,8 @@ pub struct AppPreferences {
     pub canvas_layout: String, // Canvas display mode: grid or list
     #[serde(default = "default_confirm_session_close")]
     pub confirm_session_close: bool, // Show confirmation dialog before closing sessions/worktrees
+    #[serde(default = "default_esc_closes_session")]
+    pub esc_closes_session: bool, // Whether pressing Escape closes the current session modal
     #[serde(default = "default_execution_mode")]
     pub default_execution_mode: String, // Default execution mode: "plan", "build", or "yolo"
     #[serde(default = "default_backend")]
@@ -393,6 +395,10 @@ fn default_canvas_layout() -> String {
 
 fn default_confirm_session_close() -> bool {
     true // Enabled by default
+}
+
+fn default_esc_closes_session() -> bool {
+    true // Enabled by default — Escape closes the session modal
 }
 
 fn default_execution_mode() -> String {
@@ -1184,6 +1190,7 @@ impl Default for AppPreferences {
             default_provider: None,
             canvas_layout: default_canvas_layout(),
             confirm_session_close: default_confirm_session_close(),
+            esc_closes_session: default_esc_closes_session(),
             default_execution_mode: default_execution_mode(),
             default_backend: default_backend(),
             selected_codex_model: default_codex_model(),

--- a/src-tauri/src/nightshift/checks.rs
+++ b/src-tauri/src/nightshift/checks.rs
@@ -1,0 +1,353 @@
+use super::types::{CheckCategory, CostTier, NightshiftCheck};
+
+/// Internal check definition with prompt template (not serialized to frontend)
+pub struct CheckDefinition {
+    pub check: NightshiftCheck,
+    pub prompt_template: &'static str,
+}
+
+/// All built-in check definitions
+pub fn all_checks() -> Vec<CheckDefinition> {
+    vec![
+        CheckDefinition {
+            check: NightshiftCheck {
+                id: "lint-fix".into(),
+                name: "Lint Fix".into(),
+                description: "Fix linting issues and code style violations".into(),
+                category: CheckCategory::Lint,
+                cost_tier: CostTier::Low,
+                cooldown_hours: 24,
+                default_enabled: true,
+            },
+            prompt_template: LINT_FIX_PROMPT,
+        },
+        CheckDefinition {
+            check: NightshiftCheck {
+                id: "dead-code".into(),
+                name: "Dead Code Removal".into(),
+                description: "Find and remove unused imports, functions, variables, and types"
+                    .into(),
+                category: CheckCategory::DeadCode,
+                cost_tier: CostTier::Medium,
+                cooldown_hours: 72,
+                default_enabled: true,
+            },
+            prompt_template: DEAD_CODE_PROMPT,
+        },
+        CheckDefinition {
+            check: NightshiftCheck {
+                id: "doc-drift".into(),
+                name: "Documentation Drift".into(),
+                description: "Fix stale, missing, or inaccurate documentation and comments".into(),
+                category: CheckCategory::Documentation,
+                cost_tier: CostTier::Medium,
+                cooldown_hours: 48,
+                default_enabled: true,
+            },
+            prompt_template: DOC_DRIFT_PROMPT,
+        },
+        CheckDefinition {
+            check: NightshiftCheck {
+                id: "security-audit".into(),
+                name: "Security Audit".into(),
+                description:
+                    "Find and fix security vulnerabilities (OWASP top 10, hardcoded secrets)"
+                        .into(),
+                category: CheckCategory::Security,
+                cost_tier: CostTier::High,
+                cooldown_hours: 168,
+                default_enabled: true,
+            },
+            prompt_template: SECURITY_AUDIT_PROMPT,
+        },
+        CheckDefinition {
+            check: NightshiftCheck {
+                id: "test-gaps".into(),
+                name: "Test Coverage Gaps".into(),
+                description: "Write tests for untested code paths and missing edge cases".into(),
+                category: CheckCategory::Tests,
+                cost_tier: CostTier::High,
+                cooldown_hours: 72,
+                default_enabled: true,
+            },
+            prompt_template: TEST_GAPS_PROMPT,
+        },
+        CheckDefinition {
+            check: NightshiftCheck {
+                id: "dependency-audit".into(),
+                name: "Dependency Audit".into(),
+                description: "Update outdated, deprecated, or vulnerable dependencies".into(),
+                category: CheckCategory::Dependencies,
+                cost_tier: CostTier::Medium,
+                cooldown_hours: 168,
+                default_enabled: true,
+            },
+            prompt_template: DEPENDENCY_AUDIT_PROMPT,
+        },
+        CheckDefinition {
+            check: NightshiftCheck {
+                id: "type-safety".into(),
+                name: "Type Safety".into(),
+                description: "Fix loose types (any, unknown), add missing type annotations".into(),
+                category: CheckCategory::TypeSafety,
+                cost_tier: CostTier::Medium,
+                cooldown_hours: 48,
+                default_enabled: true,
+            },
+            prompt_template: TYPE_SAFETY_PROMPT,
+        },
+        CheckDefinition {
+            check: NightshiftCheck {
+                id: "error-handling".into(),
+                name: "Error Handling".into(),
+                description: "Improve error handling: missing catches, swallowed errors, poor messages"
+                    .into(),
+                category: CheckCategory::CodeQuality,
+                cost_tier: CostTier::Medium,
+                cooldown_hours: 48,
+                default_enabled: true,
+            },
+            prompt_template: ERROR_HANDLING_PROMPT,
+        },
+        CheckDefinition {
+            check: NightshiftCheck {
+                id: "performance-review".into(),
+                name: "Performance Review".into(),
+                description:
+                    "Fix performance issues: N+1 queries, memory leaks, unnecessary re-renders"
+                        .into(),
+                category: CheckCategory::Performance,
+                cost_tier: CostTier::High,
+                cooldown_hours: 168,
+                default_enabled: false,
+            },
+            prompt_template: PERFORMANCE_REVIEW_PROMPT,
+        },
+        CheckDefinition {
+            check: NightshiftCheck {
+                id: "config-hygiene".into(),
+                name: "Config Hygiene".into(),
+                description: "Clean up configuration files: unused keys, inconsistencies, env gaps"
+                    .into(),
+                category: CheckCategory::Configuration,
+                cost_tier: CostTier::Low,
+                cooldown_hours: 168,
+                default_enabled: false,
+            },
+            prompt_template: CONFIG_HYGIENE_PROMPT,
+        },
+    ]
+}
+
+/// Look up a check definition by ID
+pub fn find_check(id: &str) -> Option<CheckDefinition> {
+    all_checks().into_iter().find(|c| c.check.id == id)
+}
+
+/// Get just the check metadata (without prompt templates) for frontend listing
+pub fn all_check_metadata() -> Vec<NightshiftCheck> {
+    all_checks().into_iter().map(|c| c.check).collect()
+}
+
+/// Get the default prompt template for a check
+pub fn get_default_prompt(id: &str) -> Option<&'static str> {
+    find_check(id).map(|c| c.prompt_template)
+}
+
+// ============================================================================
+// Action-oriented prompt templates
+// These prompts instruct Claude to directly fix issues, not just report them.
+// ============================================================================
+
+const LINT_FIX_PROMPT: &str = r#"You are performing a lint maintenance pass on this codebase.
+
+<task>Find and fix linting issues and code style violations</task>
+
+<instructions>
+1. Run the project's linter (eslint, clippy, ruff, etc.) if available
+2. Fix all auto-fixable lint violations
+3. For issues that can't be auto-fixed, make the code changes manually
+4. Focus on: unused variables, missing semicolons, inconsistent formatting, import ordering
+5. Run the linter again to verify all fixes pass
+</instructions>
+
+<constraints>
+- Only fix real lint issues, don't change logic or behavior
+- Preserve existing code behavior exactly
+- If unsure about a fix, skip it
+- Don't reformat entire files, only fix actual violations
+</constraints>"#;
+
+const DEAD_CODE_PROMPT: &str = r#"You are performing a dead code cleanup on this codebase.
+
+<task>Find and remove unused code</task>
+
+<instructions>
+1. Search for unused imports, functions, variables, types, and constants
+2. Remove unreachable code branches (dead else/match arms)
+3. Remove commented-out code blocks that are no longer relevant
+4. Remove unused dependencies from package manifests
+5. Run tests after each removal to verify nothing breaks
+</instructions>
+
+<constraints>
+- Only remove code that is genuinely unused (not just rarely used)
+- Be careful with public API exports — they may be used externally
+- Do not remove test utilities or fixture code
+- Consider dynamic imports and reflection before removing
+- Run the test suite after changes to verify nothing breaks
+</constraints>"#;
+
+const DOC_DRIFT_PROMPT: &str = r#"You are performing a documentation maintenance pass on this codebase.
+
+<task>Fix stale, missing, or inaccurate documentation</task>
+
+<instructions>
+1. Check if function/method signatures match their doc comments and fix mismatches
+2. Add documentation for public APIs that are missing it
+3. Remove or update TODO/FIXME comments that reference completed work
+4. Update README sections that are outdated relative to the code
+</instructions>
+
+<constraints>
+- Focus on public interfaces and important internal functions
+- Don't add docs for trivial getters/setters
+- Only fix genuinely wrong or misleading docs, not minor wording
+- Keep documentation concise and useful
+</constraints>"#;
+
+const SECURITY_AUDIT_PROMPT: &str = r#"You are performing a security audit on this codebase.
+
+<task>Find and fix security vulnerabilities</task>
+
+<instructions>
+1. Check for hardcoded secrets, API keys, tokens, or passwords — move them to env vars
+2. Fix SQL injection, XSS, command injection, and path traversal vulnerabilities
+3. Replace insecure cryptographic practices (weak hashing, no salt, ECB mode)
+4. Add missing input validation at system boundaries
+5. Fix insecure file permissions or unsafe deserialization
+</instructions>
+
+<constraints>
+- Focus on OWASP Top 10 vulnerabilities
+- Don't flag internal-only code that doesn't process user input
+- Ensure fixes don't break existing functionality
+- Run tests after each fix
+</constraints>"#;
+
+const TEST_GAPS_PROMPT: &str = r#"You are performing a test coverage improvement pass on this codebase.
+
+<task>Write tests for untested code paths and missing edge cases</task>
+
+<instructions>
+1. Find public functions and methods without any test coverage and write tests for them
+2. Add missing edge case tests (null, empty, boundary values)
+3. Write tests for error paths that are never tested
+4. Follow the existing test patterns and conventions in the project
+5. Run all tests to ensure they pass
+</instructions>
+
+<constraints>
+- Focus on business logic, not boilerplate or generated code
+- Don't write tests for trivial one-liner functions
+- Prioritize by risk: untested error handling > untested happy path
+- Match the existing test style and framework
+- All new tests must pass
+</constraints>"#;
+
+const DEPENDENCY_AUDIT_PROMPT: &str = r#"You are performing a dependency audit on this codebase.
+
+<task>Update outdated and fix problematic dependencies</task>
+
+<instructions>
+1. Examine package manifest files (package.json, Cargo.toml, etc.)
+2. Update deprecated or unmaintained dependencies to their replacements
+3. Remove duplicate dependencies that do the same thing
+4. Remove dependencies that are imported but never actually used in code
+5. Run tests after updates to verify compatibility
+</instructions>
+
+<constraints>
+- Only update dependencies with clear issues, not merely old ones
+- Don't make major version jumps without verifying compatibility
+- Consider if the project pins specific versions intentionally
+- Don't remove dev dependencies used only in CI/test environments
+- Run the full test suite after any dependency changes
+</constraints>"#;
+
+const TYPE_SAFETY_PROMPT: &str = r#"You are performing a type safety improvement pass on this codebase.
+
+<task>Fix loose typing and add missing type annotations</task>
+
+<instructions>
+1. Replace uses of `any` type with proper specific types
+2. Add missing return type annotations to functions
+3. Replace unsafe type assertions/casts with proper type narrowing
+4. Fix implicit `any` from untyped library usage by adding type declarations
+5. Run the type checker to verify all changes are valid
+</instructions>
+
+<constraints>
+- Only apply to TypeScript/Rust/typed language files
+- Don't replace `any` used intentionally in generic utility functions
+- Some libraries genuinely require `any` at boundaries — leave those
+- Suggest specific types, not just "remove any"
+- All changes must pass the type checker
+</constraints>"#;
+
+const ERROR_HANDLING_PROMPT: &str = r#"You are performing an error handling improvement pass on this codebase.
+
+<task>Fix poor error handling patterns</task>
+
+<instructions>
+1. Fix empty catch blocks — add proper error handling or logging
+2. Fix swallowed errors — ensure they're re-thrown or properly reported
+3. Add error handling where functions can throw but callers don't handle it
+4. Improve generic error messages to include useful debugging context
+5. Add missing error boundaries in UI components where appropriate
+</instructions>
+
+<constraints>
+- Focus on production-impacting error handling gaps
+- Don't change intentional error suppression (with comments explaining why)
+- Respect the error handling strategy of the framework being used
+- Make specific improvements, not just wrapping everything in try/catch
+- Run tests to verify error paths work correctly
+</constraints>"#;
+
+const PERFORMANCE_REVIEW_PROMPT: &str = r#"You are performing a performance optimization pass on this codebase.
+
+<task>Find and fix performance issues</task>
+
+<instructions>
+1. Fix N+1 query patterns in database access
+2. Add memoization for expensive computations (React.memo, useMemo, etc.)
+3. Convert synchronous blocking operations to async where appropriate
+4. Fix memory leaks (event listeners not cleaned up, growing caches)
+5. Remove redundant computation and unnecessary re-renders
+</instructions>
+
+<constraints>
+- Only fix issues with measurable impact, not micro-optimizations
+- Consider the scale at which the application operates
+- Don't optimize rarely-executed code paths
+- Run tests and verify the application still works correctly after changes
+</constraints>"#;
+
+const CONFIG_HYGIENE_PROMPT: &str = r#"You are performing a configuration cleanup pass on this codebase.
+
+<task>Clean up configuration files and environment setup</task>
+
+<instructions>
+1. Remove unused configuration keys from config files
+2. Add missing environment variables to .env.example that are referenced in code
+3. Fix inconsistencies between development and production configs
+4. Move hardcoded values to configuration where appropriate
+</instructions>
+
+<constraints>
+- Don't remove framework-required config keys even if they seem unused
+- Be careful with environment-specific overrides
+- Some config is intentionally different between environments
+- Focus on genuinely problematic configurations
+</constraints>"#;

--- a/src-tauri/src/nightshift/commands.rs
+++ b/src-tauri/src/nightshift/commands.rs
@@ -1,0 +1,104 @@
+use tauri::AppHandle;
+
+use super::checks::{all_check_metadata, get_default_prompt};
+use super::engine;
+use super::storage;
+use super::types::*;
+use crate::projects::storage::{load_projects_data, save_projects_data};
+
+/// Get all available built-in checks
+#[tauri::command]
+pub async fn nightshift_list_checks() -> Result<Vec<NightshiftCheck>, String> {
+    Ok(all_check_metadata())
+}
+
+/// Get Nightshift config for a project
+#[tauri::command]
+pub async fn nightshift_get_config(
+    app: AppHandle,
+    project_id: String,
+) -> Result<NightshiftConfig, String> {
+    let data = load_projects_data(&app)?;
+    let project = data
+        .find_project(&project_id)
+        .ok_or_else(|| format!("Project not found: {project_id}"))?;
+
+    Ok(project.nightshift_config.clone().unwrap_or_default())
+}
+
+/// Save Nightshift config for a project
+#[tauri::command]
+pub async fn nightshift_save_config(
+    app: AppHandle,
+    project_id: String,
+    config: NightshiftConfig,
+) -> Result<(), String> {
+    let mut data = load_projects_data(&app)?;
+    let project = data
+        .projects
+        .iter_mut()
+        .find(|p| p.id == project_id)
+        .ok_or_else(|| format!("Project not found: {project_id}"))?;
+
+    project.nightshift_config = Some(config);
+    save_projects_data(&app, &data)?;
+
+    Ok(())
+}
+
+/// Manually trigger a Nightshift run for a project.
+/// Returns immediately with run_id; progress is emitted via events.
+#[tauri::command]
+pub async fn nightshift_start_run(app: AppHandle, project_id: String) -> Result<String, String> {
+    engine::start_run(&app, &project_id, RunTrigger::Manual)
+}
+
+/// Cancel an in-progress Nightshift run
+#[tauri::command]
+pub async fn nightshift_cancel_run(run_id: String) -> Result<bool, String> {
+    engine::cancel_run(&run_id)
+}
+
+/// Get run history for a project
+#[tauri::command]
+pub async fn nightshift_get_runs(
+    app: AppHandle,
+    project_id: String,
+    limit: Option<u32>,
+) -> Result<Vec<NightshiftRun>, String> {
+    let mut runs = storage::load_runs(&app, &project_id)?;
+
+    // Sort by started_at descending
+    runs.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+
+    if let Some(limit) = limit {
+        runs.truncate(limit as usize);
+    }
+
+    Ok(runs)
+}
+
+/// Get a single run's details
+#[tauri::command]
+pub async fn nightshift_get_run(app: AppHandle, run_id: String) -> Result<NightshiftRun, String> {
+    storage::find_run(&app, &run_id)?.ok_or_else(|| format!("Run not found: {run_id}"))
+}
+
+/// Report a check completion from the frontend (after session finishes)
+#[tauri::command]
+pub async fn nightshift_report_check_done(
+    run_id: String,
+    check_id: String,
+    session_id: String,
+    success: bool,
+    error: Option<String>,
+) -> Result<(), String> {
+    engine::report_check_done(&run_id, &check_id, session_id, success, error);
+    Ok(())
+}
+
+/// Get the built-in default prompt for a check (for UI reset-to-default)
+#[tauri::command]
+pub async fn nightshift_get_default_prompt(check_id: String) -> Result<Option<String>, String> {
+    Ok(get_default_prompt(&check_id).map(|s| s.to_string()))
+}

--- a/src-tauri/src/nightshift/commands.rs
+++ b/src-tauri/src/nightshift/commands.rs
@@ -53,6 +53,17 @@ pub async fn nightshift_start_run(app: AppHandle, project_id: String) -> Result<
     engine::start_run(&app, &project_id, RunTrigger::Manual)
 }
 
+/// Manually trigger a single specific check for a project.
+/// Returns immediately with run_id; progress is emitted via events.
+#[tauri::command]
+pub async fn nightshift_start_check(
+    app: AppHandle,
+    project_id: String,
+    check_id: String,
+) -> Result<String, String> {
+    engine::start_single_check_run(&app, &project_id, &check_id)
+}
+
 /// Cancel an in-progress Nightshift run
 #[tauri::command]
 pub async fn nightshift_cancel_run(run_id: String) -> Result<bool, String> {
@@ -100,5 +111,5 @@ pub async fn nightshift_report_check_done(
 /// Get the built-in default prompt for a check (for UI reset-to-default)
 #[tauri::command]
 pub async fn nightshift_get_default_prompt(check_id: String) -> Result<Option<String>, String> {
-    Ok(get_default_prompt(&check_id).map(|s| s.to_string()))
+    Ok(get_default_prompt(&check_id).map(|s: &str| s.to_string()))
 }

--- a/src-tauri/src/nightshift/engine.rs
+++ b/src-tauri/src/nightshift/engine.rs
@@ -264,45 +264,23 @@ fn get_or_create_nightshift_worktree(
         )?;
     }
 
+    // Run jean.json setup script if configured (e.g. `bun install`)
+    let (setup_output, setup_script, setup_success) =
+        crate::projects::git::run_setup_if_configured(&worktree_path_str, &project.path, branch_name);
+
     // Register worktree in ProjectsData
     let worktree_id = uuid::Uuid::new_v4().to_string();
-    let worktree = Worktree {
-        id: worktree_id.clone(),
-        project_id: project_id.to_string(),
-        name: worktree_name.to_string(),
-        path: worktree_path_str.clone(),
-        branch: branch_name.to_string(),
-        created_at: now(),
-        setup_output: None,
-        setup_script: None,
-        session_type: crate::projects::types::SessionType::Worktree,
-        pr_number: None,
-        pr_url: None,
-        issue_number: None,
-        cached_pr_status: None,
-        cached_check_status: None,
-        cached_behind_count: None,
-        cached_ahead_count: None,
-        cached_status_at: None,
-        cached_uncommitted_added: None,
-        cached_uncommitted_removed: None,
-        cached_branch_diff_added: None,
-        cached_branch_diff_removed: None,
-        cached_base_branch_ahead_count: None,
-        cached_base_branch_behind_count: None,
-        cached_worktree_ahead_count: None,
-        cached_unpushed_count: None,
-        order: 999,
-        archived_at: None,
-        label: None,
-        last_opened_at: None,
-        setup_success: None,
-        linear_issue_identifier: None,
-        security_alert_number: None,
-        security_alert_url: None,
-        advisory_ghsa_id: None,
-        advisory_url: None,
-    };
+    let mut worktree = Worktree::new(
+        worktree_id.clone(),
+        project_id.to_string(),
+        worktree_name.to_string(),
+        worktree_path_str.clone(),
+        branch_name.to_string(),
+        999,
+    );
+    worktree.setup_output = setup_output;
+    worktree.setup_script = setup_script;
+    worktree.setup_success = setup_success;
 
     let mut data = load_projects_data(app)?;
     data.worktrees.push(worktree.clone());
@@ -439,6 +417,8 @@ pub struct RunParams<'a> {
     pub config: &'a NightshiftConfig,
     pub trigger: RunTrigger,
     pub run_id: &'a str,
+    /// When set, skip get_enabled_checks() and run only this check
+    pub check_id_override: Option<String>,
 }
 
 /// Execute a full nightshift run for a project (called from background thread)
@@ -468,6 +448,7 @@ pub fn execute_run(params: &RunParams<'_>) {
         config,
         trigger,
         run_id,
+        ..
     } = params;
     let trigger = trigger.clone();
     log::trace!("Starting nightshift run {run_id} for project {project_id}");
@@ -525,7 +506,11 @@ pub fn execute_run(params: &RunParams<'_>) {
     );
 
     // 2. Determine which checks to run
-    let check_ids = get_enabled_checks(app, project_id, config, &run.trigger);
+    let check_ids = if let Some(ref id) = params.check_id_override {
+        vec![id.clone()]
+    } else {
+        get_enabled_checks(app, project_id, config, &run.trigger)
+    };
     if check_ids.is_empty() {
         log::trace!("No checks to run for project {project_id}");
         run.status = RunStatus::Completed;
@@ -775,6 +760,55 @@ pub fn start_run(app: &AppHandle, project_id: &str, trigger: RunTrigger) -> Resu
             config: &config,
             trigger,
             run_id: &run_id_clone,
+            check_id_override: None,
+        });
+    });
+
+    Ok(run_id)
+}
+
+/// Start a nightshift run for a single specific check. Returns the run ID.
+pub fn start_single_check_run(
+    app: &AppHandle,
+    project_id: &str,
+    check_id: &str,
+) -> Result<String, String> {
+    // Validate the check_id exists
+    find_check(check_id)
+        .ok_or_else(|| format!("Unknown check: {check_id}"))?;
+
+    let data = load_projects_data(app)?;
+    let project = data
+        .find_project(project_id)
+        .ok_or_else(|| format!("Project not found: {project_id}"))?;
+
+    if project.is_folder {
+        return Err("Cannot run Nightshift on a folder".to_string());
+    }
+    if project.path.is_empty() {
+        return Err("Project has no path".to_string());
+    }
+    if is_project_running(project_id) {
+        return Err("Nightshift is already running for this project".to_string());
+    }
+
+    let config = project.nightshift_config.clone().unwrap_or_default();
+    let run_id = uuid::Uuid::new_v4().to_string();
+    let app_clone = app.clone();
+    let project_id = project_id.to_string();
+    let run_id_clone = run_id.clone();
+    let check_id = check_id.to_string();
+
+    mark_project_running(&project_id);
+
+    std::thread::spawn(move || {
+        execute_run(&RunParams {
+            app: &app_clone,
+            project_id: &project_id,
+            config: &config,
+            trigger: RunTrigger::Manual,
+            run_id: &run_id_clone,
+            check_id_override: Some(check_id),
         });
     });
 

--- a/src-tauri/src/nightshift/engine.rs
+++ b/src-tauri/src/nightshift/engine.rs
@@ -1,0 +1,849 @@
+use std::collections::HashMap;
+use std::sync::mpsc;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use once_cell::sync::Lazy;
+use tauri::AppHandle;
+
+use super::checks::{all_checks, find_check};
+use super::storage;
+use super::types::*;
+use crate::chat::storage::{save_empty_index, with_sessions_mut};
+use crate::chat::types::{Backend, Session};
+use crate::http_server::EmitExt;
+use crate::projects::storage::{get_project_worktrees_dir, load_projects_data, save_projects_data};
+use crate::projects::types::Worktree;
+
+// ============================================================================
+// Cancellation tracking
+// ============================================================================
+
+/// Set of run_ids that have been cancelled
+static NIGHTSHIFT_CANCELLED: Lazy<Mutex<std::collections::HashSet<String>>> =
+    Lazy::new(|| Mutex::new(std::collections::HashSet::new()));
+
+/// Check if a run has been cancelled
+pub fn is_run_cancelled(run_id: &str) -> bool {
+    NIGHTSHIFT_CANCELLED.lock().unwrap().contains(run_id)
+}
+
+fn mark_cancelled(run_id: &str) {
+    NIGHTSHIFT_CANCELLED
+        .lock()
+        .unwrap()
+        .insert(run_id.to_string());
+}
+
+fn cleanup_run(run_id: &str) {
+    NIGHTSHIFT_CANCELLED.lock().unwrap().remove(run_id);
+    COMPLETION_CHANNELS.lock().unwrap().remove(run_id);
+}
+
+/// Cancel a nightshift run
+pub fn cancel_run(run_id: &str) -> Result<bool, String> {
+    mark_cancelled(run_id);
+    // Wake up any waiting channel so the engine unblocks
+    if let Some(tx) = COMPLETION_CHANNELS.lock().unwrap().remove(run_id) {
+        let _ = tx.send(CheckCompletion {
+            session_id: String::new(),
+            success: false,
+            error: Some("Cancelled".to_string()),
+        });
+    }
+    Ok(true)
+}
+
+// ============================================================================
+// Running projects tracking (prevent double-scheduling)
+// ============================================================================
+
+static RUNNING_PROJECTS: Lazy<Mutex<std::collections::HashSet<String>>> =
+    Lazy::new(|| Mutex::new(std::collections::HashSet::new()));
+
+fn mark_project_running(project_id: &str) {
+    RUNNING_PROJECTS
+        .lock()
+        .unwrap()
+        .insert(project_id.to_string());
+}
+
+fn mark_project_done(project_id: &str) {
+    RUNNING_PROJECTS.lock().unwrap().remove(project_id);
+}
+
+fn is_project_running(project_id: &str) -> bool {
+    RUNNING_PROJECTS.lock().unwrap().contains(project_id)
+}
+
+// ============================================================================
+// Completion signaling (frontend → backend)
+// ============================================================================
+
+/// Channels for frontend to signal check completion back to the engine.
+/// Keyed by run_id — one channel per run (checks are sequential).
+static COMPLETION_CHANNELS: Lazy<Mutex<HashMap<String, mpsc::Sender<CheckCompletion>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Called by the `nightshift_report_check_done` Tauri command
+pub fn report_check_done(
+    run_id: &str,
+    _check_id: &str,
+    session_id: String,
+    success: bool,
+    error: Option<String>,
+) {
+    let tx = COMPLETION_CHANNELS.lock().unwrap().get(run_id).cloned();
+    if let Some(tx) = tx {
+        let _ = tx.send(CheckCompletion {
+            session_id,
+            success,
+            error,
+        });
+    }
+}
+
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Format a unix timestamp as "DD-MM-YYYY @ HH.MM" in local time
+fn format_local_timestamp(ts: u64) -> String {
+    // Convert to local time using libc (avoids adding time crate dependency)
+    let secs = ts as i64;
+    #[cfg(unix)]
+    {
+        let mut tm: libc::tm = unsafe { std::mem::zeroed() };
+        unsafe { libc::localtime_r(&secs, &mut tm) };
+        format!(
+            "{:02}-{:02}-{} @ {:02}.{:02}",
+            tm.tm_mday,
+            tm.tm_mon + 1,
+            tm.tm_year + 1900,
+            tm.tm_hour,
+            tm.tm_min,
+        )
+    }
+    #[cfg(windows)]
+    {
+        // On Windows, use the _localtime64_s equivalent via chrono-free approach
+        // Fall back to UTC-based formatting
+        let secs_in_day = 86400u64;
+        let days = ts / secs_in_day;
+        let time_of_day = ts % secs_in_day;
+        let hour = time_of_day / 3600;
+        let min = (time_of_day % 3600) / 60;
+
+        // Simple days-to-date conversion
+        let mut y = 1970i64;
+        let mut remaining = days as i64;
+        loop {
+            let days_in_year = if y % 4 == 0 && (y % 100 != 0 || y % 400 == 0) { 366 } else { 365 };
+            if remaining < days_in_year {
+                break;
+            }
+            remaining -= days_in_year;
+            y += 1;
+        }
+        let leap = y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
+        let month_days = [31, if leap { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+        let mut m = 0;
+        for &md in &month_days {
+            if remaining < md {
+                break;
+            }
+            remaining -= md;
+            m += 1;
+        }
+        format!("{:02}-{:02}-{} @ {:02}.{:02}", remaining + 1, m + 1, y, hour, min)
+    }
+}
+
+/// Get current local time as "HH:MM"
+fn current_time_hhmm() -> String {
+    let ts = now();
+    let secs = ts as i64;
+    #[cfg(unix)]
+    {
+        let mut tm: libc::tm = unsafe { std::mem::zeroed() };
+        unsafe { libc::localtime_r(&secs, &mut tm) };
+        format!("{:02}:{:02}", tm.tm_hour, tm.tm_min)
+    }
+    #[cfg(windows)]
+    {
+        let time_of_day = ts % 86400;
+        format!("{:02}:{:02}", time_of_day / 3600, (time_of_day % 3600) / 60)
+    }
+}
+
+// ============================================================================
+// Prompt resolution
+// ============================================================================
+
+/// Get the prompt for a check, respecting per-check custom prompt overrides
+fn get_check_prompt(config: &NightshiftConfig, check_id: &str) -> String {
+    // Check for per-check custom prompt override
+    if let Some(check_config) = config.check_configs.get(check_id) {
+        if let Some(ref custom) = check_config.custom_prompt {
+            if !custom.is_empty() {
+                return custom.clone();
+            }
+        }
+    }
+    // Fall back to built-in default
+    find_check(check_id)
+        .map(|c| c.prompt_template.to_string())
+        .unwrap_or_default()
+}
+
+/// Get the effective cooldown for a check
+fn get_check_cooldown(config: &NightshiftConfig, check_id: &str) -> u32 {
+    if let Some(check_config) = config.check_configs.get(check_id) {
+        if let Some(override_hours) = check_config.cooldown_hours_override {
+            return override_hours;
+        }
+    }
+    find_check(check_id)
+        .map(|c| c.check.cooldown_hours)
+        .unwrap_or(24)
+}
+
+// ============================================================================
+// Worktree + session creation
+// ============================================================================
+
+/// Get the existing "nightshift" worktree for a project, or create one if it doesn't exist.
+fn get_or_create_nightshift_worktree(
+    app: &AppHandle,
+    project_id: &str,
+) -> Result<Worktree, String> {
+    let data = load_projects_data(app)?;
+    let project = data
+        .find_project(project_id)
+        .ok_or_else(|| format!("Project not found: {project_id}"))?
+        .clone();
+
+    // Check if a "nightshift" worktree already exists for this project
+    if let Some(existing) = data.worktrees.iter().find(|w| {
+        w.project_id == project_id && w.name == "nightshift"
+    }) {
+        log::trace!("Reusing existing nightshift worktree: {}", existing.id);
+        return Ok(existing.clone());
+    }
+
+    // Create a new one
+    let worktree_name = "nightshift";
+    let branch_name = "nightshift";
+
+    let project_worktrees_dir = get_project_worktrees_dir(&project.name, project.worktrees_dir.as_deref())?;
+    let worktree_path = project_worktrees_dir.join(worktree_name);
+    let worktree_path_str = worktree_path
+        .to_str()
+        .ok_or_else(|| "Invalid worktree path".to_string())?
+        .to_string();
+
+    let base_branch = project.default_branch.clone();
+
+    // Create git worktree — try new branch first, fall back to existing branch
+    let create_result = crate::projects::git::create_worktree(
+        &project.path,
+        &worktree_path_str,
+        branch_name,
+        &base_branch,
+    );
+    if let Err(e) = create_result {
+        // Branch might already exist from a previous run — try using existing branch
+        log::trace!("New branch failed ({e}), trying existing branch");
+        crate::projects::git::create_worktree_from_existing_branch(
+            &project.path,
+            &worktree_path_str,
+            branch_name,
+        )?;
+    }
+
+    // Register worktree in ProjectsData
+    let worktree_id = uuid::Uuid::new_v4().to_string();
+    let worktree = Worktree {
+        id: worktree_id.clone(),
+        project_id: project_id.to_string(),
+        name: worktree_name.to_string(),
+        path: worktree_path_str.clone(),
+        branch: branch_name.to_string(),
+        created_at: now(),
+        setup_output: None,
+        setup_script: None,
+        session_type: crate::projects::types::SessionType::Worktree,
+        pr_number: None,
+        pr_url: None,
+        issue_number: None,
+        cached_pr_status: None,
+        cached_check_status: None,
+        cached_behind_count: None,
+        cached_ahead_count: None,
+        cached_status_at: None,
+        cached_uncommitted_added: None,
+        cached_uncommitted_removed: None,
+        cached_branch_diff_added: None,
+        cached_branch_diff_removed: None,
+        cached_base_branch_ahead_count: None,
+        cached_base_branch_behind_count: None,
+        cached_worktree_ahead_count: None,
+        cached_unpushed_count: None,
+        order: 999,
+        archived_at: None,
+        label: None,
+        last_opened_at: None,
+        setup_success: None,
+        linear_issue_identifier: None,
+        security_alert_number: None,
+        security_alert_url: None,
+        advisory_ghsa_id: None,
+        advisory_url: None,
+    };
+
+    let mut data = load_projects_data(app)?;
+    data.worktrees.push(worktree.clone());
+    save_projects_data(app, &data)?;
+
+    // Initialize empty session index (no "Session 1", auto-naming disabled)
+    save_empty_index(app, &worktree_id)?;
+
+    // Notify frontend so the worktree appears without manual refresh
+    let _ = app.emit_all(
+        "worktrees:changed",
+        &serde_json::json!({ "project_id": project_id }),
+    );
+
+    log::trace!(
+        "Created nightshift worktree: {} at {}",
+        worktree_id,
+        worktree_path_str
+    );
+
+    Ok(worktree)
+}
+
+/// Create a session within the worktree for a nightshift check
+fn create_nightshift_session(
+    app: &AppHandle,
+    worktree: &Worktree,
+    check_id: &str,
+    check_name: &str,
+    run_id: &str,
+    config: &NightshiftConfig,
+) -> Result<Session, String> {
+    let backend = match config.backend.as_deref() {
+        Some("codex") => Backend::Codex,
+        Some("opencode") => Backend::Opencode,
+        _ => Backend::Claude,
+    };
+
+    // Session name: "DD-MM-YYYY @ HH.MM - Check Name"
+    let session_name = format!("{} - {}", format_local_timestamp(now()), check_name);
+
+    let session = with_sessions_mut(app, &worktree.path, &worktree.id, |sessions| {
+        let mut session = Session::new(
+            session_name,
+            sessions.sessions.len() as u32,
+            backend,
+        );
+        session.selected_model = config.model.clone();
+        session.selected_provider = config.provider.clone();
+        session.session_naming_completed = true; // Skip auto-naming for nightshift
+        session.source = Some("nightshift".to_string());
+        session.nightshift_check_id = Some(check_id.to_string());
+        session.nightshift_run_id = Some(run_id.to_string());
+
+        sessions.sessions.push(session.clone());
+        sessions.active_session_id = Some(session.id.clone());
+
+        Ok(session)
+    })?;
+
+    log::trace!(
+        "Created nightshift session: {} for check {}",
+        session.id,
+        check_id
+    );
+
+    Ok(session)
+}
+
+// ============================================================================
+// Check filtering
+// ============================================================================
+
+/// Determine which checks to run based on config and cooldowns.
+/// Manual triggers run only the single most-overdue check.
+/// Scheduled triggers run all checks that are past their cooldown.
+fn get_enabled_checks(
+    app: &AppHandle,
+    project_id: &str,
+    config: &NightshiftConfig,
+    trigger: &RunTrigger,
+) -> Vec<String> {
+    let is_manual = matches!(trigger, RunTrigger::Manual);
+    let all = all_checks();
+    let mut candidates: Vec<(String, u64)> = Vec::new(); // (check_id, last_run_time)
+
+    for def in &all {
+        let id = &def.check.id;
+
+        // Skip explicitly disabled checks
+        if config.disabled_checks.contains(id) {
+            continue;
+        }
+
+        // Include if default-enabled or explicitly enabled
+        if def.check.default_enabled || config.extra_enabled_checks.contains(id) {
+            let last_run = storage::get_last_check_run_time(app, project_id, id)
+                .ok()
+                .flatten()
+                .unwrap_or(0);
+
+            // For scheduled runs, enforce cooldown
+            if !is_manual {
+                let cooldown_hours = get_check_cooldown(config, id);
+                let cooldown_secs = (cooldown_hours as u64) * 3600;
+                if now() < last_run + cooldown_secs {
+                    log::trace!("Skipping check {id}: still in cooldown");
+                    continue;
+                }
+            }
+
+            candidates.push((id.clone(), last_run));
+        }
+    }
+
+    if is_manual {
+        // Manual: pick only the single most-overdue check (oldest last_run)
+        candidates.sort_by_key(|(_, last_run)| *last_run);
+        candidates.into_iter().take(1).map(|(id, _)| id).collect()
+    } else {
+        // Scheduled: run all checks past cooldown
+        candidates.into_iter().map(|(id, _)| id).collect()
+    }
+}
+
+// ============================================================================
+// Run execution
+// ============================================================================
+
+/// Parameters for executing a nightshift run
+pub struct RunParams<'a> {
+    pub app: &'a AppHandle,
+    pub project_id: &'a str,
+    pub config: &'a NightshiftConfig,
+    pub trigger: RunTrigger,
+    pub run_id: &'a str,
+}
+
+/// Execute a full nightshift run for a project (called from background thread)
+/// Drop guard that ensures `cleanup_run` and `mark_project_done` are always called,
+/// even if the thread panics or returns early.
+struct RunGuard {
+    run_id: String,
+    project_id: String,
+}
+
+impl Drop for RunGuard {
+    fn drop(&mut self) {
+        cleanup_run(&self.run_id);
+        mark_project_done(&self.project_id);
+        log::trace!(
+            "RunGuard dropped: cleaned up run {} for project {}",
+            self.run_id,
+            self.project_id
+        );
+    }
+}
+
+pub fn execute_run(params: &RunParams<'_>) {
+    let RunParams {
+        app,
+        project_id,
+        config,
+        trigger,
+        run_id,
+    } = params;
+    let trigger = trigger.clone();
+    log::trace!("Starting nightshift run {run_id} for project {project_id}");
+
+    // Guard ensures cleanup_run + mark_project_done are always called on exit
+    let _guard = RunGuard {
+        run_id: run_id.to_string(),
+        project_id: project_id.to_string(),
+    };
+
+    // 1. Get or create the single nightshift worktree
+    let worktree = match get_or_create_nightshift_worktree(app, project_id) {
+        Ok(w) => w,
+        Err(e) => {
+            log::error!("Failed to get/create nightshift worktree: {e}");
+            let _ = app.emit_all(
+                "nightshift:run-failed",
+                &RunFailedEvent {
+                    run_id: run_id.to_string(),
+                    project_id: project_id.to_string(),
+                    error: format!("Failed to get/create worktree: {e}"),
+                },
+            );
+            return; // _guard handles cleanup
+        }
+    };
+
+    let mut run = NightshiftRun {
+        id: run_id.to_string(),
+        project_id: project_id.to_string(),
+        started_at: now(),
+        completed_at: None,
+        status: RunStatus::Running,
+        trigger,
+        check_results: vec![],
+        worktree_id: Some(worktree.id.clone()),
+        worktree_path: Some(worktree.path.clone()),
+        branch_name: Some(worktree.branch.clone()),
+        pr_url: None,
+        pr_number: None,
+    };
+
+    // Save initial run state
+    if let Err(e) = storage::save_run(app, &run) {
+        log::error!("Failed to save initial nightshift run: {e}");
+    }
+
+    // Emit run started event
+    let _ = app.emit_all(
+        "nightshift:run-started",
+        &RunStartedEvent {
+            run_id: run_id.to_string(),
+            project_id: project_id.to_string(),
+        },
+    );
+
+    // 2. Determine which checks to run
+    let check_ids = get_enabled_checks(app, project_id, config, &run.trigger);
+    if check_ids.is_empty() {
+        log::trace!("No checks to run for project {project_id}");
+        run.status = RunStatus::Completed;
+        run.completed_at = Some(now());
+        let _ = storage::save_run(app, &run);
+        let _ = app.emit_all(
+            "nightshift:run-completed",
+            &RunCompletedEvent {
+                run_id: run_id.to_string(),
+                project_id: project_id.to_string(),
+                status: RunStatus::Completed,
+                total_checks: 0,
+                worktree_id: Some(worktree.id.clone()),
+            },
+        );
+        return; // _guard handles cleanup
+    }
+
+    // Set up completion channel for this run
+    let (tx, rx) = mpsc::channel::<CheckCompletion>();
+    COMPLETION_CHANNELS
+        .lock()
+        .unwrap()
+        .insert(run_id.to_string(), tx);
+
+    let mut has_failures = false;
+
+    // 3. Execute each check sequentially
+    for check_id in &check_ids {
+        // Check for cancellation
+        if is_run_cancelled(run_id) {
+            log::trace!("Nightshift run {run_id} was cancelled");
+            run.status = RunStatus::Cancelled;
+            run.completed_at = Some(now());
+            let _ = storage::save_run(app, &run);
+            return; // _guard handles cleanup
+        }
+
+        let check_name = find_check(check_id)
+            .map(|c| c.check.name.clone())
+            .unwrap_or_else(|| check_id.clone());
+
+        // Create session for this check
+        let session = match create_nightshift_session(
+            app,
+            &worktree,
+            check_id,
+            &check_name,
+            run_id,
+            config,
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("Failed to create session for check {check_id}: {e}");
+                run.check_results.push(CheckResult {
+                    check_id: check_id.clone(),
+                    status: RunStatus::Failed,
+                    session_id: None,
+    
+                    duration_secs: 0,
+                    error: Some(format!("Failed to create session: {e}")),
+                });
+                has_failures = true;
+                continue;
+            }
+        };
+
+        // Get the prompt for this check
+        let prompt = get_check_prompt(config, check_id);
+
+        // Emit check started
+        let _ = app.emit_all(
+            "nightshift:check-started",
+            &CheckStartedEvent {
+                run_id: run_id.to_string(),
+                check_id: check_id.clone(),
+                check_name: check_name.clone(),
+            },
+        );
+
+        // Emit execute-check event for the frontend to pick up and send_chat_message
+        let _ = app.emit_all(
+            "nightshift:execute-check",
+            &ExecuteCheckEvent {
+                run_id: run_id.to_string(),
+                project_id: project_id.to_string(),
+                check_id: check_id.clone(),
+                check_name: check_name.clone(),
+                session_id: session.id.clone(),
+                worktree_id: worktree.id.clone(),
+                worktree_path: worktree.path.clone(),
+                prompt,
+                model: config.model.clone(),
+                provider: config.provider.clone(),
+                backend: config.backend.clone(),
+            },
+        );
+
+        let start = std::time::Instant::now();
+
+        // Wait for frontend to report completion (with 10-minute timeout per check)
+        let completion = rx.recv_timeout(Duration::from_secs(600));
+
+        let check_result = match completion {
+            Ok(_) if is_run_cancelled(run_id) => CheckResult {
+                check_id: check_id.clone(),
+                status: RunStatus::Cancelled,
+                session_id: Some(session.id.clone()),
+
+                duration_secs: start.elapsed().as_secs(),
+                error: Some("Cancelled".to_string()),
+            },
+            Ok(c) if c.success => CheckResult {
+                check_id: check_id.clone(),
+                status: RunStatus::Completed,
+                session_id: Some(c.session_id),
+
+                duration_secs: start.elapsed().as_secs(),
+                error: None,
+            },
+            Ok(c) => {
+                has_failures = true;
+                CheckResult {
+                    check_id: check_id.clone(),
+                    status: RunStatus::Failed,
+                    session_id: Some(c.session_id),
+    
+                    duration_secs: start.elapsed().as_secs(),
+                    error: c.error,
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                has_failures = true;
+                CheckResult {
+                    check_id: check_id.clone(),
+                    status: RunStatus::Failed,
+                    session_id: Some(session.id.clone()),
+    
+                    duration_secs: start.elapsed().as_secs(),
+                    error: Some("Check timed out (10 minutes)".to_string()),
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                has_failures = true;
+                CheckResult {
+                    check_id: check_id.clone(),
+                    status: RunStatus::Failed,
+                    session_id: Some(session.id.clone()),
+    
+                    duration_secs: start.elapsed().as_secs(),
+                    error: Some("Channel disconnected".to_string()),
+                }
+            }
+        };
+
+        if check_result.status == RunStatus::Cancelled {
+            run.check_results.push(check_result);
+            run.status = RunStatus::Cancelled;
+            run.completed_at = Some(now());
+            let _ = storage::save_run(app, &run);
+            return; // _guard handles cleanup
+        }
+
+        // Emit check done
+        let _ = app.emit_all(
+            "nightshift:check-done",
+            &CheckDoneEvent {
+                run_id: run_id.to_string(),
+                check_id: check_id.clone(),
+                status: check_result.status.clone(),
+            },
+        );
+
+        run.check_results.push(check_result);
+
+        // Save intermediate state
+        if let Err(e) = storage::save_run(app, &run) {
+            log::error!("Failed to save intermediate nightshift run: {e}");
+        }
+    }
+
+    // 4. Finalize run
+    run.completed_at = Some(now());
+    run.status = if has_failures {
+        RunStatus::PartiallyCompleted
+    } else {
+        RunStatus::Completed
+    };
+
+    if let Err(e) = storage::save_run(app, &run) {
+        log::error!("Failed to save final nightshift run: {e}");
+    }
+
+    log::trace!(
+        "Nightshift run {run_id} completed: status={:?}, checks={}",
+        run.status,
+        run.check_results.len()
+    );
+
+    // Release project lock BEFORE notifying frontend — prevents "already running"
+    // race where user clicks Run Now immediately after seeing the completion toast
+    drop(_guard);
+
+    let _ = app.emit_all(
+        "nightshift:run-completed",
+        &RunCompletedEvent {
+            run_id: run_id.to_string(),
+            project_id: project_id.to_string(),
+            status: run.status.clone(),
+            total_checks: run.check_results.len(),
+            worktree_id: Some(worktree.id.clone()),
+        },
+    );
+}
+
+/// Start a nightshift run in a background thread. Returns the run ID.
+pub fn start_run(app: &AppHandle, project_id: &str, trigger: RunTrigger) -> Result<String, String> {
+    let data = load_projects_data(app)?;
+
+    let project = data
+        .find_project(project_id)
+        .ok_or_else(|| format!("Project not found: {project_id}"))?;
+
+    if project.is_folder {
+        return Err("Cannot run Nightshift on a folder".to_string());
+    }
+    if project.path.is_empty() {
+        return Err("Project has no path".to_string());
+    }
+    if is_project_running(project_id) {
+        return Err("Nightshift is already running for this project".to_string());
+    }
+
+    let config = project.nightshift_config.clone().unwrap_or_default();
+
+    let run_id = uuid::Uuid::new_v4().to_string();
+    let app_clone = app.clone();
+    let project_id = project_id.to_string();
+    let run_id_clone = run_id.clone();
+
+    mark_project_running(&project_id);
+
+    std::thread::spawn(move || {
+        execute_run(&RunParams {
+            app: &app_clone,
+            project_id: &project_id,
+            config: &config,
+            trigger,
+            run_id: &run_id_clone,
+        });
+    });
+
+    Ok(run_id)
+}
+
+// ============================================================================
+// Scheduler
+// ============================================================================
+
+/// Start the nightshift scheduler. Checks every minute if any project has a
+/// scheduled nightshift run that should fire now.
+pub fn start_scheduler(app: AppHandle) {
+    std::thread::spawn(move || {
+        log::trace!("Nightshift scheduler started");
+        loop {
+            std::thread::sleep(Duration::from_secs(60));
+            check_and_run_scheduled(&app);
+        }
+    });
+}
+
+fn check_and_run_scheduled(app: &AppHandle) {
+    let data = match load_projects_data(app) {
+        Ok(d) => d,
+        Err(e) => {
+            log::warn!("Nightshift scheduler: failed to load projects: {e}");
+            return;
+        }
+    };
+
+    let now_hhmm = current_time_hhmm();
+
+    for project in &data.projects {
+        if project.is_folder || project.path.is_empty() {
+            continue;
+        }
+
+        let config = match &project.nightshift_config {
+            Some(c) if c.enabled => c,
+            _ => continue,
+        };
+
+        let schedule = match &config.schedule_time {
+            Some(t) if !t.is_empty() => t.as_str(),
+            _ => continue,
+        };
+
+        if schedule != now_hhmm {
+            continue;
+        }
+
+        if is_project_running(&project.id) {
+            continue;
+        }
+
+        log::trace!(
+            "Nightshift scheduler: triggering run for project {} at {}",
+            project.name,
+            now_hhmm
+        );
+
+        match start_run(app, &project.id, RunTrigger::Scheduled) {
+            Ok(run_id) => {
+                log::trace!("Nightshift scheduler: started run {run_id} for {}", project.name);
+            }
+            Err(e) => {
+                log::error!("Nightshift scheduler: failed to start run for {}: {e}", project.name);
+            }
+        }
+    }
+}

--- a/src-tauri/src/nightshift/mod.rs
+++ b/src-tauri/src/nightshift/mod.rs
@@ -1,0 +1,8 @@
+mod checks;
+mod commands;
+pub mod engine;
+mod storage;
+pub mod types;
+
+// Re-export commands for registration in lib.rs
+pub use commands::*;

--- a/src-tauri/src/nightshift/storage.rs
+++ b/src-tauri/src/nightshift/storage.rs
@@ -1,0 +1,133 @@
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use once_cell::sync::Lazy;
+use tauri::{AppHandle, Manager};
+
+use super::types::NightshiftRun;
+
+/// Global mutex to prevent concurrent read-modify-write races on nightshift run files.
+static NIGHTSHIFT_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+/// Max runs to keep per project
+const MAX_RUNS_PER_PROJECT: usize = 50;
+
+/// Get the nightshift runs directory
+fn get_runs_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {e}"))?;
+
+    let runs_dir = app_data_dir.join("nightshift").join("runs");
+    std::fs::create_dir_all(&runs_dir)
+        .map_err(|e| format!("Failed to create nightshift runs directory: {e}"))?;
+
+    Ok(runs_dir)
+}
+
+/// Get the path to a project's run history file
+fn get_project_runs_path(app: &AppHandle, project_id: &str) -> Result<PathBuf, String> {
+    let runs_dir = get_runs_dir(app)?;
+    Ok(runs_dir.join(format!("{project_id}.json")))
+}
+
+/// Load all runs for a project
+pub fn load_runs(app: &AppHandle, project_id: &str) -> Result<Vec<NightshiftRun>, String> {
+    let _lock = NIGHTSHIFT_LOCK.lock().unwrap();
+    let path = get_project_runs_path(app, project_id)?;
+
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read nightshift runs: {e}"))?;
+
+    serde_json::from_str(&contents).map_err(|e| format!("Failed to parse nightshift runs: {e}"))
+}
+
+/// Save a run (append or update) for a project
+pub fn save_run(app: &AppHandle, run: &NightshiftRun) -> Result<(), String> {
+    let _lock = NIGHTSHIFT_LOCK.lock().unwrap();
+    let path = get_project_runs_path(app, &run.project_id)?;
+
+    let mut runs: Vec<NightshiftRun> = if path.exists() {
+        let contents = std::fs::read_to_string(&path)
+            .map_err(|e| format!("Failed to read nightshift runs: {e}"))?;
+        serde_json::from_str(&contents)
+            .map_err(|e| format!("Failed to parse nightshift runs: {e}"))?
+    } else {
+        Vec::new()
+    };
+
+    // Update existing run or append new one
+    if let Some(existing) = runs.iter_mut().find(|r| r.id == run.id) {
+        *existing = run.clone();
+    } else {
+        runs.push(run.clone());
+    }
+
+    // Trim to max runs (keep most recent)
+    if runs.len() > MAX_RUNS_PER_PROJECT {
+        runs.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        runs.truncate(MAX_RUNS_PER_PROJECT);
+    }
+
+    let json = serde_json::to_string_pretty(&runs)
+        .map_err(|e| format!("Failed to serialize nightshift runs: {e}"))?;
+
+    // Atomic write: temp file + rename
+    let temp_path = path.with_extension("tmp");
+    std::fs::write(&temp_path, json)
+        .map_err(|e| format!("Failed to write nightshift runs: {e}"))?;
+    std::fs::rename(&temp_path, &path)
+        .map_err(|e| format!("Failed to finalize nightshift runs: {e}"))?;
+
+    Ok(())
+}
+
+/// Find a run by ID across all projects
+pub fn find_run(app: &AppHandle, run_id: &str) -> Result<Option<NightshiftRun>, String> {
+    let _lock = NIGHTSHIFT_LOCK.lock().unwrap();
+    let runs_dir = get_runs_dir(app)?;
+
+    let entries = std::fs::read_dir(&runs_dir)
+        .map_err(|e| format!("Failed to read nightshift runs directory: {e}"))?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "json") {
+            if let Ok(contents) = std::fs::read_to_string(&path) {
+                if let Ok(runs) = serde_json::from_str::<Vec<NightshiftRun>>(&contents) {
+                    if let Some(run) = runs.into_iter().find(|r| r.id == run_id) {
+                        return Ok(Some(run));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Get last run timestamp for a specific check on a project
+pub fn get_last_check_run_time(
+    app: &AppHandle,
+    project_id: &str,
+    check_id: &str,
+) -> Result<Option<u64>, String> {
+    let runs = load_runs(app, project_id)?;
+
+    let last_time = runs
+        .iter()
+        .filter(|run| {
+            run.check_results
+                .iter()
+                .any(|cr| cr.check_id == check_id && cr.status == super::types::RunStatus::Completed)
+        })
+        .map(|run| run.started_at)
+        .max();
+
+    Ok(last_time)
+}

--- a/src-tauri/src/nightshift/types.rs
+++ b/src-tauri/src/nightshift/types.rs
@@ -1,0 +1,233 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Category of maintenance check
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckCategory {
+    Lint,
+    DeadCode,
+    Documentation,
+    Security,
+    Tests,
+    Dependencies,
+    Performance,
+    CodeQuality,
+    TypeSafety,
+    Configuration,
+}
+
+/// Cost tier for token budget awareness
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum CostTier {
+    Low,
+    Medium,
+    High,
+}
+
+/// A built-in maintenance check definition
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NightshiftCheck {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub category: CheckCategory,
+    pub cost_tier: CostTier,
+    /// Minimum hours between runs of this check
+    pub cooldown_hours: u32,
+    pub default_enabled: bool,
+}
+
+/// Per-check configuration overrides
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct NightshiftCheckConfig {
+    /// Custom prompt override (None = use built-in default)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_prompt: Option<String>,
+    /// Cooldown hours override (None = use built-in default)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cooldown_hours_override: Option<u32>,
+}
+
+/// What to do after a nightshift run completes
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PostAction {
+    /// Leave changes uncommitted in the worktree
+    #[default]
+    Nothing,
+    /// Commit changes but don't create a PR
+    Commit,
+    /// Commit changes and create a PR
+    CommitAndPr,
+}
+
+/// Per-project Nightshift configuration
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct NightshiftConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Check IDs to skip (empty = run all default-enabled)
+    #[serde(default)]
+    pub disabled_checks: Vec<String>,
+    /// Additional check IDs to enable beyond defaults
+    #[serde(default)]
+    pub extra_enabled_checks: Vec<String>,
+    /// Time of day to run (HH:MM format), None = manual only
+    #[serde(default)]
+    pub schedule_time: Option<String>,
+    /// Target branch for PRs (defaults to project.default_branch)
+    #[serde(default)]
+    pub target_branch: Option<String>,
+    /// Model override (None = use global preferences model)
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Custom provider profile name (None = use default)
+    #[serde(default)]
+    pub provider: Option<String>,
+    /// Backend override (claude/codex/opencode, None = use project default)
+    #[serde(default)]
+    pub backend: Option<String>,
+    /// What to do after a run completes
+    #[serde(default)]
+    pub post_action: PostAction,
+    /// Per-check configuration overrides (check_id -> config)
+    #[serde(default)]
+    pub check_configs: HashMap<String, NightshiftCheckConfig>,
+}
+
+/// Status of a Nightshift run
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunStatus {
+    Pending,
+    Running,
+    Completed,
+    PartiallyCompleted,
+    Failed,
+    Cancelled,
+}
+
+/// Result of a single check execution within a run
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckResult {
+    pub check_id: String,
+    pub status: RunStatus,
+    /// The session that was created for this check
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    pub duration_secs: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// What triggered the run
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunTrigger {
+    Manual,
+    Scheduled,
+}
+
+/// A complete Nightshift run record
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NightshiftRun {
+    pub id: String,
+    pub project_id: String,
+    pub started_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<u64>,
+    pub status: RunStatus,
+    pub trigger: RunTrigger,
+    pub check_results: Vec<CheckResult>,
+    /// Worktree created for this run
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_id: Option<String>,
+    /// Path to the worktree
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
+    /// Branch name of the worktree
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u32>,
+}
+
+// ============================================================================
+// Event payloads
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunStartedEvent {
+    pub run_id: String,
+    pub project_id: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckStartedEvent {
+    pub run_id: String,
+    pub check_id: String,
+    pub check_name: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckDoneEvent {
+    pub run_id: String,
+    pub check_id: String,
+    pub status: RunStatus,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunCompletedEvent {
+    pub run_id: String,
+    pub project_id: String,
+    pub status: RunStatus,
+    pub total_checks: usize,
+    pub worktree_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunFailedEvent {
+    pub run_id: String,
+    pub project_id: String,
+    pub error: String,
+}
+
+/// Event telling frontend to execute a check by sending a message in a session
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecuteCheckEvent {
+    pub run_id: String,
+    pub project_id: String,
+    pub check_id: String,
+    pub check_name: String,
+    pub session_id: String,
+    pub worktree_id: String,
+    pub worktree_path: String,
+    pub prompt: String,
+    pub model: Option<String>,
+    pub provider: Option<String>,
+    pub backend: Option<String>,
+}
+
+/// Completion info reported back from frontend
+#[derive(Debug, Clone)]
+pub struct CheckCompletion {
+    pub session_id: String,
+    pub success: bool,
+    pub error: Option<String>,
+}

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -220,6 +220,7 @@ pub async fn add_project(
         linear_api_key: None,
         linear_team_id: None,
         linked_project_ids: Vec::new(),
+        nightshift_config: None,
     };
 
     data.add_project(project.clone());
@@ -380,6 +381,7 @@ pub async fn init_project(
         linear_api_key: None,
         linear_team_id: None,
         linked_project_ids: Vec::new(),
+        nightshift_config: None,
     };
 
     data.add_project(project.clone());
@@ -434,6 +436,7 @@ pub async fn clone_project(
         linear_api_key: None,
         linear_team_id: None,
         linked_project_ids: Vec::new(),
+        nightshift_config: None,
     };
 
     data.add_project(project.clone());
@@ -8233,6 +8236,7 @@ pub async fn create_folder(
         linear_api_key: None,
         linear_team_id: None,
         linked_project_ids: Vec::new(),
+        nightshift_config: None,
     };
 
     data.add_project(folder.clone());

--- a/src-tauri/src/projects/git.rs
+++ b/src-tauri/src/projects/git.rs
@@ -1737,6 +1737,34 @@ pub fn run_setup_script(
     run_jean_script("setup", worktree_path, root_path, branch, script)
 }
 
+/// Read jean.json from the project root and run the setup script if configured.
+///
+/// Returns (setup_output, setup_script, setup_success) — all None if no jean.json
+/// or no setup script is defined. Logs failures but never errors out; the worktree
+/// is still usable even if the setup script fails.
+pub fn run_setup_if_configured(
+    worktree_path: &str,
+    project_root: &str,
+    branch: &str,
+) -> (Option<String>, Option<String>, Option<bool>) {
+    let config = match read_jean_config(project_root) {
+        Some(c) => c,
+        None => return (None, None, None),
+    };
+    let script = match config.scripts.setup {
+        Some(s) if !s.is_empty() => s,
+        _ => return (None, None, None),
+    };
+    log::trace!("Found jean.json setup script, executing in {worktree_path}");
+    match run_setup_script(worktree_path, project_root, branch, &script) {
+        Ok(output) => (Some(output), Some(script), Some(true)),
+        Err(e) => {
+            log::warn!("Setup script failed (continuing): {e}");
+            (Some(e), Some(script), Some(false))
+        }
+    }
+}
+
 /// Run a teardown script in a worktree directory before deletion
 ///
 /// Executes the script using sh -c and captures output.

--- a/src-tauri/src/projects/git_status.rs
+++ b/src-tauri/src/projects/git_status.rs
@@ -15,6 +15,13 @@ pub struct ActiveWorktreeInfo {
     pub pr_url: Option<String>,
 }
 
+/// Short commit summary (hash + subject line)
+#[derive(Debug, Clone, Serialize)]
+pub struct CommitSummary {
+    pub hash: String,
+    pub message: String,
+}
+
 /// Git branch status relative to a base branch
 #[derive(Debug, Clone, Serialize)]
 pub struct GitBranchStatus {
@@ -41,6 +48,8 @@ pub struct GitBranchStatus {
     pub worktree_ahead_count: u32,
     /// Commits in HEAD not yet pushed to origin/{current_branch}
     pub unpushed_count: u32,
+    /// Short summaries of unpushed commits (hash + subject)
+    pub unpushed_commits: Vec<CommitSummary>,
 }
 
 /// Fetch the latest changes from origin for a specific branch
@@ -402,6 +411,37 @@ fn ref_exists(repo_path: &str, git_ref: &str) -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
+}
+
+/// List commit summaries (short hash + subject) between two refs
+/// Returns up to `limit` commits, newest first
+fn list_commits_between(repo_path: &str, from_ref: &str, to_ref: &str, limit: u32) -> Vec<CommitSummary> {
+    let output = silent_command("git")
+        .args([
+            "log",
+            "--format=%h %s",
+            &format!("-{limit}"),
+            &format!("{from_ref}..{to_ref}"),
+        ])
+        .current_dir(repo_path)
+        .output();
+
+    match output {
+        Ok(o) if o.status.success() => {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .filter(|line| !line.is_empty())
+                .map(|line| {
+                    let (hash, message) = line.split_once(' ').unwrap_or((line, ""));
+                    CommitSummary {
+                        hash: hash.to_string(),
+                        message: message.to_string(),
+                    }
+                })
+                .collect()
+        }
+        _ => vec![],
+    }
 }
 
 /// Count commits between two refs
@@ -770,7 +810,8 @@ pub fn get_branch_status(info: &ActiveWorktreeInfo) -> Result<GitBranchStatus, S
     // Commits not yet pushed to the upstream tracking ref
     // Uses @{upstream} to support non-origin remotes (e.g., fork/branch)
     // Falls back to origin/{current_branch} if no upstream is configured
-    let unpushed_count = if current_branch != *base_branch {
+    // Track which ref we're comparing against so we can list individual commits
+    let (unpushed_count, unpushed_from_ref) = if current_branch != *base_branch {
         let upstream_ref = get_upstream_ref(repo_path);
 
         if let Some(ref upstream) = upstream_ref {
@@ -782,21 +823,32 @@ pub fn get_branch_status(info: &ActiveWorktreeInfo) -> Result<GitBranchStatus, S
                     let _ = fetch_origin_branch(repo_path, &current_branch);
                 }
             }
-            count_commits_between(repo_path, upstream, "HEAD")
+            (count_commits_between(repo_path, upstream, "HEAD"), Some(upstream.clone()))
         } else {
             // No upstream configured — try origin/{current_branch}
             let _ = fetch_origin_branch(repo_path, &current_branch);
             let origin_current_ref = format!("origin/{current_branch}");
             if ref_exists(repo_path, &origin_current_ref) {
-                count_commits_between(repo_path, &origin_current_ref, "HEAD")
+                (count_commits_between(repo_path, &origin_current_ref, "HEAD"), Some(origin_current_ref))
             } else {
                 // Never pushed — all worktree-unique commits are unpushed
-                worktree_ahead_count
+                (worktree_ahead_count, Some(base_branch.clone()))
             }
         }
     } else {
         // On the base branch itself, unpushed = base_branch_ahead_count
-        base_branch_ahead_count
+        (base_branch_ahead_count, Some(origin_ref.clone()))
+    };
+
+    // Get unpushed commit summaries (piggybacks on existing polling, no extra round-trip)
+    let unpushed_commits = if unpushed_count > 0 {
+        if let Some(ref from) = unpushed_from_ref {
+            list_commits_between(repo_path, from, "HEAD", 20)
+        } else {
+            vec![]
+        }
+    } else {
+        vec![]
     };
 
     // Get current timestamp
@@ -821,6 +873,7 @@ pub fn get_branch_status(info: &ActiveWorktreeInfo) -> Result<GitBranchStatus, S
         base_branch_behind_count,
         worktree_ahead_count,
         unpushed_count,
+        unpushed_commits,
     })
 }
 
@@ -846,6 +899,7 @@ mod tests {
             base_branch_behind_count: 0,
             worktree_ahead_count: 3,
             unpushed_count: 1,
+            unpushed_commits: vec![CommitSummary { hash: "abc1234".to_string(), message: "fix: something".to_string() }],
         };
 
         let json = serde_json::to_string(&status).unwrap();

--- a/src-tauri/src/projects/types.rs
+++ b/src-tauri/src/projects/types.rs
@@ -123,6 +123,9 @@ pub struct Project {
     /// IDs of linked projects for cross-project context sharing
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub linked_project_ids: Vec<String>,
+    /// Nightshift configuration for this project
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nightshift_config: Option<crate::nightshift::types::NightshiftConfig>,
 }
 
 /// A git worktree created for a project

--- a/src-tauri/src/projects/types.rs
+++ b/src-tauri/src/projects/types.rs
@@ -232,6 +232,59 @@ pub struct Worktree {
     pub last_opened_at: Option<u64>,
 }
 
+impl Worktree {
+    /// Create a new Worktree with only the required fields; everything else defaults to None/0.
+    pub fn new(
+        id: String,
+        project_id: String,
+        name: String,
+        path: String,
+        branch: String,
+        order: u32,
+    ) -> Self {
+        Self {
+            id,
+            project_id,
+            name,
+            path,
+            branch,
+            created_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+            setup_output: None,
+            setup_script: None,
+            setup_success: None,
+            session_type: SessionType::Worktree,
+            pr_number: None,
+            pr_url: None,
+            issue_number: None,
+            linear_issue_identifier: None,
+            security_alert_number: None,
+            security_alert_url: None,
+            advisory_ghsa_id: None,
+            advisory_url: None,
+            cached_pr_status: None,
+            cached_check_status: None,
+            cached_behind_count: None,
+            cached_ahead_count: None,
+            cached_status_at: None,
+            cached_uncommitted_added: None,
+            cached_uncommitted_removed: None,
+            cached_branch_diff_added: None,
+            cached_branch_diff_removed: None,
+            cached_base_branch_ahead_count: None,
+            cached_base_branch_behind_count: None,
+            cached_worktree_ahead_count: None,
+            cached_unpushed_count: None,
+            order,
+            label: None,
+            archived_at: None,
+            last_opened_at: None,
+        }
+    }
+}
+
 /// Container for all persisted project data
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ProjectsData {

--- a/src-tauri/src/terminal/commands.rs
+++ b/src-tauri/src/terminal/commands.rs
@@ -1,11 +1,24 @@
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
 use tauri::AppHandle;
 
 use super::pty::{
     kill_all_terminals as pty_kill_all_terminals, kill_terminal, resize_terminal, spawn_terminal,
     write_to_terminal,
 };
-use super::registry::{get_all_terminal_ids, has_terminal};
+use super::registry::{get_all_terminal_ids, has_terminal, TERMINAL_SESSIONS};
+use crate::platform::silent_command;
 use crate::projects::git::read_jean_config;
+
+/// A TCP port that a terminal's child process is listening on
+#[derive(Clone, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalPortInfo {
+    pub terminal_id: String,
+    pub port: u16,
+    pub process_name: String,
+    pub local_address: String,
+}
 
 /// Start a terminal
 #[tauri::command]
@@ -97,4 +110,202 @@ pub async fn has_active_terminal(terminal_id: String) -> bool {
 pub fn kill_all_terminals() -> usize {
     log::trace!("kill_all_terminals command invoked");
     pty_kill_all_terminals()
+}
+
+/// Build a PID → PPID map from a single `ps -eo pid=,ppid=` call.
+/// Much cheaper than spawning one `ps` per PID when walking ancestry.
+#[cfg(unix)]
+fn build_ppid_map() -> HashMap<u32, u32> {
+    let output = match silent_command("ps")
+        .args(["-eo", "pid=,ppid="])
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return HashMap::new(),
+    };
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut map = HashMap::new();
+    for line in text.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() == 2 {
+            if let (Ok(pid), Ok(ppid)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>()) {
+                map.insert(pid, ppid);
+            }
+        }
+    }
+    map
+}
+
+/// Check if `pid` is a descendant of any PID in `ancestor_pids`.
+/// Uses the pre-built ppid map instead of spawning per-PID subprocesses.
+#[cfg(unix)]
+fn is_descendant_of(
+    pid: u32,
+    ancestor_pids: &HashSet<u32>,
+    ppid_map: &HashMap<u32, u32>,
+    max_depth: usize,
+) -> Option<u32> {
+    let mut current = pid;
+    let mut visited = HashSet::new();
+    for _ in 0..max_depth {
+        if ancestor_pids.contains(&current) {
+            return Some(current);
+        }
+        if !visited.insert(current) {
+            break;
+        }
+        match ppid_map.get(&current) {
+            Some(&ppid) if ppid > 1 => current = ppid,
+            _ => break,
+        }
+    }
+    None
+}
+
+/// Discover TCP LISTEN ports belonging to our terminal processes.
+///
+/// Strategy:
+/// 1. Collect PIDs of all active terminal shells from the registry
+/// 2. Run `lsof -P -n -iTCP -sTCP:LISTEN -F pcn` to find all LISTEN sockets
+/// 3. For each listener, walk the ppid chain to check if it descends from a terminal PID
+/// 4. Return matched ports with terminal_id, port, process name, and address
+#[tauri::command]
+pub async fn get_terminal_listening_ports() -> Vec<TerminalPortInfo> {
+    #[cfg(not(unix))]
+    {
+        // lsof is not available on Windows
+        return Vec::new();
+    }
+
+    #[cfg(unix)]
+    {
+        // Step 1: Collect terminal PIDs → terminal_id mapping
+        let terminal_pids: HashMap<u32, String> = {
+            let sessions = TERMINAL_SESSIONS.lock().unwrap();
+            sessions
+                .iter()
+                .filter_map(|(tid, session)| {
+                    session.child.process_id().map(|pid| (pid, tid.clone()))
+                })
+                .collect()
+        };
+
+        if terminal_pids.is_empty() {
+            return Vec::new();
+        }
+
+        let ancestor_pids: HashSet<u32> = terminal_pids.keys().copied().collect();
+
+        // Step 2: Run lsof to find all TCP LISTEN sockets
+        let output = match silent_command("lsof")
+            .args(["-P", "-n", "-iTCP", "-sTCP:LISTEN", "-F", "pcn"])
+            .output()
+        {
+            Ok(o) => o,
+            Err(e) => {
+                log::debug!("lsof failed: {e}");
+                return Vec::new();
+            }
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        // Step 3: Parse lsof -F output
+        // Format: lines starting with p=PID, c=command, n=address
+        // Each process block starts with pPID, then cCOMMAND, then one or more nADDRESS
+        struct LsofEntry {
+            pid: u32,
+            name: String,
+            addresses: Vec<String>,
+        }
+
+        let mut entries: Vec<LsofEntry> = Vec::new();
+        let mut current_pid: Option<u32> = None;
+        let mut current_name = String::new();
+        let mut current_addrs: Vec<String> = Vec::new();
+
+        for line in stdout.lines() {
+            if line.is_empty() {
+                continue;
+            }
+            let (tag, value) = (line.as_bytes()[0], &line[1..]);
+            match tag {
+                b'p' => {
+                    // Flush previous entry
+                    if let Some(pid) = current_pid {
+                        if !current_addrs.is_empty() {
+                            entries.push(LsofEntry {
+                                pid,
+                                name: std::mem::take(&mut current_name),
+                                addresses: std::mem::take(&mut current_addrs),
+                            });
+                        }
+                    }
+                    current_pid = value.parse::<u32>().ok();
+                    current_name.clear();
+                    current_addrs.clear();
+                }
+                b'c' => {
+                    current_name = value.to_string();
+                }
+                b'n' => {
+                    current_addrs.push(value.to_string());
+                }
+                _ => {}
+            }
+        }
+        // Flush last entry
+        if let Some(pid) = current_pid {
+            if !current_addrs.is_empty() {
+                entries.push(LsofEntry {
+                    pid,
+                    name: current_name,
+                    addresses: current_addrs,
+                });
+            }
+        }
+
+        // Step 4: Build ppid map once, then match each listener via ancestry walk
+        let ppid_map = build_ppid_map();
+        let mut results: Vec<TerminalPortInfo> = Vec::new();
+
+        for entry in &entries {
+            // Check if this process descends from one of our terminal shells
+            let ancestor_pid = if ancestor_pids.contains(&entry.pid) {
+                Some(entry.pid)
+            } else {
+                is_descendant_of(entry.pid, &ancestor_pids, &ppid_map, 20)
+            };
+
+            if let Some(ancestor) = ancestor_pid {
+                let terminal_id = match terminal_pids.get(&ancestor) {
+                    Some(tid) => tid.clone(),
+                    None => continue,
+                };
+
+                for addr in &entry.addresses {
+                    // addr format: "127.0.0.1:3000" or "*:3000" or "[::1]:3000"
+                    if let Some(port) = extract_port(addr) {
+                        results.push(TerminalPortInfo {
+                            terminal_id: terminal_id.clone(),
+                            port,
+                            process_name: entry.name.clone(),
+                            local_address: addr.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        // Dedup by (terminal_id, port)
+        let mut seen = HashSet::new();
+        results.retain(|r| seen.insert((r.terminal_id.clone(), r.port)));
+
+        results
+    }
+}
+
+/// Extract port number from an lsof address like "127.0.0.1:3000" or "*:8080" or "[::1]:3000"
+fn extract_port(addr: &str) -> Option<u16> {
+    addr.rsplit(':').next()?.parse::<u16>().ok()
 }

--- a/src/App.css
+++ b/src/App.css
@@ -523,6 +523,14 @@ kbd {
   filter: invert(1);
 }
 
+/* Chat search highlights (CSS Custom Highlight API) */
+::highlight(chat-search) {
+  background-color: rgba(250, 204, 21, 0.35);
+}
+::highlight(chat-search-active) {
+  background-color: rgba(251, 146, 60, 0.7);
+}
+
 /* Custom scrollbar styling to match Radix ScrollArea */
 .custom-scrollbar::-webkit-scrollbar {
   width: 10px;

--- a/src/App.css
+++ b/src/App.css
@@ -531,6 +531,11 @@ kbd {
   background-color: rgba(251, 146, 60, 0.7);
 }
 
+/* User-created text highlights (persistent annotations) */
+::highlight(user-highlight) {
+  background-color: rgba(250, 204, 21, 0.25);
+}
+
 /* Custom scrollbar styling to match Radix ScrollArea */
 .custom-scrollbar::-webkit-scrollbar {
   width: 10px;

--- a/src/components/chat/AgentWidget.tsx
+++ b/src/components/chat/AgentWidget.tsx
@@ -109,7 +109,11 @@ interface AgentItemProps {
 function AgentItem({ agent }: AgentItemProps) {
   return (
     <li className="flex items-start gap-2 py-0.5 text-xs">
-      <span className="mt-0.5 shrink-0">
+      <span className="mt-0.5 shrink-0" title={
+        agent.status === 'completed' ? 'Completed'
+          : agent.status === 'errored' ? 'Errored'
+          : 'Running'
+      }>
         {agent.status === 'completed' ? (
           <CheckCircle2 className="h-4 w-4 text-green-500" />
         ) : agent.status === 'errored' ? (

--- a/src/components/chat/ChatErrorFallback.tsx
+++ b/src/components/chat/ChatErrorFallback.tsx
@@ -57,7 +57,7 @@ export function ChatErrorFallback({
         </summary>
         <div className="relative mt-1">
           <CopyErrorButton error={error} />
-          <pre className="max-h-40 overflow-auto rounded border bg-muted p-2 pr-8 text-xs font-mono text-muted-foreground whitespace-pre-wrap break-words">
+          <pre className="max-h-40 overflow-auto rounded border bg-muted p-2 pr-8 text-xs font-mono text-muted-foreground whitespace-pre-wrap break-words select-text cursor-text">
             {error.message}
             {error.stack && `\n\n${error.stack}`}
           </pre>

--- a/src/components/chat/ChatSearchBar.tsx
+++ b/src/components/chat/ChatSearchBar.tsx
@@ -1,0 +1,244 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useUIStore } from '@/store/ui-store'
+import { ChevronUp, ChevronDown, X } from 'lucide-react'
+
+interface ChatSearchBarProps {
+  scrollContainerRef: React.RefObject<HTMLElement | null>
+}
+
+interface MatchInfo {
+  node: Text
+  index: number
+  length: number
+}
+
+function rangeFromMatch(m: MatchInfo): Range | null {
+  try {
+    const range = new Range()
+    range.setStart(m.node, m.index)
+    range.setEnd(m.node, m.index + m.length)
+    return range
+  } catch {
+    // DOM may have changed since match was found (React re-render)
+    return null
+  }
+}
+
+function scrollRangeIntoView(range: Range) {
+  const el =
+    range.commonAncestorContainer instanceof Element
+      ? range.commonAncestorContainer
+      : range.commonAncestorContainer.parentElement
+  el?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+}
+
+export function ChatSearchBar({ scrollContainerRef }: ChatSearchBarProps) {
+  const chatSearchOpen = useUIStore(s => s.chatSearchOpen)
+  const setChatSearchOpen = useUIStore(s => s.setChatSearchOpen)
+
+  const [query, setQuery] = useState('')
+  const [matches, setMatches] = useState<MatchInfo[]>([])
+  const [activeIndex, setActiveIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearHighlights = useCallback(() => {
+    CSS.highlights.delete('chat-search')
+    CSS.highlights.delete('chat-search-active')
+  }, [])
+
+  const highlightActiveMatch = useCallback(
+    (index: number, allMatches: MatchInfo[]) => {
+      const match = allMatches[index]
+      if (!match) return
+      const range = rangeFromMatch(match)
+      if (!range) return
+      CSS.highlights.set('chat-search-active', new Highlight(range))
+      scrollRangeIntoView(range)
+    },
+    []
+  )
+
+  const performSearch = useCallback(
+    (searchQuery: string) => {
+      clearHighlights()
+
+      if (!searchQuery || !scrollContainerRef.current) {
+        setMatches([])
+        setActiveIndex(0)
+        return
+      }
+
+      const container = scrollContainerRef.current
+      const lowerQuery = searchQuery.toLowerCase()
+      const found: MatchInfo[] = []
+
+      const walker = document.createTreeWalker(
+        container,
+        NodeFilter.SHOW_TEXT,
+        {
+          acceptNode(node) {
+            if (node.parentElement?.closest('[data-chat-search-bar]')) {
+              return NodeFilter.FILTER_REJECT
+            }
+            return NodeFilter.FILTER_ACCEPT
+          },
+        }
+      )
+
+      let textNode: Text | null
+      while ((textNode = walker.nextNode() as Text | null)) {
+        const text = textNode.textContent?.toLowerCase() ?? ''
+        let startPos = 0
+        let idx: number
+        while ((idx = text.indexOf(lowerQuery, startPos)) !== -1) {
+          found.push({ node: textNode, index: idx, length: searchQuery.length })
+          startPos = idx + 1
+        }
+      }
+
+      setMatches(found)
+      setActiveIndex(0)
+
+      if (found.length === 0) return
+
+      const allRanges = found.map(rangeFromMatch).filter((r): r is Range => r !== null)
+      if (allRanges.length > 0) {
+        CSS.highlights.set('chat-search', new Highlight(...allRanges))
+      }
+      highlightActiveMatch(0, found)
+    },
+    [scrollContainerRef, clearHighlights, highlightActiveMatch]
+  )
+
+  const navigateToMatch = useCallback(
+    (index: number) => {
+      if (matches.length === 0) return
+      const wrappedIndex =
+        ((index % matches.length) + matches.length) % matches.length
+      setActiveIndex(wrappedIndex)
+      highlightActiveMatch(wrappedIndex, matches)
+    },
+    [matches, highlightActiveMatch]
+  )
+
+  const close = useCallback(() => {
+    clearHighlights()
+    setQuery('')
+    setMatches([])
+    setActiveIndex(0)
+    setChatSearchOpen(false)
+  }, [clearHighlights, setChatSearchOpen])
+
+  // Debounced search
+  useEffect(() => {
+    if (!chatSearchOpen) return
+
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      performSearch(query)
+    }, 150)
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [query, chatSearchOpen, performSearch])
+
+  // Focus input when opened
+  useEffect(() => {
+    if (chatSearchOpen) {
+      requestAnimationFrame(() => {
+        inputRef.current?.focus()
+        inputRef.current?.select()
+      })
+    }
+  }, [chatSearchOpen])
+
+  // Listen for toggle event (re-focus or close)
+  useEffect(() => {
+    const handler = () => {
+      if (!chatSearchOpen) return
+      if (document.activeElement === inputRef.current) {
+        close()
+      } else {
+        inputRef.current?.focus()
+        inputRef.current?.select()
+      }
+    }
+    window.addEventListener('chat-search-toggle', handler)
+    return () => window.removeEventListener('chat-search-toggle', handler)
+  }, [chatSearchOpen, close])
+
+  // Cleanup on unmount (session switch)
+  useEffect(() => {
+    return () => {
+      clearHighlights()
+    }
+  }, [clearHighlights])
+
+  if (!chatSearchOpen) return null
+
+  // Escape closes search only when the input is focused (Chrome behavior).
+  // Note: Safari closes its find bar on Escape even when unfocused — no consensus.
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      e.stopPropagation() // Prevent session from also closing
+      close()
+    } else if (e.key === 'Enter' && e.shiftKey) {
+      e.preventDefault()
+      navigateToMatch(activeIndex - 1)
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      navigateToMatch(activeIndex + 1)
+    }
+  }
+
+  return (
+    <div
+      data-chat-search-bar
+      className="absolute top-2 right-4 z-30 flex items-center gap-1 rounded-md border border-border bg-popover px-2 py-1 shadow-md"
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Find in chat..."
+        className="w-40 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground"
+      />
+      {query && (
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {matches.length > 0 ? `${activeIndex + 1}/${matches.length}` : '0/0'}
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={() => navigateToMatch(activeIndex - 1)}
+        disabled={matches.length === 0}
+        className="rounded p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+        aria-label="Previous match"
+      >
+        <ChevronUp className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={() => navigateToMatch(activeIndex + 1)}
+        disabled={matches.length === 0}
+        className="rounded p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+        aria-label="Next match"
+      >
+        <ChevronDown className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={close}
+        className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+        aria-label="Close search"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -12,6 +12,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { formatShortcutDisplay, DEFAULT_KEYBINDINGS } from '@/types/keybindings'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { ChatSearchBar } from './ChatSearchBar'
 import { Button } from '@/components/ui/button'
 import {
   AlertDialog,
@@ -2216,6 +2217,7 @@ export function ChatWindow({
                           {sessionLabel.name}
                         </span>
                       )}
+                      <ChatSearchBar scrollContainerRef={scrollViewportRef} />
                       {/* Bottom fade gradient so messages don't hard-cut at the input area */}
                       <div className="pointer-events-none absolute bottom-0 left-0 right-0 z-10 h-8 bg-gradient-to-b from-transparent to-background" />
                       {/* Session digest reminder (shows when opening a session that had activity while out of focus) */}

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -108,7 +108,7 @@ import { ReviewResultsPanel } from './ReviewResultsPanel'
 import { QueuedMessagesList } from './QueuedMessageItem'
 import { FloatingButtons } from './FloatingButtons'
 import { PlanDialog } from './PlanDialog'
-import { RecapDialog } from './RecapDialog'
+import { RecapBanner } from './RecapBanner'
 import { StreamingMessage } from './StreamingMessage'
 import { StreamingStatusBar } from './StreamingStatusBar'
 import { ChatErrorFallback } from './ChatErrorFallback'
@@ -2224,6 +2224,16 @@ export function ChatWindow({
                       {activeSessionId && (
                         <SessionDigestReminder sessionId={activeSessionId} />
                       )}
+                      {/* Recap banner — non-blocking sticky bar instead of modal overlay */}
+                      <RecapBanner
+                        digest={recapDialogDigest}
+                        isOpen={isRecapDialogOpen}
+                        onClose={() => {
+                          setIsRecapDialogOpen(false)
+                          setRecapDialogDigest(null)
+                        }}
+                        isGenerating={isGeneratingRecap}
+                      />
                       <ScrollArea
                         className="h-full w-full"
                         viewportRef={scrollViewportRef}
@@ -2968,19 +2978,7 @@ export function ChatWindow({
             />
           ) : null)}
 
-        {/* Recap dialog */}
-        <RecapDialog
-          digest={recapDialogDigest}
-          isOpen={isRecapDialogOpen}
-          onClose={() => {
-            setIsRecapDialogOpen(false)
-            setRecapDialogDigest(null)
-          }}
-          isGenerating={isGeneratingRecap}
-          onRegenerate={() =>
-            window.dispatchEvent(new CustomEvent('open-recap'))
-          }
-        />
+        {/* RecapDialog replaced by RecapBanner above the ScrollArea */}
 
         {/* Merge options dialog */}
         <AlertDialog open={showMergeDialog} onOpenChange={setShowMergeDialog}>

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -13,6 +13,8 @@ import { toast } from 'sonner'
 import { formatShortcutDisplay, DEFAULT_KEYBINDINGS } from '@/types/keybindings'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { ChatSearchBar } from './ChatSearchBar'
+import { HighlightActionPopover } from './HighlightActionPopover'
+import { useTextHighlights } from './hooks/useTextHighlights'
 import { Button } from '@/components/ui/button'
 import {
   AlertDialog,
@@ -901,6 +903,9 @@ export function ChatWindow({
     activeWorktreeId,
     isSending,
   })
+
+  // Text highlights (persistent annotations via CSS Custom Highlight API)
+  useTextHighlights(activeSessionId, scrollViewportRef)
 
   // Drag and drop images into chat input
   const { isDragging } = useDragAndDropImages(activeSessionId)
@@ -2218,6 +2223,12 @@ export function ChatWindow({
                         </span>
                       )}
                       <ChatSearchBar scrollContainerRef={scrollViewportRef} />
+                      {activeSessionId && (
+                        <HighlightActionPopover
+                          sessionId={activeSessionId}
+                          containerRef={scrollViewportRef}
+                        />
+                      )}
                       {/* Bottom fade gradient so messages don't hard-cut at the input area */}
                       <div className="pointer-events-none absolute bottom-0 left-0 right-0 z-10 h-8 bg-gradient-to-b from-transparent to-background" />
                       {/* Session digest reminder (shows when opening a session that had activity while out of focus) */}

--- a/src/components/chat/FileDiffModal.tsx
+++ b/src/components/chat/FileDiffModal.tsx
@@ -189,7 +189,7 @@ export function FileDiffModal({
               matchingFile && getStatusColor(matchingFile.fileDiff.type)
             )}
           />
-          <span className="truncate">{displayFilename}</span>
+          <span className="truncate select-text cursor-text">{displayFilename}</span>
           {matchingFile && (
             <span className="text-muted-foreground font-normal text-xs ml-2">
               {stats.additions > 0 && (
@@ -283,7 +283,7 @@ export function FileDiffModal({
                     getStatusColor(matchingFile.fileDiff.type)
                   )}
                 />
-                <span className="truncate text-sm">
+                <span className="truncate text-sm select-text cursor-text">
                   {matchingFile.fileName}
                 </span>
                 {matchingFile.fileDiff.prevName &&

--- a/src/components/chat/GitDiffModal.tsx
+++ b/src/components/chat/GitDiffModal.tsx
@@ -25,6 +25,12 @@ import {
   ChevronsUpDown,
   PanelLeft,
   Check,
+  List,
+  ListTree,
+  ChevronRight,
+  Folder,
+  FolderOpen,
+  Minus,
 } from 'lucide-react'
 import {
   parsePatchFiles,
@@ -202,6 +208,327 @@ interface GitDiffModalProps {
 }
 
 type DiffStyle = 'split' | 'unified'
+type FileViewMode = 'flat' | 'tree'
+
+// Type for items in flattenedFiles (inferred, made explicit for tree building)
+export interface FlattenedFile {
+  fileDiff: FileDiffMetadata
+  fileName: string
+  key: string
+  additions: number
+  deletions: number
+}
+
+export interface FileTreeDir {
+  type: 'dir'
+  name: string
+  path: string
+  children: FileTreeNode[]
+  /** Sum of all descendant file additions */
+  additions: number
+  /** Sum of all descendant file deletions */
+  deletions: number
+}
+
+export interface FileTreeFile {
+  type: 'file'
+  name: string
+  path: string
+  file: FlattenedFile
+  index: number // index in filteredFiles
+}
+
+export type FileTreeNode = FileTreeDir | FileTreeFile
+
+/** Build a directory tree from a flat list of files. Directories sort before files; both groups sort alphabetically. */
+export function buildFileTree(files: FlattenedFile[]): FileTreeNode[] {
+  const dirMap = new Map<string, FileTreeDir>()
+  const roots: FileTreeNode[] = []
+
+  function getOrCreateDir(dirPath: string): FileTreeDir {
+    const existing = dirMap.get(dirPath)
+    if (existing) return existing
+    const parts = dirPath.split('/')
+    const dir: FileTreeDir = {
+      type: 'dir',
+      name: parts[parts.length - 1]!,
+      path: dirPath,
+      children: [],
+      additions: 0,
+      deletions: 0,
+    }
+    dirMap.set(dirPath, dir)
+    if (parts.length > 1) {
+      const parentPath = parts.slice(0, -1).join('/')
+      getOrCreateDir(parentPath).children.push(dir)
+    } else {
+      roots.push(dir)
+    }
+    return dir
+  }
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i]!
+    const normalized = file.fileName.replace(/\\/g, '/')
+    const slashIdx = normalized.lastIndexOf('/')
+    const name = slashIdx === -1 ? normalized : normalized.slice(slashIdx + 1)
+    const fileNode: FileTreeFile = { type: 'file', name, path: normalized, file, index: i }
+    if (slashIdx === -1) {
+      roots.push(fileNode)
+    } else {
+      const parentPath = normalized.slice(0, slashIdx)
+      getOrCreateDir(parentPath).children.push(fileNode)
+    }
+  }
+
+  function sortNodes(nodes: FileTreeNode[]): void {
+    nodes.sort((a, b) => {
+      if (a.type !== b.type) return a.type === 'dir' ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+    for (const node of nodes) {
+      if (node.type === 'dir') sortNodes(node.children)
+    }
+  }
+  sortNodes(roots)
+
+  // Post-order pass: aggregate +/- stats up through the directory hierarchy
+  function computeStats(nodes: FileTreeNode[]): { additions: number; deletions: number } {
+    let additions = 0, deletions = 0
+    for (const node of nodes) {
+      if (node.type === 'file') {
+        additions += node.file.additions
+        deletions += node.file.deletions
+      } else {
+        const child = computeStats(node.children)
+        node.additions = child.additions
+        node.deletions = child.deletions
+        additions += child.additions
+        deletions += child.deletions
+      }
+    }
+    return { additions, deletions }
+  }
+  computeStats(roots)
+
+  return roots
+}
+
+/** Recursively collect all file names under a tree directory node */
+export function getDirFileNames(nodes: FileTreeNode[]): string[] {
+  const names: string[] = []
+  for (const node of nodes) {
+    if (node.type === 'file') names.push(node.file.fileName)
+    else names.push(...getDirFileNames(node.children))
+  }
+  return names
+}
+
+/** Map @pierre/diffs file type back to backend git status string */
+export function diffTypeToStatus(type: string): string {
+  switch (type) {
+    case 'new': return 'added'
+    case 'deleted': return 'deleted'
+    case 'rename-pure':
+    case 'rename-changed': return 'renamed'
+    default: return 'modified'
+  }
+}
+
+interface FileTreeNodesProps {
+  nodes: FileTreeNode[]
+  depth: number
+  selectedFileIndex: number
+  activeDiffType: 'uncommitted' | 'branch' | 'commits'
+  gitDiffSelectedFiles: Set<string>
+  collapsedDirs: Set<string>
+  filterActive: boolean
+  onSelectFile: (index: number) => void
+  onToggleDir: (path: string) => void
+  onSetRevertTarget: (target: { fileName: string; fileStatus: string }) => void
+}
+
+/** Recursive tree renderer for the file list sidebar. */
+const FileTreeNodes = memo(function FileTreeNodes({
+  nodes,
+  depth,
+  selectedFileIndex,
+  activeDiffType,
+  gitDiffSelectedFiles,
+  collapsedDirs,
+  filterActive,
+  onSelectFile,
+  onToggleDir,
+  onSetRevertTarget,
+}: FileTreeNodesProps) {
+  return (
+    <>
+      {nodes.map(node => {
+        if (node.type === 'dir') {
+          const isExpanded = filterActive || !collapsedDirs.has(node.path)
+          const dirFileNames = activeDiffType === 'uncommitted'
+            ? getDirFileNames(node.children)
+            : []
+          const selectedInDir = dirFileNames.filter(n => gitDiffSelectedFiles.has(n))
+          const allChecked = dirFileNames.length > 0 && selectedInDir.length === dirFileNames.length
+          const someChecked = selectedInDir.length > 0 && !allChecked
+          return (
+            <div key={node.path}>
+              <button
+                type="button"
+                onClick={() => onToggleDir(node.path)}
+                className="w-full flex items-center gap-1.5 py-1 text-left hover:bg-muted/50 text-muted-foreground"
+                style={{ paddingLeft: `${8 + depth * 12}px`, paddingRight: '8px' }}
+              >
+                {activeDiffType === 'uncommitted' && (
+                  <div
+                    role="checkbox"
+                    aria-checked={allChecked ? true : someChecked ? 'mixed' : false}
+                    onClick={e => {
+                      e.stopPropagation()
+                      const store = useUIStore.getState()
+                      if (someChecked || allChecked) {
+                        for (const n of selectedInDir) store.toggleGitDiffSelectedFile(n)
+                      } else {
+                        for (const n of dirFileNames) store.toggleGitDiffSelectedFile(n)
+                      }
+                    }}
+                    className={cn(
+                      'h-3.5 w-3.5 shrink-0 rounded-sm border flex items-center justify-center transition-colors cursor-pointer',
+                      allChecked
+                        ? 'bg-primary border-primary text-primary-foreground'
+                        : someChecked
+                        ? 'bg-primary/40 border-primary/60 text-primary-foreground'
+                        : 'border-muted-foreground/40 hover:border-muted-foreground'
+                    )}
+                  >
+                    {allChecked && <Check className="h-2.5 w-2.5" />}
+                    {someChecked && <Minus className="h-2.5 w-2.5" />}
+                  </div>
+                )}
+                <ChevronRight
+                  className={cn(
+                    'h-3 w-3 shrink-0 transition-transform duration-100',
+                    isExpanded && 'rotate-90'
+                  )}
+                />
+                {isExpanded ? (
+                  <FolderOpen className="h-[1em] w-[1em] shrink-0 text-yellow-500/80" />
+                ) : (
+                  <Folder className="h-[1em] w-[1em] shrink-0 text-yellow-500/80" />
+                )}
+                <span className="truncate text-sm flex-1">{node.name}</span>
+                <div className="flex items-center gap-1 shrink-0 text-xs">
+                  {node.additions > 0 && (
+                    <span className="text-green-500">+{node.additions}</span>
+                  )}
+                  {node.deletions > 0 && (
+                    <span className="text-red-500">-{node.deletions}</span>
+                  )}
+                </div>
+              </button>
+              {isExpanded && (
+                <FileTreeNodes
+                  nodes={node.children}
+                  depth={depth + 1}
+                  selectedFileIndex={selectedFileIndex}
+                  activeDiffType={activeDiffType}
+                  gitDiffSelectedFiles={gitDiffSelectedFiles}
+                  collapsedDirs={collapsedDirs}
+                  filterActive={filterActive}
+                  onSelectFile={onSelectFile}
+                  onToggleDir={onToggleDir}
+                  onSetRevertTarget={onSetRevertTarget}
+                />
+              )}
+            </div>
+          )
+        }
+
+        // File node
+        const { file, index } = node
+        const isSelected = index === selectedFileIndex
+        const isCheckedForCommit =
+          activeDiffType === 'uncommitted' && gitDiffSelectedFiles.has(file.fileName)
+
+        const fileButton = (
+          <button
+            type="button"
+            data-index={index}
+            onClick={() => onSelectFile(index)}
+            className={cn(
+              'w-full flex items-center gap-2 py-2 text-left transition-colors hover:bg-muted/50',
+              isSelected && 'bg-accent',
+              isCheckedForCommit && !isSelected && 'bg-primary/10'
+            )}
+            style={{ paddingLeft: `${8 + depth * 12}px`, paddingRight: '8px' }}
+          >
+            {activeDiffType === 'uncommitted' && (
+              <div
+                role="checkbox"
+                aria-checked={isCheckedForCommit}
+                onClick={e => {
+                  e.stopPropagation()
+                  useUIStore.getState().toggleGitDiffSelectedFile(file.fileName)
+                }}
+                className={cn(
+                  'h-3.5 w-3.5 shrink-0 rounded-sm border flex items-center justify-center transition-colors cursor-pointer',
+                  isCheckedForCommit
+                    ? 'bg-primary border-primary text-primary-foreground'
+                    : 'border-muted-foreground/40 hover:border-muted-foreground'
+                )}
+              >
+                {isCheckedForCommit && <Check className="h-2.5 w-2.5" />}
+              </div>
+            )}
+            <FileText
+              className={cn('h-[1em] w-[1em] shrink-0', getStatusColor(file.fileDiff.type))}
+            />
+            <span className="truncate flex-1 select-text cursor-text text-sm">{node.name}</span>
+            <div className="flex items-center gap-1 shrink-0 text-xs">
+              {file.additions > 0 && (
+                <span className="text-green-500">+{file.additions}</span>
+              )}
+              {file.deletions > 0 && (
+                <span className="text-red-500">-{file.deletions}</span>
+              )}
+            </div>
+          </button>
+        )
+
+        return activeDiffType === 'uncommitted' ? (
+          <ContextMenu key={file.key}>
+            <Tooltip>
+              <ContextMenuTrigger asChild>
+                <TooltipTrigger asChild>{fileButton}</TooltipTrigger>
+              </ContextMenuTrigger>
+              <TooltipContent>{file.fileName}</TooltipContent>
+            </Tooltip>
+            <ContextMenuContent className="w-48">
+              <ContextMenuItem
+                variant="destructive"
+                onSelect={() =>
+                  onSetRevertTarget({
+                    fileName: file.fileName,
+                    fileStatus: diffTypeToStatus(file.fileDiff.type),
+                  })
+                }
+              >
+                <Undo2 className="mr-2 h-4 w-4" />
+                Revert File
+              </ContextMenuItem>
+            </ContextMenuContent>
+          </ContextMenu>
+        ) : (
+          <Tooltip key={file.key}>
+            <TooltipTrigger asChild>{fileButton}</TooltipTrigger>
+            <TooltipContent>{file.fileName}</TooltipContent>
+          </Tooltip>
+        )
+      })}
+    </>
+  )
+})
 
 /**
  * Modal dialog for viewing GitHub-style git diffs using @pierre/diffs
@@ -250,6 +577,10 @@ export function GitDiffModal({
   const [selectedFileIndex, setSelectedFileIndex] = useState<number>(0)
   const [fileFilter, setFileFilter] = useState('')
   const fileListRef = useRef<HTMLDivElement>(null)
+  const [fileViewMode, setFileViewMode] = useState<FileViewMode>(
+    () => (localStorage.getItem('git-diff-file-view') as FileViewMode) ?? 'flat'
+  )
+  const [collapsedDirs, setCollapsedDirs] = useState<Set<string>>(new Set())
 
   // Use transition for file switching to keep UI responsive during heavy diff rendering
   const [, startTransition] = useTransition()
@@ -361,21 +692,6 @@ export function GitDiffModal({
     if (activeDiffType === 'branch') setCachedBranchStats(stats)
     else if (activeDiffType === 'uncommitted') setCachedUncommittedStats(stats)
   }, [diff, activeDiffType])
-
-  /** Map @pierre/diffs file type back to backend git status */
-  const diffTypeToStatus = useCallback((type: string): string => {
-    switch (type) {
-      case 'new':
-        return 'added'
-      case 'deleted':
-        return 'deleted'
-      case 'rename-pure':
-      case 'rename-changed':
-        return 'renamed'
-      default:
-        return 'modified'
-    }
-  }, [])
 
   const handleRevertFile = useCallback(async () => {
     if (!revertTarget || !diffRequest) return
@@ -608,6 +924,23 @@ export function GitDiffModal({
     return flattenedFiles.filter(f => f.fileName.toLowerCase().includes(lower))
   }, [flattenedFiles, fileFilter])
 
+  // Build file tree for tree view mode
+  const fileTree = useMemo(() => buildFileTree(filteredFiles), [filteredFiles])
+
+  const handleToggleDir = useCallback((dirPath: string) => {
+    setCollapsedDirs(prev => {
+      const next = new Set(prev)
+      if (next.has(dirPath)) next.delete(dirPath)
+      else next.add(dirPath)
+      return next
+    })
+  }, [])
+
+  const handleSetFileViewMode = useCallback((mode: FileViewMode) => {
+    setFileViewMode(mode)
+    localStorage.setItem('git-diff-file-view', mode)
+  }, [])
+
   // Compute display names: show minimal disambiguating path for duplicate basenames
   const displayNameMap = useMemo(() => {
     const map = new Map<string, string>()
@@ -748,7 +1081,6 @@ export function GitDiffModal({
     filteredFiles,
     selectedFileIndex,
     activeDiffType,
-    diffTypeToStatus,
   ])
 
   // Scroll selected file into view in sidebar
@@ -1120,7 +1452,10 @@ export function GitDiffModal({
                   {/* Mobile: file selector overlay */}
                   {isMobile && showMobileSidebar && (
                     <div className="absolute inset-0 z-20 bg-background flex flex-col">
-                      <div ref={fileListRef} className="flex-1 overflow-y-auto">
+                      <div
+                        ref={fileListRef}
+                        className="flex-1 overflow-y-auto"
+                      >
                         {flattenedFiles.length > 0 && (
                           <div className="sticky top-0 z-10 bg-background border-b border-border pb-2">
                             <div className="relative">
@@ -1133,83 +1468,118 @@ export function GitDiffModal({
                                   setSelectedFileIndex(0)
                                 }}
                                 placeholder="Filter files..."
-                                className="w-full bg-muted text-sm outline-none border border-border pl-7 pr-2 py-2.5 placeholder:text-muted-foreground focus:border-ring"
+                                className="w-full bg-muted text-sm outline-none border border-border pl-7 pr-16 py-2.5 placeholder:text-muted-foreground focus:border-ring"
                               />
+                              <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex gap-0.5">
+                                <button
+                                  type="button"
+                                  onClick={() => handleSetFileViewMode('flat')}
+                                  title="Flat list"
+                                  className={cn(
+                                    'p-1 rounded transition-colors',
+                                    fileViewMode === 'flat'
+                                      ? 'text-foreground bg-accent'
+                                      : 'text-muted-foreground hover:text-foreground'
+                                  )}
+                                >
+                                  <List className="h-3.5 w-3.5" />
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => handleSetFileViewMode('tree')}
+                                  title="Tree view"
+                                  className={cn(
+                                    'p-1 rounded transition-colors',
+                                    fileViewMode === 'tree'
+                                      ? 'text-foreground bg-accent'
+                                      : 'text-muted-foreground hover:text-foreground'
+                                  )}
+                                >
+                                  <ListTree className="h-3.5 w-3.5" />
+                                </button>
+                              </div>
                             </div>
                           </div>
                         )}
                         <div>
-                          {filteredFiles.map((file, index) => {
-                            const isSelected = index === selectedFileIndex
-                            const displayName =
-                              displayNameMap.get(file.key) ??
-                              getFilename(file.fileName)
-                            const isCheckedForCommit =
-                              activeDiffType === 'uncommitted' &&
-                              gitDiffSelectedFiles.has(file.fileName)
-                            return (
-                              <button
-                                key={file.key}
-                                type="button"
-                                data-index={index}
-                                onClick={() => handleSelectFile(index)}
-                                className={cn(
-                                  'w-full flex items-center gap-2 px-3 py-2.5 text-left transition-colors',
-                                  'hover:bg-muted/50',
-                                  isSelected && 'bg-accent',
-                                  isCheckedForCommit &&
-                                    !isSelected &&
-                                    'bg-primary/10'
-                                )}
-                              >
-                                {activeDiffType === 'uncommitted' && (
-                                  <div
-                                    role="checkbox"
-                                    aria-checked={isCheckedForCommit}
-                                    onClick={e => {
-                                      e.stopPropagation()
-                                      useUIStore
-                                        .getState()
-                                        .toggleGitDiffSelectedFile(
-                                          file.fileName
-                                        )
-                                    }}
+                          {fileViewMode === 'tree' ? (
+                            <FileTreeNodes
+                              nodes={fileTree}
+                              depth={0}
+                              selectedFileIndex={selectedFileIndex}
+                              activeDiffType={activeDiffType}
+                              gitDiffSelectedFiles={gitDiffSelectedFiles}
+                              collapsedDirs={collapsedDirs}
+                              filterActive={!!fileFilter}
+                              onSelectFile={handleSelectFile}
+                              onToggleDir={handleToggleDir}
+                              onSetRevertTarget={setRevertTarget}
+                            />
+                          ) : (
+                            filteredFiles.map((file, index) => {
+                              const isSelected = index === selectedFileIndex
+                              const displayName =
+                                displayNameMap.get(file.key) ??
+                                getFilename(file.fileName)
+                              const isCheckedForCommit = activeDiffType === 'uncommitted' && gitDiffSelectedFiles.has(file.fileName)
+                              return (
+                                <button
+                                  key={file.key}
+                                  type="button"
+                                  data-index={index}
+                                  onClick={() => handleSelectFile(index)}
+                                  className={cn(
+                                    'w-full flex items-center gap-2 px-3 py-2.5 text-left transition-colors',
+                                    'hover:bg-muted/50',
+                                    isSelected && 'bg-accent',
+                                    isCheckedForCommit && !isSelected && 'bg-primary/10'
+                                  )}
+                                >
+                                  {activeDiffType === 'uncommitted' && (
+                                    <div
+                                      role="checkbox"
+                                      aria-checked={isCheckedForCommit}
+                                      onClick={e => {
+                                        e.stopPropagation()
+                                        useUIStore.getState().toggleGitDiffSelectedFile(file.fileName)
+                                      }}
+                                      className={cn(
+                                        'h-3.5 w-3.5 shrink-0 rounded-sm border flex items-center justify-center transition-colors cursor-pointer',
+                                        isCheckedForCommit
+                                          ? 'bg-primary border-primary text-primary-foreground'
+                                          : 'border-muted-foreground/40 hover:border-muted-foreground'
+                                      )}
+                                    >
+                                      {isCheckedForCommit && (
+                                        <Check className="h-2.5 w-2.5" />
+                                      )}
+                                    </div>
+                                  )}
+                                  <FileText
                                     className={cn(
-                                      'h-3.5 w-3.5 shrink-0 rounded-sm border flex items-center justify-center transition-colors cursor-pointer',
-                                      isCheckedForCommit
-                                        ? 'bg-primary border-primary text-primary-foreground'
-                                        : 'border-muted-foreground/40 hover:border-muted-foreground'
+                                      'h-[1em] w-[1em] shrink-0',
+                                      getStatusColor(file.fileDiff.type)
                                     )}
-                                  >
-                                    {isCheckedForCommit && (
-                                      <Check className="h-2.5 w-2.5" />
+                                  />
+                                  <span className="truncate flex-1 text-sm select-text cursor-text">
+                                    {displayName}
+                                  </span>
+                                  <div className="flex items-center gap-1 shrink-0 text-xs">
+                                    {file.additions > 0 && (
+                                      <span className="text-green-500">
+                                        +{file.additions}
+                                      </span>
+                                    )}
+                                    {file.deletions > 0 && (
+                                      <span className="text-red-500">
+                                        -{file.deletions}
+                                      </span>
                                     )}
                                   </div>
-                                )}
-                                <FileText
-                                  className={cn(
-                                    'h-[1em] w-[1em] shrink-0',
-                                    getStatusColor(file.fileDiff.type)
-                                  )}
-                                />
-                                <span className="truncate flex-1 text-sm">
-                                  {displayName}
-                                </span>
-                                <div className="flex items-center gap-1 shrink-0 text-xs">
-                                  {file.additions > 0 && (
-                                    <span className="text-green-500">
-                                      +{file.additions}
-                                    </span>
-                                  )}
-                                  {file.deletions > 0 && (
-                                    <span className="text-red-500">
-                                      -{file.deletions}
-                                    </span>
-                                  )}
-                                </div>
-                              </button>
-                            )
-                          })}
+                                </button>
+                              )
+                            })
+                          )}
                         </div>
                       </div>
                     </div>
@@ -1294,11 +1664,7 @@ export function GitDiffModal({
                       className="flex-1 min-h-0"
                     >
                       {/* File sidebar */}
-                      <ResizablePanel
-                        defaultSize={25}
-                        minSize={15}
-                        maxSize={50}
-                      >
+                      <ResizablePanel defaultSize={25} minSize={15} maxSize={50}>
                         <div
                           ref={fileListRef}
                           className={cn(
@@ -1318,124 +1684,155 @@ export function GitDiffModal({
                                     setSelectedFileIndex(0)
                                   }}
                                   placeholder="Filter files..."
-                                  className="w-full bg-muted text-sm outline-none border border-border pl-7 pr-2 py-2.5 placeholder:text-muted-foreground focus:border-ring"
+                                  className="w-full bg-muted text-sm outline-none border border-border pl-7 pr-16 py-2.5 placeholder:text-muted-foreground focus:border-ring"
                                 />
+                                <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex gap-0.5">
+                                  <button
+                                    type="button"
+                                    onClick={() => handleSetFileViewMode('flat')}
+                                    title="Flat list"
+                                    className={cn(
+                                      'p-1 rounded transition-colors',
+                                      fileViewMode === 'flat'
+                                        ? 'text-foreground bg-accent'
+                                        : 'text-muted-foreground hover:text-foreground'
+                                    )}
+                                  >
+                                    <List className="h-3.5 w-3.5" />
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => handleSetFileViewMode('tree')}
+                                    title="Tree view"
+                                    className={cn(
+                                      'p-1 rounded transition-colors',
+                                      fileViewMode === 'tree'
+                                        ? 'text-foreground bg-accent'
+                                        : 'text-muted-foreground hover:text-foreground'
+                                    )}
+                                  >
+                                    <ListTree className="h-3.5 w-3.5" />
+                                  </button>
+                                </div>
                               </div>
                             </div>
                           )}
                           <div>
-                            {filteredFiles.map((file, index) => {
-                              const isSelected = index === selectedFileIndex
-                              const displayName =
-                                displayNameMap.get(file.key) ??
-                                getFilename(file.fileName)
+                            {fileViewMode === 'tree' ? (
+                              <FileTreeNodes
+                                nodes={fileTree}
+                                depth={0}
+                                selectedFileIndex={selectedFileIndex}
+                                activeDiffType={activeDiffType}
+                                gitDiffSelectedFiles={gitDiffSelectedFiles}
+                                collapsedDirs={collapsedDirs}
+                                filterActive={!!fileFilter}
+                                onSelectFile={handleSelectFile}
+                                onToggleDir={handleToggleDir}
+                                onSetRevertTarget={setRevertTarget}
+                              />
+                            ) : (
+                              filteredFiles.map((file, index) => {
+                                const isSelected = index === selectedFileIndex
+                                const displayName =
+                                  displayNameMap.get(file.key) ??
+                                  getFilename(file.fileName)
 
-                              const isCheckedForCommit =
-                                activeDiffType === 'uncommitted' &&
-                                gitDiffSelectedFiles.has(file.fileName)
+                                const isCheckedForCommit = activeDiffType === 'uncommitted' && gitDiffSelectedFiles.has(file.fileName)
 
-                              const fileButton = (
-                                <button
-                                  type="button"
-                                  data-index={index}
-                                  onClick={() => handleSelectFile(index)}
-                                  className={cn(
-                                    'w-full flex items-center gap-2 px-3 py-2 text-left transition-colors',
-                                    'hover:bg-muted/50',
-                                    isSelected && 'bg-accent',
-                                    isCheckedForCommit &&
-                                      !isSelected &&
-                                      'bg-primary/10'
-                                  )}
-                                >
-                                  {activeDiffType === 'uncommitted' && (
-                                    <div
-                                      role="checkbox"
-                                      aria-checked={isCheckedForCommit}
-                                      onClick={e => {
-                                        e.stopPropagation()
-                                        useUIStore
-                                          .getState()
-                                          .toggleGitDiffSelectedFile(
-                                            file.fileName
-                                          )
-                                      }}
+                                const fileButton = (
+                                  <button
+                                    type="button"
+                                    data-index={index}
+                                    onClick={() => handleSelectFile(index)}
+                                    className={cn(
+                                      'w-full flex items-center gap-2 px-3 py-2 text-left transition-colors',
+                                      'hover:bg-muted/50',
+                                      isSelected && 'bg-accent',
+                                      isCheckedForCommit && !isSelected && 'bg-primary/10'
+                                    )}
+                                  >
+                                    {activeDiffType === 'uncommitted' && (
+                                      <div
+                                        role="checkbox"
+                                        aria-checked={isCheckedForCommit}
+                                        onClick={e => {
+                                          e.stopPropagation()
+                                          useUIStore.getState().toggleGitDiffSelectedFile(file.fileName)
+                                        }}
+                                        className={cn(
+                                          'h-3.5 w-3.5 shrink-0 rounded-sm border flex items-center justify-center transition-colors cursor-pointer',
+                                          isCheckedForCommit
+                                            ? 'bg-primary border-primary text-primary-foreground'
+                                            : 'border-muted-foreground/40 hover:border-muted-foreground'
+                                        )}
+                                      >
+                                        {isCheckedForCommit && (
+                                          <Check className="h-2.5 w-2.5" />
+                                        )}
+                                      </div>
+                                    )}
+                                    <FileText
                                       className={cn(
-                                        'h-3.5 w-3.5 shrink-0 rounded-sm border flex items-center justify-center transition-colors cursor-pointer',
-                                        isCheckedForCommit
-                                          ? 'bg-primary border-primary text-primary-foreground'
-                                          : 'border-muted-foreground/40 hover:border-muted-foreground'
+                                        'h-[1em] w-[1em] shrink-0',
+                                        getStatusColor(file.fileDiff.type)
                                       )}
-                                    >
-                                      {isCheckedForCommit && (
-                                        <Check className="h-2.5 w-2.5" />
+                                    />
+                                    <span className="truncate flex-1 select-text cursor-text">
+                                      {displayName}
+                                    </span>
+                                    <div className="flex items-center gap-1 shrink-0">
+                                      {file.additions > 0 && (
+                                        <span className="text-green-500">
+                                          +{file.additions}
+                                        </span>
+                                      )}
+                                      {file.deletions > 0 && (
+                                        <span className="text-red-500">
+                                          -{file.deletions}
+                                        </span>
                                       )}
                                     </div>
-                                  )}
-                                  <FileText
-                                    className={cn(
-                                      'h-[1em] w-[1em] shrink-0',
-                                      getStatusColor(file.fileDiff.type)
-                                    )}
-                                  />
-                                  <span className="truncate flex-1">
-                                    {displayName}
-                                  </span>
-                                  <div className="flex items-center gap-1 shrink-0">
-                                    {file.additions > 0 && (
-                                      <span className="text-green-500">
-                                        +{file.additions}
-                                      </span>
-                                    )}
-                                    {file.deletions > 0 && (
-                                      <span className="text-red-500">
-                                        -{file.deletions}
-                                      </span>
-                                    )}
-                                  </div>
-                                </button>
-                              )
+                                  </button>
+                                )
 
-                              return activeDiffType === 'uncommitted' ? (
-                                <ContextMenu key={file.key}>
-                                  <Tooltip>
-                                    <ContextMenuTrigger asChild>
-                                      <TooltipTrigger asChild>
-                                        {fileButton}
-                                      </TooltipTrigger>
-                                    </ContextMenuTrigger>
-                                    <TooltipContent>
-                                      {file.fileName}
-                                    </TooltipContent>
+                                return activeDiffType === 'uncommitted' ? (
+                                  <ContextMenu key={file.key}>
+                                    <Tooltip>
+                                      <ContextMenuTrigger asChild>
+                                        <TooltipTrigger asChild>
+                                          {fileButton}
+                                        </TooltipTrigger>
+                                      </ContextMenuTrigger>
+                                      <TooltipContent>{file.fileName}</TooltipContent>
+                                    </Tooltip>
+                                    <ContextMenuContent className="w-48">
+                                      <ContextMenuItem
+                                        variant="destructive"
+                                        onSelect={() =>
+                                          setRevertTarget({
+                                            fileName: file.fileName,
+                                            fileStatus: diffTypeToStatus(
+                                              file.fileDiff.type
+                                            ),
+                                          })
+                                        }
+                                      >
+                                        <Undo2 className="mr-2 h-4 w-4" />
+                                        Revert File
+                                      </ContextMenuItem>
+                                    </ContextMenuContent>
+                                  </ContextMenu>
+                                ) : (
+                                  <Tooltip key={file.key}>
+                                    <TooltipTrigger asChild>
+                                      {fileButton}
+                                    </TooltipTrigger>
+                                    <TooltipContent>{file.fileName}</TooltipContent>
                                   </Tooltip>
-                                  <ContextMenuContent className="w-48">
-                                    <ContextMenuItem
-                                      variant="destructive"
-                                      onSelect={() =>
-                                        setRevertTarget({
-                                          fileName: file.fileName,
-                                          fileStatus: diffTypeToStatus(
-                                            file.fileDiff.type
-                                          ),
-                                        })
-                                      }
-                                    >
-                                      <Undo2 className="mr-2 h-4 w-4" />
-                                      Revert File
-                                    </ContextMenuItem>
-                                  </ContextMenuContent>
-                                </ContextMenu>
-                              ) : (
-                                <Tooltip key={file.key}>
-                                  <TooltipTrigger asChild>
-                                    {fileButton}
-                                  </TooltipTrigger>
-                                  <TooltipContent>
-                                    {file.fileName}
-                                  </TooltipContent>
-                                </Tooltip>
-                              )
-                            })}
+                                )
+                              })
+                            )}
                           </div>
                         </div>
                       </ResizablePanel>

--- a/src/components/chat/HighlightActionPopover.tsx
+++ b/src/components/chat/HighlightActionPopover.tsx
@@ -1,0 +1,315 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Highlighter, X } from 'lucide-react'
+import { useChatStore } from '@/store/chat-store'
+import { generateId } from '@/lib/uuid'
+import type { TextHighlight } from '@/types/chat'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+interface HighlightActionPopoverProps {
+  sessionId: string
+  /** Ref to the scrollable message container */
+  containerRef: React.RefObject<HTMLDivElement | null>
+}
+
+/**
+ * Floating popover that appears when text is selected in a message.
+ * Shows a highlighter icon to create a highlight, or an X to remove an existing one.
+ */
+export function HighlightActionPopover({
+  sessionId,
+  containerRef,
+}: HighlightActionPopoverProps) {
+  const [popover, setPopover] = useState<{
+    x: number
+    y: number
+    type: 'add' | 'remove'
+    // For 'add': selection info
+    messageId?: string
+    text?: string
+    startOffset?: number
+    // For 'remove': highlight to remove
+    highlightId?: string
+  } | null>(null)
+
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Cancel any pending dismiss when the mouse enters the popover
+  const handlePopoverMouseEnter = useCallback(() => {
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current)
+      dismissTimerRef.current = null
+    }
+  }, [])
+
+  // Start dismiss timer when the mouse leaves the popover
+  const handlePopoverMouseLeave = useCallback(() => {
+    dismissTimerRef.current = setTimeout(() => {
+      setPopover(prev => (prev?.type === 'remove' ? null : prev))
+    }, 300)
+  }, [])
+
+  // Handle text selection for adding highlights.
+  // NOTE: We register the handler unconditionally on `document` and read
+  // containerRef.current lazily inside the handler. This avoids a race where
+  // the effect runs before ScrollArea mounts (containerRef.current is null)
+  // and the handler is never registered.
+  useEffect(() => {
+    const handleSelectionChange = () => {
+      const container = containerRef.current
+      if (!container) return
+
+      const selection = window.getSelection()
+      if (!selection || selection.isCollapsed || !selection.rangeCount) {
+        // Don't dismiss if mouse is over the popover
+        if (popoverRef.current?.matches(':hover')) return
+        setPopover(null)
+        return
+      }
+
+      const range = selection.getRangeAt(0)
+      if (!range || !container.contains(range.commonAncestorContainer)) {
+        return
+      }
+
+      // Find the message element containing the selection
+      const messageEl = findMessageElement(range.commonAncestorContainer)
+      if (!messageEl) return
+
+      const messageId = messageEl.getAttribute('data-message-id')
+      if (!messageId) return
+
+      const selectedText = selection.toString().trim()
+      if (!selectedText || selectedText.length < 2) return
+
+      // Compute the character offset within the message content
+      const startOffset = getTextOffset(
+        messageEl,
+        range.startContainer,
+        range.startOffset
+      )
+
+      // Position the popover near the end of the selection (viewport-fixed coords)
+      const rect = range.getBoundingClientRect()
+
+      setPopover({
+        x: rect.right,
+        y: rect.top - 32,
+        type: 'add',
+        messageId,
+        text: selectedText,
+        startOffset,
+      })
+    }
+
+    document.addEventListener('selectionchange', handleSelectionChange)
+    return () =>
+      document.removeEventListener('selectionchange', handleSelectionChange)
+  }, [containerRef, sessionId])
+
+  // Handle mouse enter on existing highlights to show remove button
+  useEffect(() => {
+    let lastCheck = 0
+    const handleMouseMove = (e: MouseEvent) => {
+      const container = containerRef.current
+      if (!container) return
+      // Throttle to ~60fps
+      const now = Date.now()
+      if (now - lastCheck < 16) return
+      lastCheck = now
+
+      // Don't show remove popover when there's an active text selection
+      const selection = window.getSelection()
+      if (selection && !selection.isCollapsed) return
+
+      if (!CSS.highlights) return
+
+      const highlight = CSS.highlights.get('user-highlight')
+      if (!highlight) return
+
+      const highlights =
+        useChatStore.getState().sessionHighlights[sessionId] ?? []
+      if (highlights.length === 0) return
+
+      // Check each highlight range to see if the mouse is over it
+      for (const abstractRange of highlight) {
+        if (!(abstractRange instanceof Range)) continue
+        const rects = abstractRange.getClientRects()
+        for (const rect of rects) {
+          if (
+            e.clientX >= rect.left &&
+            e.clientX <= rect.right &&
+            e.clientY >= rect.top &&
+            e.clientY <= rect.bottom
+          ) {
+            // Find which highlight this range belongs to
+            const rangeText = abstractRange.toString()
+            const matchingHighlight = highlights.find(
+              h => h.text === rangeText
+            )
+            if (!matchingHighlight) continue
+
+            // Cancel any pending dismiss -- mouse is back on a highlight
+            if (dismissTimerRef.current) {
+              clearTimeout(dismissTimerRef.current)
+              dismissTimerRef.current = null
+            }
+            setPopover({
+              x: rect.right,
+              y: rect.top - 32,
+              type: 'remove',
+              highlightId: matchingHighlight.id,
+            })
+            return
+          }
+        }
+      }
+
+      // Mouse not over any highlight -- dismiss with grace period
+      if (!dismissTimerRef.current) {
+        dismissTimerRef.current = setTimeout(() => {
+          dismissTimerRef.current = null
+          // Re-check: don't dismiss if mouse is now over the popover
+          if (popoverRef.current?.matches(':hover')) return
+          setPopover(prev => (prev?.type === 'remove' ? null : prev))
+        }, 300)
+      }
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      if (dismissTimerRef.current) {
+        clearTimeout(dismissTimerRef.current)
+        dismissTimerRef.current = null
+      }
+    }
+  }, [containerRef, sessionId])
+
+  // Dismiss when clicking outside
+  useEffect(() => {
+    if (!popover) return
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(e.target as Node)
+      ) {
+        // Small delay to let selection handlers fire first
+        setTimeout(() => {
+          const selection = window.getSelection()
+          if (!selection || selection.isCollapsed) {
+            setPopover(null)
+          }
+        }, 100)
+      }
+    }
+
+    document.addEventListener('mousedown', handleMouseDown)
+    return () => document.removeEventListener('mousedown', handleMouseDown)
+  }, [popover])
+
+  const handleAdd = useCallback(() => {
+    if (popover?.type !== 'add' || !popover.messageId || !popover.text) return
+
+    const highlight: TextHighlight = {
+      id: generateId(),
+      message_id: popover.messageId,
+      text: popover.text,
+      start_offset: popover.startOffset ?? 0,
+    }
+
+    useChatStore.getState().addHighlight(sessionId, highlight)
+
+    // Clear the selection
+    window.getSelection()?.removeAllRanges()
+    setPopover(null)
+  }, [popover, sessionId])
+
+  const handleRemove = useCallback(() => {
+    if (popover?.type !== 'remove' || !popover.highlightId) return
+
+    useChatStore.getState().removeHighlight(sessionId, popover.highlightId)
+    setPopover(null)
+  }, [popover, sessionId])
+
+  if (!popover) return null
+
+  return (
+    <div
+      ref={popoverRef}
+      className="fixed z-50 flex items-center"
+      style={{
+        left: popover.x,
+        top: popover.y,
+      }}
+      onMouseEnter={handlePopoverMouseEnter}
+      onMouseLeave={handlePopoverMouseLeave}
+    >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={popover.type === 'add' ? handleAdd : handleRemove}
+            className={`p-1 rounded-md shadow-md border border-border cursor-pointer transition-colors ${
+              popover.type === 'remove'
+                ? 'bg-destructive/10 hover:bg-destructive/20 text-destructive'
+                : 'bg-yellow-500/20 hover:bg-yellow-500/30 text-yellow-600 dark:text-yellow-400'
+            }`}
+          >
+            {popover.type === 'remove' ? (
+              <X className="size-3.5" />
+            ) : (
+              <Highlighter className="size-3.5" />
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          {popover.type === 'remove' ? 'Remove highlight' : 'Highlight text'}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}
+
+/** Walk up the DOM to find the nearest element with data-message-id */
+function findMessageElement(node: Node): Element | null {
+  let current: Node | null = node
+  while (current) {
+    if (
+      current instanceof Element &&
+      current.hasAttribute('data-message-id')
+    ) {
+      return current
+    }
+    current = current.parentNode
+  }
+  return null
+}
+
+/** Compute the text offset of a position within a message element */
+function getTextOffset(
+  container: Element,
+  targetNode: Node,
+  targetOffset: number
+): number {
+  const walker = document.createTreeWalker(
+    container,
+    NodeFilter.SHOW_TEXT,
+    null
+  )
+
+  let offset = 0
+  let node: Text | null
+  while ((node = walker.nextNode() as Text | null)) {
+    if (node === targetNode) {
+      return offset + targetOffset
+    }
+    offset += node.textContent?.length ?? 0
+  }
+  return offset
+}

--- a/src/components/chat/MemoizedFileDiff.tsx
+++ b/src/components/chat/MemoizedFileDiff.tsx
@@ -130,7 +130,7 @@ export const MemoizedFileDiff = memo(
               getStatusColor(fileDiff.type)
             )}
           />
-          <span className="truncate">{fileName}</span>
+          <span className="truncate select-text cursor-text">{fileName}</span>
           {fileDiff.prevName && fileDiff.prevName !== fileName && (
             <span className="text-muted-foreground truncate">
               ← {fileDiff.prevName}

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -703,7 +703,7 @@ export const MessageItem = memo(function MessageItem({
       )}
     >
       {message.role === 'user' ? (
-        <div className="relative group flex items-start gap-1 max-w-[85%] sm:max-w-[70%]">
+        <div className="relative group flex items-start gap-1 max-w-[85%] sm:max-w-[70%]" data-message-id={message.id}>
           {/* Copy to clipboard button - appears on hover */}
           {onCopyToInput && (
             <Tooltip>
@@ -724,7 +724,7 @@ export const MessageItem = memo(function MessageItem({
           </div>
         </div>
       ) : (
-        <div className="text-foreground/90 w-full min-w-0 break-words">
+        <div className="text-foreground/90 w-full min-w-0 break-words" data-message-id={message.id}>
           {messageBoxContent}
         </div>
       )}

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -51,6 +51,7 @@ import {
   stripAllMarkers,
 } from './message-content-utils'
 import { hasQuestionAnswerOutput } from '@/types/chat'
+import { usePreferences } from '@/services/preferences'
 
 interface MessageItemProps {
   /** The message to render */
@@ -166,6 +167,9 @@ export const MessageItem = memo(function MessageItem({
   hideApproveButtons,
   durationMs,
 }: MessageItemProps) {
+  const { data: preferences } = usePreferences()
+  const expandToolCalls = preferences?.expand_tool_calls ?? false
+
   // Only show Approve button for the last message with ExitPlanMode
   const isLatestPlanRequest = messageIndex === lastPlanMessageIndex
 
@@ -433,6 +437,7 @@ export const MessageItem = memo(function MessageItem({
                             allToolCalls={message.tool_calls ?? []}
                             onFileClick={onFileClick}
                             isStreaming={false}
+                            defaultExpanded={expandToolCalls}
                           />
                         )
                       case 'standalone':
@@ -441,6 +446,7 @@ export const MessageItem = memo(function MessageItem({
                             toolCall={item.tool}
                             onFileClick={onFileClick}
                             isStreaming={false}
+                            defaultExpanded={expandToolCalls}
                           />
                         )
                       case 'stackedGroup':
@@ -449,6 +455,7 @@ export const MessageItem = memo(function MessageItem({
                             items={item.items}
                             onFileClick={onFileClick}
                             isStreaming={false}
+                            defaultExpanded={expandToolCalls}
                           />
                         )
                       case 'askUserQuestion': {
@@ -506,6 +513,7 @@ export const MessageItem = memo(function MessageItem({
                             toolCall={item.tool}
                             onFileClick={onFileClick}
                             isStreaming={false}
+                            defaultExpanded={expandToolCalls}
                           />
                         )
                       case 'exitPlanMode': {
@@ -594,6 +602,7 @@ export const MessageItem = memo(function MessageItem({
               <ToolCallsDisplay
                 toolCalls={message.tool_calls}
                 sessionId={message.session_id}
+                defaultExpanded={expandToolCalls}
                 hasFollowUpMessage={hasFollowUpMessage}
                 onQuestionAnswer={onQuestionAnswer}
                 onQuestionSkip={onQuestionSkip}

--- a/src/components/chat/RecapBanner.tsx
+++ b/src/components/chat/RecapBanner.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from 'react'
+import { ChevronDown, ChevronUp, Loader2, Sparkles, X } from 'lucide-react'
+import type { SessionDigest } from '@/types/chat'
+
+interface RecapBannerProps {
+  digest: SessionDigest | null
+  isOpen: boolean
+  onClose: () => void
+  isGenerating?: boolean
+}
+
+export function RecapBanner({
+  digest,
+  isOpen,
+  onClose,
+  isGenerating,
+}: RecapBannerProps) {
+  const [expanded, setExpanded] = useState(false)
+  const prevDigestRef = useRef(digest)
+
+  // Auto-expand when digest arrives (was null -> now has value)
+  useEffect(() => {
+    if (digest && !prevDigestRef.current) {
+      setExpanded(true)
+    }
+    prevDigestRef.current = digest
+  }, [digest])
+
+  if (!isOpen) return null
+
+  const showExpanded = digest && expanded
+
+  return (
+    <div className="relative z-20 border-b border-border bg-muted/60 backdrop-blur-sm">
+      <div className="mx-auto max-w-7xl px-4 md:px-6">
+        <div className="flex items-start gap-2 py-2">
+          <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+
+          <div className="min-w-0 flex-1">
+            {isGenerating && !digest ? (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Generating recap...
+              </div>
+            ) : digest ? (
+              <div className="space-y-1">
+                <p
+                  className={`text-xs text-foreground ${showExpanded ? '' : 'line-clamp-1'}`}
+                >
+                  {digest.chat_summary}
+                </p>
+                {showExpanded && (
+                  <p className="text-xs text-muted-foreground">
+                    <span className="font-medium text-foreground">
+                      Last action:
+                    </span>{' '}
+                    {digest.last_action}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                No recap available
+              </p>
+            )}
+          </div>
+
+          <div className="flex shrink-0 items-center gap-0.5">
+            {digest && (
+              <button
+                type="button"
+                onClick={() => setExpanded(e => !e)}
+                className="rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                {showExpanded ? (
+                  <ChevronUp className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronDown className="h-3.5 w-3.5" />
+                )}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/RecapDialog.tsx
+++ b/src/components/chat/RecapDialog.tsx
@@ -33,7 +33,7 @@ export function RecapDialog({
           </DialogTitle>
         </DialogHeader>
         {digest ? (
-          <div className="space-y-4 pt-2">
+          <div className="space-y-4 pt-2 select-text cursor-text">
             <div>
               <p className="text-sm text-foreground">{digest.chat_summary}</p>
             </div>

--- a/src/components/chat/ReviewFindingBlock.tsx
+++ b/src/components/chat/ReviewFindingBlock.tsx
@@ -146,7 +146,7 @@ export function ReviewFindingBlock({
 
         {/* Content */}
         <CollapsibleContent>
-          <div className="px-3 pb-3 pt-1 space-y-3">
+          <div className="px-3 pb-3 pt-1 space-y-3 select-text cursor-text">
             {/* Description */}
             {finding.description && (
               <p className="text-sm text-muted-foreground">

--- a/src/components/chat/ReviewFindingBlock.tsx
+++ b/src/components/chat/ReviewFindingBlock.tsx
@@ -120,7 +120,7 @@ export function ReviewFindingBlock({
                 isExpanded && 'rotate-90'
               )}
             />
-            <Icon className={cn('h-4 w-4 shrink-0', config.color)} />
+            <span title={config.label}><Icon className={cn('h-4 w-4 shrink-0', config.color)} /></span>
             <Badge
               variant="outline"
               className={cn('text-xs', config.color, 'border-current')}
@@ -374,7 +374,7 @@ export function ReviewFindingsList({
       data-review-findings={unfixedCount > 0 ? 'unfixed' : 'all-fixed'}
     >
       <div className="flex items-center gap-2 mb-2">
-        <AlertCircle className="h-4 w-4 text-muted-foreground" />
+        <span title="Review findings"><AlertCircle className="h-4 w-4 text-muted-foreground" /></span>
         <span className="text-sm font-medium">
           {findings.length} finding{findings.length === 1 ? '' : 's'}
           {fixedCount > 0 && (

--- a/src/components/chat/ReviewResultsPanel.tsx
+++ b/src/components/chat/ReviewResultsPanel.tsx
@@ -436,14 +436,14 @@ Please apply all these fixes to the codebase.`
                       isFixed && 'opacity-50'
                     )}
                   >
-                    <Icon
+                    <span title={config.label}><Icon
                       className={cn('h-3.5 w-3.5 shrink-0', config.color)}
-                    />
+                    /></span>
                     <span className="flex-1 truncate text-xs">
                       {finding.title}
                     </span>
                     {isFixed && (
-                      <CheckCircle2 className="h-3 w-3 shrink-0 text-green-500" />
+                      <span title="Fixed"><CheckCircle2 className="h-3 w-3 shrink-0 text-green-500" /></span>
                     )}
                   </button>
                 )
@@ -475,6 +475,7 @@ Please apply all these fixes to the codebase.`
                           'mt-0.5 rounded-md p-1.5',
                           config.bgColor
                         )}
+                        title={config.label}
                       >
                         <Icon className={cn('h-4 w-4', config.color)} />
                       </div>

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -738,9 +738,10 @@ export function SessionChatModal({
     [worktreeId]
   )
 
-  // Close on Escape key
+  // Close on Escape key (can be disabled via preferences, respects confirm_session_close)
   useEffect(() => {
     if (!isOpen) return
+    if (preferences?.esc_closes_session === false) return
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         const target = e.target as HTMLElement
@@ -758,12 +759,21 @@ export function SessionChatModal({
         // Don't close if ESC originated inside a child dialog/sheet portal
         if (portalAncestor) return
 
-        handleClose()
+        // Respect confirm_session_close: show confirmation for non-empty sessions
+        // (same guard as CMD+W, prevents accidental close via Escape)
+        const currentSession = sessions.find(s => s.id === currentSessionId)
+        const sessionIsEmpty = !currentSession?.message_count
+        if (preferences?.confirm_session_close !== false && !sessionIsEmpty) {
+          pendingCloseAction.current = handleClose
+          setCloseConfirmOpen(true)
+        } else {
+          handleClose()
+        }
       }
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [isOpen, handleClose, closeConfirmOpen])
+  }, [isOpen, handleClose, closeConfirmOpen, preferences?.esc_closes_session, preferences?.confirm_session_close, sessions, currentSessionId])
 
   if (!isOpen || !worktreeId) return null
 

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -1151,6 +1151,7 @@ export function SessionChatModal({
                           <StatusIndicator
                             status={config.indicatorStatus}
                             variant={config.indicatorVariant}
+                            title={config.label}
                             className="h-1.5 w-1.5"
                           />
                           {idx < 9 && (

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -431,6 +431,8 @@ export function SessionChatModal({
         e.preventDefault()
         handleRenameSubmit(sessionId)
       } else if (e.key === 'Escape') {
+        // stopPropagation prevents the modal's global Escape handler from also closing the modal
+        e.stopPropagation()
         setRenamingSessionId(null)
       }
     },
@@ -537,6 +539,18 @@ export function SessionChatModal({
     window.addEventListener('toggle-session-label', handler)
     return () => window.removeEventListener('toggle-session-label', handler)
   }, [isOpen])
+
+  // Listen for command:rename-session event (CMD+E)
+  useEffect(() => {
+    if (!isOpen) return
+    const handler = () => {
+      if (currentSessionId && currentSession) {
+        handleStartRenameImmediate(currentSessionId, currentSession.name)
+      }
+    }
+    window.addEventListener('command:rename-session', handler)
+    return () => window.removeEventListener('command:rename-session', handler)
+  }, [isOpen, currentSessionId, currentSession, handleStartRenameImmediate])
 
   const handleClose = useCallback(() => {
     onClose()

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -576,8 +576,13 @@ export function SessionChatModal({
     )
   }, [worktreeId, worktreePath, createSession])
 
-  // Sorted sessions for tab order (waiting → review → idle)
+  // Sorted sessions for tab order — status-priority or flat chronological
+  const groupByStatus = preferences?.sidebar_group_by_status ?? true
   const sortedSessions = useMemo(() => {
+    if (!groupByStatus) {
+      // Flat chronological: oldest first
+      return [...sessions].sort((a, b) => a.created_at - b.created_at)
+    }
     const priority: Record<string, number> = {
       waiting: 0,
       permission: 0,
@@ -590,7 +595,7 @@ export function SessionChatModal({
       // Stable secondary sort: oldest first (consistent across refetches)
       return a.created_at - b.created_at
     })
-  }, [sessions, storeState])
+  }, [sessions, storeState, groupByStatus])
 
   // Keep ref in sync for selectVisualNeighbor (declared above sortedSessions)
   sortedSessionsRef.current = sortedSessions

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -812,6 +812,7 @@ export function SessionChatModal({
               <GitStatusBadges
                 behindCount={behindCount}
                 unpushedCount={unpushedCount}
+                unpushedCommits={gitStatus?.unpushed_commits}
                 diffAdded={isMobile ? 0 : uncommittedAdded}
                 diffRemoved={isMobile ? 0 : uncommittedRemoved}
                 branchDiffAdded={isBase || isMobile ? 0 : branchDiffAdded}

--- a/src/components/chat/SessionDebugPanel.tsx
+++ b/src/components/chat/SessionDebugPanel.tsx
@@ -97,7 +97,7 @@ export function SessionDebugPanel({
   }
 
   return (
-    <div className="p-4 space-y-2 text-sm">
+    <div className="p-4 space-y-2 text-sm select-text cursor-text">
       {/* Header */}
       <div className="flex items-center justify-between mb-2">
         <span className="font-semibold">Debug Info</span>

--- a/src/components/chat/SessionListRow.tsx
+++ b/src/components/chat/SessionListRow.tsx
@@ -103,6 +103,7 @@ export const SessionListRow = forwardRef<HTMLDivElement, SessionCardProps>(
             <StatusIndicator
               status={config.indicatorStatus}
               variant={config.indicatorVariant}
+              title={config.label}
               className="h-2 w-2 shrink-0"
             />
 

--- a/src/components/chat/SetupScriptOutput.tsx
+++ b/src/components/chat/SetupScriptOutput.tsx
@@ -65,7 +65,7 @@ export function SetupScriptOutput({
           )}
         </div>
         <CollapsibleContent>
-          <div className="border-t border-muted px-4 py-3">
+          <div className="border-t border-muted px-4 py-3 select-text cursor-text">
             <div className="mb-2 text-xs text-muted-foreground">
               <span className="opacity-60">workdir:</span> {result.worktreePath}
             </div>

--- a/src/components/chat/SetupScriptOutput.tsx
+++ b/src/components/chat/SetupScriptOutput.tsx
@@ -27,6 +27,7 @@ export function SetupScriptOutput({
 
   const StatusIcon = result.success ? CheckCircle2 : XCircle
   const statusColor = result.success ? 'text-green-500' : 'text-destructive'
+  const statusTitle = result.success ? 'Success' : 'Failed'
   const statusText = result.success
     ? `Setup script completed for ${result.worktreeName}`
     : `Setup script failed for ${result.worktreeName}`
@@ -49,7 +50,7 @@ export function SetupScriptOutput({
                 isExpanded && 'rotate-90'
               )}
             />
-            <StatusIcon className={cn('h-4 w-4 shrink-0', statusColor)} />
+            <span title={statusTitle}><StatusIcon className={cn('h-4 w-4 shrink-0', statusColor)} /></span>
             <span className="truncate text-muted-foreground">{statusText}</span>
           </CollapsibleTrigger>
           {/* Only show dismiss button on failure - success messages should persist */}

--- a/src/components/chat/StreamingMessage.tsx
+++ b/src/components/chat/StreamingMessage.tsx
@@ -22,6 +22,7 @@ import { EditedFilesDisplay } from './EditedFilesDisplay'
 import { ThinkingBlock } from './ThinkingBlock'
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary'
 import { logger } from '@/lib/logger'
+import { usePreferences } from '@/services/preferences'
 
 interface StreamingMessageProps {
   /** Session ID for the streaming message */
@@ -72,6 +73,9 @@ export const StreamingMessage = memo(function StreamingMessage({
   getSubmittedAnswers,
   areQuestionsSkipped,
 }: StreamingMessageProps) {
+  const { data: preferences } = usePreferences()
+  const expandToolCalls = preferences?.expand_tool_calls ?? false
+
   const resolvedPlan = resolvePlanContent({
     toolCalls,
     messageContent: streamingContent,
@@ -213,6 +217,7 @@ export const StreamingMessage = memo(function StreamingMessage({
                                 onFileClick={onFileClick}
                                 isStreaming={true}
                                 isIncomplete={isIncomplete}
+                                defaultExpanded={expandToolCalls}
                               />
                             )
                           case 'standalone':
@@ -222,6 +227,7 @@ export const StreamingMessage = memo(function StreamingMessage({
                                 onFileClick={onFileClick}
                                 isStreaming={true}
                                 isIncomplete={isIncomplete}
+                                defaultExpanded={expandToolCalls}
                               />
                             )
                           case 'stackedGroup':
@@ -231,6 +237,7 @@ export const StreamingMessage = memo(function StreamingMessage({
                                 onFileClick={onFileClick}
                                 isStreaming={true}
                                 isIncomplete={isIncomplete}
+                                defaultExpanded={expandToolCalls}
                               />
                             )
                           case 'askUserQuestion': {
@@ -285,6 +292,7 @@ export const StreamingMessage = memo(function StreamingMessage({
                                 onFileClick={onFileClick}
                                 isStreaming={true}
                                 isIncomplete={false}
+                                defaultExpanded={expandToolCalls}
                               />
                             )
                           case 'exitPlanMode': {
@@ -349,7 +357,7 @@ export const StreamingMessage = memo(function StreamingMessage({
           <ToolCallsDisplay
             toolCalls={toolCalls}
             sessionId={sessionId}
-            defaultExpanded={false}
+            defaultExpanded={expandToolCalls}
             isStreaming={true}
             onQuestionAnswer={onQuestionAnswer}
             onQuestionSkip={onQuestionSkip}

--- a/src/components/chat/TerminalView.tsx
+++ b/src/components/chat/TerminalView.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useRef, useCallback, memo } from 'react'
-import { Plus, X, Minus, Terminal, ChevronUp } from 'lucide-react'
+import { Plus, X, Minus, Terminal, ChevronUp, WrapText } from 'lucide-react'
 import { invoke } from '@/lib/transport'
 import { useTerminal } from '@/hooks/useTerminal'
 import { useTerminalStore, type TerminalInstance } from '@/store/terminal-store'
 import {
   disposeTerminal,
   disposeAllWorktreeTerminals,
+  setWordWrap,
+  isWordWrapEnabled,
 } from '@/lib/terminal-instances'
+import { usePreferences, usePatchPreferences } from '@/services/preferences'
 import { Kbd } from '@/components/ui/kbd'
 import { formatShortcutDisplay } from '@/types/keybindings'
 import { cn } from '@/lib/utils'
@@ -93,6 +96,43 @@ const TerminalTabContent = memo(function TerminalTabContent({
     <div className={cn('h-full w-full p-2', !isActive && 'hidden')}>
       <div ref={containerRef} className="h-full w-full overflow-hidden" />
     </div>
+  )
+})
+
+/** Toggle button for terminal word wrap */
+const WordWrapToggle = memo(function WordWrapToggle() {
+  const { data: preferences } = usePreferences()
+  const patchPreferences = usePatchPreferences()
+  const wordWrap = preferences?.terminal_word_wrap ?? true
+
+  // Sync persisted preference → module-level state on load
+  useEffect(() => {
+    if (isWordWrapEnabled() !== wordWrap) {
+      setWordWrap(wordWrap)
+    }
+  }, [wordWrap])
+
+  const handleToggle = useCallback(() => {
+    const next = !wordWrap
+    setWordWrap(next)
+    patchPreferences.mutate({ terminal_word_wrap: next })
+  }, [wordWrap, patchPreferences])
+
+  return (
+    <button
+      type="button"
+      onClick={handleToggle}
+      className={cn(
+        'flex h-full shrink-0 items-center px-2 transition-colors hover:bg-neutral-800/50',
+        wordWrap
+          ? 'text-neutral-200'
+          : 'text-neutral-500'
+      )}
+      aria-label={wordWrap ? 'Disable word wrap' : 'Enable word wrap'}
+      title={wordWrap ? 'Word wrap: on' : 'Word wrap: off'}
+    >
+      <WrapText className="h-3.5 w-3.5" />
+    </button>
   )
 })
 
@@ -288,6 +328,9 @@ export function TerminalView({
 
         {/* Spacer */}
         <div className="flex-1" />
+
+        {/* Word wrap toggle */}
+        <WordWrapToggle />
 
         {!hideControls && (
           <>

--- a/src/components/chat/ThinkingBlock.tsx
+++ b/src/components/chat/ThinkingBlock.tsx
@@ -28,7 +28,7 @@ export const ThinkingBlock = memo(function ThinkingBlock({
         <span>Thinking...</span>
         <ChevronRight className="ml-auto h-3.5 w-3.5 shrink-0 transition-transform duration-200 group-open:rotate-90" />
       </summary>
-      <div className="border-t border-border/50 px-3 py-2">
+      <div className="border-t border-border/50 px-3 py-2 select-text cursor-text">
         <div className="pl-4 border-l-2 border-purple-500/30 text-sm text-muted-foreground">
           <Markdown streaming={isStreaming}>{thinking}</Markdown>
         </div>

--- a/src/components/chat/TodoWidget.tsx
+++ b/src/components/chat/TodoWidget.tsx
@@ -112,7 +112,12 @@ interface TodoItemProps {
 function TodoItem({ todo }: TodoItemProps) {
   return (
     <li className="flex items-start gap-2 py-0.5 text-xs">
-      <span className="mt-0.5 shrink-0">
+      <span className="mt-0.5 shrink-0" title={
+        todo.status === 'completed' ? 'Completed'
+          : todo.status === 'cancelled' ? 'Cancelled'
+          : todo.status === 'in_progress' ? 'In progress'
+          : 'Pending'
+      }>
         {todo.status === 'completed' ? (
           <CheckCircle2 className="h-4 w-4 text-green-500" />
         ) : todo.status === 'cancelled' ? (

--- a/src/components/chat/ToolCallInline.tsx
+++ b/src/components/chat/ToolCallInline.tsx
@@ -110,7 +110,7 @@ export function ToolCallInline({
             </code>
           ) : null}
           {isStreaming && isIncomplete ? (
-            <Loader2 className="ml-auto h-3 w-3 shrink-0 animate-spin text-muted-foreground/50" />
+            <span title="Running"><Loader2 className="ml-auto h-3 w-3 shrink-0 animate-spin text-muted-foreground/50" /></span>
           ) : (
             <ChevronRight
               className={cn(
@@ -331,7 +331,7 @@ export function StackedGroup({
           <Layers className="h-3.5 w-3.5 shrink-0" />
           <span className="font-medium">{summary}</span>
           {isStreaming && isIncomplete ? (
-            <Loader2 className="ml-auto h-3 w-3 shrink-0 animate-spin text-muted-foreground/50" />
+            <span title="Running"><Loader2 className="ml-auto h-3 w-3 shrink-0 animate-spin text-muted-foreground/50" /></span>
           ) : (
             <ChevronRight
               className={cn(

--- a/src/components/chat/ToolCallInline.tsx
+++ b/src/components/chat/ToolCallInline.tsx
@@ -121,7 +121,7 @@ export function ToolCallInline({
           )}
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="border-t border-border/50 px-3 py-2">
+          <div className="border-t border-border/50 px-3 py-2 select-text cursor-text">
             <div className="whitespace-pre-wrap text-xs text-muted-foreground">
               {expandedContent}
             </div>
@@ -225,7 +225,7 @@ export function TaskCallInline({
           <div className="border-t border-border/50 px-3 py-2 space-y-2">
             {/* Show prompt/instructions */}
             {prompt && (
-              <div className="text-xs text-muted-foreground bg-muted/50 rounded p-2 whitespace-pre-wrap max-h-32 overflow-y-auto">
+              <div className="text-xs text-muted-foreground bg-muted/50 rounded p-2 whitespace-pre-wrap max-h-32 overflow-y-auto select-text cursor-text">
                 {prompt}
               </div>
             )}
@@ -464,7 +464,7 @@ function SubToolItem({ toolCall, onFileClick }: SubToolItemProps) {
           />
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="border-t border-border/30 px-2 py-1.5">
+          <div className="border-t border-border/30 px-2 py-1.5 select-text cursor-text">
             <div className="whitespace-pre-wrap text-[0.625rem] text-muted-foreground/70">
               {expandedContent}
             </div>

--- a/src/components/chat/ToolCallInline.tsx
+++ b/src/components/chat/ToolCallInline.tsx
@@ -383,7 +383,7 @@ function SubThinkingItem({ thinking }: SubThinkingItemProps) {
           isOpen && 'bg-muted/30'
         )}
       >
-        <CollapsibleTrigger className="flex w-full items-center gap-1.5 px-2 py-1 text-xs text-muted-foreground/80 hover:bg-muted/30 cursor-pointer select-none">
+        <CollapsibleTrigger className="flex w-full min-w-0 items-center gap-1.5 px-2 py-1 text-xs text-muted-foreground/80 hover:bg-muted/30 cursor-pointer select-none">
           <Brain className="h-3 w-3 shrink-0 text-purple-500" />
           <span className="font-medium">Thinking</span>
           <ChevronRight
@@ -434,7 +434,7 @@ function SubToolItem({ toolCall, onFileClick }: SubToolItemProps) {
           isOpen && 'bg-muted/30'
         )}
       >
-        <CollapsibleTrigger className="flex w-full items-center gap-1.5 px-2 py-1 text-xs text-muted-foreground/80 hover:bg-muted/30 cursor-pointer select-none">
+        <CollapsibleTrigger className="flex w-full min-w-0 items-center gap-1.5 px-2 py-1 text-xs text-muted-foreground/80 hover:bg-muted/30 cursor-pointer select-none">
           <span className="[&>svg]:h-3 [&>svg]:w-3">{icon}</span>
           <span className="font-medium">{label}</span>
           {detail && filePath && onFileClick ? (
@@ -721,15 +721,10 @@ function getToolDisplay(toolCall: ToolCall): ToolDisplay {
     case 'Bash': {
       const command = input.command as string | undefined
       const description = input.description as string | undefined
-      // Truncate long commands for display
-      const truncatedCommand =
-        command && command.length > 50
-          ? command.substring(0, 50) + '...'
-          : command
       return {
         icon: <Terminal className="h-4 w-4 shrink-0" />,
         label: 'Bash',
-        detail: truncatedCommand,
+        detail: command, // CSS truncate handles overflow — no JS truncation needed
         expandedContent: description
           ? `${description}\n\n$ ${command}`
           : `$ ${command ?? '(no command)'}`,
@@ -806,12 +801,10 @@ function getToolDisplay(toolCall: ToolCall): ToolDisplay {
     // Codex multi-agent tools
     case 'SpawnAgent': {
       const prompt = input.prompt as string | undefined
-      const truncatedPrompt =
-        prompt && prompt.length > 60 ? prompt.substring(0, 60) + '...' : prompt
       return {
         icon: <Users className="h-4 w-4 shrink-0" />,
         label: 'Spawn Agent',
-        detail: truncatedPrompt ?? 'sub-agent',
+        detail: prompt ?? 'sub-agent', // CSS truncate handles overflow — no JS truncation needed
         expandedContent: prompt ?? JSON.stringify(input, null, 2),
       }
     }

--- a/src/components/chat/ToolCallInline.tsx
+++ b/src/components/chat/ToolCallInline.tsx
@@ -51,6 +51,8 @@ interface ToolCallInlineProps {
   isStreaming?: boolean
   /** Whether this item is still in progress (shows spinner) */
   isIncomplete?: boolean
+  /** Whether to start expanded (from user preference) */
+  defaultExpanded?: boolean
 }
 
 /**
@@ -63,8 +65,9 @@ export function ToolCallInline({
   onFileClick,
   isStreaming,
   isIncomplete,
+  defaultExpanded = false,
 }: ToolCallInlineProps) {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(defaultExpanded)
   const { icon, label, detail, filePath, expandedContent } =
     getToolDisplay(toolCall)
 
@@ -155,6 +158,8 @@ interface TaskCallInlineProps {
   isStreaming?: boolean
   /** Whether this item is still in progress (shows spinner) */
   isIncomplete?: boolean
+  /** Whether to start expanded (from user preference) */
+  defaultExpanded?: boolean
 }
 
 /**
@@ -169,8 +174,9 @@ export function TaskCallInline({
   onFileClick,
   isStreaming,
   isIncomplete,
+  defaultExpanded = false,
 }: TaskCallInlineProps) {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(defaultExpanded)
   const input = taskToolCall.input as Record<string, unknown>
   const subagentType = input.subagent_type as string | undefined
   const description = input.description as string | undefined
@@ -273,6 +279,8 @@ interface StackedGroupProps {
   isStreaming?: boolean
   /** Whether this item is still in progress (shows spinner) */
   isIncomplete?: boolean
+  /** Whether to start expanded (from user preference) */
+  defaultExpanded?: boolean
 }
 
 /**
@@ -285,8 +293,9 @@ export function StackedGroup({
   onFileClick,
   isStreaming,
   isIncomplete,
+  defaultExpanded = false,
 }: StackedGroupProps) {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(defaultExpanded)
 
   // Count thinking blocks and tools for summary
   let thinkingCount = 0

--- a/src/components/chat/git-diff-tree.test.ts
+++ b/src/components/chat/git-diff-tree.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildFileTree,
+  diffTypeToStatus,
+  getDirFileNames,
+  type FlattenedFile,
+  type FileTreeDir,
+  type FileTreeFile,
+} from './GitDiffModal'
+
+// Minimal FlattenedFile factory for testing (fileDiff.type is only used by rendering, not buildFileTree)
+function file(fileName: string, i: number, additions = 0, deletions = 0): FlattenedFile {
+  return {
+    fileName,
+    key: `${i}`,
+    additions,
+    deletions,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fileDiff: { type: 'change', hunks: [], splitLineCount: 0, unifiedLineCount: 0 } as any,
+  }
+}
+
+describe('diffTypeToStatus', () => {
+  it('maps new → added', () => expect(diffTypeToStatus('new')).toBe('added'))
+  it('maps deleted → deleted', () => expect(diffTypeToStatus('deleted')).toBe('deleted'))
+  it('maps rename-pure → renamed', () => expect(diffTypeToStatus('rename-pure')).toBe('renamed'))
+  it('maps rename-changed → renamed', () => expect(diffTypeToStatus('rename-changed')).toBe('renamed'))
+  it('maps change → modified', () => expect(diffTypeToStatus('change')).toBe('modified'))
+  it('maps unknown → modified', () => expect(diffTypeToStatus('unknown-type')).toBe('modified'))
+})
+
+describe('buildFileTree', () => {
+  it('returns empty array for empty input', () => {
+    expect(buildFileTree([])).toEqual([])
+  })
+
+  it('places root-level files directly in roots', () => {
+    const tree = buildFileTree([file('README.md', 0), file('package.json', 1)])
+    expect(tree).toHaveLength(2)
+    expect(tree.every(n => n.type === 'file')).toBe(true)
+    const names = tree.map(n => n.name)
+    expect(names).toContain('README.md')
+    expect(names).toContain('package.json')
+  })
+
+  it('groups files under their parent directory', () => {
+    const tree = buildFileTree([file('src/index.ts', 0), file('src/utils.ts', 1)])
+    expect(tree).toHaveLength(1)
+    const src = tree[0] as FileTreeDir
+    expect(src.type).toBe('dir')
+    expect(src.name).toBe('src')
+    expect(src.children).toHaveLength(2)
+    expect(src.children.every(n => n.type === 'file')).toBe(true)
+  })
+
+  it('nests directories correctly', () => {
+    const tree = buildFileTree([file('a/b/c/deep.ts', 0)])
+    expect(tree).toHaveLength(1)
+    const a = tree[0] as FileTreeDir
+    expect(a.name).toBe('a')
+    const b = a.children[0] as FileTreeDir
+    expect(b.name).toBe('b')
+    const c = b.children[0] as FileTreeDir
+    expect(c.name).toBe('c')
+    const deep = c.children[0] as FileTreeFile
+    expect(deep.type).toBe('file')
+    expect(deep.name).toBe('deep.ts')
+    expect(deep.index).toBe(0)
+  })
+
+  it('sorts directories before files at each level', () => {
+    const tree = buildFileTree([
+      file('root.ts', 0),
+      file('src/index.ts', 1),
+      file('lib/utils.ts', 2),
+    ])
+    expect(tree[0]?.type).toBe('dir') // lib
+    expect(tree[1]?.type).toBe('dir') // src
+    expect(tree[2]?.type).toBe('file') // root.ts
+  })
+
+  it('sorts alphabetically within same type', () => {
+    const tree = buildFileTree([
+      file('src/z.ts', 0),
+      file('src/a.ts', 1),
+      file('src/m.ts', 2),
+    ])
+    const src = tree[0] as FileTreeDir
+    const names = src.children.map(n => n.name)
+    expect(names).toEqual(['a.ts', 'm.ts', 'z.ts'])
+  })
+
+  it('handles files with Windows-style backslash paths', () => {
+    const tree = buildFileTree([file('src\\utils\\helper.ts', 0)])
+    const src = tree[0] as FileTreeDir
+    expect(src.name).toBe('src')
+    const utils = src.children[0] as FileTreeDir
+    expect(utils.name).toBe('utils')
+    const helper = utils.children[0] as FileTreeFile
+    expect(helper.name).toBe('helper.ts')
+  })
+
+  it('preserves filteredFiles index on file nodes', () => {
+    const files = [file('a.ts', 0), file('b.ts', 1), file('c.ts', 2)]
+    const tree = buildFileTree(files)
+    const indices = (tree as FileTreeFile[]).map(n => n.index)
+    expect(indices).toEqual([0, 1, 2])
+  })
+
+  it('index is correct after filtering (tree built from filtered subset)', () => {
+    // Simulate what happens when the tree is built from filteredFiles
+    // where index 0 = first matching file (not necessarily original index 0)
+    const filtered = [file('src/b.ts', 1), file('src/c.ts', 2)]
+    const tree = buildFileTree(filtered)
+    const src = tree[0] as FileTreeDir
+    const fileNodes = src.children as FileTreeFile[]
+    expect(fileNodes[0]?.index).toBe(0) // index in filtered array
+    expect(fileNodes[1]?.index).toBe(1)
+  })
+
+  it('shares directories between sibling files (no duplicate dirs)', () => {
+    const tree = buildFileTree([
+      file('src/a.ts', 0),
+      file('src/b.ts', 1),
+      file('src/c.ts', 2),
+    ])
+    // Should only have one "src" dir node
+    expect(tree).toHaveLength(1)
+    expect(tree[0]?.type).toBe('dir')
+    expect((tree[0] as FileTreeDir).children).toHaveLength(3)
+  })
+
+  it('handles mixed root and nested files', () => {
+    const tree = buildFileTree([
+      file('root.ts', 0),
+      file('src/index.ts', 1),
+    ])
+    // Sorted: dirs before files → src dir first, then root.ts
+    expect(tree[0]?.type).toBe('dir')
+    expect(tree[0]?.name).toBe('src')
+    expect(tree[1]?.type).toBe('file')
+    expect(tree[1]?.name).toBe('root.ts')
+  })
+
+  it('handles sibling directories', () => {
+    const tree = buildFileTree([
+      file('src/index.ts', 0),
+      file('lib/utils.ts', 1),
+      file('test/spec.ts', 2),
+    ])
+    expect(tree).toHaveLength(3)
+    const names = tree.map(n => n.name)
+    expect(names).toEqual(['lib', 'src', 'test']) // alphabetical
+  })
+})
+
+describe('buildFileTree: aggregated stats', () => {
+  it('computes additions/deletions on dir nodes', () => {
+    const tree = buildFileTree([
+      file('src/a.ts', 0, 10, 5),
+      file('src/b.ts', 1, 3, 1),
+    ])
+    const src = tree[0] as FileTreeDir
+    expect(src.additions).toBe(13)
+    expect(src.deletions).toBe(6)
+  })
+
+  it('aggregates stats through multiple levels', () => {
+    const tree = buildFileTree([
+      file('a/b/c/deep.ts', 0, 20, 10),
+      file('a/other.ts', 1, 5, 2),
+    ])
+    const a = tree[0] as FileTreeDir
+    expect(a.additions).toBe(25)
+    expect(a.deletions).toBe(12)
+    const b = a.children.find(n => n.name === 'b') as FileTreeDir
+    expect(b.additions).toBe(20)
+    expect(b.deletions).toBe(10)
+  })
+
+  it('root-level files do not affect dir stats', () => {
+    const tree = buildFileTree([
+      file('src/index.ts', 0, 5, 3),
+      file('root.ts', 1, 100, 50),
+    ])
+    const src = tree.find(n => n.name === 'src') as FileTreeDir
+    expect(src.additions).toBe(5)
+    expect(src.deletions).toBe(3)
+  })
+
+  it('dir with zero-stat files shows zero', () => {
+    const tree = buildFileTree([file('src/empty.ts', 0, 0, 0)])
+    const src = tree[0] as FileTreeDir
+    expect(src.additions).toBe(0)
+    expect(src.deletions).toBe(0)
+  })
+})
+
+describe('getDirFileNames', () => {
+  it('returns all file names recursively', () => {
+    const tree = buildFileTree([
+      file('src/a.ts', 0),
+      file('src/sub/b.ts', 1),
+      file('src/sub/c.ts', 2),
+    ])
+    const src = tree[0] as FileTreeDir
+    const names = getDirFileNames(src.children).sort()
+    expect(names).toEqual(['src/a.ts', 'src/sub/b.ts', 'src/sub/c.ts'].sort())
+  })
+
+  it('returns empty array for empty nodes', () => {
+    expect(getDirFileNames([])).toEqual([])
+  })
+
+  it('returns file names at all nesting depths', () => {
+    const tree = buildFileTree([
+      file('a/b/c/d.ts', 0),
+      file('a/e.ts', 1),
+    ])
+    const a = tree[0] as FileTreeDir
+    const names = getDirFileNames(a.children).sort()
+    expect(names).toEqual(['a/b/c/d.ts', 'a/e.ts'].sort())
+  })
+})

--- a/src/components/chat/hooks/useChatWindowEvents.ts
+++ b/src/components/chat/hooks/useChatWindowEvents.ts
@@ -319,6 +319,54 @@ export function useChatWindowEvents({
     return () => window.removeEventListener('cycle-execution-mode', handler)
   }, [activeSessionId, activeWorktreeId, activeWorktreePath])
 
+  // Direct model switch (Cmd+; / Cmd+' / Cmd+\)
+  useEffect(() => {
+    if (!activeSessionId || !activeWorktreeId || !activeWorktreePath) return
+    const handler = (e: Event) => {
+      const model = (e as CustomEvent).detail?.model as string | undefined
+      if (!model) return
+      useChatStore.getState().setSelectedModel(activeSessionId, model)
+      invoke('broadcast_session_setting', {
+        sessionId: activeSessionId,
+        key: 'model',
+        value: model,
+      }).catch(() => undefined)
+      invoke('set_session_model', {
+        sessionId: activeSessionId,
+        worktreeId: activeWorktreeId,
+        worktreePath: activeWorktreePath,
+        model,
+      }).catch(() => undefined)
+    }
+    window.addEventListener('set-model', handler)
+    return () => window.removeEventListener('set-model', handler)
+  }, [activeSessionId, activeWorktreeId, activeWorktreePath])
+
+  // Direct execution mode switch (Ctrl+Cmd+; / Ctrl+Cmd+' / Ctrl+Cmd+\)
+  useEffect(() => {
+    if (!activeSessionId) return
+    const handler = (e: Event) => {
+      const mode = (e as CustomEvent).detail?.mode as string | undefined
+      if (!mode) return
+      useChatStore.getState().setExecutionMode(activeSessionId, mode as 'plan' | 'build' | 'yolo')
+      invoke('broadcast_session_setting', {
+        sessionId: activeSessionId,
+        key: 'executionMode',
+        value: mode,
+      }).catch(() => undefined)
+      if (activeWorktreeId && activeWorktreePath) {
+        invoke('update_session_state', {
+          worktreeId: activeWorktreeId,
+          worktreePath: activeWorktreePath,
+          sessionId: activeSessionId,
+          selectedExecutionMode: mode,
+        }).catch(() => undefined)
+      }
+    }
+    window.addEventListener('set-execution-mode', handler)
+    return () => window.removeEventListener('set-execution-mode', handler)
+  }, [activeSessionId, activeWorktreeId, activeWorktreePath])
+
   // CMD+G: Open git diff (also handles button clicks that dispatch with detail.type)
   useEffect(() => {
     const handler = (e: Event) => {

--- a/src/components/chat/hooks/useTextHighlights.ts
+++ b/src/components/chat/hooks/useTextHighlights.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { useChatStore } from '@/store/chat-store'
+import type { TextHighlight } from '@/types/chat'
+
+const HIGHLIGHT_NAME = 'user-highlight'
+
+/**
+ * Manages rendering of user-created text highlights using the CSS Custom Highlight API.
+ * Re-applies highlights whenever the message list re-renders (scrolling, new messages, etc.).
+ *
+ * @param sessionId - Current session ID
+ * @param containerRef - Ref to the scrollable message container
+ */
+export function useTextHighlights(
+  sessionId: string | undefined,
+  containerRef: React.RefObject<HTMLDivElement | null>
+) {
+  const prevHighlightsRef = useRef<TextHighlight[]>([])
+
+  // Apply highlights by walking the DOM and matching text
+  const applyHighlights = useCallback(() => {
+    if (!CSS.highlights || !containerRef.current || !sessionId) return
+
+    const highlights =
+      useChatStore.getState().sessionHighlights[sessionId] ?? []
+
+    if (highlights.length === 0) {
+      CSS.highlights.delete(HIGHLIGHT_NAME)
+      return
+    }
+
+    const container = containerRef.current
+    const ranges: Range[] = []
+
+    // Group highlights by message_id for efficient DOM traversal
+    const byMessage = new Map<string, TextHighlight[]>()
+    for (const h of highlights) {
+      const list = byMessage.get(h.message_id) ?? []
+      list.push(h)
+      byMessage.set(h.message_id, list)
+    }
+
+    for (const [messageId, messageHighlights] of byMessage) {
+      // Find the message container element
+      const messageEl = container.querySelector(
+        `[data-message-id="${messageId}"]`
+      )
+      if (!messageEl) continue
+
+      for (const highlight of messageHighlights) {
+        const range = findTextRange(messageEl, highlight.text)
+        if (range) {
+          ranges.push(range)
+        }
+      }
+    }
+
+    if (ranges.length > 0) {
+      CSS.highlights.set(HIGHLIGHT_NAME, new Highlight(...ranges))
+    } else {
+      CSS.highlights.delete(HIGHLIGHT_NAME)
+    }
+  }, [sessionId, containerRef])
+
+  // Re-apply when highlights change in store
+  useEffect(() => {
+    if (!sessionId) return
+
+    const unsubscribe = useChatStore.subscribe(state => {
+      const current = state.sessionHighlights[sessionId] ?? []
+      if (current !== prevHighlightsRef.current) {
+        prevHighlightsRef.current = current
+        // Small delay to let DOM settle after React render
+        requestAnimationFrame(() => applyHighlights())
+      }
+    })
+
+    return unsubscribe
+  }, [sessionId, applyHighlights])
+
+  // Re-apply on mount and when session changes
+  useEffect(() => {
+    // Delay to ensure messages are rendered
+    const timer = setTimeout(() => applyHighlights(), 100)
+    return () => {
+      clearTimeout(timer)
+      CSS.highlights?.delete(HIGHLIGHT_NAME)
+    }
+  }, [sessionId, applyHighlights])
+
+  // Expose manual re-apply for use after scroll/load-more
+  return { applyHighlights }
+}
+
+/**
+ * Find a text range in the DOM that matches the given text string.
+ * Uses TreeWalker to walk text nodes and find the first occurrence.
+ */
+function findTextRange(container: Element, searchText: string): Range | null {
+  const walker = document.createTreeWalker(
+    container,
+    NodeFilter.SHOW_TEXT,
+    null
+  )
+
+  // Collect all text nodes and build a concatenated string
+  const textNodes: Text[] = []
+  const offsets: number[] = [] // cumulative offset of each text node
+  let totalText = ''
+
+  let node: Text | null
+  while ((node = walker.nextNode() as Text | null)) {
+    const content = node.textContent ?? ''
+    offsets.push(totalText.length)
+    totalText += content
+    textNodes.push(node)
+  }
+
+  // Find the search text in the concatenated string
+  const matchIndex = totalText.indexOf(searchText)
+  if (matchIndex === -1) return null
+
+  // Map the match back to DOM ranges
+  const matchEnd = matchIndex + searchText.length
+  let startNode: Text | null = null
+  let startOffset = 0
+  let endNode: Text | null = null
+  let endOffset = 0
+
+  for (let i = 0; i < textNodes.length; i++) {
+    const nodeStart = offsets[i]!
+    const nodeEnd = nodeStart + (textNodes[i]!.textContent?.length ?? 0)
+
+    if (!startNode && matchIndex < nodeEnd) {
+      startNode = textNodes[i]!
+      startOffset = matchIndex - nodeStart
+    }
+    if (matchEnd <= nodeEnd) {
+      endNode = textNodes[i]!
+      endOffset = matchEnd - nodeStart
+      break
+    }
+  }
+
+  if (!startNode || !endNode) return null
+
+  try {
+    const range = new Range()
+    range.setStart(startNode, startOffset)
+    range.setEnd(endNode, endOffset)
+    return range
+  } catch {
+    return null
+  }
+}

--- a/src/components/command-palette/SessionPalette.tsx
+++ b/src/components/command-palette/SessionPalette.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState, useCallback, useMemo } from 'react'
+import { useUIStore } from '@/store/ui-store'
+import { useProjectsStore } from '@/store/projects-store'
+import { useChatStore } from '@/store/chat-store'
+import { useAllSessions } from '@/services/chat'
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from '@/components/ui/command'
+import type { Session } from '@/types/chat'
+
+/** Format a unix timestamp (seconds) to relative time like "2h ago" */
+function formatRelativeTime(timestamp: number): string {
+  const ms = timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp
+  const diffMs = Date.now() - ms
+  if (diffMs < 0) return 'just now'
+  const minuteMs = 60_000
+  const hourMs = 60 * minuteMs
+  const dayMs = 24 * hourMs
+  if (diffMs < hourMs) {
+    const minutes = Math.max(1, Math.floor(diffMs / minuteMs))
+    return `${minutes}m ago`
+  }
+  if (diffMs < dayMs) {
+    const hours = Math.floor(diffMs / hourMs)
+    return `${hours}h ago`
+  }
+  const days = Math.floor(diffMs / dayMs)
+  return `${days}d ago`
+}
+
+interface FlatSession {
+  session: Session
+  projectId: string
+  projectName: string
+  worktreeId: string
+  worktreeName: string
+  worktreePath: string
+}
+
+export function SessionPalette() {
+  const sessionPaletteOpen = useUIStore(state => state.sessionPaletteOpen)
+  const setSessionPaletteOpen = useUIStore(
+    state => state.setSessionPaletteOpen
+  )
+  const [search, setSearch] = useState('')
+
+  // Lazy-load sessions only when palette is open
+  const { data: allSessions } = useAllSessions(sessionPaletteOpen)
+
+  // Flatten, filter archived, sort by updated_at desc
+  const flatSessions = useMemo((): FlatSession[] => {
+    if (!allSessions?.entries) return []
+
+    const result: FlatSession[] = []
+    for (const entry of allSessions.entries) {
+      for (const session of entry.sessions) {
+        if (session.archived_at) continue
+        result.push({
+          session,
+          projectId: entry.project_id,
+          projectName: entry.project_name,
+          worktreeId: entry.worktree_id,
+          worktreeName: entry.worktree_name,
+          worktreePath: entry.worktree_path,
+        })
+      }
+    }
+
+    result.sort((a, b) => b.session.updated_at - a.session.updated_at)
+    return result
+  }, [allSessions])
+
+  // Group by project for display
+  const groupedSessions = useMemo(() => {
+    const groups = new Map<string, FlatSession[]>()
+    for (const item of flatSessions) {
+      const existing = groups.get(item.projectName)
+      if (existing) {
+        existing.push(item)
+      } else {
+        groups.set(item.projectName, [item])
+      }
+    }
+    return groups
+  }, [flatSessions])
+
+  const handleSelect = useCallback(
+    (item: FlatSession) => {
+      setSessionPaletteOpen(false)
+      setSearch('')
+
+      const currentProjectId =
+        useProjectsStore.getState().selectedProjectId
+
+      // Clear active worktree so we land on ProjectCanvasView
+      useChatStore.getState().clearActiveWorktree()
+
+      const crossProject = currentProjectId !== item.projectId
+
+      if (crossProject) {
+        // Race-condition safe: store intent in Zustand, then switch project.
+        // ProjectCanvasView consumes the intent on mount.
+        useUIStore
+          .getState()
+          .markWorktreeForAutoOpenSession(item.worktreeId, item.session.id)
+        useProjectsStore.getState().selectProject(item.projectId)
+      } else {
+        // Same project — set the active session, then fire event for the
+        // already-mounted ProjectCanvasView.
+        useChatStore
+          .getState()
+          .setActiveSession(item.worktreeId, item.session.id)
+        setTimeout(() => {
+          window.dispatchEvent(
+            new CustomEvent('open-session-modal', {
+              detail: {
+                sessionId: item.session.id,
+                worktreeId: item.worktreeId,
+                worktreePath: item.worktreePath,
+              },
+            })
+          )
+        }, 50)
+      }
+    },
+    [setSessionPaletteOpen]
+  )
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      setSessionPaletteOpen(open)
+      if (!open) setSearch('')
+    },
+    [setSessionPaletteOpen]
+  )
+
+  // Cmd+P keybinding (with !shiftKey guard to avoid conflict with Cmd+Shift+P)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'p' && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
+        e.preventDefault()
+        setSessionPaletteOpen(!sessionPaletteOpen)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [sessionPaletteOpen, setSessionPaletteOpen])
+
+  return (
+    <CommandDialog
+      open={sessionPaletteOpen}
+      onOpenChange={handleOpenChange}
+      title="Go to Session"
+      description="Search sessions across all projects"
+      className="top-4 translate-y-0 sm:top-[50%] sm:translate-y-[-50%] sm:max-w-2xl"
+      disablePointerSelection
+    >
+      <CommandInput
+        placeholder="Search sessions..."
+        value={search}
+        onValueChange={setSearch}
+      />
+      <CommandList className="max-h-[800px]">
+        <CommandEmpty>No sessions found.</CommandEmpty>
+
+        {Array.from(groupedSessions.entries()).map(
+          ([projectName, sessions]) => (
+            <CommandGroup key={projectName} heading={projectName}>
+              {sessions.map(item => (
+                <CommandItem
+                  key={`${item.worktreeId}-${item.session.id}`}
+                  value={`${item.session.name} ${item.worktreeName} ${item.projectName}`}
+                  onSelect={() => handleSelect(item)}
+                >
+                  <div className="flex min-w-0 flex-1 items-center gap-2">
+                    <span className="truncate">{item.session.name}</span>
+                    <span className="shrink-0 text-xs text-muted-foreground">
+                      {item.worktreeName}
+                    </span>
+                  </div>
+                  <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                    {formatRelativeTime(item.session.updated_at)}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )
+        )}
+      </CommandList>
+    </CommandDialog>
+  )
+}

--- a/src/components/command-palette/SessionPalette.tsx
+++ b/src/components/command-palette/SessionPalette.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState, useCallback, useMemo } from 'react'
 import { useUIStore } from '@/store/ui-store'
-import { useProjectsStore } from '@/store/projects-store'
-import { useChatStore } from '@/store/chat-store'
 import { useAllSessions } from '@/services/chat'
 import {
   CommandDialog,
@@ -11,36 +9,11 @@ import {
   CommandGroup,
   CommandItem,
 } from '@/components/ui/command'
-import type { Session } from '@/types/chat'
-
-/** Format a unix timestamp (seconds) to relative time like "2h ago" */
-function formatRelativeTime(timestamp: number): string {
-  const ms = timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp
-  const diffMs = Date.now() - ms
-  if (diffMs < 0) return 'just now'
-  const minuteMs = 60_000
-  const hourMs = 60 * minuteMs
-  const dayMs = 24 * hourMs
-  if (diffMs < hourMs) {
-    const minutes = Math.max(1, Math.floor(diffMs / minuteMs))
-    return `${minutes}m ago`
-  }
-  if (diffMs < dayMs) {
-    const hours = Math.floor(diffMs / hourMs)
-    return `${hours}h ago`
-  }
-  const days = Math.floor(diffMs / dayMs)
-  return `${days}d ago`
-}
-
-interface FlatSession {
-  session: Session
-  projectId: string
-  projectName: string
-  worktreeId: string
-  worktreeName: string
-  worktreePath: string
-}
+import {
+  type SessionListItem,
+  formatRelativeTime,
+  navigateToSession,
+} from '@/lib/session-utils'
 
 export function SessionPalette() {
   const sessionPaletteOpen = useUIStore(state => state.sessionPaletteOpen)
@@ -53,10 +26,10 @@ export function SessionPalette() {
   const { data: allSessions } = useAllSessions(sessionPaletteOpen)
 
   // Flatten, filter archived, sort by updated_at desc
-  const flatSessions = useMemo((): FlatSession[] => {
+  const flatSessions = useMemo((): SessionListItem[] => {
     if (!allSessions?.entries) return []
 
-    const result: FlatSession[] = []
+    const result: SessionListItem[] = []
     for (const entry of allSessions.entries) {
       for (const session of entry.sessions) {
         if (session.archived_at) continue
@@ -77,7 +50,7 @@ export function SessionPalette() {
 
   // Group by project for display
   const groupedSessions = useMemo(() => {
-    const groups = new Map<string, FlatSession[]>()
+    const groups = new Map<string, SessionListItem[]>()
     for (const item of flatSessions) {
       const existing = groups.get(item.projectName)
       if (existing) {
@@ -90,43 +63,10 @@ export function SessionPalette() {
   }, [flatSessions])
 
   const handleSelect = useCallback(
-    (item: FlatSession) => {
+    (item: SessionListItem) => {
       setSessionPaletteOpen(false)
       setSearch('')
-
-      const currentProjectId =
-        useProjectsStore.getState().selectedProjectId
-
-      // Clear active worktree so we land on ProjectCanvasView
-      useChatStore.getState().clearActiveWorktree()
-
-      const crossProject = currentProjectId !== item.projectId
-
-      if (crossProject) {
-        // Race-condition safe: store intent in Zustand, then switch project.
-        // ProjectCanvasView consumes the intent on mount.
-        useUIStore
-          .getState()
-          .markWorktreeForAutoOpenSession(item.worktreeId, item.session.id)
-        useProjectsStore.getState().selectProject(item.projectId)
-      } else {
-        // Same project — set the active session, then fire event for the
-        // already-mounted ProjectCanvasView.
-        useChatStore
-          .getState()
-          .setActiveSession(item.worktreeId, item.session.id)
-        setTimeout(() => {
-          window.dispatchEvent(
-            new CustomEvent('open-session-modal', {
-              detail: {
-                sessionId: item.session.id,
-                worktreeId: item.worktreeId,
-                worktreePath: item.worktreePath,
-              },
-            })
-          )
-        }, 50)
-      }
+      navigateToSession(item)
     },
     [setSessionPaletteOpen]
   )

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -67,6 +67,7 @@ import { useGitStatus } from '@/services/git-status'
 import { useChatStore } from '@/store/chat-store'
 import { useProjectsStore } from '@/store/projects-store'
 import { useUIStore } from '@/store/ui-store'
+import { useTerminalStore } from '@/store/terminal-store'
 import { isBaseSession, type Worktree } from '@/types/projects'
 import { getEditorLabel, getTerminalLabel } from '@/types/preferences'
 import type { LabelData, Session, WorktreeSessions } from '@/types/chat'
@@ -100,6 +101,7 @@ import {
   useCloseBaseSessionClean,
   useCloseBaseSessionArchive,
 } from '@/services/projects'
+import { TerminalStatusIndicator } from '@/hooks/useWorktreeTerminalStatus'
 import { usePreferences } from '@/services/preferences'
 import { DEFAULT_KEYBINDINGS, formatShortcutDisplay } from '@/types/keybindings'
 import { CloseWorktreeDialog } from '@/components/chat/CloseWorktreeDialog'
@@ -116,12 +118,6 @@ const LinkedProjectsModal = lazy(() =>
 )
 import type { DiffRequest } from '@/types/git-diff'
 import { toast } from 'sonner'
-import { useTerminalStore } from '@/store/terminal-store'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
 import {
   gitPush,
   fetchWorktreesStatus,
@@ -273,13 +269,6 @@ function WorktreeSectionHeader({
   const isBase = isBaseSession(worktree)
   const { data: gitStatus } = useGitStatus(worktree.id)
 
-  const hasRunningTerminal = useTerminalStore(state => {
-    const terminals = state.terminals[worktree.id] ?? []
-    // Show spinner when a run-script terminal exists: covers both "pending" (created
-    // by startRun on canvas, PTY starts when session opens) and "running" (PTY active).
-    // Terminal entry is removed on successful exit, so spinner clears automatically.
-    return terminals.some(t => !!t.command)
-  })
 
   const behindCount =
     gitStatus?.behind_count ?? worktree.cached_behind_count ?? 0
@@ -416,21 +405,19 @@ function WorktreeSectionHeader({
                 <span className="text-[9px]">⌘{shortcutNumber}</span>
               </kbd>
             )}
-            {hasRunningTerminal && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="shrink-0 block h-3 w-3 square-spinner" />
-                </TooltipTrigger>
-                <TooltipContent>
-                  Dev server running in terminal. Press ⌘R to open
-                </TooltipContent>
-              </Tooltip>
-            )}
             <span className="flex min-w-0 flex-1 flex-col gap-1 font-medium sm:flex-row sm:items-center sm:gap-1.5">
               <span className="flex min-w-0 items-center gap-1.5">
                 <span className="min-w-0 flex-1 truncate">
                   {isBase ? 'Base Session' : worktree.name}
                 </span>
+                <TerminalStatusIndicator
+                  worktreeId={worktree.id}
+                  iconSize="h-3 w-3"
+                  onClick={() => {
+                    useUIStore.getState().setSessionChatModalOpen(true, worktree.id)
+                    useTerminalStore.getState().setModalTerminalOpen(worktree.id, true)
+                  }}
+                />
                 {displayBranch && (
                   <span className="hidden items-center gap-1 rounded border border-border/50 px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground sm:inline-flex">
                     <GitBranch className="h-2.5 w-2.5" />

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -772,8 +772,11 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
         return 0
       })
 
-      // Re-order by status group so flat array matches visual group order
-      const grouped = flattenGroups(groupCardsByStatus(cards))
+      // Re-order by status group, or keep flat chronological order
+      const groupByStatus = preferences?.sidebar_group_by_status ?? true
+      const grouped = groupByStatus
+        ? flattenGroups(groupCardsByStatus(cards))
+        : [...cards].sort((a, b) => a.session.created_at - b.session.created_at)
       const latestActivityAt = getWorktreeLastActivity(
         filteredSessions,
         worktree.created_at
@@ -819,6 +822,7 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
     storeState,
     searchQuery,
     worktreeSortMode,
+    preferences?.sidebar_group_by_status,
   ])
 
   useEffect(() => {

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -465,6 +465,7 @@ function WorktreeSectionHeader({
                   <GitStatusBadges
                     behindCount={behindCount}
                     unpushedCount={unpushedCount}
+                    unpushedCommits={gitStatus?.unpushed_commits}
                     diffAdded={diffAdded}
                     diffRemoved={diffRemoved}
                     onPull={handlePull}

--- a/src/components/layout/MainWindow.tsx
+++ b/src/components/layout/MainWindow.tsx
@@ -141,6 +141,11 @@ const CloseWorktreeDialog = lazy(() =>
     default: mod.CloseWorktreeDialog,
   }))
 )
+const SessionHistoryModal = lazy(() =>
+  import('@/components/session-history/SessionHistoryModal').then(mod => ({
+    default: mod.SessionHistoryModal,
+  }))
+)
 import { FloatingDock } from '@/components/ui/floating-dock'
 import { Toaster } from '@/components/ui/sonner'
 import { useWindowMaximized } from '@/hooks/use-window-maximized'
@@ -401,6 +406,8 @@ export function MainWindow() {
   const shouldRenderArchivedModal = useRetainedMount(archivedModalOpen)
   const shouldRenderCloseWorktreeDialog = useRetainedMount(closeConfirmOpen)
   const shouldRenderGitHubDashboardModal = useRetainedMount(githubDashboardOpen)
+  const sessionHistoryOpen = useUIStore(state => state.sessionHistoryOpen)
+  const shouldRenderSessionHistoryModal = useRetainedMount(sessionHistoryOpen)
 
   // On Windows, use smaller border radius and remove it when maximized
   // On other platforms, use rounded-xl only in native app mode
@@ -600,6 +607,11 @@ export function MainWindow() {
       {shouldRenderGitHubDashboardModal && (
         <Suspense fallback={null}>
           <GitHubDashboardModal />
+        </Suspense>
+      )}
+      {shouldRenderSessionHistoryModal && (
+        <Suspense fallback={null}>
+          <SessionHistoryModal />
         </Suspense>
       )}
       <BranchConflictDialog />

--- a/src/components/layout/MainWindow.tsx
+++ b/src/components/layout/MainWindow.tsx
@@ -148,7 +148,6 @@ const SessionHistoryModal = lazy(() =>
     default: mod.SessionHistoryModal,
   }))
 )
-import { FloatingDock } from '@/components/ui/floating-dock'
 import { Toaster } from '@/components/ui/sonner'
 import { useWindowMaximized } from '@/hooks/use-window-maximized'
 import { useUIStore } from '@/store/ui-store'
@@ -482,7 +481,6 @@ export function MainWindow() {
         {/* Main Content - flex-1 to fill remaining space */}
         <div className="relative min-w-0 flex-1 overflow-hidden">
           <MainWindowContent />
-          <FloatingDock />
         </div>
       </div>
 

--- a/src/components/layout/MainWindow.tsx
+++ b/src/components/layout/MainWindow.tsx
@@ -19,6 +19,8 @@ import { SessionPalette } from '@/components/command-palette/SessionPalette'
 import { QuitConfirmationDialog } from './QuitConfirmationDialog'
 import { BranchConflictDialog } from '@/components/worktree/BranchConflictDialog'
 import { TeardownOutputDialog } from '@/components/worktree/TeardownOutputDialog'
+import { NightshiftRunsModal } from '@/components/nightshift/NightshiftRunsModal'
+import { useNightshiftEvents } from '@/hooks/useNightshiftEvents'
 
 // Lazy-loaded heavy modals (code splitting)
 const LeftSideBar = lazy(() =>
@@ -331,6 +333,9 @@ export function MainWindow() {
   // (not in sidebar) so events are received even when sidebar is closed
   useWorktreeEvents()
 
+  // Listen for Nightshift events (run progress, completion)
+  useNightshiftEvents()
+
   // Handle CMD+N keybinding to create new worktree
   useCreateWorktreeKeybinding()
 
@@ -549,6 +554,7 @@ export function MainWindow() {
           <RemotePickerModal />
         </Suspense>
       )}
+      <NightshiftRunsModal />
       {shouldRenderReleaseNotesDialog && (
         <Suspense fallback={null}>
           <ReleaseNotesDialog />

--- a/src/components/layout/MainWindow.tsx
+++ b/src/components/layout/MainWindow.tsx
@@ -15,6 +15,7 @@ import { DevModeBanner } from './DevModeBanner'
 import { SidebarWidthProvider } from './SidebarWidthContext'
 import { MainWindowContent } from './MainWindowContent'
 import { CommandPalette } from '@/components/command-palette/CommandPalette'
+import { SessionPalette } from '@/components/command-palette/SessionPalette'
 import { QuitConfirmationDialog } from './QuitConfirmationDialog'
 import { BranchConflictDialog } from '@/components/worktree/BranchConflictDialog'
 import { TeardownOutputDialog } from '@/components/worktree/TeardownOutputDialog'
@@ -475,6 +476,7 @@ export function MainWindow() {
 
       {/* Global UI Components (hidden until triggered) */}
       <CommandPalette />
+      <SessionPalette />
       {shouldRenderPreferencesDialog && (
         <Suspense fallback={null}>
           <PreferencesDialog />

--- a/src/components/magic/ReviewCommentsDialog.tsx
+++ b/src/components/magic/ReviewCommentsDialog.tsx
@@ -132,6 +132,10 @@ export function ReviewCommentsDialog() {
 
     setPhase('loading')
     setError(null)
+    // Reset isSending here because handleOpenChange doesn't fire on programmatic
+    // close (setReviewCommentsModalOpen(false) in handleSendToChat), so the flag
+    // can be stuck from a previous "Send to Chat" action.
+    setIsSending(false)
     setComments([])
     setSelected(new Set())
     setExpanded(new Set())

--- a/src/components/nightshift/NightshiftRunsModal.tsx
+++ b/src/components/nightshift/NightshiftRunsModal.tsx
@@ -1,0 +1,220 @@
+import { useCallback } from 'react'
+import {
+  CheckCircle2,
+  Clock,
+  Loader2,
+  XCircle,
+  AlertTriangle,
+  ChevronDown,
+  Moon,
+  ExternalLink,
+} from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { ModalCloseButton } from '@/components/ui/modal-close-button'
+import { Badge } from '@/components/ui/badge'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { useNightshiftStore } from '@/store/nightshift-store'
+import { useNightshiftRuns } from '@/services/nightshift'
+import type {
+  NightshiftRun,
+  NightshiftRunStatus,
+} from '@/types/nightshift'
+
+function StatusBadge({ status }: { status: NightshiftRunStatus }) {
+  switch (status) {
+    case 'completed':
+      return (
+        <Badge variant="default" className="bg-green-600 text-white">
+          <CheckCircle2 className="h-3 w-3 mr-1" />
+          Completed
+        </Badge>
+      )
+    case 'running':
+      return (
+        <Badge variant="default" className="bg-blue-600 text-white">
+          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+          Running
+        </Badge>
+      )
+    case 'failed':
+      return (
+        <Badge variant="destructive">
+          <XCircle className="h-3 w-3 mr-1" />
+          Failed
+        </Badge>
+      )
+    case 'partially_completed':
+      return (
+        <Badge variant="default" className="bg-amber-600 text-white">
+          <AlertTriangle className="h-3 w-3 mr-1" />
+          Partial
+        </Badge>
+      )
+    case 'cancelled':
+      return (
+        <Badge variant="secondary">
+          <XCircle className="h-3 w-3 mr-1" />
+          Cancelled
+        </Badge>
+      )
+    default:
+      return (
+        <Badge variant="secondary">
+          <Clock className="h-3 w-3 mr-1" />
+          Pending
+        </Badge>
+      )
+  }
+}
+
+function formatDuration(secs: number): string {
+  if (secs < 60) return `${secs}s`
+  const mins = Math.floor(secs / 60)
+  const remainSecs = secs % 60
+  return remainSecs > 0 ? `${mins}m ${remainSecs}s` : `${mins}m`
+}
+
+function RunDetail({ run }: { run: NightshiftRun }) {
+  const completedChecks = run.checkResults.filter(
+    (cr) => cr.status === 'completed'
+  ).length
+  const startDate = new Date(run.startedAt * 1000)
+  const duration = run.completedAt
+    ? run.completedAt - run.startedAt
+    : undefined
+
+  return (
+    <Collapsible>
+      <CollapsibleTrigger className="flex items-center gap-3 w-full p-3 rounded-lg border hover:bg-muted/50 transition-colors">
+        <ChevronDown className="h-4 w-4 shrink-0 transition-transform [[data-state=open]>&]:rotate-180" />
+        <div className="flex-1 text-left">
+          <div className="flex items-center gap-2">
+            <Moon className="h-3.5 w-3.5 text-purple-500 dark:text-purple-400" />
+            <span className="text-sm font-medium">
+              {startDate.toLocaleDateString()}{' '}
+              {startDate.toLocaleTimeString([], {
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </span>
+            <StatusBadge status={run.status} />
+            <span className="text-xs text-muted-foreground capitalize">
+              {run.trigger}
+            </span>
+          </div>
+          <div className="text-xs text-muted-foreground mt-0.5">
+            {completedChecks}/{run.checkResults.length} checks completed
+            {duration !== undefined ? ` · ${formatDuration(duration)}` : ''}
+            {run.branchName && (
+              <span className="ml-1">· {run.branchName}</span>
+            )}
+          </div>
+        </div>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="pl-7 pr-3 pb-3 pt-2 space-y-2">
+          {run.checkResults.map((cr) => (
+            <div
+              key={cr.checkId}
+              className="flex items-center gap-2 p-2 rounded-md border border-border/50"
+            >
+              <StatusBadge status={cr.status} />
+              <span className="text-xs font-medium text-foreground flex-1">
+                {cr.checkId}
+              </span>
+              {cr.durationSecs > 0 && (
+                <span className="text-xs text-muted-foreground">
+                  {formatDuration(cr.durationSecs)}
+                </span>
+              )}
+              {cr.sessionId && (
+                <span className="text-xs text-muted-foreground flex items-center gap-0.5">
+                  <ExternalLink className="h-3 w-3" />
+                  Session
+                </span>
+              )}
+              {cr.error && (
+                <span className="text-xs text-destructive truncate max-w-[200px]">
+                  {cr.error}
+                </span>
+              )}
+            </div>
+          ))}
+          {run.prUrl && (
+            <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
+              <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
+              <a
+                href={run.prUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs text-blue-500 hover:underline"
+              >
+                PR #{run.prNumber}
+              </a>
+            </div>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+export function NightshiftRunsModal() {
+  const { runsModalOpen, runsModalProjectId, closeRunsModal } =
+    useNightshiftStore()
+  const { data: runs = [], isLoading } = useNightshiftRuns(runsModalProjectId)
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) closeRunsModal()
+    },
+    [closeRunsModal]
+  )
+
+  if (!runsModalOpen) return null
+
+  return (
+    <Dialog open onOpenChange={handleOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="sm:max-w-2xl max-h-[80vh] flex flex-col"
+      >
+        <div className="flex items-center justify-between px-1">
+          <DialogTitle className="text-lg font-semibold">
+            Nightshift Runs
+          </DialogTitle>
+          <ModalCloseButton onClick={() => handleOpenChange(false)} />
+        </div>
+        <DialogDescription className="sr-only">
+          History of automated maintenance runs and their sessions.
+        </DialogDescription>
+
+        <div className="flex-1 overflow-y-auto space-y-2 pr-1">
+          {isLoading && (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          )}
+          {!isLoading && runs.length === 0 && (
+            <div className="text-center py-8 text-sm text-muted-foreground">
+              No runs yet. Run Nightshift from project settings or the command
+              palette.
+            </div>
+          )}
+          {runs.map((run) => (
+            <RunDetail key={run.id} run={run} />
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/nightshift/NightshiftRunsModal.tsx
+++ b/src/components/nightshift/NightshiftRunsModal.tsx
@@ -15,6 +15,11 @@ import {
   DialogDescription,
   DialogTitle,
 } from '@/components/ui/dialog'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { ModalCloseButton } from '@/components/ui/modal-close-button'
 import { Badge } from '@/components/ui/badge'
 import {
@@ -23,57 +28,82 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { useNightshiftStore } from '@/store/nightshift-store'
+import { useChatStore } from '@/store/chat-store'
 import { useNightshiftRuns } from '@/services/nightshift'
 import type {
   NightshiftRun,
   NightshiftRunStatus,
 } from '@/types/nightshift'
 
-function StatusBadge({ status }: { status: NightshiftRunStatus }) {
-  switch (status) {
-    case 'completed':
-      return (
-        <Badge variant="default" className="bg-green-600 text-white">
-          <CheckCircle2 className="h-3 w-3 mr-1" />
-          Completed
-        </Badge>
-      )
-    case 'running':
-      return (
-        <Badge variant="default" className="bg-blue-600 text-white">
-          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-          Running
-        </Badge>
-      )
-    case 'failed':
-      return (
-        <Badge variant="destructive">
-          <XCircle className="h-3 w-3 mr-1" />
-          Failed
-        </Badge>
-      )
-    case 'partially_completed':
-      return (
-        <Badge variant="default" className="bg-amber-600 text-white">
-          <AlertTriangle className="h-3 w-3 mr-1" />
-          Partial
-        </Badge>
-      )
-    case 'cancelled':
-      return (
-        <Badge variant="secondary">
-          <XCircle className="h-3 w-3 mr-1" />
-          Cancelled
-        </Badge>
-      )
-    default:
-      return (
-        <Badge variant="secondary">
-          <Clock className="h-3 w-3 mr-1" />
-          Pending
-        </Badge>
-      )
+const STATUS_CONFIG: Record<
+  string,
+  {
+    label: string
+    tooltip: string
+    icon: typeof CheckCircle2
+    variant: 'default' | 'destructive' | 'secondary'
+    className?: string
+    spin?: boolean
   }
+> = {
+  completed: {
+    label: 'Completed',
+    tooltip: 'All checks finished successfully',
+    icon: CheckCircle2,
+    variant: 'default',
+    className: 'bg-green-600 text-white',
+  },
+  running: {
+    label: 'Running',
+    tooltip: 'Checks are currently being executed',
+    icon: Loader2,
+    variant: 'default',
+    className: 'bg-blue-600 text-white',
+    spin: true,
+  },
+  failed: {
+    label: 'Failed',
+    tooltip: 'All checks failed or the run errored out',
+    icon: XCircle,
+    variant: 'destructive',
+  },
+  partially_completed: {
+    label: 'Partial',
+    tooltip: 'Some checks succeeded but others failed or timed out',
+    icon: AlertTriangle,
+    variant: 'default',
+    className: 'bg-amber-600 text-white',
+  },
+  cancelled: {
+    label: 'Cancelled',
+    tooltip: 'Run was manually cancelled before all checks finished',
+    icon: XCircle,
+    variant: 'secondary',
+  },
+}
+
+const PENDING_CONFIG = {
+  label: 'Pending',
+  tooltip: 'Run is queued and waiting to start',
+  icon: Clock,
+  variant: 'secondary' as const,
+  className: undefined as string | undefined,
+}
+
+function StatusBadge({ status }: { status: NightshiftRunStatus }) {
+  const config = STATUS_CONFIG[status] ?? PENDING_CONFIG
+  const Icon = config.icon
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge variant={config.variant} className={config.className}>
+          <Icon className={`h-3 w-3 mr-1${'spin' in config && config.spin ? ' animate-spin' : ''}`} />
+          {config.label}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>{config.tooltip}</TooltipContent>
+    </Tooltip>
+  )
 }
 
 function formatDuration(secs: number): string {
@@ -83,7 +113,7 @@ function formatDuration(secs: number): string {
   return remainSecs > 0 ? `${mins}m ${remainSecs}s` : `${mins}m`
 }
 
-function RunDetail({ run }: { run: NightshiftRun }) {
+function RunDetail({ run, onOpenSession }: { run: NightshiftRun; onOpenSession: (worktreeId: string, worktreePath: string, sessionId: string) => void }) {
   const completedChecks = run.checkResults.filter(
     (cr) => cr.status === 'completed'
   ).length
@@ -136,11 +166,18 @@ function RunDetail({ run }: { run: NightshiftRun }) {
                   {formatDuration(cr.durationSecs)}
                 </span>
               )}
-              {cr.sessionId && (
-                <span className="text-xs text-muted-foreground flex items-center gap-0.5">
+              {cr.sessionId && run.worktreeId && run.worktreePath && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation() // Don't toggle collapsible
+                    onOpenSession(run.worktreeId!, run.worktreePath!, cr.sessionId!)
+                  }}
+                  className="text-xs text-blue-500 hover:text-blue-600 hover:underline flex items-center gap-0.5 cursor-pointer"
+                >
                   <ExternalLink className="h-3 w-3" />
                   Session
-                </span>
+                </button>
               )}
               {cr.error && (
                 <span className="text-xs text-destructive truncate max-w-[200px]">
@@ -180,6 +217,24 @@ export function NightshiftRunsModal() {
     [closeRunsModal]
   )
 
+  const handleOpenSession = useCallback(
+    (worktreeId: string, worktreePath: string, sessionId: string) => {
+      closeRunsModal()
+      // Navigate to the session: clear active worktree (go to canvas), set session, dispatch event
+      const { clearActiveWorktree, setActiveSession } = useChatStore.getState()
+      clearActiveWorktree()
+      setActiveSession(worktreeId, sessionId)
+      setTimeout(() => {
+        window.dispatchEvent(
+          new CustomEvent('open-session-modal', {
+            detail: { sessionId, worktreeId, worktreePath },
+          })
+        )
+      }, 50)
+    },
+    [closeRunsModal]
+  )
+
   if (!runsModalOpen) return null
 
   return (
@@ -211,7 +266,7 @@ export function NightshiftRunsModal() {
             </div>
           )}
           {runs.map((run) => (
-            <RunDetail key={run.id} run={run} />
+            <RunDetail key={run.id} run={run} onOpenSession={handleOpenSession} />
           ))}
         </div>
       </DialogContent>

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -2261,6 +2261,22 @@ export const GeneralPane: React.FC = () => {
           </InlineField>
 
           <InlineField
+            label="Escape closes session"
+            description="Allow pressing Escape to close the current session modal"
+          >
+            <Switch
+              checked={preferences?.esc_closes_session ?? true}
+              onCheckedChange={checked => {
+                if (preferences) {
+                  patchPreferences.mutate({
+                    esc_closes_session: checked,
+                  })
+                }
+              }}
+            />
+          </InlineField>
+
+          <InlineField
             label="Close original session on clear context"
             description="Automatically close the original session when using Clear Context and yolo"
           >

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -2239,6 +2239,22 @@ export const GeneralPane: React.FC = () => {
               }}
             />
           </InlineField>
+
+          <InlineField
+            label="Expand tool calls by default"
+            description="Show tool call details expanded instead of collapsed in chat messages"
+          >
+            <Switch
+              checked={preferences?.expand_tool_calls ?? false}
+              onCheckedChange={checked => {
+                if (preferences) {
+                  patchPreferences.mutate({
+                    expand_tool_calls: checked,
+                  })
+                }
+              }}
+            />
+          </InlineField>
         </div>
       </SettingsSection>
 

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -2209,6 +2209,22 @@ export const GeneralPane: React.FC = () => {
           </InlineField>
 
           <InlineField
+            label="Group sessions by status"
+            description="Show status headers (Idle, Review, Waiting, In Progress) in sidebar and canvas"
+          >
+            <Switch
+              checked={preferences?.sidebar_group_by_status ?? true}
+              onCheckedChange={checked => {
+                if (preferences) {
+                  patchPreferences.mutate({
+                    sidebar_group_by_status: checked,
+                  })
+                }
+              }}
+            />
+          </InlineField>
+
+          <InlineField
             label="Restore last session on project switch"
             description="Automatically reopen the last worktree and session when switching projects"
           >

--- a/src/components/preferences/panes/WebAccessPane.tsx
+++ b/src/components/preferences/panes/WebAccessPane.tsx
@@ -392,6 +392,7 @@ export const WebAccessPane: React.FC = () => {
               />
               <div className="flex items-center gap-1.5">
                 <div
+                  title={serverStatus?.running ? 'Running' : 'Stopped'}
                   className={`h-2 w-2 rounded-full ${
                     serverStatus?.running
                       ? 'bg-green-500'

--- a/src/components/projects/ProjectSettingsDialog.tsx
+++ b/src/components/projects/ProjectSettingsDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react'
-import { Settings, Plug, FileJson } from 'lucide-react'
+import { Settings, Plug, FileJson, Moon } from 'lucide-react'
 import { ModalCloseButton } from '@/components/ui/modal-close-button'
 import {
   Breadcrumb,
@@ -37,13 +37,15 @@ import { useProjects } from '@/services/projects'
 import { GeneralPane } from './panes/GeneralPane'
 import { McpServersPane } from './panes/McpServersPane'
 import { JeanJsonPane } from './panes/JeanJsonPane'
+import { NightshiftPane } from './panes/NightshiftPane'
 
-type ProjectSettingsPane = 'general' | 'mcp-servers' | 'jean-json'
+type ProjectSettingsPane = 'general' | 'mcp-servers' | 'jean-json' | 'nightshift'
 
 const navigationItems = [
   { id: 'general' as const, name: 'General', icon: Settings },
   { id: 'mcp-servers' as const, name: 'MCP Servers', icon: Plug },
   { id: 'jean-json' as const, name: 'Jean.json', icon: FileJson },
+  { id: 'nightshift' as const, name: 'Nightshift (Experimental)', icon: Moon },
 ]
 
 const getPaneTitle = (pane: ProjectSettingsPane): string => {
@@ -54,6 +56,8 @@ const getPaneTitle = (pane: ProjectSettingsPane): string => {
       return 'MCP Servers'
     case 'jean-json':
       return 'Jean.json'
+    case 'nightshift':
+      return 'Nightshift'
   }
 }
 
@@ -209,6 +213,12 @@ function ProjectSettingsDialogContent({
                   )}
                   {activePane === 'jean-json' && (
                     <JeanJsonPane
+                      projectId={safeProjectId}
+                      projectPath={projectPath}
+                    />
+                  )}
+                  {activePane === 'nightshift' && (
+                    <NightshiftPane
                       projectId={safeProjectId}
                       projectPath={projectPath}
                     />

--- a/src/components/projects/ProjectTree.tsx
+++ b/src/components/projects/ProjectTree.tsx
@@ -19,13 +19,24 @@ import {
   verticalListSortingStrategy,
   useSortable,
 } from '@dnd-kit/sortable'
-import { Folder } from 'lucide-react'
+import { Folder, ChevronsUpDown, ChevronsDownUp } from 'lucide-react'
 import { isFolder, type Project } from '@/types/projects'
 import { ProjectTreeItem } from './ProjectTreeItem'
 import { FolderTreeItem } from './FolderTreeItem'
-import { useReorderItems, useMoveItem } from '@/services/projects'
+import {
+  useReorderItems,
+  useMoveItem,
+  projectsQueryKeys,
+} from '@/services/projects'
 import { useProjectsStore } from '@/store/projects-store'
+import { useQueryClient } from '@tanstack/react-query'
 import { Separator } from '@/components/ui/separator'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { formatShortcutDisplay, DEFAULT_KEYBINDINGS } from '@/types/keybindings'
 import { cn } from '@/lib/utils'
 
 const MAX_NESTING_DEPTH = 3
@@ -230,7 +241,8 @@ function RootDropZone({ isOver }: { isOver: boolean }) {
 export function ProjectTree({ projects }: ProjectTreeProps) {
   const reorderItems = useReorderItems()
   const moveItem = useMoveItem()
-  const { expandFolder, expandedFolderIds } = useProjectsStore()
+  const queryClient = useQueryClient()
+  const { expandFolder, expandedFolderIds, expandedWorktreeIds, expandAllWorktrees, collapseAllWorktrees } = useProjectsStore()
   const [activeId, setActiveId] = useState<string | null>(null)
   const [overFolderId, setOverFolderId] = useState<string | null>(null)
   const [isOverRoot, setIsOverRoot] = useState(false)
@@ -250,6 +262,47 @@ export function ProjectTree({ projects }: ProjectTreeProps) {
     .filter(p => !isFolder(p))
     .sort((a, b) => a.order - b.order)
   const hasBothTypes = rootFolders.length > 0 && rootProjects.length > 0
+  const anyWorktreesExpanded = expandedWorktreeIds.size > 0
+
+  const handleToggleAllWorktrees = useCallback((e: React.MouseEvent) => {
+    const withProjects = e.altKey
+    if (anyWorktreesExpanded) {
+      collapseAllWorktrees()
+      if (withProjects) {
+        useProjectsStore.setState({
+          expandedProjectIds: new Set<string>(),
+          expandedFolderIds: new Set<string>(),
+        })
+      }
+    } else {
+      const allWorktreeIds: string[] = []
+      const allProjectIds: string[] = []
+      const allFolderIds: string[] = []
+      for (const project of projects) {
+        if (isFolder(project)) {
+          allFolderIds.push(project.id)
+          continue
+        }
+        allProjectIds.push(project.id)
+        const worktrees =
+          queryClient.getQueryData<{ id: string }[]>(
+            projectsQueryKeys.worktrees(project.id)
+          ) ?? []
+        for (const w of worktrees) {
+          allWorktreeIds.push(w.id)
+        }
+      }
+      if (allWorktreeIds.length > 0) {
+        expandAllWorktrees(allWorktreeIds)
+      }
+      if (withProjects) {
+        useProjectsStore.setState({
+          expandedProjectIds: new Set(allProjectIds),
+          expandedFolderIds: new Set(allFolderIds),
+        })
+      }
+    }
+  }, [anyWorktreesExpanded, collapseAllWorktrees, expandAllWorktrees, projects, queryClient])
 
   // All items flattened for the SortableContext
   const allItemIds = flattenItems(projects)
@@ -520,10 +573,29 @@ export function ProjectTree({ projects }: ProjectTreeProps) {
             </div>
           )}
           {rootProjects.length > 0 && (
-            <div className="px-3 pb-1 pt-2">
+            <div className="px-3 pb-1 pt-2 flex items-center justify-between">
               <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/50">
                 Projects
               </span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="flex size-4 items-center justify-center rounded text-muted-foreground/40 transition-colors hover:text-muted-foreground"
+                    onClick={handleToggleAllWorktrees}
+                  >
+                    {anyWorktreesExpanded ? (
+                      <ChevronsDownUp className="size-3" />
+                    ) : (
+                      <ChevronsUpDown className="size-3" />
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right" className="text-xs">
+                  <p>{anyWorktreesExpanded ? 'Collapse' : 'Expand'} all worktrees ({formatShortcutDisplay(DEFAULT_KEYBINDINGS.toggle_all_worktrees_expanded)})</p>
+                  <p className="text-muted-foreground">Hold {formatShortcutDisplay('alt')} to include projects</p>
+                </TooltipContent>
+              </Tooltip>
             </div>
           )}
           {rootProjects.map(item => (

--- a/src/components/projects/ProjectTreeItem.tsx
+++ b/src/components/projects/ProjectTreeItem.tsx
@@ -207,7 +207,7 @@ export function ProjectTreeItem({ project }: ProjectTreeItemProps) {
               <TooltipTrigger asChild>
                 <button
                   onClick={handleBasePull}
-                  className="shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-[11px] font-medium text-primary transition-colors hover:bg-primary/20"
+                  className="shrink-0 text-[11px] font-medium text-primary transition-opacity hover:opacity-70"
                 >
                   <span className="flex items-center gap-0.5">
                     <ArrowDown className="h-3 w-3" />
@@ -223,7 +223,7 @@ export function ProjectTreeItem({ project }: ProjectTreeItemProps) {
               <TooltipTrigger asChild>
                 <button
                   onClick={handleBasePush}
-                  className="shrink-0 rounded bg-orange-500/10 px-1.5 py-0.5 text-[11px] font-medium text-orange-500 transition-colors hover:bg-orange-500/20"
+                  className="shrink-0 text-[11px] font-medium text-orange-500 transition-opacity hover:opacity-70"
                 >
                   <span className="flex items-center gap-0.5">
                     <ArrowUp className="h-3 w-3" />
@@ -236,7 +236,7 @@ export function ProjectTreeItem({ project }: ProjectTreeItemProps) {
           )}
 
           {showStatusBadges && (
-            <div className="hidden items-center gap-1 sm:flex">
+            <div className="hidden items-center gap-2 sm:flex">
               <NewIssuesBadge
                 projectPath={project.path}
                 projectId={project.id}

--- a/src/components/projects/ProjectTreeItem.tsx
+++ b/src/components/projects/ProjectTreeItem.tsx
@@ -215,7 +215,7 @@ export function ProjectTreeItem({ project }: ProjectTreeItemProps) {
                   </span>
                 </button>
               </TooltipTrigger>
-              <TooltipContent>{`Pull ${baseBranchBehindCount} commit${baseBranchBehindCount > 1 ? 's' : ''} on ${project.default_branch}`}</TooltipContent>
+              <TooltipContent>{`Merge ${baseBranchBehindCount} new commit${baseBranchBehindCount > 1 ? 's' : ''} from origin/${project.default_branch}`}</TooltipContent>
             </Tooltip>
           )}
           {baseBranchAheadCount > 0 && (

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -284,6 +284,11 @@ export function WorktreeItem({
     isReviewing,
   ])
 
+  // Active session for this worktree (reactive subscription)
+  const activeSessionId = useChatStore(
+    state => state.activeSessionIds[worktree.id]
+  )
+
   // Worktree expansion state for sidebar session list
   const isExpanded = expandedWorktreeIds.has(worktree.id)
   const storeState = useCanvasStoreState()
@@ -656,7 +661,14 @@ export function WorktreeItem({
                 return (
                   <div
                     key={card.session.id}
-                    className="flex items-center gap-1.5 pl-5 py-1 cursor-pointer text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 truncate"
+                    className={cn(
+                      'flex items-center gap-1.5 pl-5 py-1 cursor-pointer text-sm truncate',
+                      activeSessionId === card.session.id && isSelected
+                        ? 'text-foreground bg-primary/10 font-medium'
+                        : activeSessionId === card.session.id
+                          ? 'text-foreground/80 hover:text-foreground hover:bg-accent/50'
+                          : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+                    )}
                     onClick={e => {
                       e.stopPropagation()
                       handleSessionSelect(card.session.id)

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -12,7 +12,9 @@ import { isBaseSession, type Worktree } from '@/types/projects'
 import { useProjectsStore } from '@/store/projects-store'
 import { useChatStore } from '@/store/chat-store'
 import { useUIStore } from '@/store/ui-store'
+import { useTerminalStore } from '@/store/terminal-store'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { TerminalStatusIndicator } from '@/hooks/useWorktreeTerminalStatus'
 import { WorktreeContextMenu } from './WorktreeContextMenu'
 import { useRenameWorktree } from '@/services/projects'
 import { useSessions } from '@/services/chat'
@@ -80,6 +82,7 @@ export function WorktreeItem({
   )
   const isSelected = selectedWorktreeId === worktree.id
   const isBase = isBaseSession(worktree)
+
 
   // Get git status for this worktree from event-driven cache
   // Note: useGitStatus reads from TanStack Query cache, no network requests
@@ -546,7 +549,7 @@ export function WorktreeItem({
           onClick={handleClick}
           onDoubleClick={handleDoubleClick}
         >
-          {/* Status indicator */}
+          {/* Chat status indicator (spinner/dot) */}
           <StatusIndicator
             status={indicatorStatus}
             variant={indicatorVariant}
@@ -573,6 +576,17 @@ export function WorktreeItem({
               )}
             >
               <span className="truncate">{worktree.name}</span>
+              {/* Terminal running/failed indicator — click opens terminal */}
+              <TerminalStatusIndicator
+                worktreeId={worktree.id}
+                onClick={() => {
+                  selectProject(projectId)
+                  selectWorktree(worktree.id)
+                  useChatStore.getState().clearActiveWorktree()
+                  useUIStore.getState().setSessionChatModalOpen(true, worktree.id)
+                  useTerminalStore.getState().setModalTerminalOpen(worktree.id, true)
+                }}
+              />
               {/* Chevron for expand/collapse sessions */}
               <button
                 className="flex size-4 shrink-0 items-center justify-center rounded opacity-0 transition-opacity group-hover:opacity-50 hover:!opacity-100 hover:bg-accent-foreground/10"

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -694,6 +694,13 @@ export function WorktreeItem({
                         <span className="truncate text-xs">
                           {card.session.name || 'Untitled'}
                         </span>
+                        {card.label && (
+                          <div
+                            className="ml-auto h-2 w-2 shrink-0 rounded-full"
+                            style={{ backgroundColor: card.label.color }}
+                            title={card.label.name}
+                          />
+                        )}
                       </div>
                     )
                   })}
@@ -726,6 +733,13 @@ export function WorktreeItem({
                     <span className="truncate text-xs">
                       {card.session.name || 'Untitled'}
                     </span>
+                    {card.label && (
+                      <div
+                        className="ml-auto h-2 w-2 shrink-0 rounded-full"
+                        style={{ backgroundColor: card.label.color }}
+                        title={card.label.name}
+                      />
+                    )}
                   </div>
                 )
               })}

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -35,6 +35,7 @@ import {
   TooltipContent,
 } from '@/components/ui/tooltip'
 import { useSidebarWidth } from '@/components/layout/SidebarWidthContext'
+import { usePreferences } from '@/services/preferences'
 
 interface WorktreeItemProps {
   worktree: Worktree
@@ -299,10 +300,19 @@ export function WorktreeItem({
     return sessions.map(s => computeSessionCardData(s, storeState))
   }, [sessionsData?.sessions, storeState])
 
+  const { data: preferences } = usePreferences()
+  const groupByStatus = preferences?.sidebar_group_by_status ?? true
+
   const sessionGroups = useMemo(() => {
     if (!isExpanded) return []
     return groupCardsByStatus(allCards)
   }, [isExpanded, allCards])
+
+  // Flat chronological list (sorted by created_at, oldest first)
+  const flatCards = useMemo(() => {
+    if (!isExpanded || groupByStatus) return []
+    return [...allCards].sort((a, b) => a.session.created_at - b.session.created_at)
+  }, [isExpanded, groupByStatus, allCards])
 
   const handleChevronClick = useCallback(
     (e: React.MouseEvent) => {
@@ -640,23 +650,56 @@ export function WorktreeItem({
         </div>
       </WorktreeContextMenu>
 
-      {/* Expandable session list grouped by status */}
-      {isExpanded && sessionGroups.length > 0 && (
+      {/* Expandable session list — grouped by status or flat chronological */}
+      {isExpanded && (groupByStatus ? sessionGroups.length > 0 : flatCards.length > 0) && (
         <div
           className={cn(
             'border-l border-border/40 py-0.5',
             'ml-4'
           )}
         >
-          {sessionGroups.map(group => (
-            <div key={group.key}>
-              <div className="pl-3 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-                {group.title}{' '}
-                <span className="text-muted-foreground/60">
-                  {group.cards.length}
-                </span>
-              </div>
-              {group.cards.map(card => {
+          {groupByStatus
+            ? sessionGroups.map(group => (
+                <div key={group.key}>
+                  <div className="pl-3 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                    {group.title}{' '}
+                    <span className="text-muted-foreground/60">
+                      {group.cards.length}
+                    </span>
+                  </div>
+                  {group.cards.map(card => {
+                    const config = statusConfig[card.status]
+                    return (
+                      <div
+                        key={card.session.id}
+                        className={cn(
+                          'flex items-center gap-1.5 pl-5 py-1 cursor-pointer text-sm truncate',
+                          activeSessionId === card.session.id && isSelected
+                            ? 'text-foreground bg-primary/10 font-medium'
+                            : activeSessionId === card.session.id
+                              ? 'text-foreground/80 hover:text-foreground hover:bg-accent/50'
+                              : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+                        )}
+                        onClick={e => {
+                          e.stopPropagation()
+                          handleSessionSelect(card.session.id)
+                        }}
+                      >
+                        <StatusIndicator
+                          status={config.indicatorStatus}
+                          variant={config.indicatorVariant}
+                          title={config.label}
+                          className="h-1.5 w-1.5 shrink-0"
+                        />
+                        <span className="truncate text-xs">
+                          {card.session.name || 'Untitled'}
+                        </span>
+                      </div>
+                    )
+                  })}
+                </div>
+              ))
+            : flatCards.map(card => {
                 const config = statusConfig[card.status]
                 return (
                   <div
@@ -686,8 +729,6 @@ export function WorktreeItem({
                   </div>
                 )
               })}
-            </div>
-          ))}
         </div>
       )}
     </div>

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -37,7 +37,6 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from '@/components/ui/tooltip'
-import { useSidebarWidth } from '@/components/layout/SidebarWidthContext'
 import { usePreferences } from '@/services/preferences'
 
 interface WorktreeItemProps {
@@ -349,10 +348,6 @@ export function WorktreeItem({
     },
     [projectId, worktree.id, worktree.path, selectProject, selectWorktree]
   )
-
-  // Responsive padding based on sidebar width
-  const sidebarWidth = useSidebarWidth()
-  const isNarrowSidebar = sidebarWidth < 200
 
   // Inline editing state
   const [isEditing, setIsEditing] = useState(false)

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -4,9 +4,10 @@ import type {
   IndicatorStatus,
   IndicatorVariant,
 } from '@/components/ui/status-indicator'
-import { ArrowDown, ArrowUp, ChevronDown, GitBranch } from 'lucide-react'
+import { ArrowDown, ArrowUp, ChevronDown, GitBranch, GitPullRequestArrow } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
+import { openExternal } from '@/lib/platform'
 import { isBaseSession, type Worktree } from '@/types/projects'
 import { useProjectsStore } from '@/store/projects-store'
 import { useChatStore } from '@/store/chat-store'
@@ -584,14 +585,33 @@ export function WorktreeItem({
                   )}
                 />
               </button>
-              {/* Show branch name only when different from displayed name */}
+              {/* Show branch name when different from displayed name, and/or PR badge */}
               {(() => {
                 const displayBranch =
                   gitStatus?.current_branch ?? worktree.branch
-                return displayBranch !== worktree.name ? (
+                return displayBranch !== worktree.name || worktree.pr_number ? (
                   <span className="ml-0.5 inline-flex max-w-[80px] items-center gap-0.5 truncate text-xs text-muted-foreground">
-                    <GitBranch className="h-2.5 w-2.5" />
-                    {displayBranch}
+                    {displayBranch !== worktree.name && (
+                      <>
+                        <GitBranch className="h-2.5 w-2.5" />
+                        {displayBranch}
+                      </>
+                    )}
+                    {worktree.pr_number && (
+                      <>
+                        {displayBranch !== worktree.name && <span className="text-border">·</span>}
+                        <span
+                          className="inline-flex items-center gap-0.5 cursor-pointer hover:text-foreground transition-colors"
+                          onClick={e => {
+                            e.stopPropagation()
+                            if (worktree.pr_url) openExternal(worktree.pr_url)
+                          }}
+                        >
+                          <GitPullRequestArrow className="h-2.5 w-2.5" />
+                          #{worktree.pr_number}
+                        </span>
+                      </>
+                    )}
                   </span>
                 ) : null
               })()}

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -677,6 +677,7 @@ export function WorktreeItem({
                     <StatusIndicator
                       status={config.indicatorStatus}
                       variant={config.indicatorVariant}
+                      title={config.label}
                       className="h-1.5 w-1.5 shrink-0"
                     />
                     <span className="truncate text-xs">

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -630,7 +630,24 @@ export function WorktreeItem({
                   </span>
                 </button>
               </TooltipTrigger>
-              <TooltipContent>{`Push ${pushCount} commit${pushCount > 1 ? 's' : ''} to remote`}</TooltipContent>
+              <TooltipContent className="max-w-80">
+                <p>{`Push ${pushCount} commit${pushCount > 1 ? 's' : ''} to remote`}</p>
+                {gitStatus?.unpushed_commits && gitStatus.unpushed_commits.length > 0 && (
+                  <ul className="mt-1 space-y-0.5 border-t border-border/50 pt-1">
+                    {gitStatus.unpushed_commits.map((c: { hash: string; message: string }) => (
+                      <li key={c.hash} className="flex gap-1.5 text-[11px] leading-tight">
+                        <code className="shrink-0 text-muted-foreground">{c.hash}</code>
+                        <span className="truncate">{c.message}</span>
+                      </li>
+                    ))}
+                    {pushCount > gitStatus.unpushed_commits.length && (
+                      <li className="text-[11px] text-muted-foreground">
+                        ...and {pushCount - gitStatus.unpushed_commits.length} more
+                      </li>
+                    )}
+                  </ul>
+                )}
+              </TooltipContent>
             </Tooltip>
           )}
 

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -526,8 +526,8 @@ export function WorktreeItem({
       >
         <div
           className={cn(
-            'group relative flex cursor-pointer items-center gap-1.5 py-1.5 pr-2 overflow-hidden transition-colors duration-150',
-            isNarrowSidebar ? 'pl-4' : 'pl-7',
+            'group relative flex cursor-pointer items-center gap-1.5 py-1 pr-2 overflow-hidden transition-colors duration-150',
+            'pl-3',
             isSelected
               ? 'bg-primary/10 text-foreground before:absolute before:left-0 before:top-0 before:h-full before:w-[3px] before:bg-primary'
               : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
@@ -594,7 +594,7 @@ export function WorktreeItem({
               <TooltipTrigger asChild>
                 <button
                   onClick={handlePull}
-                  className="shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-[11px] font-medium text-primary transition-colors hover:bg-primary/20"
+                  className="shrink-0 text-[11px] font-medium text-primary transition-opacity hover:opacity-70"
                 >
                   <span className="flex items-center gap-0.5">
                     <ArrowDown className="h-3 w-3" />
@@ -612,7 +612,7 @@ export function WorktreeItem({
               <TooltipTrigger asChild>
                 <button
                   onClick={handlePush}
-                  className="shrink-0 rounded bg-orange-500/10 px-1.5 py-0.5 text-[11px] font-medium text-orange-500 transition-colors hover:bg-orange-500/20"
+                  className="shrink-0 text-[11px] font-medium text-orange-500 transition-opacity hover:opacity-70"
                 >
                   <span className="flex items-center gap-0.5">
                     <ArrowUp className="h-3 w-3" />
@@ -645,7 +645,7 @@ export function WorktreeItem({
         <div
           className={cn(
             'border-l border-border/40 py-0.5',
-            isNarrowSidebar ? 'ml-6' : 'ml-9'
+            'ml-4'
           )}
         >
           {sessionGroups.map(group => (

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -612,7 +612,7 @@ export function WorktreeItem({
                   </span>
                 </button>
               </TooltipTrigger>
-              <TooltipContent>{`Pull ${behindCount} commit${behindCount > 1 ? 's' : ''} from remote`}</TooltipContent>
+              <TooltipContent>{`Merge ${behindCount} new commit${behindCount > 1 ? 's' : ''} from origin/${defaultBranch}`}</TooltipContent>
             </Tooltip>
           )}
 

--- a/src/components/projects/WorktreeList.tsx
+++ b/src/components/projects/WorktreeList.tsx
@@ -166,7 +166,7 @@ export function WorktreeList({
     .map(w => w.id)
 
   return (
-    <div className="ml-4 border-l border-border/40 py-0.5">
+    <div className="ml-2 border-l border-border/40 py-0.5">
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}

--- a/src/components/projects/panes/NightshiftPane.tsx
+++ b/src/components/projects/panes/NightshiftPane.tsx
@@ -1,0 +1,439 @@
+import { useState, useCallback } from 'react'
+import {
+  Play,
+  History,
+  Loader2,
+  RotateCcw,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+import { Switch } from '@/components/ui/switch'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { NativeSelect, NativeSelectOption } from '@/components/ui/native-select'
+import {
+  useNightshiftChecks,
+  useNightshiftConfig,
+  useSaveNightshiftConfig,
+  useStartNightshiftRun,
+} from '@/services/nightshift'
+import { useNightshiftStore } from '@/store/nightshift-store'
+import { defaultNightshiftConfig } from '@/types/nightshift'
+import type {
+  NightshiftConfig,
+  NightshiftCheckConfig,
+} from '@/types/nightshift'
+import {
+  MODEL_OPTIONS as CLAUDE_MODEL_OPTIONS,
+  CODEX_MODEL_OPTIONS,
+  OPENCODE_MODEL_OPTIONS,
+} from '@/components/chat/toolbar/toolbar-options'
+
+const DEFAULT_OPTION = { value: '', label: 'Default' }
+
+function getModelOptionsForBackend(backend?: string) {
+  switch (backend) {
+    case 'codex':
+      return [DEFAULT_OPTION, ...CODEX_MODEL_OPTIONS]
+    case 'opencode':
+      return [DEFAULT_OPTION, ...OPENCODE_MODEL_OPTIONS]
+    default:
+      return [DEFAULT_OPTION, ...CLAUDE_MODEL_OPTIONS]
+  }
+}
+
+const BACKEND_OPTIONS = [
+  { value: '', label: 'Default (Claude)' },
+  { value: 'claude', label: 'Claude' },
+  { value: 'codex', label: 'Codex' },
+  { value: 'opencode', label: 'OpenCode' },
+]
+
+const POST_ACTION_OPTIONS = [
+  { value: 'nothing', label: 'Leave unstaged' },
+  { value: 'commit', label: 'Commit only' },
+  { value: 'commit_and_pr', label: 'Commit & PR' },
+]
+
+const SettingsSection: React.FC<{
+  title: string
+  children: React.ReactNode
+}> = ({ title, children }) => (
+  <div className="space-y-4">
+    <div>
+      <h3 className="text-lg font-medium text-foreground">{title}</h3>
+      <Separator className="mt-2" />
+    </div>
+    {children}
+  </div>
+)
+
+function SettingsRow({
+  label,
+  description,
+  children,
+}: {
+  label: string
+  description?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="space-y-0.5 min-w-0">
+        <Label className="text-sm text-foreground">{label}</Label>
+        {description && (
+          <p className="text-xs text-muted-foreground">{description}</p>
+        )}
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  )
+}
+
+export function NightshiftPane({
+  projectId,
+}: {
+  projectId: string
+  projectPath: string
+}) {
+  const { data: checks = [] } = useNightshiftChecks()
+  const { data: config } = useNightshiftConfig(projectId)
+  const saveConfig = useSaveNightshiftConfig()
+  const startRun = useStartNightshiftRun()
+  const activeRuns = useNightshiftStore(s => s.activeRuns)
+  const isRunning = !!activeRuns[projectId]
+
+  const currentConfig = config ?? defaultNightshiftConfig
+
+  const [expandedChecks, setExpandedChecks] = useState<Set<string>>(new Set())
+
+  const toggleExpanded = useCallback((checkId: string) => {
+    setExpandedChecks(prev => {
+      const next = new Set(prev)
+      if (next.has(checkId)) next.delete(checkId)
+      else next.add(checkId)
+      return next
+    })
+  }, [])
+
+  const updateConfig = useCallback(
+    (updates: Partial<NightshiftConfig>) => {
+      saveConfig.mutate({
+        projectId,
+        config: { ...currentConfig, ...updates },
+      })
+    },
+    [projectId, currentConfig, saveConfig]
+  )
+
+  const handleToggleEnabled = useCallback(() => {
+    updateConfig({ enabled: !currentConfig.enabled })
+  }, [currentConfig.enabled, updateConfig])
+
+  const handleToggleCheck = useCallback(
+    (checkId: string, isDefault: boolean) => {
+      const updatedConfig = { ...currentConfig }
+
+      if (isDefault) {
+        if (updatedConfig.disabledChecks.includes(checkId)) {
+          updatedConfig.disabledChecks = updatedConfig.disabledChecks.filter(
+            id => id !== checkId
+          )
+        } else {
+          updatedConfig.disabledChecks = [
+            ...updatedConfig.disabledChecks,
+            checkId,
+          ]
+        }
+      } else {
+        if (updatedConfig.extraEnabledChecks.includes(checkId)) {
+          updatedConfig.extraEnabledChecks =
+            updatedConfig.extraEnabledChecks.filter(id => id !== checkId)
+        } else {
+          updatedConfig.extraEnabledChecks = [
+            ...updatedConfig.extraEnabledChecks,
+            checkId,
+          ]
+        }
+      }
+
+      saveConfig.mutate({ projectId, config: updatedConfig })
+    },
+    [projectId, currentConfig, saveConfig]
+  )
+
+  const isCheckEnabled = useCallback(
+    (checkId: string, isDefault: boolean) => {
+      if (isDefault) {
+        return !currentConfig.disabledChecks.includes(checkId)
+      }
+      return currentConfig.extraEnabledChecks.includes(checkId)
+    },
+    [currentConfig]
+  )
+
+  const handleRunNow = useCallback(async () => {
+    const toastId = toast.loading('Starting Nightshift run...')
+    try {
+      await startRun.mutateAsync(projectId)
+      toast.success('Nightshift run started', { id: toastId })
+    } catch (error) {
+      toast.error(`Failed to start: ${error}`, { id: toastId })
+    }
+  }, [projectId, startRun])
+
+  const handleViewHistory = useCallback(() => {
+    useNightshiftStore.getState().openRunsModal(projectId)
+  }, [projectId])
+
+  const updateCheckConfig = useCallback(
+    (checkId: string, updates: Partial<NightshiftCheckConfig>) => {
+      const existingConfig = currentConfig.checkConfigs[checkId] ?? {}
+      const newCheckConfigs = {
+        ...currentConfig.checkConfigs,
+        [checkId]: { ...existingConfig, ...updates },
+      }
+      updateConfig({ checkConfigs: newCheckConfigs })
+    },
+    [currentConfig, updateConfig]
+  )
+
+  const handleResetPrompt = useCallback(
+    (checkId: string) => {
+      updateCheckConfig(checkId, { customPrompt: undefined })
+      toast.success('Prompt reset to default')
+    },
+    [updateCheckConfig]
+  )
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-yellow-500/20 bg-yellow-500/5 p-4">
+        <p className="text-sm text-muted-foreground">
+          <strong className="text-yellow-600 dark:text-yellow-400">
+            Experimental.
+          </strong>{' '}
+          Nightshift runs automated maintenance checks on your codebase in the
+          background.
+        </p>
+      </div>
+      <SettingsSection title="Nightshift">
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <Label className="text-sm text-foreground">Enable Nightshift</Label>
+            <p className="text-xs text-muted-foreground">
+              AI-powered maintenance that creates sessions to fix code issues
+            </p>
+          </div>
+          <Switch
+            checked={currentConfig.enabled}
+            onCheckedChange={handleToggleEnabled}
+          />
+        </div>
+
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRunNow}
+            disabled={isRunning}
+          >
+            {isRunning ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Play className="h-4 w-4" />
+            )}
+            {isRunning ? 'Running...' : 'Run Now'}
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleViewHistory}>
+            <History className="h-4 w-4" />
+            View History
+          </Button>
+        </div>
+      </SettingsSection>
+
+      <SettingsSection title="Configuration">
+        <SettingsRow label="Backend" description="CLI backend for sessions">
+          <NativeSelect
+            value={currentConfig.backend ?? ''}
+            onChange={e =>
+              updateConfig({ backend: e.target.value || undefined, model: undefined })
+            }
+          >
+            {BACKEND_OPTIONS.map(opt => (
+              <NativeSelectOption key={opt.value} value={opt.value}>
+                {opt.label}
+              </NativeSelectOption>
+            ))}
+          </NativeSelect>
+        </SettingsRow>
+
+        <SettingsRow label="Model" description="Model for nightshift sessions">
+          <NativeSelect
+            value={currentConfig.model ?? ''}
+            onChange={e => updateConfig({ model: e.target.value || undefined })}
+          >
+            {getModelOptionsForBackend(currentConfig.backend).map(opt => (
+              <NativeSelectOption key={opt.value} value={opt.value}>
+                {opt.label}
+              </NativeSelectOption>
+            ))}
+          </NativeSelect>
+        </SettingsRow>
+
+        <SettingsRow label="After Run" description="What to do with changes">
+          <NativeSelect
+            value={currentConfig.postAction}
+            onChange={e =>
+              updateConfig({
+                postAction: e.target.value as NightshiftConfig['postAction'],
+              })
+            }
+          >
+            {POST_ACTION_OPTIONS.map(opt => (
+              <NativeSelectOption key={opt.value} value={opt.value}>
+                {opt.label}
+              </NativeSelectOption>
+            ))}
+          </NativeSelect>
+        </SettingsRow>
+
+        <SettingsRow
+          label="Schedule"
+          description="Time of day to auto-run (HH:MM)"
+        >
+          <Input
+            type="time"
+            className="w-28"
+            value={currentConfig.scheduleTime ?? ''}
+            onChange={e =>
+              updateConfig({ scheduleTime: e.target.value || undefined })
+            }
+          />
+        </SettingsRow>
+      </SettingsSection>
+
+      <SettingsSection title="Checks">
+        <p className="text-xs text-muted-foreground">
+          Select which maintenance checks to run. Click a check to configure its
+          cooldown and prompt.
+        </p>
+        <div className="space-y-2">
+          {checks.map(check => {
+            const isExpanded = expandedChecks.has(check.id)
+            const effectiveCooldown =
+              currentConfig.checkConfigs[check.id]?.cooldownHoursOverride ??
+              check.cooldownHours
+            const customPrompt =
+              currentConfig.checkConfigs[check.id]?.customPrompt ?? ''
+
+            return (
+              <div key={check.id} className="border border-border rounded-md">
+                <div className="flex items-start gap-3 p-3">
+                  <Checkbox
+                    id={`check-${check.id}`}
+                    checked={isCheckEnabled(check.id, check.defaultEnabled)}
+                    onCheckedChange={() =>
+                      handleToggleCheck(check.id, check.defaultEnabled)
+                    }
+                    className="mt-0.5"
+                  />
+                  <button
+                    type="button"
+                    className="flex-1 text-left cursor-pointer"
+                    onClick={() => toggleExpanded(check.id)}
+                  >
+                    <div className="flex items-center gap-1">
+                      {isExpanded ? (
+                        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                      ) : (
+                        <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+                      )}
+                      <span className="text-sm font-medium text-foreground">
+                        {check.name}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        ({effectiveCooldown}h cooldown)
+                      </span>
+                    </div>
+                    <p className="text-xs text-muted-foreground ml-5">
+                      {check.description}
+                    </p>
+                  </button>
+                </div>
+
+                {isExpanded && (
+                  <div className="px-3 pb-3 pt-1 space-y-3 border-t border-border">
+                    <div className="flex items-center gap-2">
+                      <Label className="text-xs text-muted-foreground w-20 shrink-0">
+                        Cooldown
+                      </Label>
+                      <Input
+                        type="number"
+                        className="w-20"
+                        min={1}
+                        value={
+                          currentConfig.checkConfigs[check.id]
+                            ?.cooldownHoursOverride ?? check.cooldownHours
+                        }
+                        onChange={e => {
+                          const val = Number(e.target.value)
+                          if (val === check.cooldownHours) {
+                            updateCheckConfig(check.id, {
+                              cooldownHoursOverride: undefined,
+                            })
+                          } else {
+                            updateCheckConfig(check.id, {
+                              cooldownHoursOverride: val,
+                            })
+                          }
+                        }}
+                      />
+                      <span className="text-xs text-muted-foreground">
+                        hours
+                      </span>
+                    </div>
+
+                    <div className="space-y-1.5">
+                      <div className="flex items-center justify-between">
+                        <Label className="text-xs text-muted-foreground">
+                          Custom Prompt
+                        </Label>
+                        {customPrompt && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-6 px-2 text-xs"
+                            onClick={() => handleResetPrompt(check.id)}
+                          >
+                            <RotateCcw className="h-3 w-3 mr-1" />
+                            Reset
+                          </Button>
+                        )}
+                      </div>
+                      <Textarea
+                        className="text-xs font-mono min-h-[80px]"
+                        placeholder="Leave empty to use built-in default prompt..."
+                        value={customPrompt}
+                        onChange={e =>
+                          updateCheckConfig(check.id, {
+                            customPrompt: e.target.value || undefined,
+                          })
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </SettingsSection>
+    </div>
+  )
+}

--- a/src/components/projects/panes/NightshiftPane.tsx
+++ b/src/components/projects/panes/NightshiftPane.tsx
@@ -21,6 +21,7 @@ import {
   useNightshiftConfig,
   useSaveNightshiftConfig,
   useStartNightshiftRun,
+  useStartNightshiftCheck,
 } from '@/services/nightshift'
 import { useNightshiftStore } from '@/store/nightshift-store'
 import { defaultNightshiftConfig } from '@/types/nightshift'
@@ -105,6 +106,7 @@ export function NightshiftPane({
   const { data: config } = useNightshiftConfig(projectId)
   const saveConfig = useSaveNightshiftConfig()
   const startRun = useStartNightshiftRun()
+  const startCheck = useStartNightshiftCheck()
   const activeRuns = useNightshiftStore(s => s.activeRuns)
   const isRunning = !!activeRuns[projectId]
 
@@ -178,14 +180,23 @@ export function NightshiftPane({
   )
 
   const handleRunNow = useCallback(async () => {
-    const toastId = toast.loading('Starting Nightshift run...')
     try {
       await startRun.mutateAsync(projectId)
-      toast.success('Nightshift run started', { id: toastId })
     } catch (error) {
-      toast.error(`Failed to start: ${error}`, { id: toastId })
+      toast.error(`Failed to start: ${error}`)
     }
   }, [projectId, startRun])
+
+  const handleRunCheck = useCallback(
+    async (checkId: string, checkName: string) => {
+      try {
+        await startCheck.mutateAsync({ projectId, checkId })
+      } catch (error) {
+        toast.error(`Failed to start "${checkName}": ${error}`)
+      }
+    },
+    [projectId, startCheck]
+  )
 
   const handleViewHistory = useCallback(() => {
     useNightshiftStore.getState().openRunsModal(projectId)
@@ -248,7 +259,7 @@ export function NightshiftPane({
             ) : (
               <Play className="h-4 w-4" />
             )}
-            {isRunning ? 'Running...' : 'Run Now'}
+            {isRunning ? 'Running...' : 'Run most overdue check now'}
           </Button>
           <Button variant="outline" size="sm" onClick={handleViewHistory}>
             <History className="h-4 w-4" />
@@ -335,14 +346,24 @@ export function NightshiftPane({
             return (
               <div key={check.id} className="border border-border rounded-md">
                 <div className="flex items-start gap-3 p-3">
-                  <Checkbox
-                    id={`check-${check.id}`}
-                    checked={isCheckEnabled(check.id, check.defaultEnabled)}
-                    onCheckedChange={() =>
-                      handleToggleCheck(check.id, check.defaultEnabled)
-                    }
-                    className="mt-0.5"
-                  />
+                  <div className="flex flex-col items-center gap-1 mt-0.5">
+                    <Checkbox
+                      id={`check-${check.id}`}
+                      checked={isCheckEnabled(check.id, check.defaultEnabled)}
+                      onCheckedChange={() =>
+                        handleToggleCheck(check.id, check.defaultEnabled)
+                      }
+                    />
+                    <button
+                      type="button"
+                      title={`Run "${check.name}" now`}
+                      className="text-muted-foreground hover:text-foreground transition-colors disabled:opacity-30"
+                      disabled={isRunning}
+                      onClick={() => handleRunCheck(check.id, check.name)}
+                    >
+                      <Play className="h-3 w-3" />
+                    </button>
+                  </div>
                   <button
                     type="button"
                     className="flex-1 text-left cursor-pointer"

--- a/src/components/session-history/SessionHistoryModal.tsx
+++ b/src/components/session-history/SessionHistoryModal.tsx
@@ -1,0 +1,164 @@
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
+import { CheckCircle2, Loader2 } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+import { useAllSessions } from '@/services/chat'
+import { useUIStore } from '@/store/ui-store'
+import {
+  type SessionListItem,
+  formatRelativeTime,
+  getSessionStatus,
+  navigateToSession,
+} from '@/lib/session-utils'
+
+export function SessionHistoryModal() {
+  const open = useUIStore(state => state.sessionHistoryOpen)
+  const setOpen = useUIStore(state => state.setSessionHistoryOpen)
+  const [focusedIndex, setFocusedIndex] = useState(0)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const { data: allSessions, isLoading } = useAllSessions(open)
+
+  // Flat list of all non-archived sessions, sorted by updated_at desc
+  const items = useMemo((): SessionListItem[] => {
+    if (!allSessions?.entries) return []
+    const result: SessionListItem[] = []
+    for (const entry of allSessions.entries) {
+      for (const session of entry.sessions) {
+        if (session.archived_at) continue
+        result.push({
+          session,
+          projectId: entry.project_id,
+          projectName: entry.project_name,
+          worktreeId: entry.worktree_id,
+          worktreeName: entry.worktree_name,
+          worktreePath: entry.worktree_path,
+        })
+      }
+    }
+    return result.sort((a, b) => b.session.updated_at - a.session.updated_at)
+  }, [allSessions])
+
+  // Reset focus when items change or modal opens
+  useEffect(() => {
+    if (open) setFocusedIndex(0)
+  }, [open])
+
+  const handleSelect = useCallback(
+    (item: SessionListItem) => {
+      setOpen(false)
+      navigateToSession(item)
+    },
+    [setOpen]
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const total = items.length
+      if (!total) return
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault()
+          setFocusedIndex(i => Math.min(i + 1, total - 1))
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          setFocusedIndex(i => Math.max(i - 1, 0))
+          break
+        case 'Enter':
+          e.preventDefault()
+          if (focusedIndex >= 0 && items[focusedIndex]) {
+            handleSelect(items[focusedIndex])
+          }
+          break
+      }
+    },
+    [items, focusedIndex, handleSelect]
+  )
+
+  // Scroll focused item into view
+  useEffect(() => {
+    if (focusedIndex < 0) return
+    document
+      .querySelector(`[data-history-index="${focusedIndex}"]`)
+      ?.scrollIntoView({ block: 'nearest' })
+  }, [focusedIndex])
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent
+        className="max-w-2xl max-h-[80vh] flex flex-col gap-0 p-0"
+        onKeyDown={handleKeyDown}
+      >
+        <DialogHeader className="px-4 py-3 border-b">
+          <DialogTitle className="text-sm font-medium">
+            Session History
+          </DialogTitle>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+          </div>
+        ) : items.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground text-sm">
+            No sessions yet
+          </div>
+        ) : (
+          <div
+            ref={listRef}
+            className="overflow-y-auto flex-1 p-1"
+          >
+            {items.map((item, idx) => {
+              const status = getSessionStatus(item.session)
+              const StatusIcon = status?.icon ?? CheckCircle2
+
+              return (
+                <button
+                  key={item.session.id}
+                  type="button"
+                  data-history-index={idx}
+                  onClick={() => handleSelect(item)}
+                  onMouseEnter={() => setFocusedIndex(idx)}
+                  className={cn(
+                    'w-full text-left px-3 py-2 rounded-md hover:bg-accent/50 transition-colors cursor-pointer flex items-start gap-2',
+                    focusedIndex === idx && 'bg-accent'
+                  )}
+                >
+                  <StatusIcon
+                    className={cn(
+                      'h-3.5 w-3.5 shrink-0 mt-0.5',
+                      status?.className ?? 'text-muted-foreground'
+                    )}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-1.5">
+                      <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/50 shrink-0">
+                        {item.projectName}
+                      </span>
+                      <span className="text-[11px] text-muted-foreground/30 shrink-0">
+                        {item.worktreeName}
+                      </span>
+                      <span className="text-[11px] text-muted-foreground/40 shrink-0 ml-auto">
+                        {formatRelativeTime(item.session.updated_at)}
+                      </span>
+                    </div>
+                    <span className="text-[13px] truncate block">
+                      {item.session.name}
+                    </span>
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/shared/FailedRunsBadge.tsx
+++ b/src/components/shared/FailedRunsBadge.tsx
@@ -56,7 +56,7 @@ export function FailedRunsBadge({
           <button
             onClick={handleClick}
             className={cn(
-              'shrink-0 rounded bg-red-500/10 px-1.5 py-0.5 text-[11px] font-medium text-red-600 transition-colors hover:bg-red-500/20',
+              'shrink-0 text-[11px] font-medium text-red-600 transition-opacity hover:opacity-70',
               className
             )}
           >
@@ -78,7 +78,7 @@ export function FailedRunsBadge({
         <button
           onClick={handleClick}
           className={cn(
-            'shrink-0 rounded bg-muted-foreground/10 px-2.5 py-[4.5px] text-[11px] text-muted-foreground/50 transition-colors hover:bg-muted-foreground/20 hover:text-muted-foreground',
+            'shrink-0 text-[11px] text-muted-foreground/50 transition-opacity hover:opacity-70 hover:text-muted-foreground',
             className
           )}
         >

--- a/src/components/shared/NewIssuesBadge.tsx
+++ b/src/components/shared/NewIssuesBadge.tsx
@@ -57,7 +57,7 @@ export function NewIssuesBadge({
         <button
           onClick={handleClick}
           className={cn(
-            'shrink-0 rounded bg-green-500/10 px-1.5 py-0.5 text-[11px] font-medium text-green-600 transition-colors hover:bg-green-500/20',
+            'shrink-0 text-[11px] font-medium text-green-600 transition-opacity hover:opacity-70',
             className
           )}
         >

--- a/src/components/shared/OpenPRsBadge.tsx
+++ b/src/components/shared/OpenPRsBadge.tsx
@@ -57,7 +57,7 @@ export function OpenPRsBadge({
         <button
           onClick={handleClick}
           className={cn(
-            'shrink-0 rounded bg-blue-500/10 px-1.5 py-0.5 text-[11px] font-medium text-blue-600 transition-colors hover:bg-blue-500/20',
+            'shrink-0 text-[11px] font-medium text-blue-600 transition-opacity hover:opacity-70',
             className
           )}
         >

--- a/src/components/shared/SecurityAlertsBadge.tsx
+++ b/src/components/shared/SecurityAlertsBadge.tsx
@@ -66,7 +66,7 @@ export function SecurityAlertsBadge({
         <button
           onClick={handleClick}
           className={cn(
-            'shrink-0 rounded bg-orange-500/10 px-1.5 py-0.5 text-[11px] font-medium text-orange-600 transition-colors hover:bg-orange-500/20',
+            'shrink-0 text-[11px] font-medium text-orange-600 transition-opacity hover:opacity-70',
             className
           )}
         >

--- a/src/components/titlebar/TitleBar.tsx
+++ b/src/components/titlebar/TitleBar.tsx
@@ -22,6 +22,7 @@ import { usePreferences } from '@/services/preferences'
 import { formatShortcutDisplay, DEFAULT_KEYBINDINGS } from '@/types/keybindings'
 import { isNativeApp } from '@/lib/environment'
 import { UnreadBell } from '@/components/unread/UnreadBell'
+import { FloatingDock } from '@/components/ui/floating-dock'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { FALLBACK_APP_VERSION } from '@/lib/app-version'
 
@@ -152,6 +153,9 @@ export function TitleBar({
             </TooltipTrigger>
             <TooltipContent>Sponsor</TooltipContent>
           </Tooltip>
+          {/* Separator between upstream links and dock actions */}
+          <div className="mx-1 h-3.5 w-px bg-border/50" />
+          <FloatingDock />
         </div>
       </div>
 

--- a/src/components/ui/floating-dock.tsx
+++ b/src/components/ui/floating-dock.tsx
@@ -3,7 +3,6 @@ import {
   useState,
   useEffect,
   useCallback,
-  useSyncExternalStore,
 } from 'react'
 import {
   LayoutDashboard,
@@ -91,7 +90,7 @@ function KeybindingHintsButton({
   side = 'top',
 }: {
   hints: KeybindingHint[]
-  side?: 'top' | 'right'
+  side?: 'top' | 'right' | 'bottom'
 }) {
   return (
     <Popover>
@@ -162,21 +161,8 @@ function CodexIcon({ className }: { className: string }) {
   )
 }
 
-const WIDE_BREAKPOINT = 1280
-const lgQuery = `(min-width: ${WIDE_BREAKPOINT}px)`
-function subscribeLg(cb: () => void) {
-  const mql = window.matchMedia(lgQuery)
-  mql.addEventListener('change', cb)
-  return () => mql.removeEventListener('change', cb)
-}
-function snapshotLg() {
-  return window.matchMedia(lgQuery).matches
-}
-const serverLg = () => true
-
 export function FloatingDock() {
   const isMobile = useIsMobile()
-  const isLg = useSyncExternalStore(subscribeLg, snapshotLg, serverLg)
   const { data: preferences } = usePreferences()
   const queryClient = useQueryClient()
 
@@ -383,11 +369,14 @@ export function FloatingDock() {
   const isWebAccess = !isNativeApp()
   const showConnectionIndicator = isWebAccess
   const showKeybindingHints = isNativeApp() && !isMobile
-  const popoverSide = isMobile || isLg ? 'top' : ('right' as const)
-  const popoverAlign = isMobile ? 'end' : ('start' as const)
+
+  // Titlebar-integrated: render inline buttons, no floating container
+  const btnClass = 'h-6 w-6 rounded-none text-foreground/70 hover:text-foreground'
+  const tooltipSide = 'bottom' as const
+  const menuAlign = 'start' as const
 
   return (
-    <div className="absolute bottom-4 right-4 z-10 flex flex-row items-center gap-0.5 rounded-full border border-border/30 bg-background/60 backdrop-blur-md px-1 py-0.5 sm:left-4 sm:right-auto sm:flex-col sm:rounded-2xl sm:px-0.5 sm:py-1 xl:flex-row xl:rounded-full xl:px-1 xl:py-0.5">
+    <>
       <DropdownMenu open={menuOpen} onOpenChange={handleQuickMenuOpenChange}>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -395,14 +384,14 @@ export function FloatingDock() {
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-7 w-7 rounded-full text-muted-foreground hover:text-foreground"
+                className={btnClass}
               >
-                <Menu className="size-4" />
+                <Menu className="size-3.5" />
                 <span className="sr-only">Quick menu</span>
               </Button>
             </DropdownMenuTrigger>
           </TooltipTrigger>
-          <TooltipContent side={popoverSide}>
+          <TooltipContent side={tooltipSide}>
             Menu{' '}
             <kbd className="ml-1 text-[0.625rem] opacity-60">
               {menuShortcut}
@@ -410,8 +399,8 @@ export function FloatingDock() {
           </TooltipContent>
         </Tooltip>
         <DropdownMenuContent
-          side={popoverSide}
-          align={popoverAlign}
+          side={tooltipSide}
+          align={menuAlign}
           className="min-w-[200px]"
           onEscapeKeyDown={e => e.stopPropagation()}
         >
@@ -493,14 +482,14 @@ export function FloatingDock() {
           <Button
             variant="ghost"
             size="icon"
-            className="h-7 w-7 rounded-full text-muted-foreground hover:text-foreground"
+            className={btnClass}
             onClick={() => useUIStore.getState().setCommandPaletteOpen(true)}
           >
-            <Command className="size-4" />
+            <Command className="size-3.5" />
             <span className="sr-only">Command Palette</span>
           </Button>
         </TooltipTrigger>
-        <TooltipContent side={popoverSide}>
+        <TooltipContent side={tooltipSide}>
           Command Palette{' '}
           <kbd className="ml-1 text-[0.625rem] opacity-60">⌘K</kbd>
         </TooltipContent>
@@ -513,25 +502,17 @@ export function FloatingDock() {
               <DropdownMenuTrigger asChild>
                 <Button
                   variant="ghost"
-                  size={isLg ? 'sm' : 'icon'}
-                  className={
-                    isLg
-                      ? 'h-7 w-[88px] justify-center rounded-full px-2 text-muted-foreground hover:text-foreground'
-                      : 'h-7 w-7 rounded-full text-muted-foreground hover:text-foreground'
-                  }
+                  size="sm"
+                  className="h-6 justify-center rounded-none px-1.5 text-foreground/70 hover:text-foreground"
                 >
-                  <activeUsageEntry.Icon
-                    className={isLg ? 'mr-1 size-3.5 shrink-0' : 'size-4'}
-                  />
-                  {isLg && (
-                    <span className="text-[11px] leading-none tabular-nums">
-                      {usageBadge.text}
-                    </span>
-                  )}
+                  <activeUsageEntry.Icon className="mr-0.5 size-3 shrink-0" />
+                  <span className="text-[10px] leading-none tabular-nums">
+                    {usageBadge.text}
+                  </span>
                 </Button>
               </DropdownMenuTrigger>
             </TooltipTrigger>
-            <TooltipContent side={popoverSide}>
+            <TooltipContent side={tooltipSide}>
               {activeUsageEntry.label} Session|Weekly{' '}
               <kbd className="ml-1 text-[0.625rem] opacity-60">
                 {usageShortcut}
@@ -539,8 +520,8 @@ export function FloatingDock() {
             </TooltipContent>
           </Tooltip>
           <DropdownMenuContent
-            side={popoverSide}
-            align={popoverAlign}
+            side={tooltipSide}
+            align={menuAlign}
             className="min-w-[180px]"
             onEscapeKeyDown={e => e.stopPropagation()}
           >
@@ -583,8 +564,8 @@ export function FloatingDock() {
 
       {showConnectionIndicator && <ConnectionIndicator />}
       {showKeybindingHints && (
-        <KeybindingHintsButton hints={CANVAS_HINTS} side={popoverSide} />
+        <KeybindingHintsButton hints={CANVAS_HINTS} side={tooltipSide} />
       )}
-    </div>
+    </>
   )
 }

--- a/src/components/ui/git-status-badges.tsx
+++ b/src/components/ui/git-status-badges.tsx
@@ -80,7 +80,7 @@ export function GitStatusBadges({
               {behindCount}
             </button>
           </TooltipTrigger>
-          <TooltipContent>{`Pull ${behindCount} commit${behindCount > 1 ? 's' : ''} from remote`}</TooltipContent>
+          <TooltipContent>{`Merge ${behindCount} new commit${behindCount > 1 ? 's' : ''} from remote base branch`}</TooltipContent>
         </Tooltip>
       )}
       {unpushedCount > 0 && (

--- a/src/components/ui/git-status-badges.tsx
+++ b/src/components/ui/git-status-badges.tsx
@@ -8,6 +8,7 @@ import {
 interface GitStatusBadgesProps {
   behindCount: number
   unpushedCount: number
+  unpushedCommits?: { hash: string; message: string }[]
   diffAdded: number
   diffRemoved: number
   branchDiffAdded?: number
@@ -25,6 +26,7 @@ export function GitStatusBadges({
   diffRemoved,
   branchDiffAdded = 0,
   branchDiffRemoved = 0,
+  unpushedCommits,
   onPull,
   onPush,
   onDiffClick,
@@ -95,7 +97,24 @@ export function GitStatusBadges({
               {unpushedCount}
             </button>
           </TooltipTrigger>
-          <TooltipContent>{`Push ${unpushedCount} commit${unpushedCount > 1 ? 's' : ''} to remote`}</TooltipContent>
+          <TooltipContent className="max-w-80">
+            <p>{`Push ${unpushedCount} commit${unpushedCount > 1 ? 's' : ''} to remote`}</p>
+            {unpushedCommits && unpushedCommits.length > 0 && (
+              <ul className="mt-1 space-y-0.5 border-t border-border/50 pt-1">
+                {unpushedCommits.map(c => (
+                  <li key={c.hash} className="flex gap-1.5 text-[11px] leading-tight">
+                    <code className="shrink-0 text-muted-foreground">{c.hash}</code>
+                    <span className="truncate">{c.message}</span>
+                  </li>
+                ))}
+                {unpushedCount > unpushedCommits.length && (
+                  <li className="text-[11px] text-muted-foreground">
+                    ...and {unpushedCount - unpushedCommits.length} more
+                  </li>
+                )}
+              </ul>
+            )}
+          </TooltipContent>
         </Tooltip>
       )}
     </span>

--- a/src/components/ui/git-status-badges.tsx
+++ b/src/components/ui/git-status-badges.tsx
@@ -74,7 +74,7 @@ export function GitStatusBadges({
             <button
               type="button"
               onClick={onPull}
-              className="inline-flex shrink-0 cursor-pointer items-center gap-0.5 rounded bg-primary/10 px-1.5 py-0.5 text-[11px] font-medium text-primary transition-colors hover:bg-primary/20"
+              className="inline-flex shrink-0 cursor-pointer items-center gap-0.5 text-[11px] font-medium text-primary transition-opacity hover:opacity-70"
             >
               <ArrowDown className="h-3 w-3" />
               {behindCount}
@@ -89,7 +89,7 @@ export function GitStatusBadges({
             <button
               type="button"
               onClick={onPush}
-              className="inline-flex shrink-0 cursor-pointer items-center gap-0.5 rounded bg-orange-500/10 px-1.5 py-0.5 text-[11px] font-medium text-orange-500 transition-colors hover:bg-orange-500/20"
+              className="inline-flex shrink-0 cursor-pointer items-center gap-0.5 text-[11px] font-medium text-orange-500 transition-opacity hover:opacity-70"
             >
               <ArrowUp className="h-3 w-3" />
               {unpushedCount}

--- a/src/components/ui/status-indicator.tsx
+++ b/src/components/ui/status-indicator.tsx
@@ -13,16 +13,31 @@ interface StatusIndicatorProps {
   status: IndicatorStatus
   variant?: IndicatorVariant
   shape?: IndicatorShape
+  title?: string
   className?: string
+}
+
+function getDefaultTitle(status: IndicatorStatus, variant: IndicatorVariant): string {
+  if (status === 'running') {
+    if (variant === 'destructive') return 'Running (yolo mode)'
+    if (variant === 'loading') return 'Loading'
+    return 'Running'
+  }
+  if (status === 'waiting') return 'Waiting for input'
+  if (status === 'review') return 'Ready for review'
+  if (status === 'completed') return 'Completed'
+  return 'Idle'
 }
 
 export function StatusIndicator({
   status,
   variant = 'default',
   shape = 'circle',
+  title,
   className,
 }: StatusIndicatorProps) {
   const shapeClass = shape === 'square' ? 'rounded-sm' : 'rounded-full'
+  const resolvedTitle = title ?? getDefaultTitle(status, variant)
 
   // Running state: CSS border spinner
   if (status === 'running') {
@@ -35,6 +50,7 @@ export function StatusIndicator({
 
     return (
       <span
+        title={resolvedTitle}
         className={cn(
           'shrink-0 block animate-spin border-2 border-transparent',
           shapeClass,
@@ -55,6 +71,7 @@ export function StatusIndicator({
 
   return (
     <span
+      title={resolvedTitle}
       className={cn(
         'shrink-0 block bg-current',
         shape === 'circle' ? 'rounded-full' : 'rounded-sm',

--- a/src/components/unread/UnreadBell.tsx
+++ b/src/components/unread/UnreadBell.tsx
@@ -3,10 +3,6 @@ import {
   BellDot,
   Loader2,
   CheckCircle2,
-  AlertTriangle,
-  CirclePause,
-  HelpCircle,
-  FileText,
 } from 'lucide-react'
 import {
   Popover,
@@ -18,83 +14,18 @@ import { cn } from '@/lib/utils'
 import { invoke } from '@/lib/transport'
 import { useQueryClient } from '@tanstack/react-query'
 import { useAllSessions } from '@/services/chat'
-import { useProjectsStore } from '@/store/projects-store'
-import { useChatStore } from '@/store/chat-store'
-import { useUIStore } from '@/store/ui-store'
 import { useUnreadCount } from './useUnreadCount'
 import { formatShortcutDisplay } from '@/types/keybindings'
 import type { Session } from '@/types/chat'
 import { useIsMobile } from '@/hooks/use-mobile'
-
-function isUnread(session: Session): boolean {
-  if (session.archived_at) return false
-  const actionableStatuses = ['completed', 'cancelled', 'crashed']
-  const hasFinishedRun =
-    session.last_run_status &&
-    actionableStatuses.includes(session.last_run_status)
-  const isWaiting = session.waiting_for_input
-  const isReviewing = session.is_reviewing
-  if (!hasFinishedRun && !isWaiting && !isReviewing) return false
-  if (!session.last_opened_at) return true
-  return session.last_opened_at < session.updated_at
-}
-
-function formatRelativeTime(timestamp: number): string {
-  const ms = timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp
-  const diffMs = Date.now() - ms
-  if (diffMs < 0) return 'just now'
-  const minuteMs = 60_000
-  const hourMs = 60 * minuteMs
-  const dayMs = 24 * hourMs
-  if (diffMs < hourMs)
-    return `${Math.max(1, Math.floor(diffMs / minuteMs))}m ago`
-  if (diffMs < dayMs) return `${Math.floor(diffMs / hourMs)}h ago`
-  return `${Math.floor(diffMs / dayMs)}d ago`
-}
-
-interface UnreadItem {
-  session: Session
-  projectId: string
-  projectName: string
-  worktreeId: string
-  worktreeName: string
-  worktreePath: string
-}
-
-function getSessionStatus(session: Session) {
-  if (session.waiting_for_input) {
-    const isplan = session.waiting_for_input_type === 'plan'
-    return {
-      icon: isplan ? FileText : HelpCircle,
-      label: isplan ? 'Needs approval' : 'Needs input',
-      className: 'text-yellow-500',
-    }
-  }
-  const config: Record<
-    string,
-    { icon: typeof CheckCircle2; label: string; className: string }
-  > = {
-    completed: {
-      icon: CheckCircle2,
-      label: 'Completed',
-      className: 'text-green-500',
-    },
-    cancelled: {
-      icon: CirclePause,
-      label: 'Cancelled',
-      className: 'text-muted-foreground',
-    },
-    crashed: {
-      icon: AlertTriangle,
-      label: 'Crashed',
-      className: 'text-destructive',
-    },
-  }
-  if (session.last_run_status && config[session.last_run_status]) {
-    return config[session.last_run_status]
-  }
-  return null
-}
+import {
+  type SessionListItem,
+  isUnread,
+  isActionable,
+  formatRelativeTime,
+  getSessionStatus,
+  navigateToSession,
+} from '@/lib/session-utils'
 
 interface UnreadBellProps {
   title: string
@@ -117,13 +48,6 @@ export function UnreadBell({ title, hideTitle }: UnreadBellProps) {
       window.removeEventListener('command:open-unread-sessions', handler)
   }, [])
 
-  // Synchronous reset: guarantees open=false is committed before unreadCount
-  // can bounce back (e.g. optimistic update overwritten by in-flight refetch).
-  // A useEffect would fire after render, missing fast 1→0→1 transitions.
-  if (unreadCount === 0 && open) {
-    setOpen(false)
-  }
-
   // Invalidate cache each time popover opens
   useEffect(() => {
     if (open) {
@@ -140,25 +64,42 @@ export function UnreadBell({ title, hideTitle }: UnreadBellProps) {
     return () => window.removeEventListener('session-opened', handler)
   }, [queryClient])
 
-  const unreadItems = useMemo((): UnreadItem[] => {
-    if (!allSessions) return []
-    const results: UnreadItem[] = []
+  // Split actionable sessions into unread (top, full opacity) and read (bottom, dimmed)
+  const { unreadItems, readItems } = useMemo(() => {
+    if (!allSessions) return { unreadItems: [] as SessionListItem[], readItems: [] as SessionListItem[] }
+    const unread: SessionListItem[] = []
+    const read: SessionListItem[] = []
     for (const entry of allSessions.entries) {
       for (const session of entry.sessions) {
+        if (!isActionable(session)) continue
+        const item: SessionListItem = {
+          session,
+          projectId: entry.project_id,
+          projectName: entry.project_name,
+          worktreeId: entry.worktree_id,
+          worktreeName: entry.worktree_name,
+          worktreePath: entry.worktree_path,
+        }
         if (isUnread(session)) {
-          results.push({
-            session,
-            projectId: entry.project_id,
-            projectName: entry.project_name,
-            worktreeId: entry.worktree_id,
-            worktreeName: entry.worktree_name,
-            worktreePath: entry.worktree_path,
-          })
+          unread.push(item)
+        } else {
+          read.push(item)
         }
       }
     }
-    return results.sort((a, b) => b.session.updated_at - a.session.updated_at)
+    const byUpdated = (a: SessionListItem, b: SessionListItem) =>
+      b.session.updated_at - a.session.updated_at
+    return {
+      unreadItems: unread.sort(byUpdated),
+      readItems: read.sort(byUpdated),
+    }
   }, [allSessions])
+
+  // Combined list for keyboard navigation (unread first, then read)
+  const allItems = useMemo(
+    () => [...unreadItems, ...readItems],
+    [unreadItems, readItems]
+  )
 
   const markSessionsReadOptimistically = useCallback(
     (sessionIds: string[]) => {
@@ -192,7 +133,7 @@ export function UnreadBell({ title, hideTitle }: UnreadBellProps) {
   }, [unreadItems, queryClient, markSessionsReadOptimistically])
 
   const handleMarkOneRead = useCallback(
-    async (item: UnreadItem) => {
+    async (item: SessionListItem) => {
       markSessionsReadOptimistically([item.session.id])
       await invoke('set_session_last_opened', {
         sessionId: item.session.id,
@@ -209,50 +150,15 @@ export function UnreadBell({ title, hideTitle }: UnreadBellProps) {
     [queryClient, unreadItems.length, markSessionsReadOptimistically]
   )
 
-  const handleSelect = useCallback(
-    (item: UnreadItem) => {
-      const { selectedProjectId, selectProject } = useProjectsStore.getState()
-      const { setActiveSession, clearActiveWorktree, setLastOpenedForProject } =
-        useChatStore.getState()
-
-      const crossProject = selectedProjectId !== item.projectId
-      if (crossProject) {
-        selectProject(item.projectId)
-      }
-
-      // Navigate to ProjectCanvasView
-      clearActiveWorktree()
-      setActiveSession(item.worktreeId, item.session.id)
-      setLastOpenedForProject(item.projectId, item.worktreeId, item.session.id)
-      markSessionsReadOptimistically([item.session.id])
-      setOpen(false)
-
-      if (crossProject) {
-        // Component remounts with new projectId key — use store-based auto-open
-        useUIStore
-          .getState()
-          .markWorktreeForAutoOpenSession(item.worktreeId, item.session.id)
-      } else {
-        // Same project, component stays mounted — use event
-        setTimeout(() => {
-          window.dispatchEvent(
-            new CustomEvent('open-session-modal', {
-              detail: {
-                sessionId: item.session.id,
-                worktreeId: item.worktreeId,
-                worktreePath: item.worktreePath,
-              },
-            })
-          )
-        }, 50)
-      }
-    },
-    [markSessionsReadOptimistically]
-  )
+  const handleSelect = useCallback((item: SessionListItem) => {
+    markSessionsReadOptimistically([item.session.id])
+    setOpen(false)
+    navigateToSession(item)
+  }, [markSessionsReadOptimistically])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      const total = unreadItems.length
+      const total = allItems.length
       if (!total) return
 
       switch (e.key) {
@@ -266,19 +172,20 @@ export function UnreadBell({ title, hideTitle }: UnreadBellProps) {
           break
         case 'Enter':
           e.preventDefault()
-          if (focusedIndex >= 0 && unreadItems[focusedIndex]) {
-            handleSelect(unreadItems[focusedIndex])
+          if (focusedIndex >= 0 && allItems[focusedIndex]) {
+            handleSelect(allItems[focusedIndex])
           }
           break
         case 'Backspace':
           e.preventDefault()
-          if (focusedIndex >= 0 && unreadItems[focusedIndex]) {
+          // Only mark-read works on unread items (first N in the list)
+          if (focusedIndex >= 0 && focusedIndex < unreadItems.length && unreadItems[focusedIndex]) {
             handleMarkOneRead(unreadItems[focusedIndex])
           }
           break
       }
     },
-    [unreadItems, focusedIndex, handleSelect, handleMarkOneRead]
+    [allItems, unreadItems, focusedIndex, handleSelect, handleMarkOneRead]
   )
 
   // Scroll focused item into view
@@ -289,33 +196,37 @@ export function UnreadBell({ title, hideTitle }: UnreadBellProps) {
       ?.scrollIntoView({ block: 'nearest' })
   }, [focusedIndex])
 
-  // No unread → show normal title (or nothing if hideTitle)
-  if (unreadCount === 0) {
-    if (hideTitle) return null
-    return (
-      <span className="block truncate text-sm font-medium text-foreground/80">
-        {title}
-      </span>
-    )
-  }
-
+  // Popover is always openable (notification center style).
+  // When unread > 0, show animated bell trigger; otherwise show title as clickable button.
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <div className="card-border-spin">
+        {unreadCount > 0 ? (
+          <div className="card-border-spin">
+            <button
+              type="button"
+              className="relative z-[1] flex items-center gap-1.5 truncate rounded-md bg-background px-1.5 text-sm font-medium text-yellow-400 cursor-pointer"
+            >
+              <BellDot className="h-3.5 w-3.5 shrink-0 animate-[bell-ring_2s_ease-in-out_infinite]" />
+              {unreadCount} finished{' '}
+              {unreadCount === 1 ? 'session' : 'sessions'}
+              {!isMobile && (
+                <Kbd className="ml-1 h-4 px-1 text-[10px] opacity-60">
+                  {formatShortcutDisplay('mod+shift+f')}
+                </Kbd>
+              )}
+            </button>
+          </div>
+        ) : hideTitle ? (
+          <span className="sr-only" />
+        ) : (
           <button
             type="button"
-            className="relative z-[1] flex items-center gap-1.5 truncate rounded-md bg-background px-1.5 text-sm font-medium text-yellow-400 cursor-pointer"
+            className="block truncate text-sm font-medium text-foreground/80 cursor-pointer"
           >
-            <BellDot className="h-3.5 w-3.5 shrink-0 animate-[bell-ring_2s_ease-in-out_infinite]" />
-            {unreadCount} finished {unreadCount === 1 ? 'session' : 'sessions'}
-            {!isMobile && (
-              <Kbd className="ml-1 h-4 px-1 text-[10px] opacity-60">
-                {formatShortcutDisplay('mod+shift+f')}
-              </Kbd>
-            )}
+            {title}
           </button>
-        </div>
+        )}
       </PopoverTrigger>
       <PopoverContent
         ref={contentRef}
@@ -347,15 +258,16 @@ export function UnreadBell({ title, hideTitle }: UnreadBellProps) {
           <div className="flex items-center justify-center py-6">
             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
           </div>
-        ) : unreadItems.length === 0 ? (
+        ) : allItems.length === 0 ? (
           <div className="text-center py-6 text-muted-foreground text-xs">
-            No unread sessions
+            No sessions with activity
           </div>
         ) : (
           <div className="max-h-[min(400px,60vh)] overflow-y-auto p-1">
-            {unreadItems.map((item, idx) => {
+            {allItems.map((item, idx) => {
               const status = getSessionStatus(item.session)
               const StatusIcon = status?.icon ?? CheckCircle2
+              const isRead = idx >= unreadItems.length
 
               return (
                 <button
@@ -366,7 +278,8 @@ export function UnreadBell({ title, hideTitle }: UnreadBellProps) {
                   onMouseEnter={() => setFocusedIndex(idx)}
                   className={cn(
                     'w-full text-left px-2 py-1.5 rounded-md hover:bg-accent/50 transition-colors cursor-pointer flex items-start gap-2',
-                    focusedIndex === idx && 'bg-accent'
+                    focusedIndex === idx && 'bg-accent',
+                    isRead && 'opacity-50'
                   )}
                 >
                   <StatusIcon

--- a/src/components/unread/UnreadSessionsModal.tsx
+++ b/src/components/unread/UnreadSessionsModal.tsx
@@ -3,118 +3,25 @@ import {
   BellDot,
   Loader2,
   CheckCircle2,
-  AlertTriangle,
-  CirclePause,
-  HelpCircle,
-  FileText,
   X,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { invoke } from '@/lib/transport'
 import { useQueryClient } from '@tanstack/react-query'
 import { useAllSessions } from '@/services/chat'
-import { useProjectsStore } from '@/store/projects-store'
-import { useChatStore } from '@/store/chat-store'
-import { useUIStore } from '@/store/ui-store'
 import type { Session } from '@/types/chat'
+import {
+  type SessionListItem,
+  isUnread,
+  isActionable,
+  formatRelativeTime,
+  getSessionStatus,
+  navigateToSession,
+} from '@/lib/session-utils'
 
 interface UnreadSessionsDrawerProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-}
-
-/**
- * A session is "unread" if it has activity the user hasn't seen:
- * - Not archived
- * - Has a meaningful status (finished, waiting for input, or reviewing)
- * - Never opened, or opened before last update
- */
-function isUnread(session: Session): boolean {
-  if (session.archived_at) return false
-
-  const actionableStatuses = ['completed', 'cancelled', 'crashed']
-  const hasFinishedRun =
-    session.last_run_status &&
-    actionableStatuses.includes(session.last_run_status)
-  const isWaiting = session.waiting_for_input
-  const isReviewing = session.is_reviewing
-
-  // Must have some actionable state
-  if (!hasFinishedRun && !isWaiting && !isReviewing) return false
-
-  // Never opened → definitely unread
-  if (!session.last_opened_at) return true
-
-  // Opened before last update → unread
-  return session.last_opened_at < session.updated_at
-}
-
-/** Format a unix timestamp (seconds) to relative time like "2h ago" */
-function formatRelativeTime(timestamp: number): string {
-  const ms = timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp
-  const diffMs = Date.now() - ms
-  if (diffMs < 0) return 'just now'
-  const minuteMs = 60_000
-  const hourMs = 60 * minuteMs
-  const dayMs = 24 * hourMs
-  if (diffMs < hourMs) {
-    const minutes = Math.max(1, Math.floor(diffMs / minuteMs))
-    return `${minutes}m ago`
-  }
-  if (diffMs < dayMs) {
-    const hours = Math.floor(diffMs / hourMs)
-    return `${hours}h ago`
-  }
-  const days = Math.floor(diffMs / dayMs)
-  return `${days}d ago`
-}
-
-interface UnreadItem {
-  session: Session
-  projectId: string
-  projectName: string
-  worktreeId: string
-  worktreeName: string
-  worktreePath: string
-}
-
-/** Get display info for a session's current state */
-function getSessionStatus(session: Session) {
-  if (session.waiting_for_input) {
-    const isplan = session.waiting_for_input_type === 'plan'
-    return {
-      icon: isplan ? FileText : HelpCircle,
-      label: isplan ? 'Needs approval' : 'Needs input',
-      className: 'text-yellow-500',
-    }
-  }
-
-  const config: Record<
-    string,
-    { icon: typeof CheckCircle2; label: string; className: string }
-  > = {
-    completed: {
-      icon: CheckCircle2,
-      label: 'Completed',
-      className: 'text-green-500',
-    },
-    cancelled: {
-      icon: CirclePause,
-      label: 'Cancelled',
-      className: 'text-muted-foreground',
-    },
-    crashed: {
-      icon: AlertTriangle,
-      label: 'Crashed',
-      className: 'text-destructive',
-    },
-  }
-
-  if (session.last_run_status && config[session.last_run_status]) {
-    return config[session.last_run_status]
-  }
-
-  return null
 }
 
 export function UnreadSessionsDrawer({
@@ -135,28 +42,41 @@ export function UnreadSessionsDrawer({
     }
   }, [open, queryClient])
 
-  const unreadItems = useMemo((): UnreadItem[] => {
-    if (!allSessions) return []
-
-    const results: UnreadItem[] = []
-
+  // Split actionable sessions into unread (top, full opacity) and read (bottom, dimmed)
+  const { unreadItems, readItems } = useMemo(() => {
+    if (!allSessions) return { unreadItems: [] as SessionListItem[], readItems: [] as SessionListItem[] }
+    const unread: SessionListItem[] = []
+    const read: SessionListItem[] = []
     for (const entry of allSessions.entries) {
       for (const session of entry.sessions) {
+        if (!isActionable(session)) continue
+        const item: SessionListItem = {
+          session,
+          projectId: entry.project_id,
+          projectName: entry.project_name,
+          worktreeId: entry.worktree_id,
+          worktreeName: entry.worktree_name,
+          worktreePath: entry.worktree_path,
+        }
         if (isUnread(session)) {
-          results.push({
-            session,
-            projectId: entry.project_id,
-            projectName: entry.project_name,
-            worktreeId: entry.worktree_id,
-            worktreeName: entry.worktree_name,
-            worktreePath: entry.worktree_path,
-          })
+          unread.push(item)
+        } else {
+          read.push(item)
         }
       }
     }
-
-    return results.sort((a, b) => b.session.updated_at - a.session.updated_at)
+    const byUpdated = (a: SessionListItem, b: SessionListItem) =>
+      b.session.updated_at - a.session.updated_at
+    return {
+      unreadItems: unread.sort(byUpdated),
+      readItems: read.sort(byUpdated),
+    }
   }, [allSessions])
+
+  const allItems = useMemo(
+    () => [...unreadItems, ...readItems],
+    [unreadItems, readItems]
+  )
 
   const markSessionsReadOptimistically = useCallback(
     (sessionIds: string[]) => {
@@ -190,7 +110,7 @@ export function UnreadSessionsDrawer({
   }, [unreadItems, queryClient, markSessionsReadOptimistically])
 
   const handleMarkOneRead = useCallback(
-    async (item: UnreadItem) => {
+    async (item: SessionListItem) => {
       markSessionsReadOptimistically([item.session.id])
       await invoke('set_session_last_opened', {
         sessionId: item.session.id,
@@ -207,40 +127,10 @@ export function UnreadSessionsDrawer({
   )
 
   const handleSelect = useCallback(
-    (item: UnreadItem) => {
-      const { selectedProjectId, selectProject } = useProjectsStore.getState()
-      const { setActiveSession, clearActiveWorktree } = useChatStore.getState()
-
-      const crossProject = selectedProjectId !== item.projectId
-      if (crossProject) {
-        selectProject(item.projectId)
-      }
-
-      // Navigate to ProjectCanvasView
-      clearActiveWorktree()
-      setActiveSession(item.worktreeId, item.session.id)
+    (item: SessionListItem) => {
       markSessionsReadOptimistically([item.session.id])
       onOpenChange(false)
-
-      if (crossProject) {
-        // Component remounts with new projectId key — use store-based auto-open
-        useUIStore
-          .getState()
-          .markWorktreeForAutoOpenSession(item.worktreeId, item.session.id)
-      } else {
-        // Same project, component stays mounted — use event
-        setTimeout(() => {
-          window.dispatchEvent(
-            new CustomEvent('open-session-modal', {
-              detail: {
-                sessionId: item.session.id,
-                worktreeId: item.worktreeId,
-                worktreePath: item.worktreePath,
-              },
-            })
-          )
-        }, 50)
-      }
+      navigateToSession(item)
     },
     [onOpenChange, markSessionsReadOptimistically]
   )
@@ -252,7 +142,7 @@ export function UnreadSessionsDrawer({
         return
       }
 
-      const total = unreadItems.length
+      const total = allItems.length
       if (!total) return
 
       switch (e.key) {
@@ -266,19 +156,19 @@ export function UnreadSessionsDrawer({
           break
         case 'Enter':
           e.preventDefault()
-          if (focusedIndex >= 0 && unreadItems[focusedIndex]) {
-            handleSelect(unreadItems[focusedIndex])
+          if (focusedIndex >= 0 && allItems[focusedIndex]) {
+            handleSelect(allItems[focusedIndex])
           }
           break
         case 'Backspace':
           e.preventDefault()
-          if (focusedIndex >= 0 && unreadItems[focusedIndex]) {
+          if (focusedIndex >= 0 && focusedIndex < unreadItems.length && unreadItems[focusedIndex]) {
             handleMarkOneRead(unreadItems[focusedIndex])
           }
           break
       }
     },
-    [unreadItems, focusedIndex, handleSelect, handleMarkOneRead, onOpenChange]
+    [allItems, unreadItems, focusedIndex, handleSelect, handleMarkOneRead, onOpenChange]
   )
 
   // Scroll focused item into view
@@ -336,15 +226,16 @@ export function UnreadSessionsDrawer({
           <div className="flex items-center justify-center py-6">
             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
           </div>
-        ) : unreadItems.length === 0 ? (
+        ) : allItems.length === 0 ? (
           <div className="text-center py-6 text-muted-foreground text-xs">
-            No unread sessions
+            No sessions with activity
           </div>
         ) : (
           <div className="max-h-[min(400px,60vh)] overflow-y-auto p-1">
-            {unreadItems.map((item, idx) => {
+            {allItems.map((item, idx) => {
               const status = getSessionStatus(item.session)
               const StatusIcon = status?.icon ?? CheckCircle2
+              const isRead = idx >= unreadItems.length
 
               return (
                 <button
@@ -355,7 +246,8 @@ export function UnreadSessionsDrawer({
                   onMouseEnter={() => setFocusedIndex(idx)}
                   className={cn(
                     'w-full text-left px-2 py-1.5 rounded-md hover:bg-accent/50 transition-colors cursor-pointer flex items-center gap-2',
-                    focusedIndex === idx && 'bg-accent'
+                    focusedIndex === idx && 'bg-accent',
+                    isRead && 'opacity-50'
                   )}
                 >
                   <StatusIcon

--- a/src/components/unread/useUnreadCount.ts
+++ b/src/components/unread/useUnreadCount.ts
@@ -1,23 +1,6 @@
 import { useMemo } from 'react'
 import { useAllSessions } from '@/services/chat'
-import type { Session } from '@/types/chat'
-
-/** Check if a session counts as "unread" — has unseen activity */
-function isUnread(session: Session): boolean {
-  if (session.archived_at) return false
-
-  const actionableStatuses = ['completed', 'cancelled', 'crashed']
-  const hasFinishedRun =
-    session.last_run_status &&
-    actionableStatuses.includes(session.last_run_status)
-  const isWaiting = session.waiting_for_input
-  const isReviewing = session.is_reviewing
-
-  if (!hasFinishedRun && !isWaiting && !isReviewing) return false
-
-  if (!session.last_opened_at) return true
-  return session.last_opened_at < session.updated_at
-}
+import { isUnread } from '@/lib/session-utils'
 
 /** Returns the number of unread sessions across all projects */
 export function useUnreadCount(): number {

--- a/src/hooks/use-command-context.ts
+++ b/src/hooks/use-command-context.ts
@@ -193,12 +193,19 @@ export function useCommandContext(
   // Sessions - Rename session
   const renameSession = useCallback(() => {
     const { activeWorktreeId, getActiveSession } = useChatStore.getState()
-    if (!activeWorktreeId) {
+    const { sessionChatModalOpen, sessionChatModalWorktreeId } =
+      useUIStore.getState()
+
+    // Prefer modal's worktree when the modal is open (activeWorktreeId is null in modal context)
+    const worktreeId = sessionChatModalOpen
+      ? (sessionChatModalWorktreeId ?? activeWorktreeId)
+      : activeWorktreeId
+    if (!worktreeId) {
       notify('No worktree selected', undefined, { type: 'error' })
       return
     }
 
-    const sessionId = getActiveSession(activeWorktreeId)
+    const sessionId = getActiveSession(worktreeId)
     if (!sessionId) {
       notify('No session selected', undefined, { type: 'error' })
       return

--- a/src/hooks/useImmediateSessionStateSave.ts
+++ b/src/hooks/useImmediateSessionStateSave.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 import { useChatStore } from '@/store/chat-store'
 import { invoke } from '@/lib/transport'
 import { logger } from '@/lib/logger'
-import type { LabelData } from '@/types/chat'
+import type { LabelData, TextHighlight } from '@/types/chat'
 import { isSessionStateHydrating } from '@/lib/session-state-hydration'
 import { isBackendPersisting } from '@/lib/backend-persist-guard'
 
@@ -20,6 +20,7 @@ export function useImmediateSessionStateSave() {
   const prevReviewingRef = useRef<Record<string, boolean>>({})
   const prevWaitingRef = useRef<Record<string, boolean>>({})
   const prevLabelsRef = useRef<Record<string, LabelData>>({})
+  const prevHighlightsRef = useRef<Record<string, TextHighlight[]>>({})
 
   useEffect(() => {
     const initialState = useChatStore.getState()
@@ -31,6 +32,7 @@ export function useImmediateSessionStateSave() {
     prevReviewingRef.current = initialState.reviewingSessions
     prevWaitingRef.current = initialState.waitingForInputSessionIds
     prevLabelsRef.current = initialState.sessionLabels
+    prevHighlightsRef.current = initialState.sessionHighlights
 
     const unsubscribe = useChatStore.subscribe(state => {
       if (isSessionStateHydrating()) {
@@ -42,6 +44,7 @@ export function useImmediateSessionStateSave() {
         prevReviewingRef.current = state.reviewingSessions
         prevWaitingRef.current = state.waitingForInputSessionIds
         prevLabelsRef.current = state.sessionLabels
+        prevHighlightsRef.current = state.sessionHighlights
         return
       }
 
@@ -51,6 +54,7 @@ export function useImmediateSessionStateSave() {
         reviewingSessions,
         waitingForInputSessionIds,
         sessionLabels,
+        sessionHighlights,
         sessionWorktreeMap,
         worktreePaths,
       } = state
@@ -62,13 +66,16 @@ export function useImmediateSessionStateSave() {
       const waitingChanged =
         waitingForInputSessionIds !== prevWaitingRef.current
       const labelsChanged = sessionLabels !== prevLabelsRef.current
+      const highlightsChanged =
+        sessionHighlights !== prevHighlightsRef.current
 
       if (
         !answeredChanged &&
         !submittedChanged &&
         !reviewingChanged &&
         !waitingChanged &&
-        !labelsChanged
+        !labelsChanged &&
+        !highlightsChanged
       ) {
         return
       }
@@ -173,6 +180,25 @@ export function useImmediateSessionStateSave() {
         }
         prevLabelsRef.current = sessionLabels
       }
+
+      if (highlightsChanged) {
+        const sessionIds = new Set([
+          ...Object.keys(prevHighlightsRef.current),
+          ...Object.keys(sessionHighlights),
+        ])
+
+        for (const sessionId of sessionIds) {
+          if (
+            prevHighlightsRef.current[sessionId] !==
+            sessionHighlights[sessionId]
+          ) {
+            saveSessionStatus(sessionId, sessionWorktreeMap, worktreePaths, {
+              highlights: sessionHighlights[sessionId] ?? [],
+            })
+          }
+        }
+        prevHighlightsRef.current = sessionHighlights
+      }
     })
 
     return unsubscribe
@@ -189,6 +215,7 @@ async function saveSessionStatus(
     isReviewing?: boolean
     waitingForInput?: boolean
     label?: LabelData | null
+    highlights?: TextHighlight[]
   }
 ) {
   const worktreeId = sessionWorktreeMap[sessionId]
@@ -216,6 +243,7 @@ async function saveSessionStatus(
       waitingForInput: updates.waitingForInput,
       label: labelValue,
       clearLabel,
+      highlights: updates.highlights,
     })
   } catch (error) {
     logger.error('Failed to save session status', { sessionId, error })

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -426,6 +426,17 @@ function executeKeybindingAction(
         new CustomEvent('scroll-chat', { detail: { direction: 'down' } })
       )
       break
+    case 'search_chat': {
+      logger.debug('Keybinding: search_chat')
+      const uiStoreSearch = useUIStore.getState()
+      if (!uiStoreSearch.chatSearchOpen) {
+        uiStoreSearch.setChatSearchOpen(true)
+      } else {
+        // If open, dispatch event so the component can decide to close or re-focus
+        window.dispatchEvent(new CustomEvent('chat-search-toggle'))
+      }
+      break
+    }
     case 'open_github_dashboard':
       useUIStore.getState().setGitHubDashboardOpen(true)
       break

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -472,6 +472,61 @@ function executeKeybindingAction(
       logger.debug('Keybinding: rename_session')
       commandContext.renameSession()
       break
+    case 'navigate_back':
+    case 'navigate_forward': {
+      const navigate =
+        action === 'navigate_back'
+          ? useChatStore.getState().navigateBack
+          : useChatStore.getState().navigateForward
+      const target = navigate()
+      if (!target) break
+
+      const currentProjectId = useProjectsStore.getState().selectedProjectId
+      const crossProject = currentProjectId !== target.projectId
+
+      // Clear active worktree so we land on ProjectCanvasView
+      useChatStore.getState().clearActiveWorktree()
+
+      // Update lastOpenedForProject with skipHistory to avoid pushing a duplicate entry
+      useChatStore
+        .getState()
+        .setLastOpenedForProject(
+          target.projectId,
+          target.worktreeId,
+          target.sessionId,
+          { skipHistory: true }
+        )
+
+      if (crossProject) {
+        // Cross-project: store intent in Zustand (survives component remount), then switch
+        useUIStore
+          .getState()
+          .markWorktreeForAutoOpenSession(
+            target.worktreeId,
+            target.sessionId
+          )
+        useProjectsStore.getState().selectProject(target.projectId)
+      } else {
+        // Same project: set active session, fire event for already-mounted ProjectCanvasView
+        useChatStore
+          .getState()
+          .setActiveSession(target.worktreeId, target.sessionId)
+        const worktreePath =
+          useChatStore.getState().getWorktreePath(target.worktreeId)
+        setTimeout(() => {
+          window.dispatchEvent(
+            new CustomEvent('open-session-modal', {
+              detail: {
+                sessionId: target.sessionId,
+                worktreeId: target.worktreeId,
+                worktreePath: worktreePath ?? '',
+              },
+            })
+          )
+        }, 50)
+      }
+      break
+    }
     case 'toggle_session_label': {
       logger.debug('Keybinding: toggle_session_label')
       // Works when a session is active (modal open or in session view) or on project canvas

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -321,6 +321,24 @@ function executeKeybindingAction(
       window.dispatchEvent(new CustomEvent('cycle-execution-mode'))
       break
     }
+    case 'switch_model_haiku':
+      window.dispatchEvent(new CustomEvent('set-model', { detail: { model: 'haiku' } }))
+      break
+    case 'switch_model_sonnet':
+      window.dispatchEvent(new CustomEvent('set-model', { detail: { model: 'sonnet' } }))
+      break
+    case 'switch_model_opus':
+      window.dispatchEvent(new CustomEvent('set-model', { detail: { model: 'opus' } }))
+      break
+    case 'switch_mode_plan':
+      window.dispatchEvent(new CustomEvent('set-execution-mode', { detail: { mode: 'plan' } }))
+      break
+    case 'switch_mode_build':
+      window.dispatchEvent(new CustomEvent('set-execution-mode', { detail: { mode: 'build' } }))
+      break
+    case 'switch_mode_yolo':
+      window.dispatchEvent(new CustomEvent('set-execution-mode', { detail: { mode: 'yolo' } }))
+      break
     case 'approve_plan': {
       logger.debug('Keybinding: approve_plan')
       const planDialogOpen = useUIStore.getState().planDialogOpen

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -460,6 +460,9 @@ function executeKeybindingAction(
     case 'open_github_dashboard':
       useUIStore.getState().setGitHubDashboardOpen(true)
       break
+    case 'open_session_history':
+      useUIStore.getState().setSessionHistoryOpen(true)
+      break
     case 'open_quick_menu':
       window.dispatchEvent(new CustomEvent('toggle-quick-menu'))
       break

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -464,6 +464,10 @@ function executeKeybindingAction(
     case 'open_usage_dropdown':
       window.dispatchEvent(new CustomEvent('toggle-usage-menu'))
       break
+    case 'go_to_session':
+      logger.debug('Keybinding: go_to_session')
+      useUIStore.getState().setSessionPaletteOpen(true)
+      break
     case 'toggle_session_label': {
       logger.debug('Keybinding: toggle_session_label')
       // Works when a session is active (modal open or in session view) or on project canvas
@@ -534,6 +538,7 @@ export function useMainWindowEventListeners() {
         uiState.openInModalOpen ||
         uiState.newWorktreeModalOpen ||
         uiState.commandPaletteOpen ||
+        uiState.sessionPaletteOpen ||
         uiState.preferencesOpen ||
         uiState.releaseNotesModalOpen ||
         uiState.updatePrModalOpen

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -468,6 +468,10 @@ function executeKeybindingAction(
       logger.debug('Keybinding: go_to_session')
       useUIStore.getState().setSessionPaletteOpen(true)
       break
+    case 'rename_session':
+      logger.debug('Keybinding: rename_session')
+      commandContext.renameSession()
+      break
     case 'toggle_session_label': {
       logger.debug('Keybinding: toggle_session_label')
       // Works when a session is active (modal open or in session view) or on project canvas

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -5,6 +5,7 @@ import { notify } from '@/lib/notifications'
 import { useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { useUIStore } from '@/store/ui-store'
 import { useProjectsStore } from '@/store/projects-store'
+import type { Project } from '@/types/projects'
 import { useChatStore } from '@/store/chat-store'
 import { useTerminalStore } from '@/store/terminal-store'
 import { projectsQueryKeys } from '@/services/projects'
@@ -122,7 +123,8 @@ export function switchActiveTerminalTabByIndexForShortcut(
 function executeKeybindingAction(
   action: KeybindingAction,
   commandContext: ReturnType<typeof useCommandContext>,
-  queryClient: QueryClient
+  queryClient: QueryClient,
+  originalEvent?: { altKey?: boolean }
 ) {
   // Canvas-only actions: blocked when the session chat modal is open
   const CANVAS_ONLY_ACTIONS = new Set<KeybindingAction>([
@@ -527,6 +529,54 @@ function executeKeybindingAction(
       }
       break
     }
+    case 'toggle_all_worktrees_expanded': {
+      logger.debug('Keybinding: toggle_all_worktrees_expanded')
+      const projectsStore = useProjectsStore.getState()
+      const withProjects = originalEvent?.altKey === true
+      const isExpanded = projectsStore.expandedWorktreeIds.size > 0
+      if (isExpanded) {
+        projectsStore.collapseAllWorktrees()
+        if (withProjects) {
+          useProjectsStore.setState({
+            expandedProjectIds: new Set<string>(),
+            expandedFolderIds: new Set<string>(),
+          })
+        }
+      } else {
+        // Collect all worktree IDs from all non-folder projects in the query cache
+        const projects =
+          queryClient.getQueryData<Project[]>(
+            projectsQueryKeys.list()
+          ) ?? []
+        const allWorktreeIds: string[] = []
+        const allProjectIds: string[] = []
+        const allFolderIds: string[] = []
+        for (const project of projects) {
+          if ('is_folder' in project && project.is_folder) {
+            allFolderIds.push(project.id)
+            continue
+          }
+          allProjectIds.push(project.id)
+          const worktrees =
+            queryClient.getQueryData<{ id: string }[]>(
+              projectsQueryKeys.worktrees(project.id)
+            ) ?? []
+          for (const w of worktrees) {
+            allWorktreeIds.push(w.id)
+          }
+        }
+        if (allWorktreeIds.length > 0) {
+          projectsStore.expandAllWorktrees(allWorktreeIds)
+        }
+        if (withProjects) {
+          useProjectsStore.setState({
+            expandedProjectIds: new Set(allProjectIds),
+            expandedFolderIds: new Set(allFolderIds),
+          })
+        }
+      }
+      break
+    }
     case 'toggle_session_label': {
       logger.debug('Keybinding: toggle_session_label')
       // Works when a session is active (modal open or in session view) or on project canvas
@@ -688,6 +738,19 @@ export function useMainWindowEventListeners() {
         }
       }
 
+      // Option+Cmd+Shift+W: toggle all worktrees AND projects (alt-modified variant)
+      if (shortcut === 'mod+shift+alt+w') {
+        e.preventDefault()
+        e.stopPropagation()
+        executeKeybindingAction(
+          'toggle_all_worktrees_expanded',
+          commandContext,
+          queryClient,
+          e
+        )
+        return
+      }
+
       // Look up matching action in keybindings
       const keybindings = keybindingsRef.current
       for (const [action, binding] of Object.entries(keybindings)) {
@@ -705,7 +768,8 @@ export function useMainWindowEventListeners() {
           executeKeybindingAction(
             action as KeybindingAction,
             commandContext,
-            queryClient
+            queryClient,
+            e
           )
           return
         }

--- a/src/hooks/useNightshiftEvents.ts
+++ b/src/hooks/useNightshiftEvents.ts
@@ -1,0 +1,171 @@
+import { useEffect } from 'react'
+import { listen, invoke, type UnlistenFn } from '@/lib/transport'
+import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { useNightshiftStore } from '@/store/nightshift-store'
+import { nightshiftQueryKeys } from '@/services/nightshift'
+import type {
+  RunStartedPayload,
+  CheckStartedPayload,
+  CheckDonePayload,
+  RunCompletedPayload,
+  RunFailedPayload,
+  ExecuteCheckPayload,
+} from '@/types/nightshift'
+import type { ChatMessage } from '@/types/chat'
+
+/**
+ * Listens to nightshift:* events from the Rust backend
+ * and orchestrates session execution for each check.
+ *
+ * Flow:
+ * 1. Backend emits `nightshift:execute-check` with session + prompt info
+ * 2. Frontend calls `send_chat_message` to start the session (build mode)
+ * 3. When the session completes, frontend reports back via `nightshift_report_check_done`
+ * 4. Backend moves to the next check or finalizes the run
+ */
+export function useNightshiftEvents() {
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    const listeners: Promise<UnlistenFn>[] = []
+
+    listeners.push(
+      listen<RunStartedPayload>('nightshift:run-started', (event) => {
+        const { runId, projectId } = event.payload
+        useNightshiftStore.getState().setActiveRun(projectId, runId)
+        toast.loading('Nightshift run started...', { id: `nightshift-${runId}` })
+      })
+    )
+
+    listeners.push(
+      listen<CheckStartedPayload>('nightshift:check-started', (event) => {
+        const { runId, checkId, checkName } = event.payload
+        useNightshiftStore.getState().setRunningCheck(runId, checkId)
+        toast.loading(`Running: ${checkName}...`, {
+          id: `nightshift-${runId}`,
+        })
+      })
+    )
+
+    // Core orchestration: execute a check by sending a message in the session
+    listeners.push(
+      listen<ExecuteCheckPayload>('nightshift:execute-check', async (event) => {
+        const {
+          runId,
+          checkId,
+          sessionId,
+          worktreeId,
+          worktreePath,
+          prompt,
+          model,
+          provider,
+          backend,
+        } = event.payload
+
+        try {
+          await invoke<ChatMessage>('send_chat_message', {
+            sessionId,
+            worktreeId,
+            worktreePath,
+            message: prompt,
+            model: model ?? null,
+            executionMode: 'yolo',
+            thinkingLevel: null,
+            effortLevel: null,
+            parallelExecutionPrompt: null,
+            aiLanguage: null,
+            allowedTools: null,
+            mcpConfig: null,
+            chromeEnabled: null,
+            customProfileName: provider ?? null,
+            backend: backend ?? null,
+          })
+
+          // Session completed successfully — report back to engine
+          await invoke('nightshift_report_check_done', {
+            runId,
+            checkId,
+            sessionId,
+            success: true,
+            error: null,
+          })
+        } catch (error) {
+          // Session failed — report error to engine
+          await invoke('nightshift_report_check_done', {
+            runId,
+            checkId,
+            sessionId,
+            success: false,
+            error: String(error),
+          })
+        }
+      })
+    )
+
+    listeners.push(
+      listen<CheckDonePayload>('nightshift:check-done', (event) => {
+        const { runId } = event.payload
+        useNightshiftStore.getState().clearRunningCheck(runId)
+      })
+    )
+
+    listeners.push(
+      listen<RunCompletedPayload>('nightshift:run-completed', (event) => {
+        const { runId, projectId, status, totalChecks } = event.payload
+        useNightshiftStore.getState().clearActiveRun(projectId)
+        useNightshiftStore.getState().clearRunningCheck(runId)
+
+        // Refresh run history + sessions (new sessions were created)
+        queryClient.invalidateQueries({
+          queryKey: nightshiftQueryKeys.runs(projectId),
+        })
+
+        if (status === 'completed') {
+          toast.success(
+            `Nightshift completed ${totalChecks} check${totalChecks === 1 ? '' : 's'}`,
+            {
+              id: `nightshift-${runId}`,
+              action: {
+                label: 'View',
+                onClick: () => {
+                  useNightshiftStore.getState().openRunsModal(projectId)
+                },
+              },
+            }
+          )
+        } else if (status === 'partially_completed') {
+          toast.warning('Nightshift: some checks failed', {
+            id: `nightshift-${runId}`,
+            action: {
+              label: 'View',
+              onClick: () => {
+                useNightshiftStore.getState().openRunsModal(projectId)
+              },
+            },
+          })
+        } else if (status === 'failed') {
+          toast.error('Nightshift run failed', {
+            id: `nightshift-${runId}`,
+          })
+        }
+      })
+    )
+
+    listeners.push(
+      listen<RunFailedPayload>('nightshift:run-failed', (event) => {
+        const { runId, projectId, error } = event.payload
+        useNightshiftStore.getState().clearActiveRun(projectId)
+        useNightshiftStore.getState().clearRunningCheck(runId)
+
+        toast.error(`Nightshift failed: ${error}`, {
+          id: `nightshift-${runId}`,
+        })
+      })
+    )
+
+    return () => {
+      listeners.forEach((l) => l.then((unlisten) => unlisten()))
+    }
+  }, [queryClient])
+}

--- a/src/hooks/useNightshiftEvents.ts
+++ b/src/hooks/useNightshiftEvents.ts
@@ -34,17 +34,17 @@ export function useNightshiftEvents() {
       listen<RunStartedPayload>('nightshift:run-started', (event) => {
         const { runId, projectId } = event.payload
         useNightshiftStore.getState().setActiveRun(projectId, runId)
-        toast.loading('Nightshift run started...', { id: `nightshift-${runId}` })
       })
     )
 
+    // Toasts here are brief notifications, NOT persistent progress trackers.
+    // Checks can run for 30+ minutes — a persistent toast would obstruct the UI
+    // (especially the prompt input area). Progress is visible in View History.
     listeners.push(
       listen<CheckStartedPayload>('nightshift:check-started', (event) => {
         const { runId, checkId, checkName } = event.payload
         useNightshiftStore.getState().setRunningCheck(runId, checkId)
-        toast.loading(`Running: ${checkName}...`, {
-          id: `nightshift-${runId}`,
-        })
+        toast(`Running: ${checkName}`, { duration: 4000 })
       })
     )
 
@@ -125,7 +125,6 @@ export function useNightshiftEvents() {
           toast.success(
             `Nightshift completed ${totalChecks} check${totalChecks === 1 ? '' : 's'}`,
             {
-              id: `nightshift-${runId}`,
               action: {
                 label: 'View',
                 onClick: () => {
@@ -136,7 +135,6 @@ export function useNightshiftEvents() {
           )
         } else if (status === 'partially_completed') {
           toast.warning('Nightshift: some checks failed', {
-            id: `nightshift-${runId}`,
             action: {
               label: 'View',
               onClick: () => {
@@ -145,9 +143,7 @@ export function useNightshiftEvents() {
             },
           })
         } else if (status === 'failed') {
-          toast.error('Nightshift run failed', {
-            id: `nightshift-${runId}`,
-          })
+          toast.error('Nightshift run failed')
         }
       })
     )
@@ -158,9 +154,7 @@ export function useNightshiftEvents() {
         useNightshiftStore.getState().clearActiveRun(projectId)
         useNightshiftStore.getState().clearRunningCheck(runId)
 
-        toast.error(`Nightshift failed: ${error}`, {
-          id: `nightshift-${runId}`,
-        })
+        toast.error(`Nightshift failed: ${error}`)
       })
     )
 

--- a/src/hooks/useWorktreeTerminalStatus.tsx
+++ b/src/hooks/useWorktreeTerminalStatus.tsx
@@ -1,0 +1,113 @@
+import { useMemo } from 'react'
+import { Play } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useTerminalStore } from '@/store/terminal-store'
+import { useTerminalListeningPorts } from '@/services/projects'
+import type { TerminalPortInfo } from '@/services/projects'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+/**
+ * Shared hook for per-worktree terminal status detection.
+ * Tracks running/failed run-script terminals and discovered listening ports.
+ */
+export function useWorktreeTerminalStatus(worktreeId: string) {
+  const hasRunningTerminal = useTerminalStore(state => {
+    const terminals = state.terminals[worktreeId] ?? []
+    return terminals.some(
+      t => !!t.command && state.runningTerminals.has(t.id)
+    )
+  })
+  const hasFailedTerminal = useTerminalStore(state => {
+    const terminals = state.terminals[worktreeId] ?? []
+    return terminals.some(
+      t => !!t.command && state.failedTerminals.has(t.id)
+    )
+  })
+  const showTerminalIndicator = hasRunningTerminal || hasFailedTerminal
+
+  // Poll for listening ports only when terminals are running
+  const { data: listeningPorts = [] } =
+    useTerminalListeningPorts(hasRunningTerminal)
+
+  // Build tooltip lines on demand via getState() — no subscription needed
+  // for tooltip content (stale-by-one-render is fine for hover-only UI)
+  const tooltipLines = useMemo(() => {
+    if (!showTerminalIndicator) return null
+    const { terminals, runningTerminals, failedTerminals } =
+      useTerminalStore.getState()
+    const worktreeTerminals = terminals[worktreeId] ?? []
+    const lines: string[] = []
+    for (const t of worktreeTerminals) {
+      if (!t.command) continue
+      if (runningTerminals.has(t.id)) {
+        const ports = (listeningPorts as TerminalPortInfo[])
+          .filter(p => p.terminalId === t.id)
+          .map(p => `:${p.port}`)
+        const portSuffix = ports.length > 0 ? ` (${ports.join(', ')})` : ''
+        lines.push(`${t.command}${portSuffix}`)
+      } else if (failedTerminals.has(t.id)) {
+        lines.push(`${t.command} (crashed)`)
+      }
+    }
+    return lines
+  }, [showTerminalIndicator, worktreeId, listeningPorts])
+
+  return { hasFailedTerminal, showTerminalIndicator, tooltipLines }
+}
+
+/**
+ * Play icon with tooltip showing running/failed terminal status and listening ports.
+ * Returns null when no run-script terminals are active or failed.
+ */
+export function TerminalStatusIndicator({
+  worktreeId,
+  iconSize = 'h-2.5 w-2.5',
+  onClick,
+}: {
+  worktreeId: string
+  iconSize?: string
+  onClick?: (e: React.MouseEvent) => void
+}) {
+  const { hasFailedTerminal, showTerminalIndicator, tooltipLines } =
+    useWorktreeTerminalStatus(worktreeId)
+
+  if (!showTerminalIndicator || !tooltipLines) return null
+
+  const handleClick = onClick
+    ? (e: React.MouseEvent) => {
+        e.stopPropagation()
+        onClick(e)
+      }
+    : undefined
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Play
+          className={cn(
+            'shrink-0 fill-current',
+            iconSize,
+            handleClick && 'cursor-pointer hover:opacity-80',
+            hasFailedTerminal
+              ? 'text-red-500'
+              : 'text-yellow-400 animate-icon-glow'
+          )}
+          onClick={handleClick}
+        />
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="flex flex-col gap-0.5">
+          {tooltipLines.map((line, i) => (
+            <span key={i} className="text-xs">
+              {line}
+            </span>
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/lib/commands/index.ts
+++ b/src/lib/commands/index.ts
@@ -6,6 +6,7 @@ import { notificationCommands } from './notification-commands'
 import { projectCommands } from './project-commands'
 import { githubCommands } from './github-commands'
 import { maintenanceCommands } from './maintenance-commands'
+import { nightshiftCommands } from './nightshift-commands'
 import { windowCommands } from './window-commands'
 import { registerCommands } from './registry'
 
@@ -19,6 +20,7 @@ export function initializeCommandSystem(): void {
   registerCommands(projectCommands)
   registerCommands(githubCommands)
   registerCommands(maintenanceCommands)
+  registerCommands(nightshiftCommands)
   registerCommands(windowCommands)
 }
 
@@ -28,5 +30,6 @@ export {
   projectCommands,
   githubCommands,
   maintenanceCommands,
+  nightshiftCommands,
   windowCommands,
 }

--- a/src/lib/commands/nightshift-commands.ts
+++ b/src/lib/commands/nightshift-commands.ts
@@ -1,0 +1,47 @@
+import { Moon, History } from 'lucide-react'
+import { toast } from 'sonner'
+import { invoke } from '@/lib/transport'
+import { useNightshiftStore } from '@/store/nightshift-store'
+import { useProjectsStore } from '@/store/projects-store'
+import type { AppCommand } from './types'
+
+export const nightshiftCommands: AppCommand[] = [
+  {
+    id: 'nightshift.run-now',
+    label: 'Nightshift: Run Maintenance Checks',
+    description: 'Run AI maintenance checks on the current project',
+    icon: Moon,
+    group: 'maintenance',
+    keywords: ['nightshift', 'maintenance', 'lint', 'review', 'checks', 'audit'],
+    async execute() {
+      const projectId = useProjectsStore.getState().selectedProjectId
+      if (!projectId) {
+        toast.error('No project selected')
+        return
+      }
+      const toastId = toast.loading('Starting Nightshift run...')
+      try {
+        await invoke('nightshift_start_run', { projectId })
+        toast.success('Nightshift run started', { id: toastId })
+      } catch (error) {
+        toast.error(`Failed to start: ${error}`, { id: toastId })
+      }
+    },
+    isAvailable: (ctx) => ctx.hasSelectedProject(),
+  },
+  {
+    id: 'nightshift.view-runs',
+    label: 'Nightshift: View Run History',
+    description: 'View past Nightshift maintenance runs and findings',
+    icon: History,
+    group: 'maintenance',
+    keywords: ['nightshift', 'history', 'runs', 'findings'],
+    execute() {
+      const projectId = useProjectsStore.getState().selectedProjectId
+      if (projectId) {
+        useNightshiftStore.getState().openRunsModal(projectId)
+      }
+    },
+    isAvailable: (ctx) => ctx.hasSelectedProject(),
+  },
+]

--- a/src/lib/session-utils.ts
+++ b/src/lib/session-utils.ts
@@ -1,0 +1,134 @@
+import {
+  CheckCircle2,
+  AlertTriangle,
+  CirclePause,
+  HelpCircle,
+  FileText,
+} from 'lucide-react'
+import { useProjectsStore } from '@/store/projects-store'
+import { useChatStore } from '@/store/chat-store'
+import { useUIStore } from '@/store/ui-store'
+import type { Session } from '@/types/chat'
+
+/** A session with its parent project/worktree context */
+export interface SessionListItem {
+  session: Session
+  projectId: string
+  projectName: string
+  worktreeId: string
+  worktreeName: string
+  worktreePath: string
+}
+
+/**
+ * Whether a session has a notification-worthy status (completed/cancelled/crashed/
+ * waiting/reviewing), regardless of whether the user has already seen it.
+ */
+export function isActionable(session: Session): boolean {
+  if (session.archived_at) return false
+  const actionableStatuses = ['completed', 'cancelled', 'crashed']
+  const hasFinishedRun =
+    session.last_run_status &&
+    actionableStatuses.includes(session.last_run_status)
+  const isWaiting = session.waiting_for_input
+  const isReviewing = session.is_reviewing
+  return !!(hasFinishedRun || isWaiting || isReviewing)
+}
+
+/** Whether a session is actionable AND the user hasn't opened it since its last update */
+export function isUnread(session: Session): boolean {
+  if (!isActionable(session)) return false
+  if (!session.last_opened_at) return true
+  return session.last_opened_at < session.updated_at
+}
+
+/** Format a unix timestamp (seconds or ms) to relative time like "2m ago", "3h ago" */
+export function formatRelativeTime(timestamp: number): string {
+  const ms = timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp
+  const diffMs = Date.now() - ms
+  if (diffMs < 0) return 'just now'
+  const minuteMs = 60_000
+  const hourMs = 60 * minuteMs
+  const dayMs = 24 * hourMs
+  if (diffMs < hourMs)
+    return `${Math.max(1, Math.floor(diffMs / minuteMs))}m ago`
+  if (diffMs < dayMs) return `${Math.floor(diffMs / hourMs)}h ago`
+  return `${Math.floor(diffMs / dayMs)}d ago`
+}
+
+/** Get display info (icon, label, color) for a session's current state */
+export function getSessionStatus(session: Session) {
+  if (session.waiting_for_input) {
+    const isplan = session.waiting_for_input_type === 'plan'
+    return {
+      icon: isplan ? FileText : HelpCircle,
+      label: isplan ? 'Needs approval' : 'Needs input',
+      className: 'text-yellow-500',
+    }
+  }
+  const config: Record<
+    string,
+    { icon: typeof CheckCircle2; label: string; className: string }
+  > = {
+    completed: {
+      icon: CheckCircle2,
+      label: 'Completed',
+      className: 'text-green-500',
+    },
+    cancelled: {
+      icon: CirclePause,
+      label: 'Cancelled',
+      className: 'text-muted-foreground',
+    },
+    crashed: {
+      icon: AlertTriangle,
+      label: 'Crashed',
+      className: 'text-destructive',
+    },
+  }
+  if (session.last_run_status && config[session.last_run_status]) {
+    return config[session.last_run_status]
+  }
+  return null
+}
+
+/**
+ * Cross-project-aware navigation to a session.
+ * Handles project switching, clearActiveWorktree, setActiveSession,
+ * setLastOpenedForProject, and the cross-project auto-open vs same-project
+ * event dispatch pattern.
+ */
+export function navigateToSession(item: SessionListItem): void {
+  const { selectedProjectId, selectProject } = useProjectsStore.getState()
+  const { setActiveSession, clearActiveWorktree, setLastOpenedForProject } =
+    useChatStore.getState()
+
+  const crossProject = selectedProjectId !== item.projectId
+  if (crossProject) {
+    selectProject(item.projectId)
+  }
+
+  clearActiveWorktree()
+  setActiveSession(item.worktreeId, item.session.id)
+  setLastOpenedForProject(item.projectId, item.worktreeId, item.session.id)
+
+  if (crossProject) {
+    // Component remounts with new projectId key — use store-based auto-open
+    useUIStore
+      .getState()
+      .markWorktreeForAutoOpenSession(item.worktreeId, item.session.id)
+  } else {
+    // Same project, component stays mounted — use event
+    setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent('open-session-modal', {
+          detail: {
+            sessionId: item.session.id,
+            worktreeId: item.worktreeId,
+            worktreePath: item.worktreePath,
+          },
+        })
+      )
+    }, 50)
+  }
+}

--- a/src/lib/terminal-instances.ts
+++ b/src/lib/terminal-instances.ts
@@ -146,12 +146,17 @@ export function getOrCreateTerminal(
       const inst = instances.get(terminalId)
       inst?.onStopped?.(exitCode, signal)
 
-      // Auto-close terminal tab on:
-      // 1. Successful exit (code 0) — any terminal
-      // 2. SIGINT (Ctrl+C) — only for "run" terminals (have a command)
-      const isInterrupt = signal != null && signal.includes('Interrupt')
+      // Auto-close terminal tab on clean exit:
+      // - code 0 — any terminal
+      // - SIGINT (Ctrl+C) or SIGTERM (graceful stop) — user or system stop
+      // SIGKILL, SIGSEGV, SIGABRT, etc. are NOT clean → mark as failed.
       const isRunTerminal = inst?.command != null
-      if (inst && (exitCode === 0 || (isInterrupt && isRunTerminal))) {
+      const isIntentionalSignal =
+        signal != null &&
+        (signal.includes('Interrupt') || signal.includes('Terminated'))
+      const isCleanExit = exitCode === 0 || isIntentionalSignal
+
+      if (isCleanExit && inst) {
         const wId = inst.worktreeId
         setTimeout(() => {
           if (!instances.has(terminalId)) return // Already disposed
@@ -168,6 +173,9 @@ export function getOrCreateTerminal(
             useTerminalStore.getState().setModalTerminalOpen(wId, false)
           }
         }, 0)
+      } else if (isRunTerminal) {
+        // Non-zero exit on a run terminal → mark as failed (red indicator in sidebar)
+        useTerminalStore.getState().setTerminalFailed(terminalId, true)
       }
     }
   }).then(unlisten => listeners.push(unlisten))

--- a/src/lib/terminal-instances.ts
+++ b/src/lib/terminal-instances.ts
@@ -246,8 +246,14 @@ export async function attachToContainer(
     // animation) cause portable_pty to crash with an internal assertion failure.
     const rawCols = terminal.cols
     const rawRows = terminal.rows
-    let cols = rawCols < 2 ? 80 : rawCols
+    let cols = wordWrapEnabled ? (rawCols < 2 ? 80 : rawCols) : NO_WRAP_COLS
     let rows = rawRows < 2 ? 24 : rawRows
+    // In no-wrap mode, widen the .xterm element so the canvas renders all cols,
+    // then resize the terminal to NO_WRAP_COLS.
+    if (!wordWrapEnabled) {
+      applyNoWrapLayout(instance)
+      terminal.resize(cols, rows)
+    }
     console.log(
       `[terminal-instances] attachToContainer ${terminalId}: fit=${rawCols}x${rawRows} → used=${cols}x${rows}, initialized=${initialized}, container=${container.clientWidth}x${container.clientHeight}`
     )
@@ -338,14 +344,26 @@ export function detachFromContainer(terminalId: string): void {
 
 /**
  * Fit terminal to its container dimensions.
+ * When word wrap is disabled, only fits rows (keeps wide column count).
  */
 export function fitTerminal(terminalId: string): void {
   const instance = instances.get(terminalId)
   if (!instance) return
 
-  instance.fitAddon.fit()
-  const { cols, rows } = instance.terminal
-  invoke('terminal_resize', { terminalId, cols, rows }).catch(console.error)
+  if (wordWrapEnabled) {
+    instance.fitAddon.fit()
+    const { cols, rows } = instance.terminal
+    invoke('terminal_resize', { terminalId, cols, rows }).catch(console.error)
+  } else {
+    // Only recalculate rows from container height; keep wide cols and element width.
+    // Don't call fitAddon.fit() — it would shrink the element back to container width.
+    const dims = instance.fitAddon.proposeDimensions()
+    if (!dims) return
+    const rows = Math.max(1, dims.rows)
+    applyNoWrapLayout(instance)
+    instance.terminal.resize(NO_WRAP_COLS, rows)
+    invoke('terminal_resize', { terminalId, cols: NO_WRAP_COLS, rows }).catch(console.error)
+  }
 }
 
 /**
@@ -405,6 +423,79 @@ export function disposeAllWorktreeTerminals(worktreeId: string): void {
  */
 export function hasInstance(terminalId: string): boolean {
   return instances.has(terminalId)
+}
+
+/** Current word-wrap state (module-level so fitTerminal can read it) */
+let wordWrapEnabled = true
+
+// PTY-based terminals require a fixed column count — there's no true "infinite width" mode.
+// 500 is a pragmatic workaround: wide enough for most real-world output but still a hard limit.
+// A proper solution would decouple the renderer width from the PTY cols (like VS Code does
+// with its custom terminal renderer), but xterm.js ties them together.
+const NO_WRAP_COLS = 500
+
+/**
+ * Apply no-wrap layout to a single terminal: widen the .xterm element and
+ * make the container horizontally scrollable.
+ */
+function applyNoWrapLayout(instance: PersistentTerminal): void {
+  const el = instance.terminal.element
+  if (!el) return
+  const container = el.parentElement as HTMLElement | null
+  if (!container) return
+
+  // Derive character width from fitAddon's proposed cols (based on container width)
+  const dims = instance.fitAddon.proposeDimensions()
+  if (!dims) return
+  const charWidth = container.clientWidth / dims.cols
+  const wideWidth = Math.ceil(charWidth * NO_WRAP_COLS)
+
+  // Widen the xterm element so canvas renders all cols without internal clipping
+  el.style.width = `${wideWidth}px`
+  // Container provides horizontal scrollbar
+  container.style.overflowX = 'auto'
+  container.style.overflowY = 'hidden'
+}
+
+/**
+ * Remove no-wrap layout overrides from a terminal.
+ */
+function clearNoWrapLayout(instance: PersistentTerminal): void {
+  const el = instance.terminal.element
+  if (!el) return
+  const container = el.parentElement as HTMLElement | null
+  if (!container) return
+
+  el.style.width = ''
+  container.style.overflowX = ''
+  container.style.overflowY = ''
+}
+
+/**
+ * Set word-wrap mode for all terminal instances.
+ * When disabled, terminals use a wide fixed column count and allow horizontal scrolling.
+ */
+export function setWordWrap(enabled: boolean): void {
+  wordWrapEnabled = enabled
+
+  for (const [terminalId, instance] of instances) {
+    if (enabled) {
+      clearNoWrapLayout(instance)
+      // Re-fit to container width
+      fitTerminal(terminalId)
+    } else {
+      // Resize to wide cols, then widen the element so the canvas is fully visible
+      const rows = instance.terminal.rows
+      applyNoWrapLayout(instance)
+      instance.terminal.resize(NO_WRAP_COLS, rows)
+      invoke('terminal_resize', { terminalId, cols: NO_WRAP_COLS, rows }).catch(console.error)
+    }
+  }
+}
+
+/** Whether word wrap is currently enabled */
+export function isWordWrapEnabled(): boolean {
+  return wordWrapEnabled
 }
 
 // Pending onStopped callbacks for terminals not yet created

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -20,6 +20,7 @@ import type {
   ThinkingLevel,
   ExecutionMode,
   LabelData,
+  TextHighlight,
   QueuedMessage,
 } from '@/types/chat'
 import { isTauri, projectsQueryKeys } from '@/services/projects'
@@ -171,6 +172,7 @@ export async function prefetchSessions(
       Record<string, QuestionAnswer[]>
     > = {}
     const fixedFindingsUpdates: Record<string, Set<string>> = {}
+    const highlightsUpdates: Record<string, TextHighlight[]> = {}
     for (const session of sessions.sessions) {
       if (session.is_reviewing) {
         reviewingUpdates[session.id] = true
@@ -209,6 +211,9 @@ export async function prefetchSessions(
       }
       if (session.fixed_findings && session.fixed_findings.length > 0) {
         fixedFindingsUpdates[session.id] = new Set(session.fixed_findings)
+      }
+      if (session.highlights && session.highlights.length > 0) {
+        highlightsUpdates[session.id] = session.highlights
       }
     }
 
@@ -280,6 +285,12 @@ export async function prefetchSessions(
       storeUpdates.fixedReviewFindings = {
         ...currentState.fixedReviewFindings,
         ...fixedFindingsUpdates,
+      }
+    }
+    if (Object.keys(highlightsUpdates).length > 0) {
+      storeUpdates.sessionHighlights = {
+        ...currentState.sessionHighlights,
+        ...highlightsUpdates,
       }
     }
     if (Object.keys(storeUpdates).length > 0) {

--- a/src/services/git-status.ts
+++ b/src/services/git-status.ts
@@ -49,6 +49,8 @@ export interface GitStatusEvent {
   worktree_ahead_count: number
   /** Commits in HEAD not yet pushed to origin/current_branch */
   unpushed_count: number
+  /** Short summaries of unpushed commits (hash + subject) */
+  unpushed_commits: { hash: string; message: string }[]
 }
 
 /**

--- a/src/services/nightshift.ts
+++ b/src/services/nightshift.ts
@@ -1,0 +1,101 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { invoke } from '@/lib/transport'
+import type {
+  NightshiftCheck,
+  NightshiftConfig,
+  NightshiftRun,
+} from '@/types/nightshift'
+
+export const nightshiftQueryKeys = {
+  all: ['nightshift'] as const,
+  checks: () => [...nightshiftQueryKeys.all, 'checks'] as const,
+  config: (projectId: string) =>
+    [...nightshiftQueryKeys.all, 'config', projectId] as const,
+  runs: (projectId: string) =>
+    [...nightshiftQueryKeys.all, 'runs', projectId] as const,
+  run: (runId: string) =>
+    [...nightshiftQueryKeys.all, 'run', runId] as const,
+}
+
+/** Get all available built-in checks */
+export function useNightshiftChecks() {
+  return useQuery({
+    queryKey: nightshiftQueryKeys.checks(),
+    queryFn: () => invoke<NightshiftCheck[]>('nightshift_list_checks'),
+    staleTime: Infinity, // Built-in checks never change during runtime
+  })
+}
+
+/** Get Nightshift config for a project */
+export function useNightshiftConfig(projectId: string | null) {
+  return useQuery({
+    queryKey: nightshiftQueryKeys.config(projectId ?? ''),
+    queryFn: () =>
+      invoke<NightshiftConfig>('nightshift_get_config', { projectId }),
+    enabled: !!projectId,
+  })
+}
+
+/** Save Nightshift config for a project */
+export function useSaveNightshiftConfig() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      projectId,
+      config,
+    }: {
+      projectId: string
+      config: NightshiftConfig
+    }) => invoke<null>('nightshift_save_config', { projectId, config }),
+    onSuccess: (_, { projectId }) => {
+      queryClient.invalidateQueries({
+        queryKey: nightshiftQueryKeys.config(projectId),
+      })
+    },
+  })
+}
+
+/** Manually trigger a Nightshift run */
+export function useStartNightshiftRun() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (projectId: string) =>
+      invoke<string>('nightshift_start_run', { projectId }),
+    onSuccess: (_, projectId) => {
+      queryClient.invalidateQueries({
+        queryKey: nightshiftQueryKeys.runs(projectId),
+      })
+    },
+  })
+}
+
+/** Cancel an in-progress run */
+export function useCancelNightshiftRun() {
+  return useMutation({
+    mutationFn: (runId: string) =>
+      invoke<boolean>('nightshift_cancel_run', { runId }),
+  })
+}
+
+/** Get run history for a project */
+export function useNightshiftRuns(projectId: string | null) {
+  return useQuery({
+    queryKey: nightshiftQueryKeys.runs(projectId ?? ''),
+    queryFn: () =>
+      invoke<NightshiftRun[]>('nightshift_get_runs', {
+        projectId,
+        limit: 20,
+      }),
+    enabled: !!projectId,
+    staleTime: 1000 * 60, // 1 minute
+  })
+}
+
+/** Get a single run's details */
+export function useNightshiftRun(runId: string | null) {
+  return useQuery({
+    queryKey: nightshiftQueryKeys.run(runId ?? ''),
+    queryFn: () => invoke<NightshiftRun>('nightshift_get_run', { runId }),
+    enabled: !!runId,
+  })
+}

--- a/src/services/nightshift.ts
+++ b/src/services/nightshift.ts
@@ -69,6 +69,20 @@ export function useStartNightshiftRun() {
   })
 }
 
+/** Manually trigger a single specific check */
+export function useStartNightshiftCheck() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ projectId, checkId }: { projectId: string; checkId: string }) =>
+      invoke<string>('nightshift_start_check', { projectId, checkId }),
+    onSuccess: (_, { projectId }) => {
+      queryClient.invalidateQueries({
+        queryKey: nightshiftQueryKeys.runs(projectId),
+      })
+    },
+  })
+}
+
 /** Cancel an in-progress run */
 export function useCancelNightshiftRun() {
   return useMutation({

--- a/src/services/preferences.test.ts
+++ b/src/services/preferences.test.ts
@@ -159,6 +159,7 @@ describe('preferences service', () => {
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
+        terminal_word_wrap: true,
       }
       vi.mocked(invoke).mockResolvedValueOnce(mockPreferences)
 
@@ -283,6 +284,7 @@ describe('preferences service', () => {
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
+        terminal_word_wrap: true,
       }
       vi.mocked(invoke).mockResolvedValueOnce(prefsWithOldBinding)
 
@@ -380,6 +382,7 @@ describe('preferences service', () => {
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
+        terminal_word_wrap: true,
       }
       vi.mocked(invoke).mockResolvedValueOnce(prefsWithDeprecatedFastModel)
 
@@ -477,6 +480,7 @@ describe('preferences service', () => {
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
+        terminal_word_wrap: true,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -576,6 +580,7 @@ describe('preferences service', () => {
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
+        terminal_word_wrap: true,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -675,6 +680,7 @@ describe('preferences service', () => {
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
+        terminal_word_wrap: true,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -772,6 +778,7 @@ describe('preferences service', () => {
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
+        terminal_word_wrap: true,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {

--- a/src/services/preferences.test.ts
+++ b/src/services/preferences.test.ts
@@ -160,6 +160,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        esc_closes_session: true,
       }
       vi.mocked(invoke).mockResolvedValueOnce(mockPreferences)
 
@@ -285,6 +286,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        esc_closes_session: true,
       }
       vi.mocked(invoke).mockResolvedValueOnce(prefsWithOldBinding)
 
@@ -383,6 +385,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        esc_closes_session: true,
       }
       vi.mocked(invoke).mockResolvedValueOnce(prefsWithDeprecatedFastModel)
 
@@ -481,6 +484,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        esc_closes_session: true,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -581,6 +585,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        esc_closes_session: true,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -681,6 +686,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        esc_closes_session: true,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -779,6 +785,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        esc_closes_session: true,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {

--- a/src/services/preferences.test.ts
+++ b/src/services/preferences.test.ts
@@ -158,6 +158,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        sidebar_group_by_status: true,
       }
       vi.mocked(invoke).mockResolvedValueOnce(mockPreferences)
 
@@ -281,6 +282,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        sidebar_group_by_status: true,
       }
       vi.mocked(invoke).mockResolvedValueOnce(prefsWithOldBinding)
 
@@ -377,6 +379,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        sidebar_group_by_status: true,
       }
       vi.mocked(invoke).mockResolvedValueOnce(prefsWithDeprecatedFastModel)
 
@@ -473,6 +476,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        sidebar_group_by_status: true,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -571,6 +575,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        sidebar_group_by_status: true,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -669,6 +674,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        sidebar_group_by_status: true,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -765,6 +771,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        sidebar_group_by_status: true,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {

--- a/src/services/preferences.test.ts
+++ b/src/services/preferences.test.ts
@@ -160,6 +160,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        expand_tool_calls: false,
         esc_closes_session: true,
       }
       vi.mocked(invoke).mockResolvedValueOnce(mockPreferences)
@@ -286,6 +287,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        expand_tool_calls: false,
         esc_closes_session: true,
       }
       vi.mocked(invoke).mockResolvedValueOnce(prefsWithOldBinding)
@@ -385,6 +387,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        expand_tool_calls: false,
         esc_closes_session: true,
       }
       vi.mocked(invoke).mockResolvedValueOnce(prefsWithDeprecatedFastModel)
@@ -484,6 +487,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        expand_tool_calls: false,
         esc_closes_session: true,
       }
 
@@ -585,6 +589,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        expand_tool_calls: false,
         esc_closes_session: true,
       }
 
@@ -686,6 +691,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        expand_tool_calls: false,
         esc_closes_session: true,
       }
 
@@ -785,6 +791,7 @@ describe('preferences service', () => {
         gh_cli_source: 'jean',
         sidebar_group_by_status: true,
         terminal_word_wrap: true,
+        expand_tool_calls: false,
         esc_closes_session: true,
       }
 

--- a/src/services/projects.ts
+++ b/src/services/projects.ts
@@ -2196,6 +2196,34 @@ export function usePorts(worktreePath: string | null) {
 }
 
 /**
+ * A TCP port actively listened on by a terminal's child process.
+ * Detected at runtime via lsof (macOS/Linux only).
+ */
+export interface TerminalPortInfo {
+  terminalId: string
+  port: number
+  processName: string
+  localAddress: string
+}
+
+/**
+ * Hook to discover TCP LISTEN ports owned by terminal processes.
+ * Polls every 5s when enabled. Returns empty array on non-native platforms.
+ */
+export function useTerminalListeningPorts(enabled: boolean) {
+  return useQuery<TerminalPortInfo[]>({
+    queryKey: ['terminal-listening-ports'],
+    queryFn: async () => {
+      if (!isTauri()) return []
+      return invoke<TerminalPortInfo[]>('get_terminal_listening_ports')
+    },
+    enabled,
+    refetchInterval: 5_000,
+    staleTime: 3_000,
+  })
+}
+
+/**
  * Hook to commit changes in a worktree
  */
 export function useCommitChanges() {

--- a/src/store/chat-store.ts
+++ b/src/store/chat-store.ts
@@ -254,6 +254,14 @@ interface ChatUIState {
   // User-assigned labels per session (e.g. "Needs testing")
   sessionLabels: Record<string, LabelData>
 
+  // Browser-style navigation history (back/forward across sessions and projects)
+  navigationHistory: Array<{
+    projectId: string
+    worktreeId: string
+    sessionId: string
+  }>
+  navigationIndex: number
+
   // Pending magic command to execute when ChatWindow mounts (from canvas navigation)
   pendingMagicCommand: { command: string; prompt?: string } | null
   setPendingMagicCommand: (
@@ -301,8 +309,19 @@ interface ChatUIState {
   setLastOpenedForProject: (
     projectId: string,
     worktreeId: string,
-    sessionId: string
+    sessionId: string,
+    options?: { skipHistory?: boolean }
   ) => void
+  navigateBack: () => {
+    projectId: string
+    worktreeId: string
+    sessionId: string
+  } | null
+  navigateForward: () => {
+    projectId: string
+    worktreeId: string
+    sessionId: string
+  } | null
   registerWorktreePath: (worktreeId: string, path: string) => void
   getWorktreePath: (worktreeId: string) => string | undefined
 
@@ -672,6 +691,8 @@ export const useChatStore = create<ChatUIState>()(
       sessionDigests: {},
       worktreeLoadingOperations: {},
       sessionLabels: {},
+      navigationHistory: [],
+      navigationIndex: -1,
       pendingMagicCommand: null,
 
       // Session management
@@ -932,7 +953,7 @@ export const useChatStore = create<ChatUIState>()(
       setLastActiveWorktreeId: id =>
         set({ lastActiveWorktreeId: id }, undefined, 'setLastActiveWorktreeId'),
 
-      setLastOpenedForProject: (projectId, worktreeId, sessionId) =>
+      setLastOpenedForProject: (projectId, worktreeId, sessionId, options) =>
         set(
           state => {
             const existing = state.lastOpenedPerProject[projectId]
@@ -941,16 +962,72 @@ export const useChatStore = create<ChatUIState>()(
               existing?.sessionId === sessionId
             )
               return state
+
+            // Push to navigation history unless replaying back/forward
+            const historyUpdate: Partial<ChatUIState> = {}
+            if (!options?.skipHistory) {
+              const entry = { projectId, worktreeId, sessionId }
+              const current =
+                state.navigationIndex >= 0
+                  ? state.navigationHistory[state.navigationIndex]
+                  : null
+              // Deduplicate consecutive identical locations
+              if (
+                !current ||
+                current.projectId !== projectId ||
+                current.worktreeId !== worktreeId ||
+                current.sessionId !== sessionId
+              ) {
+                // Truncate forward history (browser-style)
+                const truncated = state.navigationHistory.slice(
+                  0,
+                  state.navigationIndex + 1
+                )
+                truncated.push(entry)
+                // Cap at 50 entries
+                if (truncated.length > 50) truncated.shift()
+                historyUpdate.navigationHistory = truncated
+                historyUpdate.navigationIndex = truncated.length - 1
+              }
+            }
+
             return {
               lastOpenedPerProject: {
                 ...state.lastOpenedPerProject,
                 [projectId]: { worktreeId, sessionId },
               },
+              ...historyUpdate,
             }
           },
           undefined,
           'setLastOpenedForProject'
         ),
+
+      navigateBack: () => {
+        const { navigationHistory, navigationIndex } = get()
+        if (navigationIndex <= 0) return null
+        const newIndex = navigationIndex - 1
+        const target = navigationHistory[newIndex]
+        set(
+          { navigationIndex: newIndex },
+          undefined,
+          'navigateBack'
+        )
+        return target
+      },
+
+      navigateForward: () => {
+        const { navigationHistory, navigationIndex } = get()
+        if (navigationIndex >= navigationHistory.length - 1) return null
+        const newIndex = navigationIndex + 1
+        const target = navigationHistory[newIndex]
+        set(
+          { navigationIndex: newIndex },
+          undefined,
+          'navigateForward'
+        )
+        return target
+      },
 
       registerWorktreePath: (worktreeId, path) =>
         set(

--- a/src/store/chat-store.ts
+++ b/src/store/chat-store.ts
@@ -23,6 +23,7 @@ import {
   type ExecutionMode,
   type SessionDigest,
   type LabelData,
+  type TextHighlight,
   EXECUTION_MODE_CYCLE,
   isPlanToolCall,
 } from '@/types/chat'
@@ -254,6 +255,9 @@ interface ChatUIState {
   // User-assigned labels per session (e.g. "Needs testing")
   sessionLabels: Record<string, LabelData>
 
+  // User-created text highlights per session
+  sessionHighlights: Record<string, TextHighlight[]>
+
   // Browser-style navigation history (back/forward across sessions and projects)
   navigationHistory: Array<{
     projectId: string
@@ -293,6 +297,11 @@ interface ChatUIState {
 
   // Actions - Session label management (persisted)
   setSessionLabel: (sessionId: string, label: LabelData | null) => void
+
+  // Actions - Text highlight management (persisted)
+  setSessionHighlights: (sessionId: string, highlights: TextHighlight[]) => void
+  addHighlight: (sessionId: string, highlight: TextHighlight) => void
+  removeHighlight: (sessionId: string, highlightId: string) => void
 
   // Actions - Plan file path management (persisted)
   setPlanFilePath: (sessionId: string, path: string | null) => void
@@ -691,6 +700,7 @@ export const useChatStore = create<ChatUIState>()(
       sessionDigests: {},
       worktreeLoadingOperations: {},
       sessionLabels: {},
+      sessionHighlights: {},
       navigationHistory: [],
       navigationIndex: -1,
       pendingMagicCommand: null,
@@ -870,6 +880,55 @@ export const useChatStore = create<ChatUIState>()(
           },
           undefined,
           'setSessionLabel'
+        ),
+
+      // Text highlight management (persisted)
+      setSessionHighlights: (sessionId, highlights) =>
+        set(
+          state => {
+            if (state.sessionHighlights[sessionId] === highlights) return state
+            return {
+              sessionHighlights: {
+                ...state.sessionHighlights,
+                [sessionId]: highlights,
+              },
+            }
+          },
+          undefined,
+          'setSessionHighlights'
+        ),
+
+      addHighlight: (sessionId, highlight) =>
+        set(
+          state => {
+            const existing = state.sessionHighlights[sessionId] ?? []
+            return {
+              sessionHighlights: {
+                ...state.sessionHighlights,
+                [sessionId]: [...existing, highlight],
+              },
+            }
+          },
+          undefined,
+          'addHighlight'
+        ),
+
+      removeHighlight: (sessionId, highlightId) =>
+        set(
+          state => {
+            const existing = state.sessionHighlights[sessionId]
+            if (!existing) return state
+            const filtered = existing.filter(h => h.id !== highlightId)
+            if (filtered.length === existing.length) return state
+            return {
+              sessionHighlights: {
+                ...state.sessionHighlights,
+                [sessionId]: filtered,
+              },
+            }
+          },
+          undefined,
+          'removeHighlight'
         ),
 
       // Plan file path management
@@ -2713,6 +2772,8 @@ export const useChatStore = create<ChatUIState>()(
             const { [sessionId]: _effort, ...restEffort } = state.effortLevels
             const { [sessionId]: _mcp, ...restMcp } = state.enabledMcpServers
             const { [sessionId]: _label, ...restLabels } = state.sessionLabels
+            const { [sessionId]: _highlights, ...restHighlights } =
+              state.sessionHighlights
 
             return {
               approvedTools: restApproved,
@@ -2731,6 +2792,7 @@ export const useChatStore = create<ChatUIState>()(
               effortLevels: restEffort,
               enabledMcpServers: restMcp,
               sessionLabels: restLabels,
+              sessionHighlights: restHighlights,
             }
           },
           undefined,

--- a/src/store/nightshift-store.ts
+++ b/src/store/nightshift-store.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand'
+
+interface NightshiftState {
+  /** Currently active runs (projectId -> runId) */
+  activeRuns: Record<string, string>
+  /** Real-time check progress (runId -> checkId being executed) */
+  runningChecks: Record<string, string>
+  /** Whether the runs modal is open */
+  runsModalOpen: boolean
+  /** Project ID for the runs modal */
+  runsModalProjectId: string | null
+
+  // Actions
+  setActiveRun: (projectId: string, runId: string) => void
+  clearActiveRun: (projectId: string) => void
+  setRunningCheck: (runId: string, checkId: string) => void
+  clearRunningCheck: (runId: string) => void
+  openRunsModal: (projectId: string) => void
+  closeRunsModal: () => void
+}
+
+export const useNightshiftStore = create<NightshiftState>()((set) => ({
+  activeRuns: {},
+  runningChecks: {},
+  runsModalOpen: false,
+  runsModalProjectId: null,
+
+  setActiveRun: (projectId, runId) =>
+    set((state) => {
+      if (state.activeRuns[projectId] === runId) return state
+      return { activeRuns: { ...state.activeRuns, [projectId]: runId } }
+    }),
+
+  clearActiveRun: (projectId) =>
+    set((state) => {
+      if (!(projectId in state.activeRuns)) return state
+      const { [projectId]: _, ...rest } = state.activeRuns
+      return { activeRuns: rest }
+    }),
+
+  setRunningCheck: (runId, checkId) =>
+    set((state) => {
+      if (state.runningChecks[runId] === checkId) return state
+      return { runningChecks: { ...state.runningChecks, [runId]: checkId } }
+    }),
+
+  clearRunningCheck: (runId) =>
+    set((state) => {
+      if (!(runId in state.runningChecks)) return state
+      const { [runId]: _, ...rest } = state.runningChecks
+      return { runningChecks: rest }
+    }),
+
+  openRunsModal: (projectId) =>
+    set({ runsModalOpen: true, runsModalProjectId: projectId }),
+
+  closeRunsModal: () =>
+    set({ runsModalOpen: false, runsModalProjectId: null }),
+}))

--- a/src/store/projects-store.ts
+++ b/src/store/projects-store.ts
@@ -61,6 +61,8 @@ interface ProjectsUIState {
 
   // Worktree expansion actions
   toggleWorktreeExpanded: (id: string) => void
+  expandAllWorktrees: (ids: string[]) => void
+  collapseAllWorktrees: () => void
 
   // Dashboard collapse actions
   toggleDashboardWorktreeCollapsed: (
@@ -207,6 +209,23 @@ export const useProjectsStore = create<ProjectsUIState>()(
           },
           undefined,
           'toggleWorktreeExpanded'
+        ),
+
+      expandAllWorktrees: ids =>
+        set(
+          { expandedWorktreeIds: new Set(ids) },
+          undefined,
+          'expandAllWorktrees'
+        ),
+
+      collapseAllWorktrees: () =>
+        set(
+          state => {
+            if (state.expandedWorktreeIds.size === 0) return state
+            return { expandedWorktreeIds: new Set<string>() }
+          },
+          undefined,
+          'collapseAllWorktrees'
         ),
 
       // Dashboard collapse actions

--- a/src/store/terminal-store.ts
+++ b/src/store/terminal-store.ts
@@ -17,6 +17,8 @@ interface TerminalState {
   activeTerminalIds: Record<string, string>
   // Set of running terminal IDs (have active PTY process)
   runningTerminals: Set<string>
+  // Set of terminal IDs that exited with non-zero exit code (crash/failure)
+  failedTerminals: Set<string>
   // Whether terminal panel is expanded (false = collapsed/minimized) - global since only one worktree visible
   terminalVisible: boolean
   // Whether terminal panel is open per worktree (worktreeId -> open)
@@ -53,6 +55,10 @@ interface TerminalState {
   setTerminalRunning: (terminalId: string, running: boolean) => void
   isTerminalRunning: (terminalId: string) => boolean
 
+  // Failed state (terminal exited with non-zero code)
+  setTerminalFailed: (terminalId: string, failed: boolean) => void
+  isTerminalFailed: (terminalId: string) => boolean
+
   // Start a run command (creates new terminal with command)
   startRun: (worktreeId: string, command: string) => string
 
@@ -77,6 +83,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   terminals: {},
   activeTerminalIds: {},
   runningTerminals: new Set(),
+  failedTerminals: new Set(),
   terminalVisible: false,
   terminalPanelOpen: {},
   terminalHeight: 30,
@@ -162,6 +169,10 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       const newRunning = new Set(state.runningTerminals)
       newRunning.delete(terminalId)
 
+      // Update failed terminals
+      const newFailed = new Set(state.failedTerminals)
+      newFailed.delete(terminalId)
+
       // Update active terminal if needed
       const currentActiveId = state.activeTerminalIds[worktreeId] ?? ''
       const newActiveId =
@@ -179,6 +190,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
           [worktreeId]: newActiveId,
         },
         runningTerminals: newRunning,
+        failedTerminals: newFailed,
       }
     }),
 
@@ -200,6 +212,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
 
   setTerminalRunning: (terminalId, running) =>
     set(state => {
+      if (running === state.runningTerminals.has(terminalId)) return state
       const newSet = new Set(state.runningTerminals)
       if (running) {
         newSet.add(terminalId)
@@ -210,6 +223,20 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     }),
 
   isTerminalRunning: terminalId => get().runningTerminals.has(terminalId),
+
+  setTerminalFailed: (terminalId, failed) =>
+    set(state => {
+      if (failed === state.failedTerminals.has(terminalId)) return state
+      const newSet = new Set(state.failedTerminals)
+      if (failed) {
+        newSet.add(terminalId)
+      } else {
+        newSet.delete(terminalId)
+      }
+      return { failedTerminals: newSet }
+    }),
+
+  isTerminalFailed: terminalId => get().failedTerminals.has(terminalId),
 
   startRun: (worktreeId, command) => {
     const state = get()
@@ -245,10 +272,12 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     const terminals = state.terminals[worktreeId] ?? []
     const terminalIds = terminals.map(t => t.id)
 
-    // Remove all running terminal IDs for this worktree
+    // Remove all running/failed terminal IDs for this worktree
     const newRunning = new Set(state.runningTerminals)
+    const newFailed = new Set(state.failedTerminals)
     for (const id of terminalIds) {
       newRunning.delete(id)
+      newFailed.delete(id)
     }
 
     set({
@@ -261,6 +290,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
         [worktreeId]: '',
       },
       runningTerminals: newRunning,
+      failedTerminals: newFailed,
       terminalPanelOpen: {
         ...state.terminalPanelOpen,
         [worktreeId]: false,

--- a/src/store/ui-store.ts
+++ b/src/store/ui-store.ts
@@ -159,6 +159,8 @@ interface UIState {
   setUIStateInitialized: (initialized: boolean) => void
   setPendingUpdateVersion: (version: string | null) => void
   setUpdateModalVersion: (version: string | null) => void
+  chatSearchOpen: boolean
+  setChatSearchOpen: (open: boolean) => void
   githubDashboardOpen: boolean
   setGitHubDashboardOpen: (open: boolean) => void
 }
@@ -223,6 +225,7 @@ export const useUIStore = create<UIState>()(
       uiStateInitialized: false,
       pendingUpdateVersion: null,
       updateModalVersion: null,
+      chatSearchOpen: false,
       githubDashboardOpen: false,
       toggleLeftSidebar: () =>
         set(
@@ -696,6 +699,9 @@ export const useUIStore = create<UIState>()(
           undefined,
           'setUpdateModalVersion'
         ),
+
+      setChatSearchOpen: (open: boolean) =>
+        set({ chatSearchOpen: open }, undefined, 'setChatSearchOpen'),
 
       setGitHubDashboardOpen: (open: boolean) =>
         set({ githubDashboardOpen: open }, undefined, 'setGitHubDashboardOpen'),

--- a/src/store/ui-store.ts
+++ b/src/store/ui-store.ts
@@ -165,6 +165,8 @@ interface UIState {
   setChatSearchOpen: (open: boolean) => void
   githubDashboardOpen: boolean
   setGitHubDashboardOpen: (open: boolean) => void
+  sessionHistoryOpen: boolean
+  setSessionHistoryOpen: (open: boolean) => void
 }
 
 // Store callback outside Zustand state to avoid serialization issues with
@@ -230,6 +232,7 @@ export const useUIStore = create<UIState>()(
       updateModalVersion: null,
       chatSearchOpen: false,
       githubDashboardOpen: false,
+      sessionHistoryOpen: false,
       toggleLeftSidebar: () =>
         set(
           state => ({ leftSidebarVisible: !state.leftSidebarVisible }),
@@ -712,6 +715,8 @@ export const useUIStore = create<UIState>()(
       setGitHubDashboardOpen: (open: boolean) =>
         set({ githubDashboardOpen: open }, undefined, 'setGitHubDashboardOpen'),
 
+      setSessionHistoryOpen: (open: boolean) =>
+        set({ sessionHistoryOpen: open }, undefined, 'setSessionHistoryOpen'),
     }),
     {
       name: 'ui-store',

--- a/src/store/ui-store.ts
+++ b/src/store/ui-store.ts
@@ -24,6 +24,7 @@ interface UIState {
   leftSidebarSize: number // Width in pixels, persisted across sessions
   rightSidebarVisible: boolean
   commandPaletteOpen: boolean
+  sessionPaletteOpen: boolean
   preferencesOpen: boolean
   preferencesPane: PreferencePane | null
   commitModalOpen: boolean
@@ -93,6 +94,7 @@ interface UIState {
   setRightSidebarVisible: (visible: boolean) => void
   toggleCommandPalette: () => void
   setCommandPaletteOpen: (open: boolean) => void
+  setSessionPaletteOpen: (open: boolean) => void
   togglePreferences: () => void
   setPreferencesOpen: (open: boolean) => void
   openPreferencesPane: (pane: PreferencePane) => void
@@ -180,6 +182,7 @@ export const useUIStore = create<UIState>()(
       leftSidebarSize: 250, // Default width in pixels
       rightSidebarVisible: false,
       commandPaletteOpen: false,
+      sessionPaletteOpen: false,
       preferencesOpen: false,
       preferencesPane: null,
       commitModalOpen: false,
@@ -267,6 +270,9 @@ export const useUIStore = create<UIState>()(
 
       setCommandPaletteOpen: open =>
         set({ commandPaletteOpen: open }, undefined, 'setCommandPaletteOpen'),
+
+      setSessionPaletteOpen: open =>
+        set({ sessionPaletteOpen: open }, undefined, 'setSessionPaletteOpen'),
 
       togglePreferences: () =>
         set(

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -182,6 +182,12 @@ export interface Session {
   archived_at?: number
   /** Whether this session was archived by the base close operation (vs user action) */
   archived_by_base_close?: boolean
+  /** Source that created this session (e.g. "nightshift") */
+  source?: string
+  /** Nightshift check ID (if source === "nightshift") */
+  nightshift_check_id?: string
+  /** Nightshift run ID (if source === "nightshift") */
+  nightshift_run_id?: string
 
   // ========================================================================
   // Session-specific UI state (moved from ui-state.json)

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -130,6 +130,17 @@ export interface DeniedMessageContext {
 }
 
 /**
+ * A persistent text highlight within a chat message.
+ * Uses text content + offset for best-effort re-matching after re-renders.
+ */
+export interface TextHighlight {
+  id: string
+  message_id: string
+  text: string
+  start_offset: number
+}
+
+/**
  * A chat session within a worktree (supports multiple sessions per worktree)
  */
 export interface Session {
@@ -224,6 +235,8 @@ export interface Session {
   label?: LabelData
   /** Messages queued for sending (synced between native + web clients) */
   queued_messages?: QueuedMessage[]
+  /** User-created text highlights (persistent annotations) */
+  highlights?: TextHighlight[]
 }
 
 /**

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -36,6 +36,7 @@ export type KeybindingAction =
   | 'open_github_dashboard'
   | 'open_quick_menu'
   | 'open_usage_dropdown'
+  | 'search_chat'
 
 // Shortcut string format: "mod+key" where mod is cmd/ctrl
 // Examples: "mod+l", "mod+shift+p", "mod+1"
@@ -91,6 +92,7 @@ export const DEFAULT_KEYBINDINGS: KeybindingsMap = {
   open_github_dashboard: 'mod+shift+d',
   open_quick_menu: 'mod+period',
   open_usage_dropdown: 'mod+u',
+  search_chat: 'mod+f',
 }
 
 // UI definitions for the settings pane
@@ -348,6 +350,13 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     description: 'Open the floating usage dropdown',
     default_shortcut: 'mod+u',
     category: 'navigation',
+  },
+  {
+    action: 'search_chat',
+    label: 'Search chat',
+    description: 'Open in-chat text search (find in messages)',
+    default_shortcut: 'mod+f',
+    category: 'chat',
   },
 ]
 

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -44,6 +44,7 @@ export type KeybindingAction =
   | 'switch_mode_build'
   | 'switch_mode_yolo'
   | 'go_to_session'
+  | 'rename_session'
 
 // Shortcut string format: "mod+key" where mod is cmd/ctrl
 // Examples: "mod+l", "mod+shift+p", "mod+1"
@@ -107,6 +108,7 @@ export const DEFAULT_KEYBINDINGS: KeybindingsMap = {
   switch_mode_build: 'mod+ctrl+quote',
   switch_mode_yolo: 'mod+ctrl+backslash',
   go_to_session: 'mod+p',
+  rename_session: 'mod+e',
 }
 
 // UI definitions for the settings pane
@@ -420,6 +422,13 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     description: 'Fuzzy-search and jump to any session across all projects',
     default_shortcut: 'mod+p',
     category: 'navigation',
+  },
+  {
+    action: 'rename_session',
+    label: 'Rename session',
+    description: 'Rename the current chat session',
+    default_shortcut: 'mod+e',
+    category: 'chat',
   },
 ]
 

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -48,6 +48,7 @@ export type KeybindingAction =
   | 'navigate_back'
   | 'navigate_forward'
   | 'toggle_all_worktrees_expanded'
+  | 'open_session_history'
 
 // Shortcut string format: "mod+key" where mod is cmd/ctrl
 // Examples: "mod+l", "mod+shift+p", "mod+1"
@@ -115,6 +116,7 @@ export const DEFAULT_KEYBINDINGS: KeybindingsMap = {
   navigate_back: 'mod+bracketleft',
   navigate_forward: 'mod+bracketright',
   toggle_all_worktrees_expanded: 'mod+shift+w',
+  open_session_history: 'mod+shift+h',
 }
 
 // UI definitions for the settings pane
@@ -455,6 +457,13 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     label: 'Toggle all worktrees',
     description: 'Expand or collapse all worktree session lists at once',
     default_shortcut: 'mod+shift+w',
+    category: 'navigation',
+  },
+  {
+    action: 'open_session_history',
+    label: 'Session history',
+    description: 'View all sessions across all projects sorted by last activity',
+    default_shortcut: 'mod+shift+h',
     category: 'navigation',
   },
 ]

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -45,6 +45,8 @@ export type KeybindingAction =
   | 'switch_mode_yolo'
   | 'go_to_session'
   | 'rename_session'
+  | 'navigate_back'
+  | 'navigate_forward'
 
 // Shortcut string format: "mod+key" where mod is cmd/ctrl
 // Examples: "mod+l", "mod+shift+p", "mod+1"
@@ -109,6 +111,8 @@ export const DEFAULT_KEYBINDINGS: KeybindingsMap = {
   switch_mode_yolo: 'mod+ctrl+backslash',
   go_to_session: 'mod+p',
   rename_session: 'mod+e',
+  navigate_back: 'mod+bracketleft',
+  navigate_forward: 'mod+bracketright',
 }
 
 // UI definitions for the settings pane
@@ -430,6 +434,20 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     default_shortcut: 'mod+e',
     category: 'chat',
   },
+  {
+    action: 'navigate_back',
+    label: 'Go back',
+    description: 'Navigate to the previously viewed session',
+    default_shortcut: 'mod+bracketleft',
+    category: 'navigation',
+  },
+  {
+    action: 'navigate_forward',
+    label: 'Go forward',
+    description: 'Navigate forward in session history',
+    default_shortcut: 'mod+bracketright',
+    category: 'navigation',
+  },
 ]
 
 // Helper to convert shortcut string to display format
@@ -472,6 +490,10 @@ export function formatShortcutDisplay(
           return '→'
         case 'slash':
           return '/'
+        case 'bracketleft':
+          return '['
+        case 'bracketright':
+          return ']'
         case 'backspace':
           return isMac ? '⌫' : 'Backspace'
         case 'enter':

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -43,6 +43,7 @@ export type KeybindingAction =
   | 'switch_mode_plan'
   | 'switch_mode_build'
   | 'switch_mode_yolo'
+  | 'go_to_session'
 
 // Shortcut string format: "mod+key" where mod is cmd/ctrl
 // Examples: "mod+l", "mod+shift+p", "mod+1"
@@ -105,6 +106,7 @@ export const DEFAULT_KEYBINDINGS: KeybindingsMap = {
   switch_mode_plan: 'mod+ctrl+semicolon',
   switch_mode_build: 'mod+ctrl+quote',
   switch_mode_yolo: 'mod+ctrl+backslash',
+  go_to_session: 'mod+p',
 }
 
 // UI definitions for the settings pane
@@ -411,6 +413,13 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     description: 'Switch execution mode to Yolo',
     default_shortcut: 'mod+ctrl+backslash',
     category: 'chat',
+  },
+  {
+    action: 'go_to_session',
+    label: 'Go to session',
+    description: 'Fuzzy-search and jump to any session across all projects',
+    default_shortcut: 'mod+p',
+    category: 'navigation',
   },
 ]
 

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -47,6 +47,7 @@ export type KeybindingAction =
   | 'rename_session'
   | 'navigate_back'
   | 'navigate_forward'
+  | 'toggle_all_worktrees_expanded'
 
 // Shortcut string format: "mod+key" where mod is cmd/ctrl
 // Examples: "mod+l", "mod+shift+p", "mod+1"
@@ -113,6 +114,7 @@ export const DEFAULT_KEYBINDINGS: KeybindingsMap = {
   rename_session: 'mod+e',
   navigate_back: 'mod+bracketleft',
   navigate_forward: 'mod+bracketright',
+  toggle_all_worktrees_expanded: 'mod+shift+w',
 }
 
 // UI definitions for the settings pane
@@ -446,6 +448,13 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     label: 'Go forward',
     description: 'Navigate forward in session history',
     default_shortcut: 'mod+bracketright',
+    category: 'navigation',
+  },
+  {
+    action: 'toggle_all_worktrees_expanded',
+    label: 'Toggle all worktrees',
+    description: 'Expand or collapse all worktree session lists at once',
+    default_shortcut: 'mod+shift+w',
     category: 'navigation',
   },
 ]

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -37,6 +37,12 @@ export type KeybindingAction =
   | 'open_quick_menu'
   | 'open_usage_dropdown'
   | 'search_chat'
+  | 'switch_model_haiku'
+  | 'switch_model_sonnet'
+  | 'switch_model_opus'
+  | 'switch_mode_plan'
+  | 'switch_mode_build'
+  | 'switch_mode_yolo'
 
 // Shortcut string format: "mod+key" where mod is cmd/ctrl
 // Examples: "mod+l", "mod+shift+p", "mod+1"
@@ -93,6 +99,12 @@ export const DEFAULT_KEYBINDINGS: KeybindingsMap = {
   open_quick_menu: 'mod+period',
   open_usage_dropdown: 'mod+u',
   search_chat: 'mod+f',
+  switch_model_haiku: 'mod+semicolon',
+  switch_model_sonnet: 'mod+quote',
+  switch_model_opus: 'mod+backslash',
+  switch_mode_plan: 'mod+ctrl+semicolon',
+  switch_mode_build: 'mod+ctrl+quote',
+  switch_mode_yolo: 'mod+ctrl+backslash',
 }
 
 // UI definitions for the settings pane
@@ -358,6 +370,48 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     default_shortcut: 'mod+f',
     category: 'chat',
   },
+  {
+    action: 'switch_model_haiku',
+    label: 'Switch to Haiku',
+    description: 'Switch model to Haiku',
+    default_shortcut: 'mod+semicolon',
+    category: 'chat',
+  },
+  {
+    action: 'switch_model_sonnet',
+    label: 'Switch to Sonnet',
+    description: 'Switch model to Sonnet',
+    default_shortcut: 'mod+quote',
+    category: 'chat',
+  },
+  {
+    action: 'switch_model_opus',
+    label: 'Switch to Opus',
+    description: 'Switch model to Opus',
+    default_shortcut: 'mod+backslash',
+    category: 'chat',
+  },
+  {
+    action: 'switch_mode_plan',
+    label: 'Switch to Plan',
+    description: 'Switch execution mode to Plan',
+    default_shortcut: 'mod+ctrl+semicolon',
+    category: 'chat',
+  },
+  {
+    action: 'switch_mode_build',
+    label: 'Switch to Build',
+    description: 'Switch execution mode to Build',
+    default_shortcut: 'mod+ctrl+quote',
+    category: 'chat',
+  },
+  {
+    action: 'switch_mode_yolo',
+    label: 'Switch to Yolo',
+    description: 'Switch execution mode to Yolo',
+    default_shortcut: 'mod+ctrl+backslash',
+    category: 'chat',
+  },
 ]
 
 // Helper to convert shortcut string to display format
@@ -380,6 +434,8 @@ export function formatShortcutDisplay(
       switch (part) {
         case 'mod':
           return useMacCtrl ? '⌃' : isMac ? '⌘' : 'Ctrl'
+        case 'ctrl':
+          return isMac ? '⌃' : 'Ctrl'
         case 'shift':
           return isMac ? '⇧' : 'Shift'
         case 'alt':
@@ -408,6 +464,12 @@ export function formatShortcutDisplay(
           return 'Esc'
         case 'backquote':
           return '`'
+        case 'semicolon':
+          return ';'
+        case 'quote':
+          return "'"
+        case 'backslash':
+          return '\\'
         default:
           return part.toUpperCase()
       }
@@ -422,8 +484,18 @@ export function eventToShortcutString(e: KeyboardEvent): ShortcutString | null {
     return null
   }
 
+  const isMac =
+    typeof navigator !== 'undefined' && navigator.platform.includes('Mac')
+
   const parts: string[] = []
-  if (e.metaKey || e.ctrlKey) parts.push('mod')
+  // On macOS, Cmd and Ctrl are separate physical keys. Detect when both are held
+  // so we can distinguish mod+key from mod+ctrl+key (e.g. Cmd+; vs Ctrl+Cmd+;).
+  if (isMac && e.metaKey && e.ctrlKey) {
+    parts.push('mod')
+    parts.push('ctrl')
+  } else if (e.metaKey || e.ctrlKey) {
+    parts.push('mod')
+  }
   if (e.shiftKey) parts.push('shift')
   if (e.altKey) parts.push('alt')
 

--- a/src/types/nightshift.ts
+++ b/src/types/nightshift.ts
@@ -1,0 +1,133 @@
+// Mirrors Rust nightshift types with camelCase (matching #[serde(rename_all = "camelCase")])
+
+export type CheckCategory =
+  | 'lint'
+  | 'dead_code'
+  | 'documentation'
+  | 'security'
+  | 'tests'
+  | 'dependencies'
+  | 'performance'
+  | 'code_quality'
+  | 'type_safety'
+  | 'configuration'
+
+export type CostTier = 'low' | 'medium' | 'high'
+
+export interface NightshiftCheck {
+  id: string
+  name: string
+  description: string
+  category: CheckCategory
+  costTier: CostTier
+  cooldownHours: number
+  defaultEnabled: boolean
+}
+
+export type PostAction = 'nothing' | 'commit' | 'commit_and_pr'
+
+export interface NightshiftCheckConfig {
+  customPrompt?: string
+  cooldownHoursOverride?: number
+}
+
+export interface NightshiftConfig {
+  enabled: boolean
+  disabledChecks: string[]
+  extraEnabledChecks: string[]
+  scheduleTime?: string
+  targetBranch?: string
+  model?: string
+  provider?: string
+  backend?: string
+  postAction: PostAction
+  checkConfigs: Record<string, NightshiftCheckConfig>
+}
+
+export type NightshiftRunStatus =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'partially_completed'
+  | 'failed'
+  | 'cancelled'
+
+export interface CheckResult {
+  checkId: string
+  status: NightshiftRunStatus
+  sessionId?: string
+  durationSecs: number
+  error?: string
+}
+
+export type RunTrigger = 'manual' | 'scheduled'
+
+export interface NightshiftRun {
+  id: string
+  projectId: string
+  startedAt: number
+  completedAt?: number
+  status: NightshiftRunStatus
+  trigger: RunTrigger
+  checkResults: CheckResult[]
+  worktreeId?: string
+  worktreePath?: string
+  branchName?: string
+  prUrl?: string
+  prNumber?: number
+}
+
+// Event payloads
+export interface RunStartedPayload {
+  runId: string
+  projectId: string
+}
+
+export interface CheckStartedPayload {
+  runId: string
+  checkId: string
+  checkName: string
+}
+
+export interface CheckDonePayload {
+  runId: string
+  checkId: string
+  status: NightshiftRunStatus
+}
+
+export interface RunCompletedPayload {
+  runId: string
+  projectId: string
+  status: NightshiftRunStatus
+  totalChecks: number
+  worktreeId?: string
+}
+
+export interface RunFailedPayload {
+  runId: string
+  projectId: string
+  error: string
+}
+
+/** Event telling frontend to execute a check by sending a message in a session */
+export interface ExecuteCheckPayload {
+  runId: string
+  projectId: string
+  checkId: string
+  checkName: string
+  sessionId: string
+  worktreeId: string
+  worktreePath: string
+  prompt: string
+  model?: string
+  provider?: string
+  backend?: string
+}
+
+export const defaultNightshiftConfig: NightshiftConfig = {
+  enabled: false,
+  disabledChecks: [],
+  extraEnabledChecks: [],
+  postAction: 'nothing',
+  checkConfigs: {},
+}

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -982,6 +982,7 @@ export interface AppPreferences {
   opencode_cli_source: 'jean' | 'path' // OpenCode CLI source: 'jean' (managed) or 'path' (system PATH)
   gh_cli_source: 'jean' | 'path' // GitHub CLI source: 'jean' (managed) or 'path' (system PATH)
   sidebar_group_by_status: boolean // Group sidebar sessions by status headers (default: true)
+  terminal_word_wrap: boolean // Terminal word wrap (default: true, false = horizontal scroll)
 }
 
 export interface CustomCliProfile {
@@ -1548,4 +1549,5 @@ export const defaultPreferences: AppPreferences = {
   opencode_cli_source: 'jean', // Default: Jean-managed
   gh_cli_source: 'jean', // Default: Jean-managed
   sidebar_group_by_status: true, // Default: group by status
+  terminal_word_wrap: true, // Default: word wrap enabled
 }

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -960,6 +960,7 @@ export interface AppPreferences {
   default_provider: string | null // Default provider profile name (null = Anthropic direct)
 
   confirm_session_close: boolean // Show confirmation dialog before closing sessions/worktrees
+  esc_closes_session: boolean // Whether pressing Escape closes the current session modal
   default_execution_mode: ExecutionMode // Default execution mode for new sessions: 'plan', 'build', or 'yolo'
   default_backend: CliBackend // Default CLI backend for new sessions: 'claude', 'codex', or 'opencode'
   selected_codex_model: CodexModel // Default Codex model
@@ -1527,6 +1528,7 @@ export const defaultPreferences: AppPreferences = {
   custom_cli_profiles: [],
   default_provider: null,
   confirm_session_close: true, // Default: enabled (show confirmation)
+  esc_closes_session: true, // Default: Escape closes session modal
   default_execution_mode: 'plan', // Default: plan mode
   default_backend: 'claude', // Default: Claude
   selected_codex_model: 'gpt-5.4', // Default: latest Codex model

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -984,6 +984,7 @@ export interface AppPreferences {
   gh_cli_source: 'jean' | 'path' // GitHub CLI source: 'jean' (managed) or 'path' (system PATH)
   sidebar_group_by_status: boolean // Group sidebar sessions by status headers (default: true)
   terminal_word_wrap: boolean // Terminal word wrap (default: true, false = horizontal scroll)
+  expand_tool_calls: boolean // Expand tool call groups by default in chat (default: false)
 }
 
 export interface CustomCliProfile {
@@ -1552,4 +1553,5 @@ export const defaultPreferences: AppPreferences = {
   gh_cli_source: 'jean', // Default: Jean-managed
   sidebar_group_by_status: true, // Default: group by status
   terminal_word_wrap: true, // Default: word wrap enabled
+  expand_tool_calls: false, // Default: collapsed (click to expand)
 }

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -981,6 +981,7 @@ export interface AppPreferences {
   codex_cli_source: 'jean' | 'path' // Codex CLI source: 'jean' (managed) or 'path' (system PATH)
   opencode_cli_source: 'jean' | 'path' // OpenCode CLI source: 'jean' (managed) or 'path' (system PATH)
   gh_cli_source: 'jean' | 'path' // GitHub CLI source: 'jean' (managed) or 'path' (system PATH)
+  sidebar_group_by_status: boolean // Group sidebar sessions by status headers (default: true)
 }
 
 export interface CustomCliProfile {
@@ -1546,4 +1547,5 @@ export const defaultPreferences: AppPreferences = {
   codex_cli_source: 'jean', // Default: Jean-managed
   opencode_cli_source: 'jean', // Default: Jean-managed
   gh_cli_source: 'jean', // Default: Jean-managed
+  sidebar_group_by_status: true, // Default: group by status
 }


### PR DESCRIPTION
## Summary

- **Single-check runs**: Add `nightshift_start_check` command and `start_single_check_run` engine function to run one specific check without triggering all enabled checks. Uses a new `check_id_override` field in `RunParams`.
- **Setup script integration**: Nightshift worktrees now automatically run the jean.json setup script (e.g. `bun install`) on creation, matching the behavior of regular worktrees.
- **`Worktree::new()` constructor**: Replaces a 30-field struct literal in the nightshift engine with a clean constructor call, reducing boilerplate and making it easier to add new fields.
- **`run_setup_if_configured()` helper**: Reads jean.json and runs the setup script if configured, returning results without failing worktree creation on script error.
- **UI**: Per-check run button in NightshiftPane and NightshiftRunsModal; improved event handling in `useNightshiftEvents`; removed redundant nightshift indicator from WorktreeItem.

## Test plan

- [ ] Run Nightshift via the normal "Run All" button — verify all enabled checks still execute
- [ ] Click the per-check run button for a single check — verify only that check runs (run modal shows one entry)
- [ ] Create a project with a jean.json `setup` script; trigger a Nightshift run — verify setup output appears on the worktree
- [ ] Create a project without jean.json — verify nightshift worktree creation still succeeds
- [ ] Check WorktreeItem no longer shows a redundant nightshift running indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)