### PR TITLE
feat(chat): add GPT 5.4 Mini Codex model

### DIFF
--- a/src-tauri/src/chat/codex.rs
+++ b/src-tauri/src/chat/codex.rs
@@ -407,6 +407,7 @@ fn emit_codex_plan_tool_call(
 fn split_fast_model(model: &str) -> (&str, bool) {
     match model {
         "gpt-5.4-fast" => ("gpt-5.4", true),
+        "gpt-5.4-mini-fast" => ("gpt-5.4-mini", true),
         other => (other.strip_suffix("-fast").unwrap_or(other), false),
     }
 }
@@ -3109,8 +3110,14 @@ mod tests {
     }
 
     #[test]
+    fn split_fast_model_recognises_gpt_5_4_mini_fast() {
+        assert_eq!(split_fast_model("gpt-5.4-mini-fast"), ("gpt-5.4-mini", true));
+    }
+
+    #[test]
     fn split_fast_model_passes_through_normal_models() {
         assert_eq!(split_fast_model("gpt-5.4"), ("gpt-5.4", false));
+        assert_eq!(split_fast_model("gpt-5.4-mini"), ("gpt-5.4-mini", false));
         assert_eq!(split_fast_model("o3"), ("o3", false));
     }
 

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1115,6 +1115,7 @@ export const effortLevelOptions: {
 export type CodexModel =
   | 'gpt-5.4'
   | 'gpt-5.4-fast'
+  | 'gpt-5.4-mini'
   | 'gpt-5.3'
   | 'gpt-5.3-codex'
   | 'gpt-5.2-codex'
@@ -1125,6 +1126,7 @@ export type CodexModel =
 export const codexModelOptions: { value: CodexModel; label: string }[] = [
   { value: 'gpt-5.4', label: 'GPT 5.4' },
   { value: 'gpt-5.4-fast', label: 'GPT 5.4 - Fast' },
+  { value: 'gpt-5.4-mini', label: 'GPT 5.4 Mini' },
   { value: 'gpt-5.3', label: 'GPT 5.3' },
   { value: 'gpt-5.3-codex', label: 'GPT 5.3 Codex' },
   { value: 'gpt-5.2-codex', label: 'GPT 5.2 Codex' },


### PR DESCRIPTION
## Summary
- add `gpt-5.4-mini` to Codex model type definitions and preference dropdown options
- support `gpt-5.4-mini-fast` in Codex fast-model normalization for thread start params
- extend Codex model tests to cover `gpt-5.4-mini` and `gpt-5.4-mini-fast`

## Breaking Changes
- None

---

Fixes #283