### PR TITLE
feat(chat): recover Codex runs across crashes and reconnects

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "jean"
-version = "0.1.38"
+version = "0.1.39"
 dependencies = [
  "arboard",
  "axum",

--- a/src-tauri/src/chat/codex.rs
+++ b/src-tauri/src/chat/codex.rs
@@ -584,6 +584,7 @@ pub fn execute_codex_via_server(
     app: &tauri::AppHandle,
     session_id: &str,
     worktree_id: &str,
+    run_id: &str,
     output_file: &std::path::Path,
     working_dir: &std::path::Path,
     existing_thread_id: Option<&str>,
@@ -676,6 +677,13 @@ pub fn execute_codex_via_server(
         }
     };
 
+    // Persist codex_thread_id on the RunEntry so crash recovery can find it
+    if let Ok(mut writer) = super::run_log::RunLogWriter::resume(app, session_id, run_id) {
+        if let Err(e) = writer.set_codex_ids(&thread_id, None) {
+            log::warn!("Failed to persist codex_thread_id on run: {e}");
+        }
+    }
+
     // Build turn params
     let turn_params = build_turn_start_params(
         &thread_id,
@@ -713,6 +721,7 @@ pub fn execute_codex_via_server(
         app,
         session_id,
         worktree_id,
+        run_id,
         &thread_id,
         output_file,
         is_plan_mode,
@@ -725,6 +734,13 @@ pub fn execute_codex_via_server(
     codex_server::unregister_session(&thread_id);
     super::registry::unregister_codex_turn(session_id);
 
+    // Clear turn_id from RunEntry (turn completed)
+    if let Ok(mut writer) = super::run_log::RunLogWriter::resume(app, session_id, run_id) {
+        if let Err(e) = writer.clear_codex_turn_id() {
+            log::warn!("Failed to clear codex_turn_id after turn complete: {e}");
+        }
+    }
+
     // Set the thread_id on the response
     let mut resp = response;
     if resp.thread_id.is_empty() {
@@ -732,6 +748,157 @@ pub fn execute_codex_via_server(
     }
 
     Ok(resp)
+}
+
+/// Resume a Codex session after Jean crashed.
+///
+/// Spawns a new app-server (if needed), calls `thread/resume` to reconnect
+/// to the persisted thread, then checks whether a turn was in-flight.
+///
+/// Returns `Ok(true)` if the run was successfully recovered (either by
+/// re-entering the event loop for an active turn or by marking a completed
+/// turn). Returns `Ok(false)` if the thread is gone/expired and the run
+/// should be marked as Crashed.
+pub fn resume_codex_after_crash(
+    app: &tauri::AppHandle,
+    session_id: &str,
+    worktree_id: &str,
+    run_id: &str,
+    thread_id: &str,
+    had_active_turn: bool,
+) -> Result<bool, String> {
+    use super::codex_server;
+    use super::run_log::RunLogWriter;
+    use super::storage::get_session_dir;
+
+    log::info!(
+        "Codex crash recovery: session={session_id}, thread={thread_id}, had_active_turn={had_active_turn}"
+    );
+
+    // 1. Ensure the app-server is running
+    codex_server::ensure_running(app)?;
+
+    // 2. Call thread/resume to reconnect to the persisted thread
+    let resume_params = serde_json::json!({
+        "threadId": thread_id,
+        "persistExtendedHistory": true,
+    });
+
+    let resume_result = codex_server::send_request("thread/resume", resume_params);
+
+    match resume_result {
+        Err(e) => {
+            // Thread gone/expired — cannot recover
+            log::warn!("Codex crash recovery: thread/resume failed for {thread_id}: {e}");
+            codex_server::decrement_usage_count();
+            return Ok(false);
+        }
+        Ok(response) => {
+            log::trace!("Codex crash recovery: thread/resume succeeded for {thread_id}");
+
+            // Check thread status from response
+            let thread_status = response
+                .get("thread")
+                .and_then(|t| t.get("status"))
+                .and_then(|s| s.as_str())
+                .unwrap_or("unknown");
+
+            if had_active_turn && thread_status != "completed" {
+                // Turn was in-flight when Jean crashed and thread is still active.
+                // Register for events and enter the event loop to stream remaining output.
+                let session_dir = get_session_dir(app, session_id)?;
+                let output_file = session_dir.join(format!("{run_id}.jsonl"));
+
+                let (event_tx, event_rx) = std::sync::mpsc::channel();
+                let ctx = codex_server::SessionContext {
+                    session_id: session_id.to_string(),
+                    worktree_id: worktree_id.to_string(),
+                    event_tx,
+                };
+                codex_server::register_session(thread_id, ctx);
+                super::registry::register_codex_turn(
+                    session_id.to_string(),
+                    thread_id.to_string(),
+                    String::new(),
+                );
+
+                // Determine execution mode from run metadata (single load)
+                let exec_mode = super::storage::load_metadata(app, session_id)?.and_then(|m| {
+                    m.runs
+                        .iter()
+                        .find(|r| r.run_id == run_id)
+                        .and_then(|r| r.execution_mode.clone())
+                });
+                let is_plan_mode = exec_mode.as_deref() == Some("plan");
+                let is_build_mode = exec_mode.as_deref() == Some("build");
+
+                super::increment_tailer_count();
+                let response = process_turn_events(
+                    app,
+                    session_id,
+                    worktree_id,
+                    run_id,
+                    thread_id,
+                    &output_file,
+                    is_plan_mode,
+                    is_build_mode,
+                    &event_rx,
+                );
+                super::decrement_tailer_count();
+
+                codex_server::unregister_session(thread_id);
+                super::registry::unregister_codex_turn(session_id);
+
+                // Clear turn_id from RunEntry
+                if let Ok(mut writer) = RunLogWriter::resume(app, session_id, run_id) {
+                    if let Err(e) = writer.clear_codex_turn_id() {
+                        log::warn!("Failed to clear codex_turn_id after crash recovery: {e}");
+                    }
+                }
+
+                // Complete the run
+                if let Ok(mut writer) = RunLogWriter::resume(app, session_id, run_id) {
+                    let assistant_message_id = uuid::Uuid::new_v4().to_string();
+                    if let Err(e) = writer.complete(&assistant_message_id, None, response.usage) {
+                        log::error!("Failed to complete run after crash recovery: {e}");
+                    }
+                }
+
+                return Ok(true);
+            }
+
+            // Thread is idle — turn completed while Jean was down, or no turn was active.
+            // The JSONL file may already have the result from before the crash.
+            // Mark the run as completed (the JSONL output is the source of truth).
+            codex_server::decrement_usage_count();
+
+            // Check if the JSONL file has a result line (turn completed before crash)
+            let has_result = super::run_log::jsonl_has_result_line(app, session_id, run_id);
+
+            if has_result {
+                log::trace!("Codex crash recovery: run {run_id} already has result in JSONL");
+                // Run completed before the crash — mark as completed
+                if let Ok(mut writer) = RunLogWriter::resume(app, session_id, run_id) {
+                    let assistant_message_id = uuid::Uuid::new_v4().to_string();
+                    if let Err(e) = writer.complete(&assistant_message_id, None, None) {
+                        log::error!("Failed to complete run during crash recovery: {e}");
+                    }
+                }
+                return Ok(true);
+            }
+
+            // No result in JSONL — turn may have completed on the server side
+            // but events weren't written. Mark as completed with empty content.
+            log::trace!("Codex crash recovery: thread idle, marking run {run_id} as completed");
+            if let Ok(mut writer) = RunLogWriter::resume(app, session_id, run_id) {
+                let assistant_message_id = uuid::Uuid::new_v4().to_string();
+                if let Err(e) = writer.complete(&assistant_message_id, None, None) {
+                    log::error!("Failed to complete run during crash recovery: {e}");
+                }
+            }
+            return Ok(true);
+        }
+    }
 }
 
 /// Start a new Codex thread via app-server.
@@ -774,6 +941,7 @@ fn process_turn_events(
     app: &tauri::AppHandle,
     session_id: &str,
     worktree_id: &str,
+    run_id: &str,
     thread_id: &str,
     output_file: &std::path::Path,
     is_plan_mode: bool,
@@ -873,7 +1041,7 @@ fn process_turn_events(
                     is_plan_mode,
                 );
 
-                // Update turn_id for cancellation
+                // Update turn_id for cancellation + crash recovery
                 if method == "turn/started" {
                     if let Some(turn_id) = params
                         .get("turn")
@@ -885,6 +1053,14 @@ fn process_turn_events(
                             thread_id.to_string(),
                             turn_id.to_string(),
                         );
+                        // Persist turn_id so crash recovery knows a turn was in-flight
+                        if let Ok(mut writer) =
+                            super::run_log::RunLogWriter::resume(app, session_id, run_id)
+                        {
+                            if let Err(e) = writer.set_codex_ids(thread_id, Some(turn_id)) {
+                                log::warn!("Failed to persist codex_turn_id on run: {e}");
+                            }
+                        }
                     }
                 }
             }
@@ -3214,6 +3390,8 @@ mod tests {
             claude_session_id: None,
             pid: None,
             usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -3252,6 +3430,8 @@ mod tests {
             claude_session_id: None,
             pid: None,
             usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -3302,6 +3482,8 @@ mod tests {
             claude_session_id: None,
             pid: None,
             usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -3367,6 +3549,8 @@ mod tests {
             claude_session_id: None,
             pid: None,
             usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -3417,6 +3601,8 @@ mod tests {
             claude_session_id: None,
             pid: None,
             usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -3472,6 +3658,8 @@ mod tests {
             claude_session_id: None,
             pid: None,
             usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -3508,6 +3696,8 @@ mod tests {
             claude_session_id: None,
             pid: None,
             usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");

--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -1574,6 +1574,17 @@ pub async fn send_chat_message(
         })?;
     }
 
+    // Clear stale completion flags from previous turn — prevents approve
+    // buttons from appearing on WS reconnect during this turn.
+    with_sessions_mut(&app, &worktree_path, &worktree_id, |sessions| {
+        if let Some(session) = sessions.find_session_mut(&session_id) {
+            session.waiting_for_input = false;
+            session.is_reviewing = false;
+            session.waiting_for_input_type = None;
+        }
+        Ok(())
+    })?;
+
     // Build context for Claude
     let context = ClaudeContext::new(worktree_path.clone());
 
@@ -1687,6 +1698,7 @@ pub async fn send_chat_message(
     let thread_working_dir = context.worktree_path.clone();
     let thread_claude_session_id = claude_session_id.clone();
     let thread_codex_thread_id = codex_thread_id.clone();
+    let thread_run_id = run_id.clone();
     let thread_opencode_session_id = opencode_session_id.clone();
     let thread_model = model.clone();
     let thread_execution_mode = execution_mode.clone();
@@ -2159,6 +2171,7 @@ pub async fn send_chat_message(
                     &thread_app,
                     &thread_session_id,
                     &thread_worktree_id,
+                    &thread_run_id,
                     &thread_output_file,
                     std::path::Path::new(&thread_working_dir),
                     thread_codex_thread_id.as_deref(),
@@ -4823,11 +4836,13 @@ pub async fn resume_session(
         }
     };
 
-    // Find resumable runs
+    // Find resumable runs — include both PID-based (Claude) and Codex (thread_id-based)
     let resumable_runs: Vec<_> = metadata
         .runs
         .iter()
-        .filter(|r| r.status == RunStatus::Resumable && r.pid.is_some())
+        .filter(|r| {
+            r.status == RunStatus::Resumable && (r.pid.is_some() || r.codex_thread_id.is_some())
+        })
         .cloned()
         .collect();
 
@@ -4851,7 +4866,95 @@ pub async fn resume_session(
     // Process each resumable run
     for run in resumable_runs {
         let run_id = run.run_id.clone();
-        let pid = run.pid.unwrap(); // Safe because we filtered for Some above
+
+        // === Codex crash recovery path ===
+        if let Some(ref codex_tid) = run.codex_thread_id {
+            let had_active_turn = run.codex_turn_id.is_some();
+            log::trace!(
+                "Resuming Codex run: {run_id}, thread={codex_tid}, had_active_turn={had_active_turn}"
+            );
+
+            // Mark the run as Running again
+            if let Some(metadata_run) = metadata.find_run_mut(&run_id) {
+                metadata_run.status = RunStatus::Running;
+            }
+            save_metadata(&app, &metadata)?;
+
+            let app_clone = app.clone();
+            let session_id_clone = session_id.clone();
+            let worktree_id_clone = worktree_id.clone();
+            let run_id_clone = run_id.clone();
+            let thread_id_clone = codex_tid.clone();
+
+            // Use std::thread::spawn (NOT tauri::async_runtime::spawn) because
+            // resume_codex_after_crash blocks on sync mpsc — blocking a tokio
+            // worker would starve the async runtime.
+            std::thread::spawn(move || {
+                let emit_done = |app: &tauri::AppHandle, sid: &str, wid: &str| {
+                    let _ = app.emit_all(
+                        "chat:done",
+                        &serde_json::json!({ "session_id": sid, "worktree_id": wid, "waiting_for_plan": false }),
+                    );
+                };
+
+                match super::codex::resume_codex_after_crash(
+                    &app_clone,
+                    &session_id_clone,
+                    &worktree_id_clone,
+                    &run_id_clone,
+                    &thread_id_clone,
+                    had_active_turn,
+                ) {
+                    Ok(true) => {
+                        log::info!(
+                            "Codex crash recovery succeeded for session {session_id_clone}, run {run_id_clone}"
+                        );
+                        // process_turn_events (if active turn) or
+                        // resume_codex_after_crash (if idle) already emitted
+                        // chat:done, so only emit here for non-active-turn
+                        // paths where the function handled completion internally.
+                        if !had_active_turn {
+                            emit_done(&app_clone, &session_id_clone, &worktree_id_clone);
+                        }
+                        // For active turns, process_turn_events emits chat:done.
+                    }
+                    Ok(false) => {
+                        // Thread expired — mark as crashed
+                        log::warn!(
+                            "Codex crash recovery: thread expired for session {session_id_clone}, marking crashed"
+                        );
+                        if let Ok(mut writer) =
+                            RunLogWriter::resume(&app_clone, &session_id_clone, &run_id_clone)
+                        {
+                            if let Err(e) = writer.crash() {
+                                log::error!("Failed to mark run as crashed: {e}");
+                            }
+                        }
+                        emit_done(&app_clone, &session_id_clone, &worktree_id_clone);
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "Codex crash recovery failed for session {session_id_clone}: {e}"
+                        );
+                        if let Ok(mut writer) =
+                            RunLogWriter::resume(&app_clone, &session_id_clone, &run_id_clone)
+                        {
+                            if let Err(e) = writer.crash() {
+                                log::error!("Failed to mark run as crashed: {e}");
+                            }
+                        }
+                        emit_done(&app_clone, &session_id_clone, &worktree_id_clone);
+                    }
+                }
+            });
+            continue;
+        }
+
+        // === Claude PID-based resume path ===
+        let pid = match run.pid {
+            Some(p) => p,
+            None => continue,
+        };
         let output_file = session_dir.join(format!("{run_id}.jsonl"));
 
         log::trace!(
@@ -4880,7 +4983,6 @@ pub async fn resume_session(
         let session_id_clone = session_id.clone();
         let worktree_id_clone = worktree_id.clone();
         let run_id_clone = run_id.clone();
-        let is_codex = metadata.backend == Backend::Codex;
 
         // Spawn a task to tail the output file
         tauri::async_runtime::spawn(async move {
@@ -4894,22 +4996,8 @@ pub async fn resume_session(
                 );
             };
 
-            // Tail the output file — route by backend
-            let (resume_id, usage, cancelled) = if is_codex {
-                // Codex uses app-server now — no detached process to tail.
-                // Mark as crashed; the user's next message will use thread/resume.
-                log::trace!("Codex session {session_id_clone}: no process to tail (app-server mode), marking run complete");
-                super::registry::unregister_process(&session_id_clone);
-                if let Ok(mut writer) =
-                    RunLogWriter::resume(&app_clone, &session_id_clone, &run_id_clone)
-                {
-                    if let Err(e) = writer.crash() {
-                        log::error!("Failed to mark run as crashed: {e}");
-                    }
-                }
-                emit_done(&app_clone, &session_id_clone, &worktree_id_clone);
-                return;
-            } else {
+            // Tail the output file — Claude backend only (Codex handled above)
+            let (resume_id, usage, cancelled) = {
                 match super::claude::tail_claude_output(
                     &app_clone,
                     &session_id_clone,

--- a/src-tauri/src/chat/registry.rs
+++ b/src-tauri/src/chat/registry.rs
@@ -198,10 +198,9 @@ pub fn is_process_running(session_id: &str) -> bool {
 
 /// Get all session IDs that currently have running processes
 pub fn get_running_sessions() -> Vec<String> {
-    lock_recover(&PROCESS_REGISTRY, "PROCESS_REGISTRY")
-        .keys()
-        .cloned()
-        .collect()
+    let mut sessions: Vec<String> = get_actively_managed_sessions().into_iter().collect();
+    sessions.sort();
+    sessions
 }
 
 /// Get all session IDs that are actively managed (running process, cancel flag, or codex turn).
@@ -226,6 +225,46 @@ pub fn is_session_actively_managed(session_id: &str) -> bool {
     lock_recover(&PROCESS_REGISTRY, "PROCESS_REGISTRY").contains_key(session_id)
         || lock_recover(&CANCEL_FLAGS, "CANCEL_FLAGS").contains_key(session_id)
         || lock_recover(&CODEX_TURN_REGISTRY, "CODEX_TURN_REGISTRY").contains_key(session_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn clear_registries() {
+        lock_recover(&PROCESS_REGISTRY, "PROCESS_REGISTRY").clear();
+        lock_recover(&PENDING_CANCELS, "PENDING_CANCELS").clear();
+        lock_recover(&CANCEL_FLAGS, "CANCEL_FLAGS").clear();
+        lock_recover(&CODEX_TURN_REGISTRY, "CODEX_TURN_REGISTRY").clear();
+    }
+
+    #[test]
+    fn get_running_sessions_includes_all_backend_registries() {
+        clear_registries();
+
+        assert!(register_process("claude-session".to_string(), 4242));
+        assert!(register_cancel_flag(
+            "opencode-session".to_string(),
+            Arc::new(AtomicBool::new(false))
+        ));
+        assert!(register_codex_turn(
+            "codex-session".to_string(),
+            "thread-1".to_string(),
+            "turn-1".to_string()
+        ));
+
+        let running = get_running_sessions();
+        assert_eq!(
+            running,
+            vec![
+                "claude-session".to_string(),
+                "codex-session".to_string(),
+                "opencode-session".to_string()
+            ]
+        );
+
+        clear_registries();
+    }
 }
 
 /// Cancel a running Claude process for a session by sending SIGKILL to the process group

--- a/src-tauri/src/chat/run_log.rs
+++ b/src-tauri/src/chat/run_log.rs
@@ -235,6 +235,57 @@ impl RunLogWriter {
         })
     }
 
+    /// Set the Codex thread ID and (optionally) turn ID on the run entry.
+    /// Called after thread/start or thread/resume returns the thread ID,
+    /// and again after turn/started returns the turn ID.
+    pub fn set_codex_ids(&mut self, thread_id: &str, turn_id: Option<&str>) -> Result<(), String> {
+        let run_id = self.run_id.clone();
+        let tid = thread_id.to_string();
+        let tuid = turn_id.map(|s| s.to_string());
+
+        with_metadata_mut(
+            &self.app,
+            &self.session_id,
+            &self.worktree_id,
+            &self.session_name,
+            self.order,
+            |metadata| {
+                if let Some(run) = metadata.find_run_mut(&run_id) {
+                    run.codex_thread_id = Some(tid);
+                    run.codex_turn_id = tuid;
+                }
+                Ok(())
+            },
+        )?;
+
+        log::trace!(
+            "Set codex IDs for run {}: thread={thread_id}, turn={turn_id:?}",
+            self.run_id
+        );
+        Ok(())
+    }
+
+    /// Clear the Codex turn ID (turn completed successfully).
+    pub fn clear_codex_turn_id(&mut self) -> Result<(), String> {
+        let run_id = self.run_id.clone();
+
+        with_metadata_mut(
+            &self.app,
+            &self.session_id,
+            &self.worktree_id,
+            &self.session_name,
+            self.order,
+            |metadata| {
+                if let Some(run) = metadata.find_run_mut(&run_id) {
+                    run.codex_turn_id = None;
+                }
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
     /// Mark the run as crashed (used when resume fails)
     pub fn crash(&mut self) -> Result<(), String> {
         let now = now_timestamp();
@@ -329,6 +380,8 @@ pub fn start_run(
         claude_session_id: None,
         pid: None,   // Set later via set_pid() after spawning detached process
         usage: None, // Set on completion via complete()
+        codex_thread_id: None,
+        codex_turn_id: None,
     };
 
     with_metadata_mut(
@@ -877,6 +930,8 @@ mod tests {
             claude_session_id: None,
             pid: None,
             usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
         }
     }
 
@@ -1216,6 +1271,31 @@ pub fn recover_incomplete_runs(app: &tauri::AppHandle) -> Result<Vec<RecoveredRu
                                 metadata.claude_session_id = Some(sid);
                             }
                         }
+                    } else if run.codex_thread_id.is_some() {
+                        // Codex sessions can be resumed via thread/resume even after
+                        // Jean crashes — threads are persisted to disk by app-server.
+                        // Mark as Resumable so resume_session can recover them.
+                        run.status = RunStatus::Resumable;
+
+                        recovered.push(RecoveredRun {
+                            session_id: session_id.clone(),
+                            worktree_id: metadata.worktree_id.clone(),
+                            run_id: run.run_id.clone(),
+                            user_message: run.user_message.clone(),
+                            resumable: true,
+                            execution_mode: run.execution_mode.clone(),
+                            started_at: run.started_at,
+                        });
+
+                        log::trace!(
+                            "Found resumable Codex run: {} in session {} (thread_id: {:?})",
+                            run.run_id,
+                            session_id,
+                            run.codex_thread_id
+                        );
+
+                        modified = true;
+                        continue;
                     } else {
                         run.status = RunStatus::Crashed;
                     }

--- a/src-tauri/src/chat/storage.rs
+++ b/src-tauri/src/chat/storage.rs
@@ -692,6 +692,7 @@ pub fn load_sessions(
                 digest: None,
                 last_run_status: None,
                 last_run_execution_mode: None,
+                last_run_started_at: None,
                 label: None,
                 queued_messages: vec![],
             }
@@ -780,6 +781,7 @@ where
                 digest: None,
                 last_run_status: None,
                 last_run_execution_mode: None,
+                last_run_started_at: None,
                 label: None,
                 queued_messages: vec![],
             }

--- a/src-tauri/src/chat/types.rs
+++ b/src-tauri/src/chat/types.rs
@@ -1132,6 +1132,13 @@ pub struct RunEntry {
     /// Token usage for this run (captured from Claude CLI result)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage: Option<UsageData>,
+    /// Codex thread ID — persisted per-run so crash recovery can resume via thread/resume
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_thread_id: Option<String>,
+    /// Codex turn ID — set when a turn is in-flight, cleared on completion.
+    /// Presence indicates a turn was active when Jean crashed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_turn_id: Option<String>,
 }
 
 /// Session metadata - single source of truth for session data and run history
@@ -1719,6 +1726,8 @@ mod tests {
             claude_session_id: None,
             pid: Some(12345),
             usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
         });
 
         assert!(metadata.find_run("run-1").is_some());
@@ -1755,6 +1764,8 @@ mod tests {
             claude_session_id: None,
             pid: None,
             usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
         });
 
         assert!(metadata.latest_claude_session_id().is_none());
@@ -1777,6 +1788,8 @@ mod tests {
             claude_session_id: Some("claude-sess-abc".to_string()),
             pid: None,
             usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
         });
 
         assert_eq!(metadata.latest_claude_session_id(), Some("claude-sess-abc"));

--- a/src-tauri/src/chat/types.rs
+++ b/src-tauri/src/chat/types.rs
@@ -613,6 +613,9 @@ pub struct Session {
     /// Execution mode of the last run (plan/build/yolo)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_run_execution_mode: Option<String>,
+    /// Unix timestamp when the last run started
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run_started_at: Option<u64>,
     /// User-assigned label with color (e.g. "Needs testing")
     #[serde(
         default,
@@ -681,6 +684,7 @@ impl Session {
             digest: None,
             last_run_status: None,
             last_run_execution_mode: None,
+            last_run_started_at: None,
             label: None,
             queued_messages: vec![],
         }
@@ -875,6 +879,7 @@ impl SessionMetadata {
             // Populate from last run for status recovery on app restart
             last_run_status: last_run.map(|r| r.status.clone()),
             last_run_execution_mode: last_run.and_then(|r| r.execution_mode.clone()),
+            last_run_started_at: last_run.map(|r| r.started_at),
             label: self.label.clone(),
             queued_messages: self.queued_messages.clone(),
         }

--- a/src-tauri/src/http_server/mod.rs
+++ b/src-tauri/src/http_server/mod.rs
@@ -4,14 +4,44 @@ pub mod server;
 pub mod websocket;
 
 use serde::Serialize;
-use std::sync::Arc;
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::broadcast;
+
+/// Global monotonic sequence counter for event replay.
+static EVENT_SEQ: AtomicU64 = AtomicU64::new(1);
+
+/// Maximum events buffered per session for replay.
+const SESSION_BUFFER_CAP: usize = 2000;
+
+/// Events that are worth buffering for replay on reconnect.
+const REPLAYABLE_EVENTS: &[&str] = &[
+    "chat:sending",
+    "chat:chunk",
+    "chat:tool_use",
+    "chat:tool_block",
+    "chat:tool_result",
+    "chat:thinking",
+    "chat:permission_denied",
+    "chat:codex_command_approval_request",
+    "chat:codex_permission_request",
+    "chat:codex_user_input_request",
+    "chat:codex_mcp_elicitation_request",
+    "chat:codex_dynamic_tool_call_request",
+    "chat:done",
+    "chat:cancelled",
+    "chat:error",
+];
 
 /// Broadcast channel for sending events to all connected WebSocket clients.
 /// Managed as Tauri state so any code with an AppHandle can broadcast.
 pub struct WsBroadcaster {
     tx: broadcast::Sender<WsEvent>,
+    /// Per-session ring buffer for event replay on WebSocket reconnect.
+    /// Key: session_id extracted from the event payload.
+    session_buffers: Mutex<HashMap<String, VecDeque<(u64, Arc<str>)>>>,
 }
 
 /// A pre-serialized WebSocket event.
@@ -20,6 +50,8 @@ pub struct WsBroadcaster {
 #[derive(Clone, Debug)]
 pub struct WsEvent {
     pub json: Arc<str>,
+    /// Monotonic sequence number for replay ordering.
+    pub seq: u64,
 }
 
 /// Wire-format envelope serialized once in `broadcast()`.
@@ -29,6 +61,8 @@ struct WsEnvelope<'a, S: Serialize> {
     msg_type: &'static str,
     event: &'a str,
     payload: &'a S,
+    /// Monotonic sequence number for replay ordering.
+    seq: u64,
 }
 
 impl WsBroadcaster {
@@ -37,17 +71,25 @@ impl WsBroadcaster {
         // multiple clients. Each WsEvent is ~16 bytes (Arc pointer + len).
         let (tx, _) = broadcast::channel(8192);
         let tx_clone = tx.clone();
-        (Self { tx }, tx_clone)
+        (
+            Self {
+                tx,
+                session_buffers: Mutex::new(HashMap::new()),
+            },
+            tx_clone,
+        )
     }
 
     /// Serialize the payload once into the wire-format JSON envelope.
     /// Each broadcast receiver gets an `Arc<str>` clone (cheap ref-count
     /// increment) instead of re-serializing per client.
     pub fn broadcast<S: Serialize>(&self, event: &str, payload: &S) {
+        let seq = EVENT_SEQ.fetch_add(1, Ordering::Relaxed);
         let envelope = WsEnvelope {
             msg_type: "event",
             event,
             payload,
+            seq,
         };
         let json = match serde_json::to_string(&envelope) {
             Ok(s) => s,
@@ -56,14 +98,63 @@ impl WsBroadcaster {
                 return;
             }
         };
+        let json_arc: Arc<str> = Arc::from(json);
+
+        // Buffer replayable events per session
+        if REPLAYABLE_EVENTS.contains(&event) {
+            // Try to extract session_id from the payload
+            if let Ok(val) = serde_json::to_value(payload) {
+                if let Some(sid) = val.get("session_id").and_then(|v| v.as_str()) {
+                    if let Ok(mut buffers) = self.session_buffers.lock() {
+                        let buf = buffers
+                            .entry(sid.to_string())
+                            .or_insert_with(|| VecDeque::with_capacity(SESSION_BUFFER_CAP));
+                        if buf.len() >= SESSION_BUFFER_CAP {
+                            buf.pop_front();
+                        }
+                        buf.push_back((seq, json_arc.clone()));
+                    }
+                }
+            }
+        }
+
+        // Clean up session buffer on chat:done or chat:cancelled
+        if event == "chat:done" || event == "chat:cancelled" {
+            if let Ok(val) = serde_json::to_value(payload) {
+                if let Some(sid) = val.get("session_id").and_then(|v| v.as_str()) {
+                    if let Ok(mut buffers) = self.session_buffers.lock() {
+                        buffers.remove(sid);
+                    }
+                }
+            }
+        }
+
         // Ignore send errors (no active receivers is fine)
         let _ = self.tx.send(WsEvent {
-            json: Arc::from(json),
+            json: json_arc,
+            seq,
         });
     }
 
     pub fn subscribe(&self) -> broadcast::Receiver<WsEvent> {
         self.tx.subscribe()
+    }
+
+    /// Replay buffered events for a session after the given sequence number.
+    /// Returns events in order, each with its sequence number and pre-serialized JSON.
+    pub fn replay_events(&self, session_id: &str, after_seq: u64) -> Vec<(u64, Arc<str>)> {
+        let buffers = match self.session_buffers.lock() {
+            Ok(b) => b,
+            Err(_) => return Vec::new(),
+        };
+        match buffers.get(session_id) {
+            Some(buf) => buf
+                .iter()
+                .filter(|(seq, _)| *seq > after_seq)
+                .cloned()
+                .collect(),
+            None => Vec::new(),
+        }
     }
 }
 

--- a/src-tauri/src/http_server/server.rs
+++ b/src-tauri/src/http_server/server.rs
@@ -569,6 +569,35 @@ async fn init_handler(Query(params): Query<WsAuth>, State(state): State<AppState
     let running_sessions = crate::chat::registry::get_running_sessions();
     response["runningSessions"] = serde_json::to_value(&running_sessions).unwrap_or_default();
 
+    if !running_sessions.is_empty() {
+        let mut replay_events: Vec<Value> = state
+            .app
+            .try_state::<WsBroadcaster>()
+            .map(|broadcaster| {
+                let mut events: Vec<Value> = running_sessions
+                    .iter()
+                    .flat_map(|session_id| broadcaster.replay_events(session_id, 0))
+                    .filter_map(|(_, json)| serde_json::from_str::<Value>(&json).ok())
+                    .collect();
+                events.sort_by_key(|event| {
+                    event
+                        .get("seq")
+                        .and_then(|seq| seq.as_u64())
+                        .unwrap_or_default()
+                });
+                events
+            })
+            .unwrap_or_default();
+
+        replay_events.dedup_by(|a, b| {
+            a.get("seq").and_then(|seq| seq.as_u64()) == b.get("seq").and_then(|seq| seq.as_u64())
+        });
+
+        if !replay_events.is_empty() {
+            response["replayEvents"] = Value::Array(replay_events);
+        }
+    }
+
     match ui_state {
         Some(cleaned_ui) => {
             if let Ok(val) = serde_json::to_value(&cleaned_ui) {

--- a/src-tauri/src/http_server/websocket.rs
+++ b/src-tauri/src/http_server/websocket.rs
@@ -2,12 +2,30 @@ use axum::extract::ws::{Message, WebSocket};
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tokio::sync::{broadcast, mpsc};
 
 use super::dispatch::dispatch_command;
-use super::WsEvent;
+use super::{WsBroadcaster, WsEvent};
 
+/// Typed client message parsed from JSON with `"type"` tag.
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+enum WsClientMessage {
+    /// Standard command invocation: `{ type: "invoke", id, command, args }`.
+    #[serde(rename = "invoke")]
+    Invoke {
+        id: String,
+        command: String,
+        #[serde(default)]
+        args: Value,
+    },
+    /// Request replay of missed events after reconnection.
+    #[serde(rename = "replay")]
+    Replay { session_id: String, last_seq: u64 },
+}
+
+/// Legacy invoke request without `type` field (backwards compat).
 #[derive(Deserialize)]
 struct InvokeRequest {
     id: String,
@@ -61,18 +79,17 @@ pub async fn handle_ws_connection(
             msg = ws_rx.next() => {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
-                        match serde_json::from_str::<InvokeRequest>(&text) {
-                            Ok(req) => {
+                        match serde_json::from_str::<WsClientMessage>(&text) {
+                            Ok(WsClientMessage::Invoke { id, command, args }) => {
                                 // Spawn dispatch as a separate task so the
                                 // select loop stays free to drain events.
                                 let app_clone = app.clone();
                                 let tx = resp_tx.clone();
                                 tokio::spawn(async move {
-                                    let id = req.id.clone();
                                     let resp = match dispatch_command(
                                         &app_clone,
-                                        &req.command,
-                                        req.args,
+                                        &command,
+                                        args,
                                     )
                                     .await
                                     {
@@ -94,16 +111,62 @@ pub async fn handle_ws_connection(
                                     }
                                 });
                             }
+                            Ok(WsClientMessage::Replay { session_id, last_seq }) => {
+                                // Replay missed events for this session
+                                if let Some(broadcaster) = app.try_state::<WsBroadcaster>() {
+                                    let events = broadcaster.replay_events(&session_id, last_seq);
+                                    for (_seq, json) in events {
+                                        if ws_tx.send(Message::Text(json.to_string().into())).await.is_err() {
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
                             Err(e) => {
-                                let resp = InvokeResponse {
-                                    msg_type: "error".to_string(),
-                                    id: "unknown".to_string(),
-                                    data: None,
-                                    error: Some(format!("Invalid request: {e}")),
-                                };
-                                if let Ok(json) = serde_json::to_string(&resp) {
-                                    if ws_tx.send(Message::Text(json.into())).await.is_err() {
-                                        break;
+                                // Try legacy format (no "type" field — old clients send bare invoke)
+                                match serde_json::from_str::<InvokeRequest>(&text) {
+                                    Ok(req) => {
+                                        let app_clone = app.clone();
+                                        let tx = resp_tx.clone();
+                                        tokio::spawn(async move {
+                                            let id = req.id.clone();
+                                            let resp = match dispatch_command(
+                                                &app_clone,
+                                                &req.command,
+                                                req.args,
+                                            )
+                                            .await
+                                            {
+                                                Ok(data) => InvokeResponse {
+                                                    msg_type: "response".to_string(),
+                                                    id,
+                                                    data: Some(data),
+                                                    error: None,
+                                                },
+                                                Err(err) => InvokeResponse {
+                                                    msg_type: "error".to_string(),
+                                                    id,
+                                                    data: None,
+                                                    error: Some(err),
+                                                },
+                                            };
+                                            if let Ok(json) = serde_json::to_string(&resp) {
+                                                let _ = tx.send(json);
+                                            }
+                                        });
+                                    }
+                                    Err(_) => {
+                                        let resp = InvokeResponse {
+                                            msg_type: "error".to_string(),
+                                            id: "unknown".to_string(),
+                                            data: None,
+                                            error: Some(format!("Invalid request: {e}")),
+                                        };
+                                        if let Ok(json) = serde_json::to_string(&resp) {
+                                            if ws_tx.send(Message::Text(json.into())).await.is_err() {
+                                                break;
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import {
+  connectTransport,
+  ingestBootstrapEvents,
   invoke,
   useWsConnectionStatus,
   useWsDataReady,
@@ -109,6 +111,7 @@ function App() {
   // Track preloading state for web view
   const [isPreloading, setIsPreloading] = useState(!isNativeApp())
   const queryClient = useQueryClient()
+  const hasStartedTransportRef = useRef(false)
 
   // Holds the update object so the title bar indicator can trigger install later
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -264,6 +267,15 @@ function App() {
             ...worktreePaths,
           }
         }
+        // Clear stale waiting/reviewing state for sessions actively running a turn.
+        // The server persists these flags from the previous turn's completion;
+        // if a new turn is in-flight they're stale and would show approve buttons.
+        if (data.runningSessions?.length) {
+          for (const sessionId of data.runningSessions) {
+            delete reviewingUpdates[sessionId]
+            delete waitingUpdates[sessionId]
+          }
+        }
         // Replace (not merge) reviewing/waiting state — server is source of truth.
         // Merging would keep stale entries from sessions that changed while disconnected.
         storeUpdates.reviewingSessions = reviewingUpdates
@@ -352,6 +364,7 @@ function App() {
             projects: Array.isArray(data.projects) ? data.projects.length : 0,
           })
           seedCache(data)
+          ingestBootstrapEvents(data.replayEvents ?? [])
           setWsDataReady(true)
         }
       })
@@ -378,6 +391,14 @@ function App() {
   // Global streaming event listeners - must be at App level so they stay active
   // even when ChatWindow is unmounted (e.g., when viewing a different worktree)
   useStreamingEvents({ queryClient })
+
+  // Browser mode: only open WebSocket after preload + listener registration.
+  // This lets us replay buffered server events before live events start arriving.
+  useEffect(() => {
+    if (isNativeApp() || isPreloading || hasStartedTransportRef.current) return
+    hasStartedTransportRef.current = true
+    connectTransport()
+  }, [isPreloading])
 
   // Global queue processor - must be at App level so queued messages execute
   // even when the worktree is not focused (ChatWindow unmounted)
@@ -418,6 +439,7 @@ function App() {
         .then(data => {
           if (data) {
             seedCache(data)
+            ingestBootstrapEvents(data.replayEvents ?? [])
             logger.info('Reconnect: re-seeded cache from HTTP')
             setWsDataReady(true)
             // Invalidate non-preloaded queries after a frame so the seeded

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -318,23 +318,49 @@ function App() {
       // This clears sessions that finished while disconnected and restores
       // sessions that are still running — server is source of truth.
       const runningSendingIds: Record<string, boolean> = {}
+      const runningSendStartedAt: Record<string, number> = {}
       if (data.runningSessions?.length) {
         for (const sessionId of data.runningSessions) {
           runningSendingIds[sessionId] = true
+          const startedAt = data.sessionsByWorktree
+            ? Object.values(data.sessionsByWorktree)
+                .flatMap(ws => (ws as WorktreeSessions).sessions)
+                .find(session => session.id === sessionId)?.last_run_started_at
+            : undefined
+          if (startedAt) {
+            runningSendStartedAt[sessionId] = startedAt * 1000
+          }
         }
       }
       useChatStore.setState(state => {
         const current = state.sendingSessionIds
+        const currentSendStartedAt = state.sendStartedAt
         // Check if anything actually changed to avoid unnecessary re-renders
         const currentKeys = Object.keys(current)
         const newKeys = Object.keys(runningSendingIds)
+        const currentStartKeys = Object.keys(currentSendStartedAt).filter(
+          key => runningSendingIds[key]
+        )
+        const newStartKeys = Object.keys(runningSendStartedAt)
         if (
           currentKeys.length === newKeys.length &&
-          newKeys.every(k => current[k])
+          newKeys.every(k => current[k]) &&
+          currentStartKeys.length === newStartKeys.length &&
+          newStartKeys.every(k => currentSendStartedAt[k] === runningSendStartedAt[k])
         ) {
           return state
         }
-        return { sendingSessionIds: runningSendingIds }
+        return {
+          sendingSessionIds: runningSendingIds,
+          sendStartedAt: {
+            ...Object.fromEntries(
+              Object.entries(currentSendStartedAt).filter(
+                ([sessionId]) => !runningSendingIds[sessionId]
+              )
+            ),
+            ...runningSendStartedAt,
+          },
+        }
       })
       // Note: Git status is included in worktree cached_* fields, no separate cache needed
       // Seed preferences into cache

--- a/src/lib/transport.test.ts
+++ b/src/lib/transport.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const setWsConnectedMock = vi.fn()
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances: MockWebSocket[] = []
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onclose: ((event: Event) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.(new Event('close'))
+  })
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this)
+    queueMicrotask(() => {
+      this.readyState = MockWebSocket.OPEN
+      this.onopen?.(new Event('open'))
+    })
+  }
+}
+
+async function flushAsync() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+async function loadTransportModule() {
+  vi.resetModules()
+  vi.doMock('./environment', () => ({
+    isNativeApp: () => false,
+    setWsConnected: setWsConnectedMock,
+  }))
+  return import('./transport')
+}
+
+describe('transport bootstrap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    MockWebSocket.instances = []
+    localStorage.clear()
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      })
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.doUnmock('./environment')
+  })
+
+  it('does not open websocket until bootstrap explicitly connects it', async () => {
+    const transport = await loadTransportModule()
+
+    await transport.listen('chat:chunk', vi.fn())
+    expect(MockWebSocket.instances).toHaveLength(0)
+
+    transport.connectTransport()
+    await flushAsync()
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(setWsConnectedMock).toHaveBeenCalledWith(true)
+  })
+
+  it('buffers bootstrap replay events before listeners connect and replays them in seq order', async () => {
+    const transport = await loadTransportModule()
+    const handler = vi.fn()
+
+    transport.ingestBootstrapEvents([
+      {
+        type: 'event',
+        event: 'chat:chunk',
+        payload: { session_id: 'session-1', content: 'second' },
+        seq: 2,
+      },
+      {
+        type: 'event',
+        event: 'chat:chunk',
+        payload: { session_id: 'session-1', content: 'first' },
+        seq: 1,
+      },
+    ])
+
+    await transport.listen('chat:chunk', handler)
+
+    expect(handler.mock.calls).toEqual([
+      [{ payload: { session_id: 'session-1', content: 'first' } }],
+      [{ payload: { session_id: 'session-1', content: 'second' } }],
+    ])
+    expect(MockWebSocket.instances).toHaveLength(0)
+  })
+})

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -139,6 +139,7 @@ export interface InitialData {
   sessionsByWorktree: Record<string, unknown> // worktreeId -> WorktreeSessions
   activeSessions?: Record<string, unknown> // sessionId -> Session (with messages)
   runningSessions?: string[] // sessionIds with active CLI processes
+  replayEvents?: BootstrapEvent[]
   preferences: unknown
   uiState: unknown
   appDataDir?: string
@@ -257,6 +258,15 @@ interface WsMessage {
   error?: string
   event?: string
   payload?: unknown
+  /** Monotonic sequence number for event replay on reconnect. */
+  seq?: number
+}
+
+export interface BootstrapEvent {
+  type: 'event'
+  event: string
+  payload: unknown
+  seq?: number
 }
 
 class WsTransport {
@@ -285,6 +295,11 @@ class WsTransport {
   private _tokenValidated = false
   private _lastConnectTime = 0
   private _subscribers = new Set<() => void>()
+  private _connectEnabled = false
+  /** Track last seen seq per session for replay on reconnect. */
+  private _lastSeqBySession = new Map<string, number>()
+  /** Sessions that were actively streaming when we disconnected. */
+  private _activeStreamingSessions = new Set<string>()
 
   get connected(): boolean {
     return this._connected
@@ -347,6 +362,7 @@ class WsTransport {
 
   /** Connect to the WebSocket server (validates token first). */
   connect(): void {
+    if (!this._connectEnabled) return
     if (
       this._connecting ||
       this.ws?.readyState === WebSocket.OPEN ||
@@ -383,6 +399,12 @@ class WsTransport {
         this._connecting = false
       })
     }
+  }
+
+  enableConnect(): void {
+    if (this._connectEnabled) return
+    this._connectEnabled = true
+    this.connect()
   }
 
   private async validateAndConnect(token: string): Promise<void> {
@@ -442,6 +464,20 @@ class WsTransport {
       this._lastConnectTime = Date.now()
       this.setConnected(true)
       this.reconnectAttempt = 0
+
+      // Replay missed events for sessions that were actively streaming
+      for (const sessionId of this._activeStreamingSessions) {
+        const lastSeq = this._lastSeqBySession.get(sessionId)
+        if (lastSeq != null) {
+          this.ws?.send(
+            JSON.stringify({
+              type: 'replay',
+              session_id: sessionId,
+              last_seq: lastSeq,
+            })
+          )
+        }
+      }
 
       // Flush queued messages
       for (const item of this.queue) {
@@ -603,8 +639,10 @@ class WsTransport {
       }
     }
 
-    // Ensure connected
-    this.connect()
+    // Ensure connected once bootstrap explicitly enables it
+    if (this._connectEnabled) {
+      this.connect()
+    }
 
     return () => {
       this.listeners.get(event)?.delete(typedHandler)
@@ -630,6 +668,32 @@ class WsTransport {
         pending.reject(new Error(msg.error || 'Unknown error'))
       }
     } else if (msg.type === 'event' && msg.event) {
+      // Track seq per session for replay dedup + reconnect
+      if (msg.seq != null && msg.payload) {
+        const payload = msg.payload as Record<string, unknown>
+        const sessionId = payload.session_id as string | undefined
+        if (sessionId) {
+          const lastSeen = this._lastSeqBySession.get(sessionId)
+          if (lastSeen != null && msg.seq <= lastSeen) {
+            return // Already processed — skip duplicate from replay
+          }
+          this._lastSeqBySession.set(sessionId, msg.seq)
+          // Track actively streaming sessions
+          if (
+            msg.event === 'chat:chunk' ||
+            msg.event === 'chat:thinking'
+          ) {
+            this._activeStreamingSessions.add(sessionId)
+          } else if (
+            msg.event === 'chat:done' ||
+            msg.event === 'chat:cancelled'
+          ) {
+            this._activeStreamingSessions.delete(sessionId)
+            this._lastSeqBySession.delete(sessionId)
+          }
+        }
+      }
+
       const handlers = this.listeners.get(msg.event)
       if (handlers && handlers.size > 0) {
         for (const handler of handlers) {
@@ -688,20 +752,20 @@ class WsTransport {
     }
     this.scheduleReconnect()
   }
+
+  ingestBootstrapEvents(events: BootstrapEvent[]): void {
+    const sorted = [...events].sort(
+      (a, b) =>
+        (a.seq ?? Number.MAX_SAFE_INTEGER) - (b.seq ?? Number.MAX_SAFE_INTEGER)
+    )
+    for (const event of sorted) {
+      this.handleMessage(event)
+    }
+  }
 }
 
 // Singleton instance
 const wsTransport = new WsTransport()
-
-// Auto-connect in browser mode (skip when E2E mocks are active)
-if (
-  !isNativeApp() &&
-  typeof window !== 'undefined' &&
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  !(window as any).__JEAN_E2E_MOCK__
-) {
-  wsTransport.connect()
-}
 
 // ---------------------------------------------------------------------------
 // React hooks for connection status (browser mode only)
@@ -745,6 +809,18 @@ export function useWsDataReady(): boolean {
 /** Mark WebSocket data as ready (called by App.tsx after seedCache). */
 export function setWsDataReady(value: boolean): void {
   wsTransport.setDataReady(value)
+}
+
+/** Start browser WebSocket transport after preload/bootstrap is complete. */
+export function connectTransport(): void {
+  if (isNativeApp() || isE2eMocked) return
+  wsTransport.enableConnect()
+}
+
+/** Feed replayed server events through the normal event pipeline before connect. */
+export function ingestBootstrapEvents(events: BootstrapEvent[]): void {
+  if (events.length === 0) return
+  wsTransport.ingestBootstrapEvents(events)
 }
 
 /**

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -220,6 +220,8 @@ export interface Session {
   last_run_status?: RunStatus
   /** Execution mode of the last run (plan/build/yolo) */
   last_run_execution_mode?: ExecutionMode
+  /** Unix timestamp when the last run started */
+  last_run_started_at?: number
   /** User-assigned label with color (e.g. "Needs testing") */
   label?: LabelData
   /** Messages queued for sending (synced between native + web clients) */


### PR DESCRIPTION
## Summary
- persist Codex `thread_id` and active `turn_id` on each run so interrupted sessions can be resumed after app crashes
- add Codex crash-recovery flow in `resume_session`, including replaying active turns, completing finished runs, and marking expired threads as crashed
- buffer and replay WebSocket chat events by session with monotonic sequence numbers so browser clients can restore streaming state after reconnects
- delay browser transport startup until bootstrap data is loaded, ingest replayed events before live traffic, and clear stale waiting/reviewing UI flags for active sessions
- update registry/run-log coverage and add transport tests for deferred connect and ordered replay

## Breaking Changes
- None