### PR TITLE
fix(chat): allow git commits in worktree sandboxes

### DIFF
--- a/src-tauri/src/chat/codex.rs
+++ b/src-tauri/src/chat/codex.rs
@@ -522,6 +522,7 @@ pub fn build_turn_start_params(
     execution_mode: Option<&str>,
     reasoning_effort: Option<&str>,
     add_dirs: &[String],
+    git_writable_roots: &[String],
 ) -> serde_json::Value {
     let mut params = serde_json::json!({
         "threadId": thread_id,
@@ -539,12 +540,16 @@ pub fn build_turn_start_params(
 
     // Sandbox policy — grant read access to add_dirs (pasted files, contexts, etc.)
     // in ALL modes, and writable roots only in build/yolo modes.
+    // Also include git metadata dirs so worktree commits work (issue #280).
     let mode = execution_mode.unwrap_or("plan");
-    if !add_dirs.is_empty() {
+    if !add_dirs.is_empty() || !git_writable_roots.is_empty() {
         let is_writable = mode == "build" || mode == "yolo";
         let writable_roots: Vec<serde_json::Value> = if is_writable {
             let mut roots = vec![serde_json::json!(working_dir.to_string_lossy())];
             for dir in add_dirs {
+                roots.push(serde_json::json!(dir));
+            }
+            for dir in git_writable_roots {
                 roots.push(serde_json::json!(dir));
             }
             roots
@@ -676,6 +681,19 @@ pub fn execute_codex_via_server(
         }
     };
 
+    // Resolve git metadata dirs for worktree sandbox access (issue #280).
+    // For worktrees, git needs write access to dirs outside the checkout path.
+    let git_writable_roots: Vec<String> =
+        crate::projects::git::resolve_git_dirs(working_dir)
+            .map(|(git_dir, common_dir)| {
+                let mut dirs = vec![git_dir.clone()];
+                if common_dir != git_dir {
+                    dirs.push(common_dir);
+                }
+                dirs
+            })
+            .unwrap_or_default();
+
     // Build turn params
     let turn_params = build_turn_start_params(
         &thread_id,
@@ -684,6 +702,7 @@ pub fn execute_codex_via_server(
         execution_mode,
         reasoning_effort,
         add_dirs,
+        &git_writable_roots,
     );
 
     // Set up event channel for this session

--- a/src-tauri/src/projects/git.rs
+++ b/src-tauri/src/projects/git.rs
@@ -5,6 +5,45 @@ use serde::{Deserialize, Serialize};
 
 use super::types::{JeanConfig, MergeType};
 
+/// Resolve the git metadata directories for a working directory.
+///
+/// Returns `(git_dir, git_common_dir)` as absolute, canonicalized paths.
+/// - `git_dir`: worktree-specific metadata (e.g., `/repo/.git/worktrees/feat-x`)
+/// - `git_common_dir`: shared metadata (e.g., `/repo/.git`)
+///
+/// For non-worktree repos, both point to the same `.git` directory.
+/// Returns `None` if the path is not a git repo or the command fails.
+pub fn resolve_git_dirs(working_dir: &Path) -> Option<(String, String)> {
+    let output = silent_command("git")
+        .args(["rev-parse", "--git-dir", "--git-common-dir"])
+        .current_dir(working_dir)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines();
+    let git_dir_raw = lines.next()?.trim();
+    let git_common_dir_raw = lines.next()?.trim();
+
+    let resolve = |p: &str| -> Option<String> {
+        let path = Path::new(p);
+        let abs = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            working_dir.join(path)
+        };
+        std::fs::canonicalize(&abs)
+            .ok()
+            .map(|p| p.to_string_lossy().into_owned())
+    };
+
+    Some((resolve(git_dir_raw)?, resolve(git_common_dir_raw)?))
+}
+
 /// Repository identifier extracted from GitHub remote URL
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RepoIdentifier {


### PR DESCRIPTION
## Summary
- add git metadata directories to Codex turn sandbox writable roots in `build` and `yolo` modes
- resolve both `git_dir` and `git_common_dir` from the current repo so git worktrees can create lock files outside the checkout path
- fix issue #280 where `git add` and `git commit` failed in worktrees because `.git/worktrees/...` was outside the writable sandbox

## Breaking Changes
- None

---

Fixes #280