### PR TITLE
refactor(chat): remove stall detection timeout from codex event loop

### DIFF
--- a/src-tauri/src/chat/codex.rs
+++ b/src-tauri/src/chat/codex.rs
@@ -967,8 +967,6 @@ fn process_turn_events(
 ) -> CodexResponse {
     use super::codex_server::ServerEvent;
     use std::io::Write;
-    use std::time::Duration;
-
     let mut full_content = String::new();
     let mut response_thread_id = thread_id.to_string();
     let mut tool_calls: Vec<ToolCall> = Vec::new();
@@ -988,43 +986,13 @@ fn process_turn_events(
         .open(output_file)
         .ok();
 
-    let mut stall_count: u32 = 0;
-
     'outer: loop {
-        // Receive with 30s intermediate timeouts for earlier stall detection
-        let event = loop {
-            match event_rx.recv_timeout(Duration::from_secs(30)) {
-                Ok(e) => {
-                    stall_count = 0;
-                    break e;
-                }
-                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                    stall_count += 1;
-                    if stall_count >= 10 {
-                        // 10 × 30s = 300s total
-                        log::warn!("Turn event timeout for session {session_id} after {stall_count} intervals");
-                        let _ = app.emit_all(
-                            "chat:error",
-                            &ErrorEvent {
-                                session_id: session_id.to_string(),
-                                worktree_id: worktree_id.to_string(),
-                                error: "Codex response timed out".to_string(),
-                            },
-                        );
-                        error_emitted = true;
-                        break 'outer;
-                    }
-                    log::info!(
-                        "No codex events for {}s (session {session_id}, interval {stall_count}/10)",
-                        stall_count * 30
-                    );
-                    continue;
-                }
-                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                    log::warn!("Event channel disconnected for session {session_id}");
-                    cancelled = true;
-                    break 'outer;
-                }
+        let event = match event_rx.recv() {
+            Ok(e) => e,
+            Err(_) => {
+                log::warn!("Event channel disconnected for session {session_id}");
+                cancelled = true;
+                break 'outer;
             }
         };
 


### PR DESCRIPTION
## Summary

Closes #300

- Removes the 10×30s stall detection timeout from `process_turn_events()` in `codex.rs`
- Replaces `recv_timeout` loop with a simple blocking `recv()` call
- Eliminates the race condition where Jean emitted `chat:error` / timed out locally while the Codex turn continued running invisibly on the app-server
- The event loop now waits indefinitely for events; it only exits when the channel is explicitly disconnected (i.e. the turn completes or is cancelled via the normal cancel path in `registry.rs`)

## Why

The previous timeout treated a *quiet* turn (no events for 300s) the same as a *stalled* turn. This caused Jean to detach from an active session and surface a timeout error in the UI, while backend work kept running and writing to the worktree with no visible output. Removing the client-side timeout means the event loop stays attached for as long as the turn is in flight, matching the behavior of the explicit cancel path.


---

Fixes #300