### PR TITLE
feat(sounds): simplify notification sounds and add preview buttons

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -140,9 +140,9 @@ pub struct AppPreferences {
     #[serde(default = "default_allow_web_tools_in_plan_mode")]
     pub allow_web_tools_in_plan_mode: bool, // Allow WebFetch/WebSearch in plan mode without prompts
     #[serde(default = "default_waiting_sound")]
-    pub waiting_sound: String, // Sound when session is waiting for input: none, ding, chime, pop, choochoo
+    pub waiting_sound: String, // Sound when session is waiting for input: none, workwork
     #[serde(default = "default_review_sound")]
-    pub review_sound: String, // Sound when session finishes reviewing: none, ding, chime, pop, choochoo
+    pub review_sound: String, // Sound when session finishes reviewing: none, workwork
     #[serde(default)]
     pub http_server_enabled: bool, // Whether HTTP server is enabled
     #[serde(default)]

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -888,12 +888,10 @@ export default function useStreamingEvents({
             // Question waiting state is persisted by the backend — no frontend persist needed.
           }
 
-          // Play waiting sound if not currently viewing this session
-          if (!isCurrentlyViewing) {
-            const waitingSound = (preferences?.waiting_sound ??
-              'none') as NotificationSound
-            playNotificationSound(waitingSound)
-          }
+          // Play waiting sound
+          const waitingSound = (preferences?.waiting_sound ??
+            'none') as NotificationSound
+          playNotificationSound(waitingSound)
         }
       } else if (event.payload.waiting_for_plan) {
         // Codex/Opencode plan-mode run completed with content — enter plan-waiting state.
@@ -1004,12 +1002,10 @@ export default function useStreamingEvents({
           }
         }
 
-        // Play waiting sound only if not currently viewing this session
-        if (!isCurrentlyViewing) {
-          const waitingSound = (preferences?.waiting_sound ??
-            'none') as NotificationSound
-          playNotificationSound(waitingSound)
-        }
+        // Play waiting sound
+        const waitingSound = (preferences?.waiting_sound ??
+          'none') as NotificationSound
+        playNotificationSound(waitingSound)
       } else {
         // No blocking tools — add optimistic message FIRST, then batch-clear state.
         // This eliminates the flicker gap where neither streaming nor persisted content is visible.
@@ -1106,12 +1102,10 @@ export default function useStreamingEvents({
 
         // Reviewing state is persisted by the backend — no frontend persist needed.
 
-        // Play review sound if not currently viewing this session
-        if (!isCurrentlyViewing) {
-          const reviewSound = (preferences?.review_sound ??
-            'none') as NotificationSound
-          playNotificationSound(reviewSound)
-        }
+        // Play review sound
+        const reviewSound = (preferences?.review_sound ??
+          'none') as NotificationSound
+        playNotificationSound(reviewSound)
 
         // Auto-save context (fire-and-forget, no blocking)
         if (preferences?.auto_save_context === true) {

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -9,7 +9,7 @@ import React, {
 import { invoke } from '@/lib/transport'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { Loader2, ChevronDown, Check, ChevronsUpDown } from 'lucide-react'
+import { Loader2, ChevronDown, Check, ChevronsUpDown, Play } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
@@ -2545,42 +2545,76 @@ export const GeneralPane: React.FC = () => {
             label="Waiting sound"
             description="Play when session needs your input"
           >
-            <Select
-              value={preferences?.waiting_sound ?? 'none'}
-              onValueChange={handleWaitingSoundChange}
-            >
-              <SelectTrigger className="w-full sm:min-w-96">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {notificationSoundOptions.map(option => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <div className="flex items-center gap-2">
+              <Select
+                value={preferences?.waiting_sound ?? 'none'}
+                onValueChange={handleWaitingSoundChange}
+              >
+                <SelectTrigger className="w-full sm:min-w-96">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {notificationSoundOptions.map(option => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button
+                variant="outline"
+                size="icon"
+                disabled={
+                  !preferences?.waiting_sound ||
+                  preferences.waiting_sound === 'none'
+                }
+                onClick={() =>
+                  playNotificationSound(
+                    preferences?.waiting_sound ?? 'none'
+                  )
+                }
+              >
+                <Play className="h-4 w-4" />
+              </Button>
+            </div>
           </InlineField>
 
           <InlineField
             label="Review sound"
             description="Play when session finishes"
           >
-            <Select
-              value={preferences?.review_sound ?? 'none'}
-              onValueChange={handleReviewSoundChange}
-            >
-              <SelectTrigger className="w-full sm:min-w-96">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {notificationSoundOptions.map(option => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <div className="flex items-center gap-2">
+              <Select
+                value={preferences?.review_sound ?? 'none'}
+                onValueChange={handleReviewSoundChange}
+              >
+                <SelectTrigger className="w-full sm:min-w-96">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {notificationSoundOptions.map(option => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button
+                variant="outline"
+                size="icon"
+                disabled={
+                  !preferences?.review_sound ||
+                  preferences.review_sound === 'none'
+                }
+                onClick={() =>
+                  playNotificationSound(
+                    preferences?.review_sound ?? 'none'
+                  )
+                }
+              >
+                <Play className="h-4 w-4" />
+              </Button>
+            </div>
           </InlineField>
         </div>
       </SettingsSection>

--- a/src/lib/sounds.ts
+++ b/src/lib/sounds.ts
@@ -3,21 +3,13 @@
  * Plays sounds when sessions complete or need input.
  */
 
-export type NotificationSound = 'none' | 'ding' | 'chime' | 'pop' | 'choochoo'
-
-export const notificationSoundOptions: {
-  value: NotificationSound
-  label: string
-}[] = [
-  { value: 'none', label: 'None' },
-  { value: 'ding', label: 'Ding' },
-  { value: 'chime', label: 'Chime' },
-  { value: 'pop', label: 'Pop' },
-  { value: 'choochoo', label: 'Choo-choo' },
-]
+import {
+  type NotificationSound,
+  notificationSoundOptions,
+} from '../types/preferences'
 
 const notificationSoundAssetMap: Partial<Record<NotificationSound, string>> = {
-  choochoo: '/sounds/peon-work-work.mp3',
+  workwork: '/sounds/peon-work-work.mp3',
 }
 
 // Single audio instance to prevent overlapping sounds

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -6,18 +6,14 @@ import { isMacOS, isWindows } from '../lib/platform'
 // Notification Sounds
 // =============================================================================
 
-export type NotificationSound = 'none' | 'ding' | 'chime' | 'pop' | 'choochoo'
+export type NotificationSound = 'none' | 'workwork'
 
 export const notificationSoundOptions: {
   value: NotificationSound
   label: string
 }[] = [
   { value: 'none', label: 'None' },
-  // More sounds will be added later:
-  // { value: 'ding', label: 'Ding' },
-  // { value: 'chime', label: 'Chime' },
-  // { value: 'pop', label: 'Pop' },
-  // { value: 'choochoo', label: 'Choo-choo' },
+  { value: 'workwork', label: 'Work Work' },
 ]
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Closes #289

- Adds a "Work Work" sound option to notification settings, replacing the previously commented-out placeholder sounds (`ding`, `chime`, `pop`, `choochoo`) that were never implemented — users only saw "None"
- Simplifies `NotificationSound` type to `'none' | 'workwork'` and updates the asset map accordingly
- Adds preview play buttons next to the waiting and review sound selectors in General preferences so users can audition sounds before committing
- Removes the `isCurrentlyViewing` guard on sound playback — sounds now always play regardless of whether the session is currently in view

## Breaking Changes

- Previously saved preferences using sound values `ding`, `chime`, `pop`, or `choochoo` will no longer match a valid option and will fall back to `none`


---

Fixes #289