### PR TITLE
fix(release): fix AppImage auto-update by generating proper updater artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,11 +107,57 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.version }}
         run: |
           VERSION="${RELEASE_TAG#v}"
-          # Find the AppImage regardless of arch suffix (amd64 or aarch64)
-          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name "Jean_${VERSION}_*.AppImage" -print -quit 2>/dev/null)
+          BUNDLE_DIR="src-tauri/target/release/bundle/appimage"
+          APPIMAGE=$(find "$BUNDLE_DIR" -name "Jean_${VERSION}_*.AppImage" ! -name "*.tar.gz" -print -quit 2>/dev/null)
           if [ -n "$APPIMAGE" ] && [ -f "$APPIMAGE" ]; then
             gh release upload "$RELEASE_TAG" "$APPIMAGE" --clobber
+            # Upload updater artifacts (.tar.gz + .sig)
+            [ -f "${APPIMAGE}.tar.gz" ] && gh release upload "$RELEASE_TAG" "${APPIMAGE}.tar.gz" --clobber
+            [ -f "${APPIMAGE}.tar.gz.sig" ] && gh release upload "$RELEASE_TAG" "${APPIMAGE}.tar.gz.sig" --clobber
           fi
+
+      - name: Patch latest.json for AppImage updater
+        if: startsWith(matrix.platform, 'ubuntu')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.version }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          BUNDLE_DIR="src-tauri/target/release/bundle/appimage"
+          ARCH_LABEL="amd64"
+          PLATFORM_KEY="linux-x86_64"
+          if [ "$(uname -m)" = "aarch64" ]; then
+            ARCH_LABEL="arm64"
+            PLATFORM_KEY="linux-aarch64"
+          fi
+
+          APPIMAGE_TAR="Jean_${VERSION}_${ARCH_LABEL}.AppImage.tar.gz"
+          SIG_FILE="${BUNDLE_DIR}/${APPIMAGE_TAR}.sig"
+
+          if [ ! -f "$SIG_FILE" ]; then
+            echo "No signature file found at $SIG_FILE, skipping latest.json patch"
+            exit 0
+          fi
+
+          SIGNATURE=$(cat "$SIG_FILE")
+          URL="https://github.com/coollabsio/jean/releases/download/${RELEASE_TAG}/${APPIMAGE_TAR}"
+
+          # Download current latest.json, patch Linux platform entry, re-upload
+          gh release download "$RELEASE_TAG" -p "latest.json" -D /tmp --clobber
+
+          SIG_CONTENT="$SIGNATURE" node -e "
+            const fs = require('fs');
+            const data = JSON.parse(fs.readFileSync('/tmp/latest.json', 'utf8'));
+            data.platforms = data.platforms || {};
+            data.platforms['${PLATFORM_KEY}'] = {
+              signature: process.env.SIG_CONTENT,
+              url: '${URL}'
+            };
+            fs.writeFileSync('/tmp/latest.json', JSON.stringify(data, null, 2));
+          "
+
+          gh release upload "$RELEASE_TAG" /tmp/latest.json --clobber
+          echo "Patched latest.json: ${PLATFORM_KEY} -> ${URL}"
 
   update-homebrew-tap:
     name: Update Homebrew Tap

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -85,6 +85,21 @@ if [ -f "$OUTPUT_NAME" ]; then
     FINAL_NAME="Jean_${VERSION}_${ARCH_LABEL}.AppImage"
     mv "$OUTPUT_NAME" "$FINAL_NAME"
     echo "==> AppImage built successfully: $BUNDLE_DIR/$FINAL_NAME"
+
+    echo "==> Creating updater artifact (.tar.gz)..."
+    tar -czf "${FINAL_NAME}.tar.gz" "$FINAL_NAME"
+
+    if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+        echo "==> Signing updater artifact..."
+        cd "$PROJECT_DIR"
+        bun run tauri signer sign \
+            --private-key "$TAURI_SIGNING_PRIVATE_KEY" \
+            --password "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}" \
+            "$BUNDLE_DIR/${FINAL_NAME}.tar.gz"
+        echo "==> Updater artifacts created: ${FINAL_NAME}.tar.gz + .sig"
+    else
+        echo "WARN: TAURI_SIGNING_PRIVATE_KEY not set, skipping signature"
+    fi
 else
     echo "ERROR: Repackaging failed"
     exit 1


### PR DESCRIPTION
## Summary

Fixes #295 — AppImage auto-update was downloading the wrong artifact (a `.deb` package instead of the AppImage), resulting in a corrupt/unusable file after restart.

- **`scripts/build-appimage.sh`**: After building the AppImage, now creates a `.tar.gz` updater artifact and signs it with the Tauri signing key (when `TAURI_SIGNING_PRIVATE_KEY` is set)
- **`.github/workflows/release.yml`**: 
  - Updated AppImage find command to exclude `.tar.gz` files so the raw AppImage is uploaded correctly
  - Uploads the `.tar.gz` and `.sig` updater artifacts alongside the AppImage
  - Adds a new step to patch `latest.json` with the correct Linux platform URL and signature, ensuring the Tauri updater points to the AppImage tar.gz instead of falling back to the `.deb`


---

Fixes #295