### PR TITLE
fix: auto-resize textarea on WebKitGTK (Linux)

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { useAutoResize } from '@/hooks/use-auto-resize'
 import { invoke } from '@/lib/transport'
 import { generateId } from '@/lib/uuid'
 import { toast } from 'sonner'
@@ -69,6 +70,7 @@ export const ChatInput = memo(function ChatInput({
   installedBackends,
 }: ChatInputProps) {
   const isMobile = useIsMobile()
+  const resizeTextarea = useAutoResize(inputRef)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   // PERFORMANCE: Use uncontrolled input pattern - track value in ref, not state
@@ -138,8 +140,9 @@ export const ChatInput = memo(function ChatInput({
 
     if (inputRef.current) {
       inputRef.current.value = draft
+      resizeTextarea()
     }
-  }, [activeSessionId, inputRef])
+  }, [activeSessionId, inputRef, resizeTextarea])
 
   // Listen for command:focus-chat-input event from command palette
   useEffect(() => {
@@ -169,6 +172,7 @@ export const ChatInput = memo(function ChatInput({
         valueRef.current = ''
         setShowHint(true)
         onHasValueChangeRef.current?.(false)
+        resizeTextarea()
       }
 
       // React to external restores (draft went from empty to non-empty)
@@ -178,9 +182,10 @@ export const ChatInput = memo(function ChatInput({
         valueRef.current = draft
         setShowHint(false)
         onHasValueChangeRef.current?.(true)
+        resizeTextarea()
       }
     })
-  }, [activeSessionId, inputRef])
+  }, [activeSessionId, inputRef, resizeTextarea])
 
   const clearInputState = useCallback(() => {
     clearTimeout(debouncedSaveRef.current)
@@ -190,7 +195,8 @@ export const ChatInput = memo(function ChatInput({
     valueRef.current = ''
     setShowHint(true)
     onHasValueChangeRef.current?.(false)
-  }, [inputRef])
+    resizeTextarea()
+  }, [inputRef, resizeTextarea])
 
   useEffect(() => {
     onRegisterClearHandler?.(clearInputState)
@@ -461,6 +467,7 @@ export const ChatInput = memo(function ChatInput({
         setShowHint(true)
         const textarea = e.target as HTMLTextAreaElement
         textarea.value = ''
+        resizeTextarea()
       }
       // Shift+Enter adds a new line (default behavior)
     },
@@ -474,6 +481,7 @@ export const ChatInput = memo(function ChatInput({
       canSwitchBackendWithTab,
       onSwitchBackendWithTab,
       isMobile,
+      resizeTextarea,
     ]
   )
 
@@ -515,6 +523,7 @@ export const ChatInput = memo(function ChatInput({
                 .getState()
                 .setInputDraft(activeSessionId, textarea.value)
               onHasValueChangeRef.current?.(Boolean(textarea.value.trim()))
+              resizeTextarea()
             }
 
             const {
@@ -733,7 +742,7 @@ export const ChatInput = memo(function ChatInput({
         }
       }
     },
-    [activeSessionId, activeWorktreePath, inputRef]
+    [activeSessionId, activeWorktreePath, inputRef, resizeTextarea]
   )
 
   const handleFileInputChange = useCallback(
@@ -775,6 +784,7 @@ export const ChatInput = memo(function ChatInput({
         // PERFORMANCE: Update DOM directly, no React render
         inputRef.current.value = newValue
         valueRef.current = newValue
+        resizeTextarea()
 
         // Set cursor position after the inserted filename
         requestAnimationFrame(() => {
@@ -791,7 +801,7 @@ export const ChatInput = memo(function ChatInput({
       // Refocus input
       inputRef.current?.focus()
     },
-    [activeSessionId, atTriggerIndex, inputRef]
+    [activeSessionId, atTriggerIndex, inputRef, resizeTextarea]
   )
 
   // Handle skill selection from / mention popover
@@ -814,6 +824,7 @@ export const ChatInput = memo(function ChatInput({
         // PERFORMANCE: Update DOM directly, no React render
         inputRef.current.value = newValue
         valueRef.current = newValue
+        resizeTextarea()
 
         // Cancel pending debounced save (it still has the old "/query" value)
         // and sync cleaned value to store immediately
@@ -835,7 +846,7 @@ export const ChatInput = memo(function ChatInput({
       // Refocus input
       inputRef.current?.focus()
     },
-    [activeSessionId, slashTriggerIndex, inputRef]
+    [activeSessionId, slashTriggerIndex, inputRef, resizeTextarea]
   )
 
   // Handle command selection from / mention popover (executes immediately)
@@ -852,6 +863,7 @@ export const ChatInput = memo(function ChatInput({
       if (activeSessionId) {
         useChatStore.getState().setInputDraft(activeSessionId, '')
       }
+      resizeTextarea()
 
       // Reset slash popover state
       setSlashPopoverOpen(false)
@@ -862,7 +874,7 @@ export const ChatInput = memo(function ChatInput({
       // Notify parent to execute command
       onCommandExecute?.(command)
     },
-    [activeSessionId, inputRef, onCommandExecute]
+    [activeSessionId, inputRef, onCommandExecute, resizeTextarea]
   )
 
   // Determine if slash is at prompt start (for enabling commands)
@@ -905,7 +917,7 @@ export const ChatInput = memo(function ChatInput({
         onKeyDown={handleKeyDown}
         onPaste={handlePaste}
         disabled={false}
-        className="custom-scrollbar min-h-[40px] max-h-[240px] w-full resize-none overflow-x-hidden overflow-y-auto border-0 dark:bg-transparent p-0 font-mono text-base shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 md:text-sm"
+        className="custom-scrollbar min-h-[40px] max-h-[50vh] w-full resize-none overflow-x-hidden overflow-y-auto border-0 dark:bg-transparent p-0 font-mono text-base shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 md:text-sm"
         rows={1}
         autoFocus={!isMobile}
       />

--- a/src/hooks/use-auto-resize.ts
+++ b/src/hooks/use-auto-resize.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+/**
+ * Auto-resize textarea fallback for engines that don't support CSS `field-sizing: content`.
+ * WebKitGTK (Tauri on Linux) lacks support — this hook provides a JS-based equivalent.
+ *
+ * When `field-sizing: content` IS supported (Chrome 123+, Firefox 131+, Safari 18.4+),
+ * the hook is a no-op — CSS handles everything.
+ */
+export function useAutoResize(
+  ref: React.RefObject<HTMLTextAreaElement | null>
+) {
+  const supportsFieldSizing = useRef<boolean | null>(null)
+
+  // Lazily detect support once
+  if (supportsFieldSizing.current === null) {
+    supportsFieldSizing.current =
+      typeof CSS !== 'undefined' &&
+      CSS.supports('field-sizing', 'content')
+  }
+
+  const resize = useCallback(() => {
+    if (supportsFieldSizing.current) return
+    const el = ref.current
+    if (!el) return
+
+    // Reset to auto so scrollHeight reflects actual content
+    el.style.height = 'auto'
+
+    // Compute max height from CSS (max-height) or fall back to a large value
+    const computed = getComputedStyle(el)
+    const maxHeight = parseFloat(computed.maxHeight) || el.clientHeight * 10
+
+    if (el.scrollHeight > maxHeight) {
+      el.style.height = `${maxHeight}px`
+      el.style.overflowY = 'auto'
+    } else {
+      el.style.height = `${el.scrollHeight}px`
+      el.style.overflowY = 'hidden'
+    }
+  }, [ref])
+
+  useEffect(() => {
+    if (supportsFieldSizing.current) return
+    const el = ref.current
+    if (!el) return
+
+    // Initial sizing
+    resize()
+
+    // Listen for user input
+    el.addEventListener('input', resize)
+
+    // Re-calc on window resize (viewport-relative max-height may change)
+    window.addEventListener('resize', resize)
+
+    return () => {
+      el.removeEventListener('input', resize)
+      window.removeEventListener('resize', resize)
+    }
+  }, [ref, resize])
+
+  return resize
+}


### PR DESCRIPTION
## Summary

- Add JS fallback for textarea auto-resize on WebKitGTK (Linux), where CSS `field-sizing: content` is not supported
- New `useAutoResize` hook detects support via `CSS.supports()` — no-op on Chrome/Firefox/Safari, JS resize on WebKitGTK
- Bump `max-height` from `240px` to `50vh` for better multi-line editing
- Hook called at all 9 programmatic value-change sites in `ChatInput.tsx`

## How it works

- If `field-sizing: content` is supported (Chrome 123+, Firefox 131+, Safari 18.4+) → the hook is a complete no-op, CSS handles everything as before
- If not supported (WebKitGTK/Tauri Linux) → the hook resets `height: auto`, reads `scrollHeight`, and caps at `max-height`, toggling `overflowY` as needed
- Listens on `input` + window `resize` events, plus imperative `resizeTextarea()` calls after every programmatic `.value =` assignment

## Test plan

- [x] Type multiple lines → textarea grows line by line
- [x] Delete text → textarea shrinks
- [x] Paste multi-line text → grows up to 50vh then scrolls
- [x] Insert @filename → resizes if text expands
- [x] Enter to send → returns to 1 line
- [x] Switch sessions → resizes for loaded draft
- [x] Verify no regression on Chrome/macOS (field-sizing: content still works natively)