### PR TITLE
feat(titlebar): add Linux window controls

### DIFF
--- a/src/components/titlebar/LinuxWindowControls.tsx
+++ b/src/components/titlebar/LinuxWindowControls.tsx
@@ -1,0 +1,86 @@
+import type React from 'react'
+import { Copy, Minus, Square, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useWindowMaximized } from '@/hooks/use-window-maximized'
+
+const getAppWindow = async () => {
+  const { getCurrentWindow } = await import('@tauri-apps/api/window')
+  return getCurrentWindow()
+}
+
+const handleMinimize = async () => {
+  const appWindow = await getAppWindow()
+  await appWindow.minimize()
+}
+
+const handleToggleMaximize = async () => {
+  const appWindow = await getAppWindow()
+  await appWindow.toggleMaximize()
+}
+
+const handleClose = async () => {
+  const appWindow = await getAppWindow()
+  await appWindow.close()
+}
+
+export function LinuxWindowControls() {
+  const isMaximized = useWindowMaximized()
+
+  return (
+    <div
+      className="flex h-8 items-center"
+      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+    >
+      <ControlButton onClick={handleMinimize} aria-label="Minimize">
+        <Minus className="size-3.5" />
+      </ControlButton>
+      <ControlButton
+        onClick={handleToggleMaximize}
+        aria-label={isMaximized ? 'Restore' : 'Maximize'}
+      >
+        {isMaximized ? (
+          <Copy className="size-3 -scale-x-100" />
+        ) : (
+          <Square className="size-3" />
+        )}
+      </ControlButton>
+      <ControlButton
+        onClick={handleClose}
+        aria-label="Close"
+        className="hover:bg-red-600 hover:text-white"
+      >
+        <X className="size-3.5" />
+      </ControlButton>
+    </div>
+  )
+}
+
+interface ControlButtonProps {
+  onClick: () => void
+  className?: string
+  children: React.ReactNode
+  'aria-label': string
+}
+
+function ControlButton({
+  onClick,
+  className,
+  children,
+  ...rest
+}: ControlButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      type="button"
+      className={cn(
+        'flex h-8 w-[46px] items-center justify-center text-foreground/70 transition-colors hover:bg-foreground/10 hover:text-foreground',
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </button>
+  )
+}
+
+export default LinuxWindowControls

--- a/src/components/titlebar/TitleBar.tsx
+++ b/src/components/titlebar/TitleBar.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { useState, useEffect } from 'react'
 import { cn } from '@/lib/utils'
-import { isMacOS, openExternal } from '@/lib/platform'
+import { isLinux, isMacOS, openExternal } from '@/lib/platform'
 import { Button } from '@/components/ui/button'
 import {
   Tooltip,
@@ -24,6 +24,7 @@ import { isNativeApp } from '@/lib/environment'
 import { UnreadBell } from '@/components/unread/UnreadBell'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { FALLBACK_APP_VERSION } from '@/lib/app-version'
+import { LinuxWindowControls } from './LinuxWindowControls'
 
 interface TitleBarProps {
   className?: string
@@ -198,6 +199,7 @@ export function TitleBar({
             v{appVersion}
           </button>
         )}
+        {native && isLinux && <LinuxWindowControls />}
       </div>
     </div>
   )

--- a/src/hooks/use-window-maximized.ts
+++ b/src/hooks/use-window-maximized.ts
@@ -1,18 +1,18 @@
 import { useEffect, useState } from 'react'
-import { isWindows } from '@/lib/platform'
+import { isLinux, isWindows } from '@/lib/platform'
 import { isNativeApp } from '@/lib/environment'
 
 /**
  * Hook to track whether the current window is maximized.
  * Useful for adjusting UI elements like border radius when maximized.
  *
- * Only relevant for native Tauri windows on Windows — returns false in web mode.
+ * Only relevant for native Tauri windows on Windows and Linux — returns false in web mode.
  */
 export function useWindowMaximized() {
   const [isMaximized, setIsMaximized] = useState(false)
 
   useEffect(() => {
-    if (!isWindows || !isNativeApp()) return
+    if ((!isWindows && !isLinux) || !isNativeApp()) return
 
     let unlisten: (() => void) | null = null
     let cancelled = false

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -2,6 +2,7 @@ import { isNativeApp } from './environment'
 
 export const isMacOS = navigator.platform.includes('Mac')
 export const isWindows = navigator.platform.includes('Win')
+export const isLinux = navigator.platform.includes('Linux')
 
 /**
  * Pre-open a blank browser tab synchronously during a user gesture.


### PR DESCRIPTION
Closes #318 

Add a LinuxWindowControls component with minimize, maximize/restore, and close buttons styled to match the app's design system. Extend useWindowMaximized and the isLinux platform flag to support Linux alongside the existing Windows path.