### PR TITLE
feat(preferences): add expand tool calls by default setting

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -234,6 +234,8 @@ pub struct AppPreferences {
     pub opencode_cli_source: String, // OpenCode CLI source: "jean" (managed) or "path" (system PATH)
     #[serde(default = "default_cli_source")]
     pub gh_cli_source: String, // GitHub CLI source: "jean" (managed) or "path" (system PATH)
+    #[serde(default)]
+    pub expand_tool_calls_by_default: bool, // Expand all tool call collapsibles by default (default: false)
 }
 
 fn default_true() -> Option<bool> {
@@ -1468,6 +1470,7 @@ impl Default for AppPreferences {
             codex_cli_source: default_cli_source(),
             opencode_cli_source: default_cli_source(),
             gh_cli_source: default_cli_source(),
+            expand_tool_calls_by_default: false,
         }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,9 +30,7 @@
         "shadow": true,
         "dragDropEnabled": true,
         "windowEffects": {
-          "effects": [
-            "sidebar"
-          ],
+          "effects": ["sidebar"],
           "radius": 12,
           "state": "active"
         }
@@ -43,10 +41,7 @@
       "assetProtocol": {
         "enable": true,
         "scope": {
-          "allow": [
-            "**/.jean/images/**",
-            "$APPDATA/**"
-          ],
+          "allow": ["**/.jean/images/**", "$APPDATA/**"],
           "requireLiteralLeadingDot": false
         }
       }

--- a/src/components/chat/StreamingMessage.tsx
+++ b/src/components/chat/StreamingMessage.tsx
@@ -347,7 +347,6 @@ export const StreamingMessage = memo(function StreamingMessage({
           <ToolCallsDisplay
             toolCalls={toolCalls}
             sessionId={sessionId}
-            defaultExpanded={false}
             isStreaming={true}
             onQuestionAnswer={onQuestionAnswer}
             onQuestionSkip={onQuestionSkip}

--- a/src/components/chat/ToolCallInline.test.tsx
+++ b/src/components/chat/ToolCallInline.test.tsx
@@ -1,6 +1,10 @@
 import { fireEvent, render, screen } from '@/test/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { ToolCallInline } from './ToolCallInline'
+
+vi.mock('@/services/preferences', () => ({
+  usePreferences: () => ({ data: undefined }),
+}))
 
 describe('ToolCallInline', () => {
   it('renders Cursor EnterPlanMode instructions', () => {

--- a/src/components/chat/ToolCallInline.tsx
+++ b/src/components/chat/ToolCallInline.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import { usePreferences } from '@/services/preferences'
 import {
   FileText,
   Edit,
@@ -64,7 +65,10 @@ export function ToolCallInline({
   isStreaming,
   isIncomplete,
 }: ToolCallInlineProps) {
-  const [isOpen, setIsOpen] = useState(false)
+  const { data: preferences } = usePreferences()
+  const [isOpen, setIsOpen] = useState(
+    preferences?.expand_tool_calls_by_default ?? false
+  )
   const { icon, label, detail, filePath, expandedContent } =
     getToolDisplay(toolCall)
 
@@ -170,7 +174,10 @@ export function TaskCallInline({
   isStreaming,
   isIncomplete,
 }: TaskCallInlineProps) {
-  const [isOpen, setIsOpen] = useState(false)
+  const { data: preferences } = usePreferences()
+  const [isOpen, setIsOpen] = useState(
+    preferences?.expand_tool_calls_by_default ?? false
+  )
   const input = taskToolCall.input as Record<string, unknown>
   const subagentType = input.subagent_type as string | undefined
   const description = input.description as string | undefined
@@ -286,7 +293,10 @@ export function StackedGroup({
   isStreaming,
   isIncomplete,
 }: StackedGroupProps) {
-  const [isOpen, setIsOpen] = useState(false)
+  const { data: preferences } = usePreferences()
+  const [isOpen, setIsOpen] = useState(
+    preferences?.expand_tool_calls_by_default ?? false
+  )
 
   // Count thinking blocks and tools for summary
   let thinkingCount = 0
@@ -373,7 +383,10 @@ interface SubThinkingItemProps {
  * Similar style to SubToolItem but for thinking content
  */
 function SubThinkingItem({ thinking }: SubThinkingItemProps) {
-  const [isOpen, setIsOpen] = useState(false)
+  const { data: preferences } = usePreferences()
+  const [isOpen, setIsOpen] = useState(
+    preferences?.expand_tool_calls_by_default ?? false
+  )
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -415,7 +428,10 @@ interface SubToolItemProps {
  * Even more minimal than ToolCallInline - just icon, label, and detail inline
  */
 function SubToolItem({ toolCall, onFileClick }: SubToolItemProps) {
-  const [isOpen, setIsOpen] = useState(false)
+  const { data: preferences } = usePreferences()
+  const [isOpen, setIsOpen] = useState(
+    preferences?.expand_tool_calls_by_default ?? false
+  )
   const { icon, label, detail, filePath, expandedContent } =
     getToolDisplay(toolCall)
 

--- a/src/components/chat/ToolCallsDisplay.tsx
+++ b/src/components/chat/ToolCallsDisplay.tsx
@@ -1,4 +1,5 @@
 import { memo, useState, useCallback } from 'react'
+import { usePreferences } from '@/services/preferences'
 import type { ToolCall, Question, QuestionAnswer } from '@/types/chat'
 import {
   hasQuestionAnswerOutput,
@@ -71,7 +72,7 @@ interface ToolCallsDisplayProps {
 export const ToolCallsDisplay = memo(function ToolCallsDisplay({
   toolCalls,
   sessionId,
-  defaultExpanded = false,
+  defaultExpanded,
   isStreaming = false,
   hasFollowUpMessage = false,
   onQuestionAnswer,
@@ -80,7 +81,10 @@ export const ToolCallsDisplay = memo(function ToolCallsDisplay({
   onQuestionSkip,
   areQuestionsSkipped,
 }: ToolCallsDisplayProps) {
-  const [expanded, setExpanded] = useState(defaultExpanded)
+  const { data: preferences } = usePreferences()
+  const [expanded, setExpanded] = useState(
+    defaultExpanded ?? preferences?.expand_tool_calls_by_default ?? false
+  )
 
   // Memoized toggle handler
   const handleToggle = useCallback(() => {

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -2687,6 +2687,22 @@ export const GeneralPane: React.FC = () => {
               }}
             />
           </InlineField>
+
+          <InlineField
+            label="Expand tool calls by default"
+            description="Automatically expand tool call details in chat instead of showing a collapsed summary"
+          >
+            <Switch
+              checked={preferences?.expand_tool_calls_by_default ?? false}
+              onCheckedChange={checked => {
+                if (preferences) {
+                  patchPreferences.mutate({
+                    expand_tool_calls_by_default: checked,
+                  })
+                }
+              }}
+            />
+          </InlineField>
         </div>
       </SettingsSection>
 

--- a/src/services/preferences.test.ts
+++ b/src/services/preferences.test.ts
@@ -161,6 +161,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        expand_tool_calls_by_default: false,
       }
       vi.mocked(invoke).mockResolvedValueOnce(mockPreferences)
 
@@ -287,6 +288,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        expand_tool_calls_by_default: false,
       }
       vi.mocked(invoke).mockResolvedValueOnce(prefsWithOldBinding)
 
@@ -386,6 +388,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        expand_tool_calls_by_default: false,
       }
       vi.mocked(invoke).mockResolvedValueOnce(prefsWithDeprecatedFastModel)
 
@@ -485,6 +488,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        expand_tool_calls_by_default: false,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -586,6 +590,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        expand_tool_calls_by_default: false,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -687,6 +692,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        expand_tool_calls_by_default: false,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {
@@ -786,6 +792,7 @@ describe('preferences service', () => {
         codex_cli_source: 'jean',
         opencode_cli_source: 'jean',
         gh_cli_source: 'jean',
+        expand_tool_calls_by_default: false,
       }
 
       const { result } = renderHook(() => useSavePreferences(), {

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -983,6 +983,7 @@ export interface AppPreferences {
   codex_cli_source: 'jean' | 'path' // Codex CLI source: 'jean' (managed) or 'path' (system PATH)
   opencode_cli_source: 'jean' | 'path' // OpenCode CLI source: 'jean' (managed) or 'path' (system PATH)
   gh_cli_source: 'jean' | 'path' // GitHub CLI source: 'jean' (managed) or 'path' (system PATH)
+  expand_tool_calls_by_default: boolean // Expand all tool call collapsibles by default
 }
 
 export interface CustomCliProfile {
@@ -1575,4 +1576,5 @@ export const defaultPreferences: AppPreferences = {
   codex_cli_source: 'jean', // Default: Jean-managed
   opencode_cli_source: 'jean', // Default: Jean-managed
   gh_cli_source: 'jean', // Default: Jean-managed
+  expand_tool_calls_by_default: false, // Default: collapsed
 }


### PR DESCRIPTION
## Summary

- Adds `expand_tool_calls_by_default` boolean preference (default: `false`) to `AppPreferences` in Rust backend and TypeScript types
- Wires preference into all collapsible tool call components: `ToolCallInline`, `TaskCallInline`, `StackedGroup`, `SubThinkingItem`, `SubToolItem`
- `ToolCallsDisplay` now reads preference as fallback when no explicit `defaultExpanded` prop passed
- Adds toggle to General preferences pane under existing session settings
- Updates test fixtures to include new field; mocks `usePreferences` in `ToolCallInline` tests

Closes #310


---

Fixes #310