### PR TITLE
feat(worktree): add branch stacking support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "jean"
-version = "0.1.43"
+version = "0.1.44"
 dependencies = [
  "arboard",
  "axum",

--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -1012,6 +1012,7 @@ pub async fn restore_session_with_base(
         name: project.default_branch.clone(),
         path: project.path.clone(),
         branch: project.default_branch.clone(),
+        base_branch: None,
         created_at: now(),
         setup_output: None,
         setup_script: None,

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -722,6 +722,7 @@ pub async fn create_worktree(
         name: name.clone(),
         path: worktree_path_str.clone(),
         branch: name.clone(),
+        base_branch: Some(base.clone()),
         created_at,
         setup_output: None,
         setup_script: None,
@@ -783,7 +784,10 @@ pub async fn create_worktree(
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
             log::trace!("Background: Creating git worktree {name_clone} at {worktree_path_clone}");
 
-            // Fetch base branch if enabled, use origin/<base> for up-to-date start point
+            // Fetch base branch if enabled, use origin/<base> for up-to-date start point.
+            // If the base is only available as a remote-tracking branch (e.g. stacking on a
+            // PR head that wasn't fetched locally), also use the origin/<base> ref.
+            let has_local_branch = git::branch_exists(&project_path, &base_clone);
             let effective_base = if should_auto_pull {
                 log::trace!("Fetching base branch {base_clone} before worktree creation");
                 match git::git_fetch(&project_path, &base_clone, None) {
@@ -793,11 +797,17 @@ pub async fn create_worktree(
                     }
                     Err(e) => {
                         log::warn!("Failed to fetch base branch {base_clone}: {e}");
-                        base_clone.clone()
+                        if has_local_branch {
+                            base_clone.clone()
+                        } else {
+                            format!("origin/{base_clone}")
+                        }
                     }
                 }
-            } else {
+            } else if has_local_branch {
                 base_clone.clone()
+            } else {
+                format!("origin/{base_clone}")
             };
 
             // Check if path already exists
@@ -1261,6 +1271,7 @@ pub async fn create_worktree(
                     name: name_clone.clone(),
                     path: worktree_path_clone.clone(),
                     branch: final_branch.clone(),
+                    base_branch: Some(base_clone.clone()),
                     created_at,
                     setup_output: None,
                     setup_script: pending_setup_script.clone(),
@@ -1463,6 +1474,7 @@ pub async fn create_worktree_from_existing_branch(
         name: name.clone(),
         path: worktree_path_str.clone(),
         branch: name.clone(),
+        base_branch: Some(branch_name.clone()),
         created_at,
         setup_output: None,
         setup_script: None,
@@ -1842,7 +1854,8 @@ pub async fn create_worktree_from_existing_branch(
                     project_id: project_id_clone.clone(),
                     name: name_clone.clone(),
                     path: worktree_path_clone.clone(),
-                    branch: branch_name_clone,
+                    branch: branch_name_clone.clone(),
+                    base_branch: Some(branch_name_clone),
                     created_at,
                     setup_output,
                     setup_script,
@@ -2078,6 +2091,7 @@ pub async fn checkout_pr(
         name: final_worktree_name.clone(),
         path: worktree_path_str.clone(),
         branch: pr_detail.head_ref_name.clone(), // Use PR's actual branch name
+        base_branch: None,
         created_at,
         setup_output: None,
         setup_script: None,
@@ -2398,6 +2412,7 @@ pub async fn checkout_pr(
                     name: worktree_name_clone.clone(),
                     path: worktree_path_clone.clone(),
                     branch: actual_branch.clone(),
+                    base_branch: None,
                     created_at,
                     setup_output,
                     setup_script,
@@ -2729,6 +2744,7 @@ pub async fn create_base_session(app: AppHandle, project_id: String) -> Result<W
         name: project.default_branch.clone(),
         path: project.path.clone(), // Uses project's base directory directly
         branch: project.default_branch.clone(),
+        base_branch: None,
         created_at: now(),
         setup_output: None,
         setup_script: None,
@@ -3139,6 +3155,7 @@ pub async fn import_worktree(
         name,
         path: path.clone(),
         branch,
+        base_branch: None,
         created_at: now(),
         setup_output: None,
         setup_script: None,

--- a/src-tauri/src/projects/git.rs
+++ b/src-tauri/src/projects/git.rs
@@ -470,6 +470,20 @@ pub fn branch_exists(repo_path: &str, branch_name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Check if a remote-tracking branch exists (refs/remotes/origin/<branch>)
+pub fn remote_branch_exists(repo_path: &str, branch_name: &str) -> bool {
+    silent_command("git")
+        .args([
+            "rev-parse",
+            "--verify",
+            &format!("refs/remotes/origin/{branch_name}"),
+        ])
+        .current_dir(repo_path)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
 /// Check if a repository has any commits
 pub fn has_commits(repo_path: &str) -> bool {
     silent_command("git")
@@ -493,8 +507,10 @@ pub fn get_valid_base_branch(repo_path: &str, preferred_branch: &str) -> Result<
             .to_string());
     }
 
-    // Try preferred branch first
-    if branch_exists(repo_path, preferred_branch) {
+    // Try preferred branch first (local or remote-tracking)
+    if branch_exists(repo_path, preferred_branch)
+        || remote_branch_exists(repo_path, preferred_branch)
+    {
         return Ok(preferred_branch.to_string());
     }
 

--- a/src-tauri/src/projects/types.rs
+++ b/src-tauri/src/projects/types.rs
@@ -138,6 +138,9 @@ pub struct Worktree {
     pub path: String,
     /// Git branch name (same as workspace name)
     pub branch: String,
+    /// Base branch this worktree was created from (None for legacy worktrees or base sessions)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_branch: Option<String>,
     /// Unix timestamp when worktree was created
     pub created_at: u64,
     /// Output from setup script (if any)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,9 +30,7 @@
         "shadow": true,
         "dragDropEnabled": true,
         "windowEffects": {
-          "effects": [
-            "sidebar"
-          ],
+          "effects": ["sidebar"],
           "radius": 12,
           "state": "active"
         }
@@ -43,10 +41,7 @@
       "assetProtocol": {
         "enable": true,
         "scope": {
-          "allow": [
-            "**/.jean/images/**",
-            "$APPDATA/**"
-          ],
+          "allow": ["**/.jean/images/**", "$APPDATA/**"],
           "requireLiteralLeadingDot": false
         }
       }

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -15,6 +15,8 @@ import {
   EyeOff,
   FileText,
   FolderOpen,
+  GitBranchPlus,
+  GitPullRequestArrow,
   Github,
   MoreHorizontal,
   Pencil,
@@ -51,6 +53,7 @@ import {
 } from '@/services/chat'
 import { usePreferences } from '@/services/preferences'
 import { useWorktree, useProjects, useRunScripts } from '@/services/projects'
+import { useGitHubPRs } from '@/services/github'
 import {
   useGitStatus,
   gitPush,
@@ -350,6 +353,11 @@ export function SessionChatModal({
   const project = worktree
     ? projects?.find(p => p.id === worktree.project_id)
     : null
+  const { data: openPRs } = useGitHubPRs(project?.path ?? null, 'open')
+  const stackedOnPR =
+    worktree?.base_branch && worktree.base_branch !== project?.default_branch
+      ? openPRs?.find(pr => pr.headRefName === worktree.base_branch)
+      : undefined
   const isBase = worktree ? isBaseSession(worktree) : false
   const { data: gitStatus } = useGitStatus(worktreeId)
   const behindCount =
@@ -830,6 +838,22 @@ export function SessionChatModal({
                   )}
                   {isBase ? 'Base Session' : (worktree?.name ?? 'Worktree')}
                 </h2>
+                {worktree?.base_branch &&
+                  worktree.base_branch !== project?.default_branch && (
+                    <span className="inline-flex items-center gap-1 rounded border border-border/50 px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground">
+                      <GitBranchPlus className="h-2.5 w-2.5" />
+                      <span className="max-w-40 truncate">
+                        {worktree.base_branch}
+                      </span>
+                      {stackedOnPR && (
+                        <>
+                          <span className="text-border">·</span>
+                          <GitPullRequestArrow className="h-2.5 w-2.5" />#
+                          {stackedOnPR.number}
+                        </>
+                      )}
+                    </span>
+                  )}
                 <GitStatusBadges
                   behindCount={behindCount}
                   unpushedCount={unpushedCount}

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -20,6 +20,7 @@ import {
   FileJson,
   Clock3,
   GitBranch,
+  GitBranchPlus,
   GitPullRequestArrow,
   ShieldAlert,
   Code,
@@ -63,6 +64,7 @@ import {
   useCreateSession,
   cancelChatMessage,
 } from '@/services/chat'
+import { useGitHubPRs } from '@/services/github'
 import { useGitStatus } from '@/services/git-status'
 import { useChatStore } from '@/store/chat-store'
 import { useProjectsStore } from '@/store/projects-store'
@@ -244,6 +246,7 @@ function WorktreeSectionHeader({
   worktree,
   projectId,
   defaultBranch,
+  openPRs,
   cards,
   showDetails = false,
   isSelected,
@@ -254,6 +257,7 @@ function WorktreeSectionHeader({
   worktree: Worktree
   projectId: string
   defaultBranch: string
+  openPRs?: { number: number; headRefName: string }[]
   cards?: SessionCardData[]
   showDetails?: boolean
   isSelected?: boolean
@@ -265,6 +269,10 @@ function WorktreeSectionHeader({
     type: 'uncommitted' | 'branch'
   ) => void
 }) {
+  const stackedOnPR =
+    worktree.base_branch && worktree.base_branch !== defaultBranch
+      ? openPRs?.find(pr => pr.headRefName === worktree.base_branch)
+      : undefined
   const isBase = isBaseSession(worktree)
   const { data: gitStatus } = useGitStatus(worktree.id)
 
@@ -416,6 +424,22 @@ function WorktreeSectionHeader({
                   <span className="hidden items-center gap-1 rounded border border-border/50 px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground sm:inline-flex">
                     <GitBranch className="h-2.5 w-2.5" />
                     <span className="max-w-40 truncate">{displayBranch}</span>
+                    {worktree.base_branch &&
+                      worktree.base_branch !== defaultBranch && (
+                        <>
+                          <span className="text-border">·</span>
+                          <GitBranchPlus className="h-2.5 w-2.5" />
+                          <span className="max-w-32 truncate">
+                            {worktree.base_branch}
+                          </span>
+                          {stackedOnPR && (
+                            <>
+                              <GitPullRequestArrow className="h-2.5 w-2.5" />#
+                              {stackedOnPR.number}
+                            </>
+                          )}
+                        </>
+                      )}
                     {worktree.pr_number && (
                       <>
                         <span className="text-border">·</span>
@@ -460,6 +484,22 @@ function WorktreeSectionHeader({
                 <span className="inline-flex max-w-full items-center gap-1 self-start rounded border border-border/50 px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground sm:hidden">
                   <GitBranch className="h-2.5 w-2.5 shrink-0" />
                   <span className="max-w-full truncate">{displayBranch}</span>
+                  {worktree.base_branch &&
+                    worktree.base_branch !== defaultBranch && (
+                      <>
+                        <span className="text-border">·</span>
+                        <GitBranchPlus className="h-2.5 w-2.5 shrink-0" />
+                        <span className="max-w-32 truncate">
+                          {worktree.base_branch}
+                        </span>
+                        {stackedOnPR && (
+                          <>
+                            <GitPullRequestArrow className="h-2.5 w-2.5 shrink-0" />
+                            #{stackedOnPR.number}
+                          </>
+                        )}
+                      </>
+                    )}
                   {worktree.pr_number && (
                     <>
                       <span className="text-border">·</span>
@@ -569,6 +609,9 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
   // Get project info
   const { data: projects = [], isLoading: projectsLoading } = useProjects()
   const project = projects.find(p => p.id === projectId)
+
+  // Open PRs: used to link a worktree's base_branch to a PR number in row badges
+  const { data: openPRs } = useGitHubPRs(project?.path ?? null, 'open')
 
   // Get worktrees
   const { data: worktrees = [], isLoading: worktreesLoading } =
@@ -2238,6 +2281,7 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
                         worktree={section.worktree}
                         projectId={projectId}
                         defaultBranch={project.default_branch}
+                        openPRs={openPRs}
                         cards={section.cards}
                         showDetails={true}
                         isSelected={selectedIndex === currentIndex}

--- a/src/components/worktree/BranchesTab.tsx
+++ b/src/components/worktree/BranchesTab.tsx
@@ -20,7 +20,9 @@ export interface BranchesTabProps {
   selectedIndex: number
   setSelectedIndex: (index: number) => void
   onSelectBranch: (branchName: string, background?: boolean) => void
+  onStackBranch: (branchName: string, background?: boolean) => void
   creatingFromBranch: string | null
+  stackingFromBranch: string | null
   searchInputRef: React.RefObject<HTMLInputElement | null>
 }
 
@@ -35,7 +37,9 @@ export function BranchesTab({
   selectedIndex,
   setSelectedIndex,
   onSelectBranch,
+  onStackBranch,
   creatingFromBranch,
+  stackingFromBranch,
   searchInputRef,
 }: BranchesTabProps) {
   return (
@@ -118,8 +122,10 @@ export function BranchesTab({
                 index={index}
                 isSelected={index === selectedIndex}
                 isCreating={creatingFromBranch === branch}
+                isStacking={stackingFromBranch === branch}
                 onMouseEnter={() => setSelectedIndex(index)}
                 onClick={bg => onSelectBranch(branch, bg)}
+                onStack={bg => onStackBranch(branch, bg)}
               />
             ))}
           </div>

--- a/src/components/worktree/GitHubPRsTab.tsx
+++ b/src/components/worktree/GitHubPRsTab.tsx
@@ -28,8 +28,10 @@ export interface GitHubPRsTabProps {
   setSelectedIndex: (index: number) => void
   onSelectPR: (pr: GitHubPullRequest, background?: boolean) => void
   onInvestigatePR: (pr: GitHubPullRequest, background?: boolean) => void
+  onStackPR: (pr: GitHubPullRequest, background?: boolean) => void
   onPreviewPR: (pr: GitHubPullRequest) => void
   creatingFromNumber: number | null
+  stackingFromPR: number | null
   searchInputRef: React.RefObject<HTMLInputElement | null>
   onGhLogin: () => void
   isGhInstalled: boolean
@@ -50,8 +52,10 @@ export function GitHubPRsTab({
   setSelectedIndex,
   onSelectPR,
   onInvestigatePR,
+  onStackPR,
   onPreviewPR,
   creatingFromNumber,
+  stackingFromPR,
   searchInputRef,
   onGhLogin,
   isGhInstalled,
@@ -168,9 +172,11 @@ export function GitHubPRsTab({
                 index={index}
                 isSelected={index === selectedIndex}
                 isCreating={creatingFromNumber === pr.number}
+                isStacking={stackingFromPR === pr.number}
                 onMouseEnter={() => setSelectedIndex(index)}
                 onClick={bg => onSelectPR(pr, bg)}
                 onInvestigate={bg => onInvestigatePR(pr, bg)}
+                onStack={bg => onStackPR(pr, bg)}
                 onPreview={() => onPreviewPR(pr)}
                 onLabelClick={handleLabelClick}
               />

--- a/src/components/worktree/NewWorktreeItems.tsx
+++ b/src/components/worktree/NewWorktreeItems.tsx
@@ -1,6 +1,7 @@
 import { getModifierSymbol } from '@/lib/platform'
 import {
   GitBranch,
+  GitBranchPlus,
   GitPullRequest,
   Loader2,
   CircleDot,
@@ -203,9 +204,11 @@ export interface PRItemProps {
   index: number
   isSelected: boolean
   isCreating: boolean
+  isStacking: boolean
   onMouseEnter: () => void
   onClick: (background: boolean) => void
   onInvestigate: (background: boolean) => void
+  onStack: (background: boolean) => void
   onPreview: () => void
   onLabelClick?: (label: string) => void
 }
@@ -215,12 +218,15 @@ export function PRItem({
   index,
   isSelected,
   isCreating,
+  isStacking,
   onMouseEnter,
   onClick,
   onInvestigate,
+  onStack,
   onPreview,
   onLabelClick,
 }: PRItemProps) {
+  const busy = isCreating || isStacking
   return (
     <div
       data-item-index={index}
@@ -229,10 +235,10 @@ export function PRItem({
         'group w-full flex items-start gap-3 px-3 py-2.5 sm:py-2 text-left transition-colors',
         'hover:bg-accent',
         isSelected && 'bg-accent',
-        isCreating && 'opacity-50'
+        busy && 'opacity-50'
       )}
     >
-      {isCreating ? (
+      {busy ? (
         <Loader2 className="h-4 w-4 mt-0.5 animate-spin text-muted-foreground flex-shrink-0" />
       ) : (
         <GitPullRequest
@@ -248,7 +254,7 @@ export function PRItem({
       )}
       <button
         onClick={e => onClick(e.metaKey)}
-        disabled={isCreating}
+        disabled={busy}
         className="flex-1 min-w-0 text-left focus:outline-none disabled:cursor-not-allowed"
       >
         <div className="flex items-center gap-2">
@@ -316,6 +322,28 @@ export function PRItem({
           </TooltipTrigger>
           <TooltipContent>Preview PR ({getModifierSymbol()}O)</TooltipContent>
         </Tooltip>
+        {/* Stack button — new worktree branched off this PR's head */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={e => {
+                e.stopPropagation()
+                onStack(e.metaKey || e.ctrlKey)
+              }}
+              disabled={busy}
+              className="inline-flex h-6 w-6 items-center justify-center rounded px-1 text-foreground/80 transition-colors hover:bg-muted hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              {isStacking ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <GitBranchPlus className="h-3.5 w-3.5" />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            New worktree based on {pr.headRefName}
+          </TooltipContent>
+        </Tooltip>
         {/* Investigate button */}
         <Tooltip>
           <TooltipTrigger asChild>
@@ -324,7 +352,7 @@ export function PRItem({
                 e.stopPropagation()
                 onInvestigate(e.metaKey || e.ctrlKey)
               }}
-              disabled={isCreating}
+              disabled={busy}
               className="inline-flex h-6 w-6 items-center justify-center rounded px-1 text-foreground/80 transition-colors hover:bg-muted hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
             >
               <Wand2 className="h-3 w-3 text-current dark:text-yellow-400" />
@@ -344,8 +372,10 @@ export interface BranchItemProps {
   index: number
   isSelected: boolean
   isCreating: boolean
+  isStacking: boolean
   onMouseEnter: () => void
   onClick: (background: boolean) => void
+  onStack: (background: boolean) => void
 }
 
 export function BranchItem({
@@ -353,30 +383,57 @@ export function BranchItem({
   index,
   isSelected,
   isCreating,
+  isStacking,
   onMouseEnter,
   onClick,
+  onStack,
 }: BranchItemProps) {
+  const busy = isCreating || isStacking
   return (
-    <button
+    <div
       data-item-index={index}
       onMouseEnter={onMouseEnter}
-      onClick={e => onClick(e.metaKey)}
-      disabled={isCreating}
       className={cn(
-        'w-full flex items-center gap-3 px-3 py-2.5 sm:py-2 text-left transition-colors',
+        'group w-full flex items-center gap-3 px-3 py-2.5 sm:py-2 text-left transition-colors',
         'hover:bg-accent',
         isSelected && 'bg-accent',
-        isCreating && 'opacity-50',
-        'focus:outline-none disabled:cursor-not-allowed'
+        busy && 'opacity-50'
       )}
     >
-      {isCreating ? (
+      {busy ? (
         <Loader2 className="h-4 w-4 animate-spin text-muted-foreground flex-shrink-0" />
       ) : (
         <GitBranch className="h-4 w-4 text-muted-foreground flex-shrink-0" />
       )}
-      <span className="text-sm truncate">{branch}</span>
-    </button>
+      <button
+        onClick={e => onClick(e.metaKey)}
+        disabled={busy}
+        className="flex-1 min-w-0 text-left focus:outline-none disabled:cursor-not-allowed"
+      >
+        <span className="text-sm truncate">{branch}</span>
+      </button>
+      <div className="shrink-0 flex items-center gap-1 self-center">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={e => {
+                e.stopPropagation()
+                onStack(e.metaKey || e.ctrlKey)
+              }}
+              disabled={busy}
+              className="inline-flex h-6 w-6 items-center justify-center rounded px-1 text-foreground/80 transition-colors hover:bg-muted hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              {isStacking ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <GitBranchPlus className="h-3.5 w-3.5" />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>New worktree based on {branch}</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
   )
 }
 

--- a/src/components/worktree/NewWorktreeModal.tsx
+++ b/src/components/worktree/NewWorktreeModal.tsx
@@ -286,8 +286,10 @@ export function NewWorktreeModal() {
                 setSelectedIndex={setSelectedItemIndex}
                 onSelectPR={handlers.handleSelectPR}
                 onInvestigatePR={handlers.handleSelectPRAndInvestigate}
+                onStackPR={handlers.handleStackOnPR}
                 onPreviewPR={handlePreviewPR}
                 creatingFromNumber={handlers.creatingFromNumber}
+                stackingFromPR={handlers.stackingFromPR}
                 searchInputRef={searchInputRef}
                 onGhLogin={triggerGhLogin}
                 isGhInstalled={isGhInstalled}
@@ -364,7 +366,9 @@ export function NewWorktreeModal() {
                 selectedIndex={selectedItemIndex}
                 setSelectedIndex={setSelectedItemIndex}
                 onSelectBranch={handlers.handleSelectBranch}
+                onStackBranch={handlers.handleStackOnBranch}
                 creatingFromBranch={handlers.creatingFromBranch}
+                stackingFromBranch={handlers.stackingFromBranch}
                 searchInputRef={searchInputRef}
               />
             )}

--- a/src/components/worktree/hooks/useNewWorktreeHandlers.ts
+++ b/src/components/worktree/hooks/useNewWorktreeHandlers.ts
@@ -61,6 +61,10 @@ export function useNewWorktreeHandlers(data: Data, setters: Setters) {
   const [creatingFromGhsaId, setCreatingFromGhsaId] = useState<string | null>(
     null
   )
+  const [stackingFromPR, setStackingFromPR] = useState<number | null>(null)
+  const [stackingFromBranch, setStackingFromBranch] = useState<string | null>(
+    null
+  )
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -68,6 +72,8 @@ export function useNewWorktreeHandlers(data: Data, setters: Setters) {
       setCreatingFromLinearId(null)
       setCreatingFromBranch(null)
       setCreatingFromGhsaId(null)
+      setStackingFromPR(null)
+      setStackingFromBranch(null)
       setSearchQuery('')
       setSelectedItemIndex(0)
 
@@ -795,11 +801,71 @@ export function useNewWorktreeHandlers(data: Data, setters: Setters) {
     [selectedProjectId, createWorktree, handleOpenChange]
   )
 
+  // =========================================================================
+  // Stack handlers: create new worktree branched off a PR head or a branch
+  // =========================================================================
+
+  const handleStackOnPR = useCallback(
+    (pr: GitHubPullRequest, background = false) => {
+      if (!selectedProjectId) {
+        toast.error('No project selected')
+        return
+      }
+      setStackingFromPR(pr.number)
+      if (background)
+        useUIStore.getState().incrementPendingBackgroundCreations()
+      createWorktree.mutate(
+        {
+          projectId: selectedProjectId,
+          baseBranch: pr.headRefName,
+          background,
+        },
+        {
+          onError: () => setStackingFromPR(null),
+          onSuccess: () => {
+            if (background) setStackingFromPR(null)
+          },
+        }
+      )
+      if (!background) handleOpenChange(false)
+    },
+    [selectedProjectId, createWorktree, handleOpenChange]
+  )
+
+  const handleStackOnBranch = useCallback(
+    (branchName: string, background = false) => {
+      if (!selectedProjectId) {
+        toast.error('No project selected')
+        return
+      }
+      setStackingFromBranch(branchName)
+      if (background)
+        useUIStore.getState().incrementPendingBackgroundCreations()
+      createWorktree.mutate(
+        {
+          projectId: selectedProjectId,
+          baseBranch: branchName,
+          background,
+        },
+        {
+          onError: () => setStackingFromBranch(null),
+          onSuccess: () => {
+            if (background) setStackingFromBranch(null)
+          },
+        }
+      )
+      if (!background) handleOpenChange(false)
+    },
+    [selectedProjectId, createWorktree, handleOpenChange]
+  )
+
   return {
     creatingFromNumber,
     creatingFromLinearId,
     creatingFromBranch,
     creatingFromGhsaId,
+    stackingFromPR,
+    stackingFromBranch,
     handleOpenChange,
     handleCreateWorktree,
     handleBaseSession,
@@ -808,6 +874,8 @@ export function useNewWorktreeHandlers(data: Data, setters: Setters) {
     handleSelectIssueAndInvestigate,
     handleSelectPR,
     handleSelectPRAndInvestigate,
+    handleStackOnPR,
+    handleStackOnBranch,
     handleSelectSecurityAlert,
     handleSelectSecurityAlertAndInvestigate,
     handleSelectAdvisory,

--- a/src/lib/terminal-instances.ts
+++ b/src/lib/terminal-instances.ts
@@ -208,7 +208,9 @@ export function getOrCreateTerminal(
         const signal = event.payload.signal
         const exitLabel =
           signal != null ? `signal ${signal}` : `code ${exitCode ?? 'unknown'}`
-        terminal.writeln(`\r\n\x1b[90m[Process exited with ${exitLabel}]\x1b[0m`)
+        terminal.writeln(
+          `\r\n\x1b[90m[Process exited with ${exitLabel}]\x1b[0m`
+        )
         const inst = instances.get(terminalId)
         inst?.onStopped?.(exitCode, signal)
 

--- a/src/types/projects.ts
+++ b/src/types/projects.ts
@@ -81,6 +81,8 @@ export interface Worktree {
   path: string
   /** Git branch name (same as workspace name) */
   branch: string
+  /** Base branch this worktree was created from (undefined for legacy worktrees or base sessions) */
+  base_branch?: string
   /** Unix timestamp when worktree was created */
   created_at: number
   /** Output from setup script (if any) */


### PR DESCRIPTION
## Summary

- Add `base_branch` field to `Worktree` type (Rust + TypeScript) tracking which branch a worktree was created from
- Handle remote-only branches as stack bases: fall back to `origin/<branch>` when no local ref exists, even on fetch failure
- Add `remote_branch_exists()` git helper; `get_valid_base_branch` now accepts remote-tracking refs as valid bases
- Add "Stack" button (`GitBranchPlus`) to PR items and branch items in the new-worktree modal — creates a new worktree branched off that PR head or branch
- Add `handleStackOnPR` / `handleStackOnBranch` handlers with independent loading state (`stackingFromPR`, `stackingFromBranch`)
- Show stacked-branch badge in `WorktreeSectionHeader` and `SessionChatModal` header; badge includes linked PR number when the base branch matches an open PR's `headRefName`
- Populate `base_branch` across all worktree creation paths (`create_worktree`, `create_worktree_from_existing_branch`, `create_base_session`, `checkout_pr`, `import_worktree`, `restore_session_with_base`)
