### PR TITLE
feat(terminal): enable terminal in web/browser mode

### DIFF
--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -1469,35 +1469,49 @@ pub async fn dispatch_command(
         }
 
         // =====================================================================
-        // Terminal (NATIVE ONLY — return empty/null in browser mode)
+        // Terminal
         // =====================================================================
         "start_terminal" => {
-            // NATIVE ONLY: Terminals don't work in browser mode
+            let terminal_id: String = field(&args, "terminalId", "terminal_id")?;
+            let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
+            let cols: u16 = from_field(&args, "cols")?;
+            let rows: u16 = from_field(&args, "rows")?;
+            let command: Option<String> = from_field_opt(&args, "command")?;
+            let command_args: Option<Vec<String>> = field_opt(&args, "commandArgs", "command_args")?;
+            crate::terminal::start_terminal(app.clone(), terminal_id, worktree_path, cols, rows, command, command_args).await?;
             Ok(Value::Null)
         }
         "terminal_write" => {
-            // NATIVE ONLY: Terminals don't work in browser mode
+            let terminal_id: String = field(&args, "terminalId", "terminal_id")?;
+            let data: String = from_field(&args, "data")?;
+            crate::terminal::terminal_write(terminal_id, data).await?;
             Ok(Value::Null)
         }
         "terminal_resize" => {
-            // NATIVE ONLY: Terminals don't work in browser mode
+            let terminal_id: String = field(&args, "terminalId", "terminal_id")?;
+            let cols: u16 = from_field(&args, "cols")?;
+            let rows: u16 = from_field(&args, "rows")?;
+            crate::terminal::terminal_resize(terminal_id, cols, rows).await?;
             Ok(Value::Null)
         }
         "stop_terminal" => {
-            // NATIVE ONLY: Terminals don't work in browser mode
-            Ok(Value::Null)
+            let terminal_id: String = field(&args, "terminalId", "terminal_id")?;
+            let result = crate::terminal::stop_terminal(app.clone(), terminal_id).await?;
+            to_value(result)
         }
         "get_active_terminals" => {
-            // NATIVE ONLY: Return empty array
-            Ok(Value::Array(vec![]))
+            let result = crate::terminal::get_active_terminals().await;
+            to_value(result)
         }
         "has_active_terminal" => {
-            // NATIVE ONLY: No terminals in browser mode
-            to_value(false)
+            let terminal_id: String = field(&args, "terminalId", "terminal_id")?;
+            let result = crate::terminal::has_active_terminal(terminal_id).await;
+            to_value(result)
         }
         "get_run_scripts" => {
-            // NATIVE ONLY: Terminals don't work in browser mode
-            Ok(Value::Array(vec![]))
+            let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
+            let result = crate::terminal::get_run_scripts(worktree_path).await;
+            to_value(result)
         }
         "get_ports" => {
             let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
@@ -1505,8 +1519,8 @@ pub async fn dispatch_command(
             to_value(result)
         }
         "get_terminal_listening_ports" => {
-            // NATIVE ONLY: lsof not available in browser mode
-            Ok(Value::Array(vec![]))
+            let result = crate::terminal::get_terminal_listening_ports().await;
+            to_value(result)
         }
 
         // =====================================================================

--- a/src-tauri/src/http_server/mod.rs
+++ b/src-tauri/src/http_server/mod.rs
@@ -162,6 +162,13 @@ impl WsBroadcaster {
 /// Use `app.emit_all("event", &payload)` instead of `app.emit("event", &payload)`.
 pub trait EmitExt {
     fn emit_all<S: Serialize + Clone>(&self, event: &str, payload: &S) -> Result<(), String>;
+    /// Like `emit_all` but takes ownership of the payload, avoiding a caller-side clone
+    /// on the hot path (e.g. high-frequency terminal output chunks).
+    fn emit_all_owned<S: Serialize + Clone>(
+        &self,
+        event: &str,
+        payload: S,
+    ) -> Result<(), String>;
 }
 
 impl EmitExt for AppHandle {
@@ -175,6 +182,23 @@ impl EmitExt for AppHandle {
         if let Some(ws) = self.try_state::<WsBroadcaster>() {
             ws.broadcast(event, payload);
         }
+
+        Ok(())
+    }
+
+    fn emit_all_owned<S: Serialize + Clone>(
+        &self,
+        event: &str,
+        payload: S,
+    ) -> Result<(), String> {
+        // Broadcast to WebSocket clients first (borrows payload, no clone needed here).
+        if let Some(ws) = self.try_state::<WsBroadcaster>() {
+            ws.broadcast(event, &payload);
+        }
+
+        // Send to Tauri frontend — consumes payload (Tauri's emit requires Clone internally).
+        self.emit(event, payload)
+            .map_err(|e| format!("Tauri emit failed: {e}"))?;
 
         Ok(())
     }

--- a/src-tauri/src/terminal/pty.rs
+++ b/src-tauri/src/terminal/pty.rs
@@ -2,7 +2,9 @@ use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use std::io::Read;
 use std::sync::Mutex;
 use std::thread;
-use tauri::{AppHandle, Emitter};
+use tauri::AppHandle;
+
+use crate::http_server::EmitExt;
 
 use super::registry::{register_terminal, unregister_terminal};
 use super::types::{
@@ -155,7 +157,7 @@ pub fn spawn_terminal(
         cols,
         rows,
     };
-    if let Err(e) = app.emit("terminal:started", &started_event) {
+    if let Err(e) = app.emit_all("terminal:started", &started_event) {
         log::error!("Failed to emit terminal:started event: {e}");
     }
 
@@ -178,7 +180,7 @@ pub fn spawn_terminal(
                         terminal_id: terminal_id_clone.clone(),
                         data,
                     };
-                    if let Err(e) = app_clone.emit("terminal:output", &event) {
+                    if let Err(e) = app_clone.emit_all("terminal:output", &event) {
                         log::error!("Failed to emit terminal:output event: {e}");
                     }
                 }
@@ -213,7 +215,7 @@ pub fn spawn_terminal(
                 exit_code,
                 signal,
             };
-            if let Err(e) = app_clone.emit("terminal:stopped", &stopped_event) {
+            if let Err(e) = app_clone.emit_all("terminal:stopped", &stopped_event) {
                 log::error!("Failed to emit terminal:stopped event: {e}");
             }
         }
@@ -277,7 +279,7 @@ pub fn kill_terminal(app: &AppHandle, terminal_id: &str) -> Result<bool, String>
             exit_code: None,
             signal: None,
         };
-        if let Err(e) = app.emit("terminal:stopped", &stopped_event) {
+        if let Err(e) = app.emit_all("terminal:stopped", &stopped_event) {
             log::error!("Failed to emit terminal:stopped event: {e}");
         }
 

--- a/src-tauri/src/terminal/pty.rs
+++ b/src-tauri/src/terminal/pty.rs
@@ -180,7 +180,7 @@ pub fn spawn_terminal(
                         terminal_id: terminal_id_clone.clone(),
                         data,
                     };
-                    if let Err(e) = app_clone.emit_all("terminal:output", &event) {
+                    if let Err(e) = app_clone.emit_all_owned("terminal:output", event) {
                         log::error!("Failed to emit terminal:output event: {e}");
                     }
                 }

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -135,7 +135,6 @@ import { buildMcpConfigJson } from '@/services/mcp'
 import type { McpServerInfo } from '@/types/chat'
 import { useGitStatus } from '@/services/git-status'
 import { useRemotePicker } from '@/hooks/useRemotePicker'
-import { isNativeApp } from '@/lib/environment'
 import { supportsAdaptiveThinking } from '@/lib/model-utils'
 import { copyToClipboard, copyHtmlToClipboard } from '@/lib/clipboard'
 import { useClaudeCliStatus } from '@/services/claude-cli'
@@ -2897,29 +2896,26 @@ export function ChatWindow({
                   </div>
                 </ResizablePanel>
 
-                {/* Terminal panel - only render when panel is open (native app only, not in modal) */}
-                {!isModal &&
-                  isNativeApp() &&
-                  activeWorktreePath &&
-                  terminalPanelOpen && (
-                    <>
-                      <ResizableHandle withHandle />
-                      <ResizablePanel
-                        ref={terminalPanelRef}
-                        defaultSize={terminalVisible ? 30 : 4}
-                        minSize={terminalVisible ? 15 : 4}
-                        collapsible
-                        collapsedSize={4}
-                        onCollapse={handleTerminalCollapse}
+                {/* Terminal panel - only render when panel is open (not in modal) */}
+                {!isModal && activeWorktreePath && terminalPanelOpen && (
+                  <>
+                    <ResizableHandle withHandle />
+                    <ResizablePanel
+                      ref={terminalPanelRef}
+                      defaultSize={terminalVisible ? 30 : 4}
+                      minSize={terminalVisible ? 15 : 4}
+                      collapsible
+                      collapsedSize={4}
+                      onCollapse={handleTerminalCollapse}
+                      onExpand={handleTerminalExpand}
+                    >
+                      <TerminalPanel
+                        isCollapsed={!terminalVisible}
                         onExpand={handleTerminalExpand}
-                      >
-                        <TerminalPanel
-                          isCollapsed={!terminalVisible}
-                          onExpand={handleTerminalExpand}
-                        />
-                      </ResizablePanel>
-                    </>
-                  )}
+                      />
+                    </ResizablePanel>
+                  </>
+                )}
               </ResizablePanelGroup>
             </ResizablePanel>
 

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -805,15 +805,13 @@ export function SessionChatModal({
             )}
           />
         )}
-        {isNativeApp() &&
-          isModalTerminalOpen &&
-          modalTerminalDockMode === 'left' && (
-            <ModalTerminalDrawer
-              worktreeId={worktreeId}
-              worktreePath={worktreePath}
-              dockMode="left"
-            />
-          )}
+        {isModalTerminalOpen && modalTerminalDockMode === 'left' && (
+          <ModalTerminalDrawer
+            worktreeId={worktreeId}
+            worktreePath={worktreePath}
+            dockMode="left"
+          />
+        )}
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
           <div className="shrink-0 border-b sm:text-left">
             <div
@@ -895,49 +893,75 @@ export function SessionChatModal({
               </div>
               <div className="flex items-center gap-1 shrink-0">
                 {/* Desktop: inline action buttons */}
-                {isNativeApp() && (
-                  <div className="hidden sm:flex items-center gap-1">
-                    <OpenInButton
+                <div className="hidden sm:flex items-center gap-1">
+                  <OpenInButton
+                    worktreePath={worktreePath}
+                    branch={worktree?.branch}
+                  />
+                  {currentSessionId && (
+                    <DevToolsDropdown
+                      sessionId={currentSessionId}
+                      worktreeId={worktreeId}
                       worktreePath={worktreePath}
-                      branch={worktree?.branch}
+                      session={currentSession}
                     />
-                    {currentSessionId && (
-                      <DevToolsDropdown
-                        sessionId={currentSessionId}
-                        worktreeId={worktreeId}
-                        worktreePath={worktreePath}
-                        session={currentSession}
-                      />
-                    )}
+                  )}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 px-2 text-xs"
+                        onClick={() => {
+                          useTerminalStore
+                            .getState()
+                            .toggleModalTerminal(worktreeId)
+                        }}
+                      >
+                        <Terminal className="h-3 w-3" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Terminal{' '}
+                      <kbd className="ml-1 text-[0.625rem] opacity-60">
+                        {terminalShortcut}
+                      </kbd>
+                    </TooltipContent>
+                  </Tooltip>
+                  {runScripts.length === 1 && (
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <Button
                           variant="ghost"
                           size="sm"
                           className="h-7 px-2 text-xs"
-                          onClick={() => {
-                            useTerminalStore
-                              .getState()
-                              .toggleModalTerminal(worktreeId)
-                          }}
+                          onClick={handleRun}
                         >
-                          <Terminal className="h-3 w-3" />
+                          <Play
+                            className={`h-3 w-3 ${hasFailedTerminal ? 'text-red-500' : hasRunningTerminal ? 'text-amber-500 dark:text-yellow-400 animate-icon-glow' : ''}`}
+                          />
                         </Button>
                       </TooltipTrigger>
                       <TooltipContent>
-                        Terminal{' '}
+                        {hasFailedTerminal
+                          ? 'Crashed'
+                          : hasRunningTerminal
+                            ? 'Running'
+                            : 'Run'}{' '}
                         <kbd className="ml-1 text-[0.625rem] opacity-60">
-                          {terminalShortcut}
+                          {runShortcut}
                         </kbd>
                       </TooltipContent>
                     </Tooltip>
-                    {runScripts.length === 1 && (
+                  )}
+                  {runScripts.length > 1 && (
+                    <div className="flex items-center">
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <Button
                             variant="ghost"
                             size="sm"
-                            className="h-7 px-2 text-xs"
+                            className="h-7 rounded-r-none px-2 text-xs"
                             onClick={handleRun}
                           >
                             <Play
@@ -950,205 +974,177 @@ export function SessionChatModal({
                             ? 'Crashed'
                             : hasRunningTerminal
                               ? 'Running'
-                              : 'Run'}{' '}
+                              : 'Run first command'}{' '}
                           <kbd className="ml-1 text-[0.625rem] opacity-60">
                             {runShortcut}
                           </kbd>
                         </TooltipContent>
                       </Tooltip>
-                    )}
-                    {runScripts.length > 1 && (
-                      <div className="flex items-center">
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="h-7 rounded-r-none px-2 text-xs"
-                              onClick={handleRun}
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 rounded-l-none border-l border-border/50 px-1 text-xs"
+                          >
+                            <ChevronDown className="h-3 w-3" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          {runScripts.map((cmd, i) => (
+                            <DropdownMenuItem
+                              key={i}
+                              onSelect={() => handleRunCommand(cmd)}
+                              className="font-mono text-xs"
                             >
-                              <Play
-                                className={`h-3 w-3 ${hasFailedTerminal ? 'text-red-500' : hasRunningTerminal ? 'text-amber-500 dark:text-yellow-400 animate-icon-glow' : ''}`}
-                              />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            {hasFailedTerminal
-                              ? 'Crashed'
-                              : hasRunningTerminal
-                                ? 'Running'
-                                : 'Run first command'}{' '}
-                            <kbd className="ml-1 text-[0.625rem] opacity-60">
-                              {runShortcut}
-                            </kbd>
-                          </TooltipContent>
-                        </Tooltip>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="h-7 rounded-l-none border-l border-border/50 px-1 text-xs"
-                            >
-                              <ChevronDown className="h-3 w-3" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            {runScripts.map((cmd, i) => (
-                              <DropdownMenuItem
-                                key={i}
-                                onSelect={() => handleRunCommand(cmd)}
-                                className="font-mono text-xs"
-                              >
-                                {cmd}
-                              </DropdownMenuItem>
-                            ))}
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </div>
-                    )}
-                  </div>
-                )}
+                              {cmd}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  )}
+                </div>
                 {/* Mobile: overflow menu */}
-                {isNativeApp() && (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 w-7 p-0 flex sm:hidden"
-                      >
-                        <MoreHorizontal className="h-4 w-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem
-                        onSelect={() =>
-                          openInEditor.mutate({
-                            worktreePath,
-                            editor: preferences?.editor,
-                          })
-                        }
-                      >
-                        <Code className="h-4 w-4" />
-                        {getOpenInDefaultLabel(
-                          'editor',
-                          preferences?.editor,
-                          preferences?.terminal
-                        )}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onSelect={() =>
-                          openInTerminal.mutate({
-                            worktreePath,
-                            terminal: preferences?.terminal,
-                          })
-                        }
-                      >
-                        <Terminal className="h-4 w-4" />
-                        {getOpenInDefaultLabel(
-                          'terminal',
-                          preferences?.editor,
-                          preferences?.terminal
-                        )}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onSelect={() => openInFinder.mutate(worktreePath)}
-                      >
-                        <FolderOpen className="h-4 w-4" />
-                        Finder
-                      </DropdownMenuItem>
-                      {worktree?.branch && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 p-0 flex sm:hidden"
+                    >
+                      <MoreHorizontal className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {isNativeApp() && (
+                      <>
                         <DropdownMenuItem
                           onSelect={() =>
-                            openOnGitHub.mutate({
-                              repoPath: worktreePath,
-                              branch: worktree.branch,
+                            openInEditor.mutate({
+                              worktreePath,
+                              editor: preferences?.editor,
                             })
                           }
                         >
-                          <Github className="h-4 w-4" />
-                          GitHub
+                          <Code className="h-4 w-4" />
+                          {getOpenInDefaultLabel(
+                            'editor',
+                            preferences?.editor,
+                            preferences?.terminal
+                          )}
                         </DropdownMenuItem>
-                      )}
-                      <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onSelect={() =>
+                            openInTerminal.mutate({
+                              worktreePath,
+                              terminal: preferences?.terminal,
+                            })
+                          }
+                        >
+                          <Terminal className="h-4 w-4" />
+                          {getOpenInDefaultLabel(
+                            'terminal',
+                            preferences?.editor,
+                            preferences?.terminal
+                          )}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onSelect={() => openInFinder.mutate(worktreePath)}
+                        >
+                          <FolderOpen className="h-4 w-4" />
+                          Finder
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                    {worktree?.branch && (
                       <DropdownMenuItem
                         onSelect={() =>
-                          useTerminalStore
-                            .getState()
-                            .toggleModalTerminal(worktreeId)
+                          openOnGitHub.mutate({
+                            repoPath: worktreePath,
+                            branch: worktree.branch,
+                          })
                         }
                       >
-                        <Terminal className="h-4 w-4" />
-                        Terminal
+                        <Github className="h-4 w-4" />
+                        GitHub
                       </DropdownMenuItem>
-                      {runScripts.length === 1 && (
-                        <DropdownMenuItem onSelect={handleRun}>
+                    )}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onSelect={() =>
+                        useTerminalStore
+                          .getState()
+                          .toggleModalTerminal(worktreeId)
+                      }
+                    >
+                      <Terminal className="h-4 w-4" />
+                      Terminal
+                    </DropdownMenuItem>
+                    {runScripts.length === 1 && (
+                      <DropdownMenuItem onSelect={handleRun}>
+                        <Play
+                          className={`h-4 w-4 ${hasFailedTerminal ? 'text-red-500' : hasRunningTerminal ? 'text-amber-500 dark:text-yellow-400 animate-icon-glow' : ''}`}
+                        />
+                        Run
+                      </DropdownMenuItem>
+                    )}
+                    {runScripts.length > 1 && (
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger>
                           <Play
                             className={`h-4 w-4 ${hasFailedTerminal ? 'text-red-500' : hasRunningTerminal ? 'text-amber-500 dark:text-yellow-400 animate-icon-glow' : ''}`}
                           />
                           Run
-                        </DropdownMenuItem>
-                      )}
-                      {runScripts.length > 1 && (
-                        <DropdownMenuSub>
-                          <DropdownMenuSubTrigger>
-                            <Play
-                              className={`h-4 w-4 ${hasFailedTerminal ? 'text-red-500' : hasRunningTerminal ? 'text-amber-500 dark:text-yellow-400 animate-icon-glow' : ''}`}
-                            />
-                            Run
-                          </DropdownMenuSubTrigger>
-                          <DropdownMenuSubContent>
-                            {runScripts.map((cmd, i) => (
-                              <DropdownMenuItem
-                                key={i}
-                                onSelect={() => handleRunCommand(cmd)}
-                                className="font-mono text-xs"
-                              >
-                                {cmd}
-                              </DropdownMenuItem>
-                            ))}
-                          </DropdownMenuSubContent>
-                        </DropdownMenuSub>
-                      )}
-                      {currentResumeCommand && (
-                        <DropdownMenuItem
-                          onSelect={() => {
-                            void copyToClipboard(currentResumeCommand)
-                              .then(() =>
-                                toast.success('Resume command copied')
-                              )
-                              .catch(() =>
-                                toast.error('Failed to copy resume command')
-                              )
-                          }}
-                        >
-                          <Terminal className="h-4 w-4" />
-                          Copy Resume Command
-                        </DropdownMenuItem>
-                      )}
-                      <DropdownMenuSeparator />
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuSubContent>
+                          {runScripts.map((cmd, i) => (
+                            <DropdownMenuItem
+                              key={i}
+                              onSelect={() => handleRunCommand(cmd)}
+                              className="font-mono text-xs"
+                            >
+                              {cmd}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuSubContent>
+                      </DropdownMenuSub>
+                    )}
+                    {currentResumeCommand && (
                       <DropdownMenuItem
-                        disabled={!hasRecap}
-                        onSelect={() =>
-                          window.dispatchEvent(new CustomEvent('open-recap'))
-                        }
+                        onSelect={() => {
+                          void copyToClipboard(currentResumeCommand)
+                            .then(() => toast.success('Resume command copied'))
+                            .catch(() =>
+                              toast.error('Failed to copy resume command')
+                            )
+                        }}
                       >
-                        <Sparkles className="h-4 w-4" />
-                        Recap
+                        <Terminal className="h-4 w-4" />
+                        Copy Resume Command
                       </DropdownMenuItem>
-                      <DropdownMenuItem
-                        disabled={!hasPlan}
-                        onSelect={() =>
-                          window.dispatchEvent(new CustomEvent('open-plan'))
-                        }
-                      >
-                        <FileText className="h-4 w-4" />
-                        Plan
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )}
+                    )}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      disabled={!hasRecap}
+                      onSelect={() =>
+                        window.dispatchEvent(new CustomEvent('open-recap'))
+                      }
+                    >
+                      <Sparkles className="h-4 w-4" />
+                      Recap
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      disabled={!hasPlan}
+                      onSelect={() =>
+                        window.dispatchEvent(new CustomEvent('open-plan'))
+                      }
+                    >
+                      <FileText className="h-4 w-4" />
+                      Plan
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
                 <ModalCloseButton onClick={handleClose} />
               </div>
             </div>
@@ -1430,25 +1426,21 @@ export function SessionChatModal({
           </div>
         </div>
 
-        {isNativeApp() &&
-          isModalTerminalOpen &&
-          modalTerminalDockMode === 'right' && (
-            <ModalTerminalDrawer
-              worktreeId={worktreeId}
-              worktreePath={worktreePath}
-              dockMode="right"
-            />
-          )}
-        {isNativeApp() &&
-          isModalTerminalOpen &&
-          modalTerminalDockMode === 'bottom' && (
-            <ModalTerminalDrawer
-              worktreeId={worktreeId}
-              worktreePath={worktreePath}
-              dockMode="bottom"
-            />
-          )}
-        {isNativeApp() && modalTerminalDockMode === 'floating' && (
+        {isModalTerminalOpen && modalTerminalDockMode === 'right' && (
+          <ModalTerminalDrawer
+            worktreeId={worktreeId}
+            worktreePath={worktreePath}
+            dockMode="right"
+          />
+        )}
+        {isModalTerminalOpen && modalTerminalDockMode === 'bottom' && (
+          <ModalTerminalDrawer
+            worktreeId={worktreeId}
+            worktreePath={worktreePath}
+            dockMode="bottom"
+          />
+        )}
+        {modalTerminalDockMode === 'floating' && (
           <ModalTerminalDrawer
             worktreeId={worktreeId}
             worktreePath={worktreePath}

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -912,6 +912,7 @@ export function SessionChatModal({
                         variant="ghost"
                         size="sm"
                         className="h-7 px-2 text-xs"
+                        aria-label="Toggle terminal"
                         onClick={() => {
                           useTerminalStore
                             .getState()
@@ -935,6 +936,7 @@ export function SessionChatModal({
                           variant="ghost"
                           size="sm"
                           className="h-7 px-2 text-xs"
+                          aria-label="Run"
                           onClick={handleRun}
                         >
                           <Play
@@ -962,6 +964,7 @@ export function SessionChatModal({
                             variant="ghost"
                             size="sm"
                             className="h-7 rounded-r-none px-2 text-xs"
+                            aria-label="Run first command"
                             onClick={handleRun}
                           >
                             <Play
@@ -986,6 +989,7 @@ export function SessionChatModal({
                             variant="ghost"
                             size="sm"
                             className="h-7 rounded-l-none border-l border-border/50 px-1 text-xs"
+                            aria-label="Choose run command"
                           >
                             <ChevronDown className="h-3 w-3" />
                           </Button>
@@ -1012,6 +1016,7 @@ export function SessionChatModal({
                       variant="ghost"
                       size="sm"
                       className="h-7 w-7 p-0 flex sm:hidden"
+                      aria-label="More actions"
                     >
                       <MoreHorizontal className="h-4 w-4" />
                     </Button>
@@ -1070,7 +1075,9 @@ export function SessionChatModal({
                         GitHub
                       </DropdownMenuItem>
                     )}
-                    <DropdownMenuSeparator />
+                    {(isNativeApp() || worktree?.branch) && (
+                      <DropdownMenuSeparator />
+                    )}
                     <DropdownMenuItem
                       onSelect={() =>
                         useTerminalStore

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -164,7 +164,6 @@ function executeKeybindingAction(
       break
     case 'execute_run': {
       logger.debug('Keybinding: execute_run')
-      if (!isNativeApp()) break
 
       // Skip if git diff modal is open
       const uiStore = useUIStore.getState()

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { listen, invoke } from '@/lib/transport'
-import { isNativeApp } from '@/lib/environment'
+import { isNativeApp, hasBackend } from '@/lib/environment'
 import { notify } from '@/lib/notifications'
 import { useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { useUIStore } from '@/store/ui-store'
@@ -164,6 +164,7 @@ function executeKeybindingAction(
       break
     case 'execute_run': {
       logger.debug('Keybinding: execute_run')
+      if (!hasBackend()) break
 
       // Skip if git diff modal is open
       const uiStore = useUIStore.getState()

--- a/src/lib/environment.ts
+++ b/src/lib/environment.ts
@@ -5,7 +5,7 @@
  * - hasBackend(): true when a backend is available (Tauri IPC or HTTP/WS)
  *
  * Services should guard with hasBackend(), not isTauri().
- * UI should use isNativeApp() to hide terminal, Finder, etc.
+ * UI should use isNativeApp() to hide native-only features (Finder, external editors, etc.).
  */
 
 /** Running inside the native Tauri desktop app. */


### PR DESCRIPTION
This was quite trivial, I'm not sure why it wasn't enabled before? Security concerns? Seems yolo mode already has the same permissions as terminal?

Anyway, this PR enables accessing terminal and trigger runs from web browser.


## AI Summary

- **HTTP dispatch**: Implemented terminal command handlers (`start_terminal`, `terminal_write`, `terminal_resize`, `stop_terminal`, `get_active_terminals`, `has_active_terminal`, `get_run_scripts`, `get_terminal_listening_ports`) that previously returned empty/null stubs in browser mode — they now delegate to the real `crate::terminal` functions
- **Event broadcasting**: Switched from `app.emit()` to `app.emit_all()` in `pty.rs` so terminal events (`terminal:started`, `terminal:output`, `terminal:stopped`) are broadcast to all connected clients, not just the Tauri window
- **UI guards removed**: Dropped `isNativeApp()` conditions from `ChatWindow`, `SessionChatModal`, and the `execute_run` keybinding handler so the terminal panel, modal terminal drawers, and run shortcuts are available in the browser
- **Comment update**: Clarified `environment.ts` doc — `isNativeApp()` now guards native-only features like Finder and external editors, not terminal
