### PR TITLE
feat(chat): add hover copy button on assistant messages

### DIFF
--- a/src/components/chat/MessageItem.test.tsx
+++ b/src/components/chat/MessageItem.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
 import { render, screen } from '@/test/test-utils'
 import { MessageItem } from './MessageItem'
 import type {
@@ -7,6 +8,21 @@ import type {
   QuestionAnswer,
   Question,
 } from '@/types/chat'
+
+const copyToClipboardMock = vi.fn(async (_text: string) => undefined)
+const toastSuccessMock = vi.fn()
+const toastErrorMock = vi.fn()
+
+vi.mock('@/lib/clipboard', () => ({
+  copyToClipboard: (text: string) => copyToClipboardMock(text),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (msg: string) => toastSuccessMock(msg),
+    error: (msg: string) => toastErrorMock(msg),
+  },
+}))
 
 describe('MessageItem', () => {
   const noopQuestionAnswer = (
@@ -337,5 +353,111 @@ describe('MessageItem', () => {
     )
 
     expect(screen.getByText('Raptors')).toBeVisible()
+  })
+
+  describe('assistant copy button', () => {
+    it('renders copy button for assistant messages with content', () => {
+      render(
+        <MessageItem
+          {...baseProps}
+          message={{
+            ...baseMessage,
+            content: 'Hello world',
+            tool_calls: [],
+            content_blocks: [{ type: 'text', text: 'Hello world' }],
+          }}
+        />
+      )
+
+      expect(
+        screen.getByRole('button', { name: /copy message/i })
+      ).toBeInTheDocument()
+    })
+
+    it('copies the assistant message content on click', async () => {
+      copyToClipboardMock.mockClear()
+      toastSuccessMock.mockClear()
+
+      render(
+        <MessageItem
+          {...baseProps}
+          message={{
+            ...baseMessage,
+            content: 'Reply body',
+            tool_calls: [],
+            content_blocks: [{ type: 'text', text: 'Reply body' }],
+          }}
+        />
+      )
+
+      const user = userEvent.setup()
+      await user.click(screen.getByRole('button', { name: /copy message/i }))
+
+      expect(copyToClipboardMock).toHaveBeenCalledWith('Reply body')
+      expect(toastSuccessMock).toHaveBeenCalledWith('Copied to clipboard')
+    })
+
+    it('shows error toast when copy fails', async () => {
+      copyToClipboardMock.mockClear()
+      toastErrorMock.mockClear()
+      copyToClipboardMock.mockRejectedValueOnce(new Error('boom'))
+
+      render(
+        <MessageItem
+          {...baseProps}
+          message={{
+            ...baseMessage,
+            content: 'Reply body',
+            tool_calls: [],
+            content_blocks: [{ type: 'text', text: 'Reply body' }],
+          }}
+        />
+      )
+
+      const user = userEvent.setup()
+      await user.click(screen.getByRole('button', { name: /copy message/i }))
+
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to copy')
+      )
+    })
+
+    it('does not render copy button for assistant messages with empty content', () => {
+      render(
+        <MessageItem
+          {...baseProps}
+          message={{
+            ...baseMessage,
+            content: '   ',
+            tool_calls: [],
+            content_blocks: [],
+          }}
+        />
+      )
+
+      expect(
+        screen.queryByRole('button', { name: /copy message/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('does not render assistant copy button on user messages', () => {
+      render(
+        <MessageItem
+          {...baseProps}
+          message={{
+            id: 'user-1',
+            session_id: 'session-1',
+            role: 'user',
+            content: 'Hi',
+            timestamp: 1,
+            tool_calls: [],
+          }}
+        />
+      )
+
+      expect(
+        screen.queryByRole('button', { name: /copy message/i })
+      ).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -1,6 +1,8 @@
 import { memo, useCallback } from 'react'
 import { Copy } from 'lucide-react'
+import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
+import { copyToClipboard } from '@/lib/clipboard'
 import { normalizePath } from '@/lib/path-utils'
 import { Markdown } from '@/components/ui/markdown'
 import type {
@@ -232,6 +234,19 @@ export const MessageItem = memo(function MessageItem({
   const handleCopyToInput = useCallback(() => {
     onCopyToInput?.(message)
   }, [onCopyToInput, message])
+
+  // Copy assistant message content to clipboard
+  const handleCopyAssistantContent = useCallback(async () => {
+    try {
+      await copyToClipboard(message.content)
+      toast.success('Copied to clipboard')
+    } catch (error) {
+      toast.error(`Failed to copy: ${error}`)
+    }
+  }, [message.content])
+
+  const canCopyAssistantContent =
+    message.role === 'assistant' && message.content.trim().length > 0
 
   // Content for the message box (shared between user and assistant)
   const resolvedPlan = resolvePlanContent({
@@ -792,8 +807,23 @@ export const MessageItem = memo(function MessageItem({
           </div>
         </div>
       ) : (
-        <div className="text-foreground/90 w-full min-w-0 break-words">
+        <div className="relative group text-foreground/90 w-full min-w-0 break-words">
           {messageBoxContent}
+          {canCopyAssistantContent && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleCopyAssistantContent}
+                  aria-label="Copy message"
+                  className="absolute top-0 right-0 p-1 rounded cursor-pointer text-muted-foreground/0 hover:text-muted-foreground hover:bg-muted/50 group-hover:text-muted-foreground/50 transition-colors"
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Copy message</TooltipContent>
+            </Tooltip>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Adds a hover-only Copy icon at the top-right of assistant messages in `MessageItem`. Click copies the raw markdown content via `copyToClipboard`, with a sonner toast on success/failure.
- Mirrors the existing copy-to-input affordance on user messages, using the same `Copy` icon already imported.
- Restores three accidental placeholder strings in the legacy fallback render path (`fallbackPrePlanText`, `stripFindingBlocks(displayContent)`, `displayContent`) that were breaking fallback rendering.

## Tests

- Adds 4 new tests in `MessageItem.test.tsx` covering: button presence on assistant messages, click → clipboard call + success toast, error toast on copy failure, hidden when content is empty or message role is user.
- Mocks `@/lib/clipboard` and `sonner` to keep tests hermetic.