### PR TITLE
feat(chat): show local receive time next to message duration

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -35,7 +35,7 @@ import {
 import { ThinkingBlock } from './ThinkingBlock'
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary'
 import { logger } from '@/lib/logger'
-import { formatDuration } from './time-utils'
+import { formatDuration, formatLocalTime } from './time-utils'
 import {
   parseReviewFindings,
   hasReviewFindings,
@@ -744,11 +744,17 @@ export const MessageItem = memo(function MessageItem({
         </span>
       )}
 
-      {message.role === 'assistant' && durationMs != null && durationMs > 0 && (
-        <span className="mt-1 block min-h-4 text-xs leading-4 text-muted-foreground/40 tabular-nums font-mono">
-          {formatDuration(durationMs)}
-        </span>
-      )}
+      {message.role === 'assistant' &&
+        ((durationMs != null && durationMs > 0) || message.timestamp > 0) && (
+          <span className="mt-1 block min-h-4 text-xs leading-4 text-muted-foreground/40 tabular-nums font-mono">
+            {durationMs != null && durationMs > 0 && formatDuration(durationMs)}
+            {durationMs != null &&
+              durationMs > 0 &&
+              message.timestamp > 0 &&
+              ' · '}
+            {message.timestamp > 0 && formatLocalTime(message.timestamp)}
+          </span>
+        )}
     </>
   )
 

--- a/src/components/chat/time-utils.test.ts
+++ b/src/components/chat/time-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { formatDuration, formatLocalTime } from './time-utils'
+
+describe('formatDuration', () => {
+  it('floors milliseconds to whole seconds', () => {
+    expect(formatDuration(0)).toBe('0s')
+    expect(formatDuration(999)).toBe('0s')
+    expect(formatDuration(1500)).toBe('1s')
+    expect(formatDuration(145_000)).toBe('145s')
+  })
+})
+
+describe('formatLocalTime', () => {
+  it('returns the same string the platform produces for hour/minute/second', () => {
+    const ts = Date.UTC(2026, 3, 25, 12, 34, 56)
+    const expected = new Date(ts).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    expect(formatLocalTime(ts)).toBe(expected)
+  })
+
+  it('renders distinct times for different timestamps', () => {
+    const a = Date.UTC(2026, 3, 25, 9, 0, 0)
+    const b = Date.UTC(2026, 3, 25, 21, 0, 0)
+    expect(formatLocalTime(a)).not.toBe(formatLocalTime(b))
+  })
+})

--- a/src/components/chat/time-utils.ts
+++ b/src/components/chat/time-utils.ts
@@ -5,3 +5,14 @@
 export function formatDuration(ms: number): string {
   return `${Math.floor(ms / 1000)}s`
 }
+
+/**
+ * Format a Unix ms timestamp as a local hour:minute string using the user's locale.
+ */
+export function formatLocalTime(ms: number): string {
+  return new Date(ms).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  })
+}


### PR DESCRIPTION
## Summary
- Display the local receive time of each assistant message next to the existing duration indicator.
- Add `formatLocalTime` helper that formats Unix ms timestamps using the user's locale (hour/minute/second).
- Add unit tests for `formatDuration` and `formatLocalTime`.