### PR TITLE
fix(ui): replace native Windows scrollbars with the app's custom style

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -580,18 +580,28 @@ kbd {
   background-color: rgba(251, 146, 60, 0.6);
 }
 
-/* Custom scrollbar styling to match Radix ScrollArea */
-.custom-scrollbar::-webkit-scrollbar {
+/* Global custom scrollbar — applies to every scrollable element so Windows
+   WebView2 doesn't render its native gray scrollbar. */
+*::-webkit-scrollbar {
   width: 10px;
+  height: 10px;
 }
-.custom-scrollbar::-webkit-scrollbar-track {
+*::-webkit-scrollbar-track {
   background: transparent;
 }
-.custom-scrollbar::-webkit-scrollbar-thumb {
+*::-webkit-scrollbar-thumb {
   background: var(--border);
   border-radius: 9999px;
   border: 1px solid transparent;
   background-clip: padding-box;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--muted-foreground);
+  background-clip: padding-box;
+}
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
 }
 
 .xterm,

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -917,7 +917,7 @@ export const ChatInput = memo(function ChatInput({
         onKeyDown={handleKeyDown}
         onPaste={handlePaste}
         disabled={false}
-        className="custom-scrollbar min-h-[40px] max-h-[50vh] w-full resize-none overflow-x-hidden overflow-y-auto border-0 dark:bg-transparent p-0 font-mono text-base shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 md:text-sm"
+        className="min-h-[40px] max-h-[50vh] w-full resize-none overflow-x-hidden overflow-y-auto border-0 dark:bg-transparent p-0 font-mono text-base shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 md:text-sm"
         rows={1}
         autoFocus={!isMobile}
       />

--- a/src/components/preferences/PreferencesDialog.tsx
+++ b/src/components/preferences/PreferencesDialog.tsx
@@ -635,7 +635,7 @@ export function PreferencesDialog() {
 
             <div
               ref={scrollContainerRef}
-              className="flex flex-1 flex-col gap-4 overflow-y-auto p-4 min-h-0 custom-scrollbar"
+              className="flex flex-1 flex-col gap-4 overflow-y-auto p-4 min-h-0"
             >
               <PreferencesSearchBar
                 variant="mobile"

--- a/src/components/projects/ProjectSettingsDialog.tsx
+++ b/src/components/projects/ProjectSettingsDialog.tsx
@@ -192,7 +192,7 @@ function ProjectSettingsDialogContent({
               </div>
             </header>
 
-            <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4 pt-0 min-h-0 custom-scrollbar">
+            <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4 pt-0 min-h-0">
               {safeProjectId && projectPath && (
                 <>
                   {activePane === 'general' && (


### PR DESCRIPTION
## Summary

I use Jean daily on Windows and the native WebView2 scrollbar looks awful to me.  There was a custom scrollbar styles but only used it inside Settings, Preferences and the chat input). It's especially noticeable in the chat scroll, the file viewer, and any modal with overflow content.

Attaching before / after screenshots so you can see the difference.

<img width="125" height="1335" alt="image" src="https://github.com/user-attachments/assets/b4b1ee2e-3699-4aed-b5b3-99c1220d159f" />

<img width="55" height="859" alt="image" src="https://github.com/user-attachments/assets/e04cf087-8f70-47a6-8a8b-a5cef77bdc5c" />

## Root cause

The custom scrollbar styles in `src/App.css` were scoped to a `.custom-scrollbar` class, so they only applied to elements that explicitly opted in. Most scroll containers across the app (chat viewport, `FileContentModal`, diff modals, markdown blocks, `ScrollArea` viewport, etc.) never received the class, so on Windows they fell back to the native gray scrollbar.

The same problem also produced an ugly horizontal scrollbar in the file viewer because the original rule only set `width`, not `height`.

## Fix

Made the scrollbar styles **global** instead of opt-in:

- Changed selector from `.custom-scrollbar::-webkit-scrollbar*` to `*::-webkit-scrollbar*` in `src/App.css`.
- Added `height: 10px` so horizontal scrollbars are also styled (fixes the file viewer).
- Added `*::-webkit-scrollbar-thumb:hover` for a subtle hover state.
- Added the W3C-standard `scrollbar-width: thin` and `scrollbar-color` for forward-compat with non-WebKit engines.
- Removed the now-redundant `custom-scrollbar` class from the three components that used it (`ChatInput`, `PreferencesDialog`, `ProjectSettingsDialog`).

This is the approach also prevents the bug from ever returning when someone adds a new component with `overflow-auto`.

## Platform impact

- **Windows**: native gray scrollbars are replaced everywhere. This is the actual fix.
- **macOS**: scrollbars that were previously native overlay (autohide) become the same persistent 10px thin bar that's already shown in Settings / Preferences today. Pure visual change, no behavior or layout difference. Same look as the existing dialogs that already use this style, so the app is now visually consistent.
- **Linux**: same as macOS.

## Tests

This is a global CSS change, so I haven't added unit tests.

## To test

- [ ] Open a chat with enough messages to scroll → thin custom scrollbar (10px), not native gray (Windows).
- [ ] Open a file via `FileContentModal` → both vertical and horizontal scrollbars styled.
- [ ] Open a diff modal, markdown with tables, CodeMirror editor, dropdowns → all scrollbars consistent.
- [ ] Settings / Preferences look the same as before.
- [ ] Hover over the thumb → slight color change.
- [ ] macOS / Linux: scrollbars match the ones already shown in Settings.
