### PR TITLE
fix(ui): replace native tooltip with shadcn Tooltip on chat input men…

### DIFF
--- a/src/components/chat/toolbar/DockBurgerButton.tsx
+++ b/src/components/chat/toolbar/DockBurgerButton.tsx
@@ -26,6 +26,11 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { invoke } from '@/lib/transport'
 import { useWsConnectionStatus } from '@/lib/transport'
@@ -236,19 +241,24 @@ export function DockBurgerButton({
 
   return (
     <DropdownMenu open={menuOpen} onOpenChange={handleOpenChange}>
-      <DropdownMenuTrigger asChild>
-        <button
-          ref={triggerRef}
-          type="button"
-          title={`Menu (${menuShortcut})`}
-          className={cn(
-            'flex h-8 items-center gap-1 px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground',
-            className
-          )}
-        >
-          <Menu className="h-3.5 w-3.5" />
-        </button>
-      </DropdownMenuTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <button
+              ref={triggerRef}
+              type="button"
+              aria-label={`Menu (${menuShortcut})`}
+              className={cn(
+                'flex h-8 items-center gap-1 px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground',
+                className
+              )}
+            >
+              <Menu className="h-3.5 w-3.5" />
+            </button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Menu ({menuShortcut})</TooltipContent>
+      </Tooltip>
       <DropdownMenuContent
         side="top"
         align="start"


### PR DESCRIPTION
## Summary

The burger menu button in the chat input dock shows the native browser tooltip instead of the styled shadcn Tooltip used by every other button in the same toolbar. It's a small inconsistency but very visible because the native tooltip looks completely different.

## Root cause

`src/components/chat/toolbar/DockBurgerButton.tsx` used the HTML `title` attribute on the `<button>` instead of wrapping the trigger in `<Tooltip>` like the surrounding controls (`DesktopBackendModelPicker`, `DesktopToolbarControls`, `McpStatusDot`, `SendCancelButton`, etc.). The native browser tooltip kicks in on hover and overrides any visual consistency.

## Fix

Wrapped the existing `DropdownMenuTrigger` with the same `<Tooltip><TooltipTrigger asChild>` pattern that `DesktopBackendModelPicker` already uses for its `PopoverTrigger`. This preserves the dropdown behavior while showing the consistent tooltip.

- Imported `Tooltip`, `TooltipTrigger`, `TooltipContent` from `@/components/ui/tooltip`.
- Wrapped the `<DropdownMenuTrigger asChild>` inside `<Tooltip><TooltipTrigger asChild>...</TooltipTrigger><TooltipContent>...</TooltipContent></Tooltip>`.
- Removed the `title={...}` attribute (which produced the native tooltip).
- Replaced it with `aria-label={...}` so screen readers still announce the button purpose with the same shortcut hint.

## Tests

Small JSX wrapping change, no unit tests cover this surface.

## To test

- [ ] Hover the burger menu button in the chat input dock → see the styled shadcn tooltip ("Menu (⌘⇧K)" or your shortcut), not the native browser one.
- [ ] Click the button → dropdown menu still opens normally.
- [ ] Trigger the global shortcut (default `⌘⇧K` / `Ctrl+Shift+K`) → menu opens, no regressions.
- [ ] Tab to the button with keyboard → focus styles still visible, screen readers still announce the label via `aria-label`.
- [ ] Compare with sibling buttons (Backend/Model picker, send button) → tooltip styling and delay are identical.
