### PR TITLE
feat(git): add tree view to git diff modal file sidebar

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1604,6 +1604,10 @@ pub struct UIState {
     #[serde(default)]
     pub last_opened_per_project: std::collections::HashMap<String, LastOpenedEntry>,
 
+    /// Git diff modal file list view mode: 'list' or 'tree'
+    #[serde(default)]
+    pub git_diff_view_mode: Option<String>,
+
     /// Version for future migration support
     #[serde(default = "default_ui_state_version")]
     pub version: u32,
@@ -1666,6 +1670,7 @@ impl Default for UIState {
             dashboard_worktree_collapse_overrides: std::collections::HashMap::new(),
             project_canvas_settings: std::collections::HashMap::new(),
             last_opened_per_project: std::collections::HashMap::new(),
+            git_diff_view_mode: None,
             version: default_ui_state_version(),
         }
     }

--- a/src/components/chat/GitDiffFileTree.tsx
+++ b/src/components/chat/GitDiffFileTree.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState } from 'react'
+import { ChevronRight, Folder, FolderOpen } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { buildFileTree, type TreeNode } from './git-diff-tree'
+
+const INDENT_PX = 12
+
+interface FileItem {
+  key: string
+  fileName: string
+}
+
+interface GitDiffFileTreeProps<F extends FileItem> {
+  /** Already-filtered files (search filter is applied by the parent). */
+  files: F[]
+  /** Render the row for a single file at the given indent (already includes selection, checkbox, context-menu, tooltip — same UI as list view). */
+  renderFile: (file: F, index: number, indentPx: number) => React.ReactNode
+  /** When true (search active), all folders are auto-expanded so matches stay visible. */
+  searchActive: boolean
+  /** Collapse single-child folder chains (VSCode-style). */
+  compactFolders?: boolean
+  /** Smaller row height for mobile. */
+  isMobile?: boolean
+}
+
+export function GitDiffFileTree<F extends FileItem>({
+  files,
+  renderFile,
+  searchActive,
+  compactFolders = true,
+  isMobile = false,
+}: GitDiffFileTreeProps<F>) {
+  const tree = useMemo(
+    () => buildFileTree(files, { compactFolders }),
+    [files, compactFolders]
+  )
+
+  // Folder expand state (full path → expanded). Default: all collapsed.
+  // Stale paths (folders no longer in the tree) are kept on purpose so the
+  // user's expand choice is restored if the folder reappears (e.g. clearing
+  // a search filter that hid it).
+  const [manualExpanded, setManualExpanded] = useState<Set<string>>(
+    () => new Set()
+  )
+
+  // When search is active, every folder is treated as expanded so matches
+  // stay visible. The check is per-row (`isExpandedFolder`) to avoid
+  // building a full path set on every render.
+  const isExpandedFolder = (path: string) =>
+    searchActive || manualExpanded.has(path)
+
+  const toggle = (path: string) =>
+    setManualExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+
+  return (
+    <>
+      {tree.children.map(child => (
+        <TreeRow
+          key={child.type === 'folder' ? `f:${child.fullPath}` : child.file.key}
+          node={child}
+          depth={0}
+          isExpandedFolder={isExpandedFolder}
+          onToggle={toggle}
+          renderFile={renderFile}
+          isMobile={isMobile}
+        />
+      ))}
+    </>
+  )
+}
+
+interface TreeRowProps<F extends FileItem> {
+  node: TreeNode<F>
+  depth: number
+  isExpandedFolder: (path: string) => boolean
+  onToggle: (path: string) => void
+  renderFile: GitDiffFileTreeProps<F>['renderFile']
+  isMobile: boolean
+}
+
+function TreeRow<F extends FileItem>({
+  node,
+  depth,
+  isExpandedFolder,
+  onToggle,
+  renderFile,
+  isMobile,
+}: TreeRowProps<F>) {
+  if (node.type === 'file') {
+    return <>{renderFile(node.file, node.index, depth * INDENT_PX)}</>
+  }
+
+  const isExpanded = isExpandedFolder(node.fullPath)
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => onToggle(node.fullPath)}
+        className={cn(
+          'w-full flex items-center gap-1.5 text-left text-muted-foreground transition-colors hover:bg-muted/50 cursor-pointer',
+          isMobile ? 'py-2 text-sm' : 'py-1.5'
+        )}
+        style={{ paddingLeft: depth * INDENT_PX + 8, paddingRight: 8 }}
+      >
+        <ChevronRight
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 transition-transform duration-150',
+            isExpanded && 'rotate-90'
+          )}
+        />
+        {isExpanded ? (
+          <FolderOpen className="h-[1em] w-[1em] shrink-0" />
+        ) : (
+          <Folder className="h-[1em] w-[1em] shrink-0" />
+        )}
+        <span className="truncate">{node.name}</span>
+      </button>
+      {isExpanded &&
+        node.children.map(child => (
+          <TreeRow
+            key={
+              child.type === 'folder' ? `f:${child.fullPath}` : child.file.key
+            }
+            node={child}
+            depth={depth + 1}
+            isExpandedFolder={isExpandedFolder}
+            onToggle={onToggle}
+            renderFile={renderFile}
+            isMobile={isMobile}
+          />
+        ))}
+    </>
+  )
+}

--- a/src/components/chat/GitDiffFileTree.tsx
+++ b/src/components/chat/GitDiffFileTree.tsx
@@ -13,13 +13,10 @@ interface FileItem {
 interface GitDiffFileTreeProps<F extends FileItem> {
   /** Already-filtered files (search filter is applied by the parent). */
   files: F[]
-  /** Render the row for a single file at the given indent (already includes selection, checkbox, context-menu, tooltip — same UI as list view). */
   renderFile: (file: F, index: number, indentPx: number) => React.ReactNode
-  /** When true (search active), all folders are auto-expanded so matches stay visible. */
+  /** When true, all folders are auto-expanded so search matches stay visible. */
   searchActive: boolean
-  /** Collapse single-child folder chains (VSCode-style). */
   compactFolders?: boolean
-  /** Smaller row height for mobile. */
   isMobile?: boolean
 }
 

--- a/src/components/chat/GitDiffModal.tsx
+++ b/src/components/chat/GitDiffModal.tsx
@@ -25,6 +25,8 @@ import {
   ChevronsUpDown,
   PanelLeft,
   Check,
+  LayoutList,
+  FolderTree,
 } from 'lucide-react'
 import {
   parsePatchFiles,
@@ -84,6 +86,7 @@ import { useUIStore } from '@/store/ui-store'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { usePreferences } from '@/services/preferences'
 import { CommitsTabView } from './CommitsTabView'
+import { GitDiffFileTree } from './GitDiffFileTree'
 import {
   MemoizedFileDiff,
   getStatusColor,
@@ -233,6 +236,8 @@ export function GitDiffModal({
   const isMobile = useIsMobile()
   const { data: preferences } = usePreferences()
   const gitDiffSelectedFiles = useUIStore(state => state.gitDiffSelectedFiles)
+  const gitDiffViewMode = useUIStore(state => state.gitDiffViewMode)
+  const setGitDiffViewMode = useUIStore(state => state.setGitDiffViewMode)
 
   // On mobile, show file sidebar as an overlay panel toggled by a button
   const [showMobileSidebar, setShowMobileSidebar] = useState(false)
@@ -820,6 +825,163 @@ export function GitDiffModal({
       ? 'Uncommitted Changes'
       : `Changes vs ${diffRequest?.baseBranch ?? 'main'}`
 
+  // File-row renderers — shared by both list and tree views.
+  // `indentPx` is added to the base padding so tree depth indents the row.
+  const renderDesktopFileRow = (
+    file: (typeof filteredFiles)[number],
+    index: number,
+    indentPx: number
+  ) => {
+    const isSelected = index === selectedFileIndex
+    const displayName =
+      displayNameMap.get(file.key) ?? getFilename(file.fileName)
+    const isCheckedForCommit =
+      activeDiffType === 'uncommitted' &&
+      gitDiffSelectedFiles.has(file.fileName)
+
+    const fileButton = (
+      <button
+        type="button"
+        data-index={index}
+        onClick={() => handleSelectFile(index)}
+        style={{ paddingLeft: indentPx + 12, paddingRight: 12 }}
+        className={cn(
+          'w-full flex items-center gap-2 py-2 text-left transition-colors',
+          'hover:bg-muted/50',
+          isSelected && 'bg-accent',
+          isCheckedForCommit && !isSelected && 'bg-primary/10'
+        )}
+      >
+        {activeDiffType === 'uncommitted' && (
+          <div
+            role="checkbox"
+            aria-checked={isCheckedForCommit}
+            onClick={e => {
+              e.stopPropagation()
+              useUIStore.getState().toggleGitDiffSelectedFile(file.fileName)
+            }}
+            className={cn(
+              'h-3.5 w-3.5 shrink-0 rounded-sm border flex items-center justify-center transition-colors cursor-pointer',
+              isCheckedForCommit
+                ? 'bg-primary border-primary text-primary-foreground'
+                : 'border-muted-foreground/40 hover:border-muted-foreground'
+            )}
+          >
+            {isCheckedForCommit && <Check className="h-2.5 w-2.5" />}
+          </div>
+        )}
+        <FileText
+          className={cn(
+            'h-[1em] w-[1em] shrink-0',
+            getStatusColor(file.fileDiff.type)
+          )}
+        />
+        <span className="truncate flex-1">{displayName}</span>
+        <div className="flex items-center gap-1 shrink-0">
+          {file.additions > 0 && (
+            <span className="text-green-500">+{file.additions}</span>
+          )}
+          {file.deletions > 0 && (
+            <span className="text-red-500">-{file.deletions}</span>
+          )}
+        </div>
+      </button>
+    )
+
+    return activeDiffType === 'uncommitted' ? (
+      <ContextMenu key={file.key}>
+        <Tooltip>
+          <ContextMenuTrigger asChild>
+            <TooltipTrigger asChild>{fileButton}</TooltipTrigger>
+          </ContextMenuTrigger>
+          <TooltipContent>{file.fileName}</TooltipContent>
+        </Tooltip>
+        <ContextMenuContent className="w-48">
+          <ContextMenuItem
+            variant="destructive"
+            onSelect={() =>
+              setRevertTarget({
+                fileName: file.fileName,
+                fileStatus: diffTypeToStatus(file.fileDiff.type),
+              })
+            }
+          >
+            <Undo2 className="mr-2 h-4 w-4" />
+            Revert File
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    ) : (
+      <Tooltip key={file.key}>
+        <TooltipTrigger asChild>{fileButton}</TooltipTrigger>
+        <TooltipContent>{file.fileName}</TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  const renderMobileFileRow = (
+    file: (typeof filteredFiles)[number],
+    index: number,
+    indentPx: number
+  ) => {
+    const isSelected = index === selectedFileIndex
+    const displayName =
+      displayNameMap.get(file.key) ?? getFilename(file.fileName)
+    const isCheckedForCommit =
+      activeDiffType === 'uncommitted' &&
+      gitDiffSelectedFiles.has(file.fileName)
+
+    return (
+      <button
+        key={file.key}
+        type="button"
+        data-index={index}
+        onClick={() => handleSelectFile(index)}
+        style={{ paddingLeft: indentPx + 12, paddingRight: 12 }}
+        className={cn(
+          'w-full flex items-center gap-2 py-2.5 text-left transition-colors',
+          'hover:bg-muted/50',
+          isSelected && 'bg-accent',
+          isCheckedForCommit && !isSelected && 'bg-primary/10'
+        )}
+      >
+        {activeDiffType === 'uncommitted' && (
+          <div
+            role="checkbox"
+            aria-checked={isCheckedForCommit}
+            onClick={e => {
+              e.stopPropagation()
+              useUIStore.getState().toggleGitDiffSelectedFile(file.fileName)
+            }}
+            className={cn(
+              'h-3.5 w-3.5 shrink-0 rounded-sm border flex items-center justify-center transition-colors cursor-pointer',
+              isCheckedForCommit
+                ? 'bg-primary border-primary text-primary-foreground'
+                : 'border-muted-foreground/40 hover:border-muted-foreground'
+            )}
+          >
+            {isCheckedForCommit && <Check className="h-2.5 w-2.5" />}
+          </div>
+        )}
+        <FileText
+          className={cn(
+            'h-[1em] w-[1em] shrink-0',
+            getStatusColor(file.fileDiff.type)
+          )}
+        />
+        <span className="truncate flex-1 text-sm">{displayName}</span>
+        <div className="flex items-center gap-1 shrink-0 text-xs">
+          {file.additions > 0 && (
+            <span className="text-green-500">+{file.additions}</span>
+          )}
+          {file.deletions > 0 && (
+            <span className="text-red-500">-{file.deletions}</span>
+          )}
+        </div>
+      </button>
+    )
+  }
+
   return (
     <>
       <Dialog open={!!diffRequest} onOpenChange={open => !open && onClose()}>
@@ -1123,93 +1285,41 @@ export function GitDiffModal({
                       <div ref={fileListRef} className="flex-1 overflow-y-auto">
                         {flattenedFiles.length > 0 && (
                           <div className="sticky top-0 z-10 bg-background border-b border-border pb-2">
-                            <div className="relative">
-                              <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-[1em] w-[1em] text-muted-foreground pointer-events-none" />
-                              <input
-                                type="text"
-                                value={fileFilter}
-                                onChange={e => {
-                                  setFileFilter(e.target.value)
-                                  setSelectedFileIndex(0)
-                                }}
-                                placeholder="Filter files..."
-                                className="w-full bg-muted text-base outline-none border border-border pl-7 pr-2 py-2.5 placeholder:text-muted-foreground focus:border-ring md:text-sm"
+                            <div className="flex items-stretch">
+                              <div className="relative flex-1">
+                                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-[1em] w-[1em] text-muted-foreground pointer-events-none" />
+                                <input
+                                  type="text"
+                                  value={fileFilter}
+                                  onChange={e => {
+                                    setFileFilter(e.target.value)
+                                    setSelectedFileIndex(0)
+                                  }}
+                                  placeholder="Filter files..."
+                                  className="w-full bg-muted text-base outline-none border border-border pl-7 pr-2 py-2.5 placeholder:text-muted-foreground focus:border-ring md:text-sm"
+                                />
+                              </div>
+                              <ViewModeToggle
+                                mode={gitDiffViewMode}
+                                onChange={setGitDiffViewMode}
                               />
                             </div>
                           </div>
                         )}
                         <div>
-                          {filteredFiles.map((file, index) => {
-                            const isSelected = index === selectedFileIndex
-                            const displayName =
-                              displayNameMap.get(file.key) ??
-                              getFilename(file.fileName)
-                            const isCheckedForCommit =
-                              activeDiffType === 'uncommitted' &&
-                              gitDiffSelectedFiles.has(file.fileName)
-                            return (
-                              <button
-                                key={file.key}
-                                type="button"
-                                data-index={index}
-                                onClick={() => handleSelectFile(index)}
-                                className={cn(
-                                  'w-full flex items-center gap-2 px-3 py-2.5 text-left transition-colors',
-                                  'hover:bg-muted/50',
-                                  isSelected && 'bg-accent',
-                                  isCheckedForCommit &&
-                                    !isSelected &&
-                                    'bg-primary/10'
-                                )}
-                              >
-                                {activeDiffType === 'uncommitted' && (
-                                  <div
-                                    role="checkbox"
-                                    aria-checked={isCheckedForCommit}
-                                    onClick={e => {
-                                      e.stopPropagation()
-                                      useUIStore
-                                        .getState()
-                                        .toggleGitDiffSelectedFile(
-                                          file.fileName
-                                        )
-                                    }}
-                                    className={cn(
-                                      'h-3.5 w-3.5 shrink-0 rounded-sm border flex items-center justify-center transition-colors cursor-pointer',
-                                      isCheckedForCommit
-                                        ? 'bg-primary border-primary text-primary-foreground'
-                                        : 'border-muted-foreground/40 hover:border-muted-foreground'
-                                    )}
-                                  >
-                                    {isCheckedForCommit && (
-                                      <Check className="h-2.5 w-2.5" />
-                                    )}
-                                  </div>
-                                )}
-                                <FileText
-                                  className={cn(
-                                    'h-[1em] w-[1em] shrink-0',
-                                    getStatusColor(file.fileDiff.type)
-                                  )}
-                                />
-                                <span className="truncate flex-1 text-sm">
-                                  {displayName}
-                                </span>
-                                <div className="flex items-center gap-1 shrink-0 text-xs">
-                                  {file.additions > 0 && (
-                                    <span className="text-green-500">
-                                      +{file.additions}
-                                    </span>
-                                  )}
-                                  {file.deletions > 0 && (
-                                    <span className="text-red-500">
-                                      -{file.deletions}
-                                    </span>
-                                  )}
-                                </div>
-                              </button>
+                          {gitDiffViewMode === 'tree' ? (
+                            <GitDiffFileTree
+                              files={filteredFiles}
+                              renderFile={renderMobileFileRow}
+                              searchActive={fileFilter.length > 0}
+                              compactFolders
+                              isMobile
+                            />
+                          ) : (
+                            filteredFiles.map((file, index) =>
+                              renderMobileFileRow(file, index, 0)
                             )
-                          })}
+                          )}
                         </div>
                       </div>
                     </div>
@@ -1308,134 +1418,40 @@ export function GitDiffModal({
                         >
                           {flattenedFiles.length > 0 && (
                             <div className="sticky top-0 z-10 bg-background border-b border-border pb-2">
-                              <div className="relative">
-                                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-[1em] w-[1em] text-muted-foreground pointer-events-none" />
-                                <input
-                                  type="text"
-                                  value={fileFilter}
-                                  onChange={e => {
-                                    setFileFilter(e.target.value)
-                                    setSelectedFileIndex(0)
-                                  }}
-                                  placeholder="Filter files..."
-                                  className="w-full bg-muted text-base outline-none border border-border pl-7 pr-2 py-2.5 placeholder:text-muted-foreground focus:border-ring md:text-sm"
+                              <div className="flex items-center gap-1">
+                                <div className="relative flex-1">
+                                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-[1em] w-[1em] text-muted-foreground pointer-events-none" />
+                                  <input
+                                    type="text"
+                                    value={fileFilter}
+                                    onChange={e => {
+                                      setFileFilter(e.target.value)
+                                      setSelectedFileIndex(0)
+                                    }}
+                                    placeholder="Filter files..."
+                                    className="w-full bg-muted text-base outline-none border border-border pl-7 pr-2 py-2.5 placeholder:text-muted-foreground focus:border-ring md:text-sm"
+                                  />
+                                </div>
+                                <ViewModeToggle
+                                  mode={gitDiffViewMode}
+                                  onChange={setGitDiffViewMode}
                                 />
                               </div>
                             </div>
                           )}
                           <div>
-                            {filteredFiles.map((file, index) => {
-                              const isSelected = index === selectedFileIndex
-                              const displayName =
-                                displayNameMap.get(file.key) ??
-                                getFilename(file.fileName)
-
-                              const isCheckedForCommit =
-                                activeDiffType === 'uncommitted' &&
-                                gitDiffSelectedFiles.has(file.fileName)
-
-                              const fileButton = (
-                                <button
-                                  type="button"
-                                  data-index={index}
-                                  onClick={() => handleSelectFile(index)}
-                                  className={cn(
-                                    'w-full flex items-center gap-2 px-3 py-2 text-left transition-colors',
-                                    'hover:bg-muted/50',
-                                    isSelected && 'bg-accent',
-                                    isCheckedForCommit &&
-                                      !isSelected &&
-                                      'bg-primary/10'
-                                  )}
-                                >
-                                  {activeDiffType === 'uncommitted' && (
-                                    <div
-                                      role="checkbox"
-                                      aria-checked={isCheckedForCommit}
-                                      onClick={e => {
-                                        e.stopPropagation()
-                                        useUIStore
-                                          .getState()
-                                          .toggleGitDiffSelectedFile(
-                                            file.fileName
-                                          )
-                                      }}
-                                      className={cn(
-                                        'h-3.5 w-3.5 shrink-0 rounded-sm border flex items-center justify-center transition-colors cursor-pointer',
-                                        isCheckedForCommit
-                                          ? 'bg-primary border-primary text-primary-foreground'
-                                          : 'border-muted-foreground/40 hover:border-muted-foreground'
-                                      )}
-                                    >
-                                      {isCheckedForCommit && (
-                                        <Check className="h-2.5 w-2.5" />
-                                      )}
-                                    </div>
-                                  )}
-                                  <FileText
-                                    className={cn(
-                                      'h-[1em] w-[1em] shrink-0',
-                                      getStatusColor(file.fileDiff.type)
-                                    )}
-                                  />
-                                  <span className="truncate flex-1">
-                                    {displayName}
-                                  </span>
-                                  <div className="flex items-center gap-1 shrink-0">
-                                    {file.additions > 0 && (
-                                      <span className="text-green-500">
-                                        +{file.additions}
-                                      </span>
-                                    )}
-                                    {file.deletions > 0 && (
-                                      <span className="text-red-500">
-                                        -{file.deletions}
-                                      </span>
-                                    )}
-                                  </div>
-                                </button>
+                            {gitDiffViewMode === 'tree' ? (
+                              <GitDiffFileTree
+                                files={filteredFiles}
+                                renderFile={renderDesktopFileRow}
+                                searchActive={fileFilter.length > 0}
+                                compactFolders
+                              />
+                            ) : (
+                              filteredFiles.map((file, index) =>
+                                renderDesktopFileRow(file, index, 0)
                               )
-
-                              return activeDiffType === 'uncommitted' ? (
-                                <ContextMenu key={file.key}>
-                                  <Tooltip>
-                                    <ContextMenuTrigger asChild>
-                                      <TooltipTrigger asChild>
-                                        {fileButton}
-                                      </TooltipTrigger>
-                                    </ContextMenuTrigger>
-                                    <TooltipContent>
-                                      {file.fileName}
-                                    </TooltipContent>
-                                  </Tooltip>
-                                  <ContextMenuContent className="w-48">
-                                    <ContextMenuItem
-                                      variant="destructive"
-                                      onSelect={() =>
-                                        setRevertTarget({
-                                          fileName: file.fileName,
-                                          fileStatus: diffTypeToStatus(
-                                            file.fileDiff.type
-                                          ),
-                                        })
-                                      }
-                                    >
-                                      <Undo2 className="mr-2 h-4 w-4" />
-                                      Revert File
-                                    </ContextMenuItem>
-                                  </ContextMenuContent>
-                                </ContextMenu>
-                              ) : (
-                                <Tooltip key={file.key}>
-                                  <TooltipTrigger asChild>
-                                    {fileButton}
-                                  </TooltipTrigger>
-                                  <TooltipContent>
-                                    {file.fileName}
-                                  </TooltipContent>
-                                </Tooltip>
-                              )
-                            })}
+                            )}
                           </div>
                         </div>
                       </ResizablePanel>
@@ -1544,5 +1560,37 @@ export function GitDiffModal({
         </AlertDialogContent>
       </AlertDialog>
     </>
+  )
+}
+
+interface ViewModeToggleProps {
+  mode: 'list' | 'tree'
+  onChange: (mode: 'list' | 'tree') => void
+}
+
+/** Compact list ↔ tree toggle for the GitDiffModal sidebar. */
+function ViewModeToggle({ mode, onChange }: ViewModeToggleProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={() => onChange(mode === 'list' ? 'tree' : 'list')}
+          aria-label={
+            mode === 'list' ? 'Switch to tree view' : 'Switch to list view'
+          }
+          className="flex shrink-0 items-center justify-center self-stretch border border-border border-l-0 bg-muted px-2.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground cursor-pointer"
+        >
+          {mode === 'list' ? (
+            <FolderTree className="h-4 w-4" />
+          ) : (
+            <LayoutList className="h-4 w-4" />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {mode === 'list' ? 'Switch to tree view' : 'Switch to list view'}
+      </TooltipContent>
+    </Tooltip>
   )
 }

--- a/src/components/chat/git-diff-tree.test.ts
+++ b/src/components/chat/git-diff-tree.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import { buildFileTree, type FolderNode, type TreeNode } from './git-diff-tree'
+
+interface TestFile {
+  fileName: string
+}
+
+const mk = (...names: string[]): TestFile[] => names.map(fileName => ({ fileName }))
+
+/** Find a child folder by name in a folder node. */
+function folder<F>(node: FolderNode<F>, name: string): FolderNode<F> {
+  const child = node.children.find(
+    (c): c is FolderNode<F> => c.type === 'folder' && c.name === name
+  )
+  if (!child) throw new Error(`Folder '${name}' not found in '${node.fullPath}'`)
+  return child
+}
+
+/** Get the names of all children in order. */
+const childNames = <F>(node: FolderNode<F>) =>
+  node.children.map((c: TreeNode<F>) => c.name)
+
+describe('buildFileTree', () => {
+  it('returns an empty root when there are no files', () => {
+    const tree = buildFileTree([])
+    expect(tree.type).toBe('folder')
+    expect(tree.children).toEqual([])
+  })
+
+  it('preserves the original file index on each leaf (used for selection)', () => {
+    const tree = buildFileTree(mk('a.ts', 'b.ts', 'c.ts'))
+    const indexes = tree.children.map(c =>
+      c.type === 'file' ? c.index : -1
+    )
+    // children are alphabetically sorted, so order matches input here
+    expect(indexes).toEqual([0, 1, 2])
+  })
+
+  it('places top-level files directly under the root', () => {
+    const tree = buildFileTree(mk('README.md'))
+    expect(tree.children).toHaveLength(1)
+    const child = tree.children[0]
+    expect(child?.type).toBe('file')
+    if (child?.type === 'file') {
+      expect(child.name).toBe('README.md')
+      expect(child.fullPath).toBe('README.md')
+    }
+  })
+
+  it('normalizes Windows backslashes to forward slashes', () => {
+    const tree = buildFileTree(mk('src\\components\\foo.ts'))
+    const src = folder(tree, 'src')
+    const components = folder(src, 'components')
+    expect(components.children).toHaveLength(1)
+    const file = components.children[0]
+    expect(file?.type).toBe('file')
+    if (file?.type === 'file') expect(file.name).toBe('foo.ts')
+  })
+
+  it('sorts folders before files, both alphabetical', () => {
+    const tree = buildFileTree(
+      mk('z.ts', 'a.ts', 'src/x.ts', 'lib/y.ts')
+    )
+    expect(childNames(tree)).toEqual(['lib', 'src', 'a.ts', 'z.ts'])
+  })
+
+  it('groups files into the right folders', () => {
+    const tree = buildFileTree(
+      mk('src/a.ts', 'src/b.ts', 'docs/README.md')
+    )
+    expect(folder(tree, 'src').children).toHaveLength(2)
+    expect(folder(tree, 'docs').children).toHaveLength(1)
+  })
+})
+
+describe('compactFolders option', () => {
+  it('collapses single-child folder chains when enabled', () => {
+    const tree = buildFileTree(mk('src/components/ui/button.tsx'), {
+      compactFolders: true,
+    })
+    expect(tree.children).toHaveLength(1)
+    const collapsed = tree.children[0]
+    expect(collapsed?.type).toBe('folder')
+    if (collapsed?.type === 'folder') {
+      expect(collapsed.name).toBe('src/components/ui')
+      expect(collapsed.children).toHaveLength(1)
+      const file = collapsed.children[0]
+      if (file?.type === 'file') expect(file.name).toBe('button.tsx')
+    }
+  })
+
+  it('does not collapse when a folder has multiple children', () => {
+    const tree = buildFileTree(
+      mk('src/components/a.ts', 'src/components/b.ts'),
+      { compactFolders: true }
+    )
+    // src/components has two files, so the chain stops at "src/components"
+    const collapsed = folder(tree, 'src/components')
+    expect(collapsed.children).toHaveLength(2)
+  })
+
+  it('stops collapsing when a folder has both a sub-folder and a file', () => {
+    const tree = buildFileTree(
+      mk('src/components/ui/button.tsx', 'src/components/index.ts'),
+      { compactFolders: true }
+    )
+    const components = folder(tree, 'src/components')
+    expect(childNames(components)).toEqual(['ui', 'index.ts'])
+  })
+
+  it('never merges into the root (top-level entries stay separate)', () => {
+    const tree = buildFileTree(
+      mk('src/foo/bar.ts', 'docs/readme.md'),
+      { compactFolders: true }
+    )
+    // Two top-level entries: src/foo and docs (each compacted internally)
+    expect(tree.children).toHaveLength(2)
+    expect(childNames(tree).sort()).toEqual(['docs', 'src/foo'])
+  })
+
+  it('leaves the tree unchanged when compactFolders is omitted', () => {
+    const tree = buildFileTree(mk('src/components/ui/button.tsx'))
+    // Without compaction, each segment is its own folder node
+    const src = folder(tree, 'src')
+    const components = folder(src, 'components')
+    const ui = folder(components, 'ui')
+    expect(ui.children).toHaveLength(1)
+  })
+})

--- a/src/components/chat/git-diff-tree.ts
+++ b/src/components/chat/git-diff-tree.ts
@@ -7,21 +7,17 @@ export interface FolderNode<F> {
   type: 'folder'
   /** Display segment(s) for this folder. With compaction, may contain '/'. */
   name: string
-  /** Full path from the root, used as a stable key for expand/collapse state. */
+  /** Stable key for expand/collapse state. */
   fullPath: string
-  /** Sorted children: folders first, then files, both alphabetical. */
   children: TreeNode<F>[]
 }
 
 export interface FileNode<F> {
   type: 'file'
-  /** Filename only (last segment). */
   name: string
-  /** Full path from the root (matches the input fileName). */
   fullPath: string
   /** Original index in the input list — needed by callers to keep selection in sync. */
   index: number
-  /** The original file payload. */
   file: F
 }
 
@@ -78,7 +74,6 @@ export function buildFileTree<F extends { fileName: string }>(
   return root
 }
 
-/** Sort each folder: folders first (alpha), then files (alpha). Recursive. */
 function sortTree<F>(node: FolderNode<F>) {
   node.children.sort((a, b) => {
     if (a.type !== b.type) return a.type === 'folder' ? -1 : 1
@@ -98,8 +93,6 @@ function compactTree<F>(node: FolderNode<F>) {
   for (const child of node.children) {
     if (child.type === 'folder') compactTree(child)
   }
-  // Compact this folder's direct children: while a child folder has exactly one
-  // grandchild that is also a folder, merge them into the child.
   for (const child of node.children) {
     if (child.type !== 'folder') continue
     let inner = child.children[0]

--- a/src/components/chat/git-diff-tree.ts
+++ b/src/components/chat/git-diff-tree.ts
@@ -1,0 +1,118 @@
+import { normalizePath } from '@/lib/path-utils'
+
+/** A node in the git diff file tree — either a folder or a leaf file. */
+export type TreeNode<F> = FolderNode<F> | FileNode<F>
+
+export interface FolderNode<F> {
+  type: 'folder'
+  /** Display segment(s) for this folder. With compaction, may contain '/'. */
+  name: string
+  /** Full path from the root, used as a stable key for expand/collapse state. */
+  fullPath: string
+  /** Sorted children: folders first, then files, both alphabetical. */
+  children: TreeNode<F>[]
+}
+
+export interface FileNode<F> {
+  type: 'file'
+  /** Filename only (last segment). */
+  name: string
+  /** Full path from the root (matches the input fileName). */
+  fullPath: string
+  /** Original index in the input list — needed by callers to keep selection in sync. */
+  index: number
+  /** The original file payload. */
+  file: F
+}
+
+interface BuildOptions {
+  /** Collapse folders that contain only a single sub-folder into one row (VSCode-style). */
+  compactFolders?: boolean
+}
+
+/**
+ * Build a tree from a flat list of files identified by `fileName` (forward-slash path).
+ * The original index is preserved on each leaf so callers can keep their selection.
+ */
+export function buildFileTree<F extends { fileName: string }>(
+  files: F[],
+  options: BuildOptions = {}
+): FolderNode<F> {
+  const root: FolderNode<F> = {
+    type: 'folder',
+    name: '',
+    fullPath: '',
+    children: [],
+  }
+
+  files.forEach((file, index) => {
+    const segments = normalizePath(file.fileName).split('/').filter(Boolean)
+    const fileName = segments.pop()
+    if (!fileName) return
+
+    let currentFolder = root
+    let path = ''
+    for (const segment of segments) {
+      path = path ? `${path}/${segment}` : segment
+      let next = currentFolder.children.find(
+        (c): c is FolderNode<F> => c.type === 'folder' && c.fullPath === path
+      )
+      if (!next) {
+        next = { type: 'folder', name: segment, fullPath: path, children: [] }
+        currentFolder.children.push(next)
+      }
+      currentFolder = next
+    }
+
+    currentFolder.children.push({
+      type: 'file',
+      name: fileName,
+      fullPath: file.fileName,
+      index,
+      file,
+    })
+  })
+
+  sortTree(root)
+  if (options.compactFolders) compactTree(root)
+  return root
+}
+
+/** Sort each folder: folders first (alpha), then files (alpha). Recursive. */
+function sortTree<F>(node: FolderNode<F>) {
+  node.children.sort((a, b) => {
+    if (a.type !== b.type) return a.type === 'folder' ? -1 : 1
+    return a.name.localeCompare(b.name)
+  })
+  for (const child of node.children) {
+    if (child.type === 'folder') sortTree(child)
+  }
+}
+
+/**
+ * Collapse single-child folder chains into a combined row, like VSCode "compact folders".
+ * Example: src → components → ui → button.tsx becomes "src/components/ui" + button.tsx.
+ * Never merges into the root; the root keeps each top-level entry separate.
+ */
+function compactTree<F>(node: FolderNode<F>) {
+  for (const child of node.children) {
+    if (child.type === 'folder') compactTree(child)
+  }
+  // Compact this folder's direct children: while a child folder has exactly one
+  // grandchild that is also a folder, merge them into the child.
+  for (const child of node.children) {
+    if (child.type !== 'folder') continue
+    let inner = child.children[0]
+    while (
+      child.children.length === 1 &&
+      inner &&
+      inner.type === 'folder'
+    ) {
+      child.name = `${child.name}/${inner.name}`
+      child.fullPath = inner.fullPath
+      child.children = inner.children
+      inner = child.children[0]
+    }
+  }
+}
+

--- a/src/hooks/useUIStatePersistence.ts
+++ b/src/hooks/useUIStatePersistence.ts
@@ -88,7 +88,8 @@ export function useUIStatePersistence() {
       dashboardWorktreeCollapseOverrides,
       projectCanvasSettings,
     } = useProjectsStore.getState()
-    const { leftSidebarSize, leftSidebarVisible } = useUIStore.getState()
+    const { leftSidebarSize, leftSidebarVisible, gitDiffViewMode } =
+      useUIStore.getState()
     const {
       modalTerminalOpen,
       modalTerminalDockMode,
@@ -153,6 +154,8 @@ export function useUIStatePersistence() {
           { worktree_id: entry.worktreeId, session_id: entry.sessionId },
         ])
       ),
+      // Git diff modal view mode
+      git_diff_view_mode: gitDiffViewMode,
       version: 1, // Reset for first release
     }
   }, [])
@@ -225,6 +228,14 @@ export function useUIStatePersistence() {
         visible: uiState.left_sidebar_visible,
       })
       useUIStore.getState().setLeftSidebarVisible(uiState.left_sidebar_visible)
+    }
+
+    // Restore git diff view mode
+    if (
+      uiState.git_diff_view_mode === 'list' ||
+      uiState.git_diff_view_mode === 'tree'
+    ) {
+      useUIStore.getState().setGitDiffViewMode(uiState.git_diff_view_mode)
     }
 
     // Restore active project first (selectProject clears selectedWorktreeId)
@@ -537,6 +548,7 @@ export function useUIStatePersistence() {
       useProjectsStore.getState().projectCanvasSettings
     let prevLeftSidebarSize = useUIStore.getState().leftSidebarSize
     let prevLeftSidebarVisible = useUIStore.getState().leftSidebarVisible
+    let prevGitDiffViewMode = useUIStore.getState().gitDiffViewMode
     let prevWorktreeId = useChatStore.getState().activeWorktreeId
     let prevWorktreePath = useChatStore.getState().activeWorktreePath
     let prevLastActiveWorktreeId = useChatStore.getState().lastActiveWorktreeId
@@ -599,15 +611,18 @@ export function useUIStatePersistence() {
       }
     })
 
-    // Subscribe to ui-store changes (sidebar size and visibility)
+    // Subscribe to ui-store changes (sidebar size, visibility, and git diff view mode)
     const unsubUI = useUIStore.subscribe(state => {
       const sizeChanged = state.leftSidebarSize !== prevLeftSidebarSize
       const visibilityChanged =
         state.leftSidebarVisible !== prevLeftSidebarVisible
+      const gitDiffViewModeChanged =
+        state.gitDiffViewMode !== prevGitDiffViewMode
 
-      if (sizeChanged || visibilityChanged) {
+      if (sizeChanged || visibilityChanged || gitDiffViewModeChanged) {
         prevLeftSidebarSize = state.leftSidebarSize
         prevLeftSidebarVisible = state.leftSidebarVisible
+        prevGitDiffViewMode = state.gitDiffViewMode
         const currentState = getCurrentUIState()
         debouncedSaveRef.current?.(currentState)
       }

--- a/src/store/ui-store.ts
+++ b/src/store/ui-store.ts
@@ -86,6 +86,8 @@ interface UIState {
   gitDiffModalOpen: boolean
   /** File paths selected for commit in GitDiffModal (uncommitted tab only) */
   gitDiffSelectedFiles: Set<string>
+  /** Git diff modal sidebar file list view mode (persisted across sessions) */
+  gitDiffViewMode: 'list' | 'tree'
   /** Whether a plan dialog is open (blocks canvas approve keybindings) */
   planDialogOpen: boolean
   /** Whether the context viewer dialog is open (blocks SessionChatModal ESC close) */
@@ -167,6 +169,7 @@ interface UIState {
   setGitDiffModalOpen: (open: boolean) => void
   toggleGitDiffSelectedFile: (filePath: string) => void
   clearGitDiffSelectedFiles: () => void
+  setGitDiffViewMode: (mode: 'list' | 'tree') => void
   setPlanDialogOpen: (open: boolean) => void
   setContextViewerOpen: (open: boolean) => void
   setFeatureTourOpen: (open: boolean) => void
@@ -235,6 +238,7 @@ export const useUIStore = create<UIState>()(
       chatToolbarMounted: false,
       gitDiffModalOpen: false,
       gitDiffSelectedFiles: new Set<string>(),
+      gitDiffViewMode: 'list',
       planDialogOpen: false,
       contextViewerOpen: false,
       featureTourOpen: false,
@@ -694,6 +698,16 @@ export const useUIStore = create<UIState>()(
           },
           undefined,
           'clearGitDiffSelectedFiles'
+        ),
+
+      setGitDiffViewMode: (mode: 'list' | 'tree') =>
+        set(
+          state => {
+            if (state.gitDiffViewMode === mode) return state
+            return { gitDiffViewMode: mode }
+          },
+          undefined,
+          'setGitDiffViewMode'
         ),
 
       setPlanDialogOpen: (open: boolean) =>

--- a/src/types/ui-state.ts
+++ b/src/types/ui-state.ts
@@ -79,6 +79,8 @@ export interface UIState {
     string,
     { worktree_id: string; session_id: string }
   >
+  /** Git diff modal file list view mode */
+  git_diff_view_mode?: 'list' | 'tree'
   version: number
 }
 
@@ -108,5 +110,6 @@ export const defaultUIState: UIState = {
   browser_modal_height: 400,
   browser_bottom_panel_open: {},
   browser_bottom_panel_height: 360,
+  git_diff_view_mode: 'list',
   version: 1,
 }


### PR DESCRIPTION
## Summary

The GitDiffModal sidebar shows files as a flat list. When I have many changes spread across nested folders, the sidebar gets visually busy and it's hard to scan by area. VSCode's git panel has a list ↔ tree toggle for exactly this (and I do rlly enjoy it) adding the same here so i can adapt Jean as my only to go and no need to open vscode again :) .

<img width="708" height="427" alt="image" src="https://github.com/user-attachments/assets/3eb29901-fa63-40d1-9fd6-253e68cd44a0" />

<img width="630" height="589" alt="image" src="https://github.com/user-attachments/assets/f67e5be5-e006-4d6e-8107-f5991a0f8161" />


## Implementation

- New helper `src/components/chat/git-diff-tree.ts` builds a hierarchical tree from the existing flat `flattenedFiles` array. Includes a "compact folders" pass that collapses single-child folder chains (e.g. `src/components/ui/` shown as one row instead of three).
- New component `src/components/chat/GitDiffFileTree.tsx` renders the tree recursively with `Folder` / `FolderOpen` / chevron icons. Per-folder expand state is local; when the search filter is active, all folders auto-expand so matches stay visible, and they collapse back when the filter clears.
- `GitDiffModal.tsx`: small list ↔ tree toggle next to the filter input (`LayoutList` / `FolderTree` icons), styled to look like an extension of the input. Extracted the existing inline `.map()` row JSX into `renderDesktopFileRow` / `renderMobileFileRow` helpers shared between list and tree modes (same selection, checkboxes, context menu and tooltip behavior). Tree mode just adds left padding per depth.

## Persistence

The view mode persists across sessions via the existing `UIState` infrastructure (so users don't re-toggle every time the modal opens):

- `src/types/ui-state.ts` — `git_diff_view_mode?: 'list' | 'tree'`
- `src-tauri/src/lib.rs` — matching `Option<String>` field on the Rust `UIState` struct
- `src/store/ui-store.ts` — `gitDiffViewMode` + `setGitDiffViewMode` setter
- `src/hooks/useUIStatePersistence.ts` — extract on save, restore on load, subscribe for changes

Default is `list` so existing users see no change unless they toggle.

## Tests

Added `src/components/chat/git-diff-tree.test.ts` with 11 unit tests covering the tree builder (`buildFileTree`):

- Empty input → empty root
- Original file index preserved on each leaf (used by selection)
- Top-level files placed directly under root
- Windows backslashes normalized to `/`
- Sort order: folders before files, both alphabetical
- Files grouped under the right folders
- `compactFolders`: collapses single-child folder chains
- `compactFolders`: stops collapsing on multiple children
- `compactFolders`: stops on mixed sub-folder + file
- `compactFolders`: never merges into the root (top-level entries stay separate)
- `compactFolders` omitted → tree left unchanged

Also ran the existing test suite for components that touch `useUIStore` (`PreferencesDialog.test.tsx`). 4/4 pass.

## To test

- [ ] Open the git diff modal in a worktree with several changed files across folders.
- [ ] See the new toggle next to the "Filter files..." input — `FolderTree` icon when in list mode, `LayoutList` when in tree mode.
- [ ] Click toggle → switches to tree view, single-child folder chains are compacted (e.g. `src/components/ui` as one row instead of three).
- [ ] Click a folder row → expands/collapses without changing file selection.
- [ ] Selecting a file in tree view works the same as in list view (diff panel updates).
- [ ] In the `uncommitted` tab: checkboxes for commit selection still work in tree mode; right-click "Revert File" still works.
- [ ] Type in the filter input → all folders auto-expand so matching files stay visible. Clear the filter → folders return to their previous expand state.
- [ ] Close and re-open the modal (or restart the app) → the chosen view mode persists.
- [ ] Mobile (resize window < 768px): toggle is also visible, tree renders with adjusted padding.