### PR TITLE
feat(models): add Claude Opus 4.7 1M context window variant

### DIFF
--- a/src/components/chat/ChatToolbar.tsx
+++ b/src/components/chat/ChatToolbar.tsx
@@ -219,15 +219,17 @@ export const ChatToolbar = memo(function ChatToolbar({
     (value: string) => {
       const provider = value === 'default' ? null : value
       onProviderChange(provider)
-      if (
-        provider &&
-        provider !== '__anthropic__' &&
-        (selectedModel === 'claude-opus-4-6[1m]' ||
+      if (provider && provider !== '__anthropic__') {
+        if (selectedModel === 'claude-opus-4-7[1m]') {
+          onModelChange('claude-opus-4-7' as ClaudeModel)
+        } else if (
+          selectedModel === 'claude-opus-4-6[1m]' ||
           selectedModel === 'claude-sonnet-4-6[1m]' ||
           selectedModel === 'claude-opus-4-6-fast' ||
-          selectedModel === 'claude-opus-4-6[1m]-fast')
-      ) {
-        onModelChange('claude-opus-4-6' as ClaudeModel)
+          selectedModel === 'claude-opus-4-6[1m]-fast'
+        ) {
+          onModelChange('claude-opus-4-6' as ClaudeModel)
+        }
       }
     },
     [onProviderChange, onModelChange, selectedModel]

--- a/src/components/chat/toolbar/toolbar-options.ts
+++ b/src/components/chat/toolbar/toolbar-options.ts
@@ -3,6 +3,7 @@ import type { EffortLevel, ThinkingLevel } from '@/types/chat'
 
 export const MODEL_OPTIONS: { value: ClaudeModel; label: string }[] = [
   { value: 'claude-opus-4-7', label: 'Opus 4.7' },
+  { value: 'claude-opus-4-7[1m]', label: 'Opus 4.7 (1M)' },
   { value: 'claude-opus-4-6', label: 'Opus 4.6' },
   { value: 'claude-opus-4-5-20251101', label: 'Opus 4.5' },
   { value: 'claude-opus-4-6[1m]', label: 'Opus 4.6 (1M)' },

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1076,6 +1076,7 @@ export const fileEditModeOptions: { value: FileEditMode; label: string }[] = [
 
 export type ClaudeModel =
   | 'claude-opus-4-7'
+  | 'claude-opus-4-7[1m]'
   | 'claude-opus-4-6'
   | 'claude-opus-4-5-20251101'
   | 'claude-opus-4-6[1m]'
@@ -1088,6 +1089,7 @@ export type ClaudeModel =
 
 export const modelOptions: { value: ClaudeModel; label: string }[] = [
   { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
+  { value: 'claude-opus-4-7[1m]', label: 'Claude Opus 4.7 (1M)' },
   { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
   { value: 'claude-opus-4-5-20251101', label: 'Claude Opus 4.5' },
   { value: 'claude-opus-4-6[1m]', label: 'Claude Opus 4.6 (1M)' },


### PR DESCRIPTION
## Summary

- Add `claude-opus-4-7[1m]` to `ClaudeModel` type in `preferences.ts`
- Add `claude-opus-4-7[1m]` to `modelOptions` and `MODEL_OPTIONS` arrays
- Fix provider change handler in `ChatToolbar.tsx` to fall back to `claude-opus-4-7` (non-1M) when switching away from Anthropic while `claude-opus-4-7[1m]` is selected

Closes #341


---

Fixes #341