### PR TITLE
fix(errors): prevent UI crash on unhandled rejections and null session data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -419,6 +419,60 @@ function App() {
       })
   }, [queryClient, seedCache])
 
+  // Global safety net for uncaught async errors / promise rejections.
+  // Without this, a thrown invoke() (e.g. auth/network failure) can leave the
+  // app in a half-broken state until the next ErrorBoundary catches it.
+  useEffect(() => {
+    const truncate = (s: string, n: number) =>
+      s.length > n ? `${s.slice(0, n)}…` : s
+
+    const isAlreadySurfacedAuthError = (msg: string): boolean => {
+      const lower = msg.toLowerCase()
+      return (
+        lower.includes('not authenticated') ||
+        lower.includes('unauthorized') ||
+        lower.includes('connection failed')
+      )
+    }
+
+    const handleRejection = (event: PromiseRejectionEvent) => {
+      const reason = event.reason
+      const message =
+        reason instanceof Error
+          ? reason.message
+          : typeof reason === 'string'
+            ? reason
+            : 'Unknown error'
+      logger.error('Unhandled promise rejection', {
+        message,
+        stack: reason instanceof Error ? reason.stack : undefined,
+      })
+      if (!isAlreadySurfacedAuthError(message)) {
+        toast.error(`Unexpected error: ${truncate(message, 200)}`)
+      }
+      event.preventDefault()
+    }
+
+    const handleError = (event: ErrorEvent) => {
+      const message = event.error?.message ?? event.message ?? 'Unknown error'
+      logger.error('Uncaught window error', {
+        message,
+        stack: event.error?.stack,
+        filename: event.filename,
+      })
+      if (!isAlreadySurfacedAuthError(message)) {
+        toast.error(`Unexpected error: ${truncate(message, 200)}`)
+      }
+    }
+
+    window.addEventListener('unhandledrejection', handleRejection)
+    window.addEventListener('error', handleError)
+    return () => {
+      window.removeEventListener('unhandledrejection', handleRejection)
+      window.removeEventListener('error', handleError)
+    }
+  }, [])
+
   // Apply font settings from preferences
   useFontSettings()
 

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -379,6 +379,7 @@ export function ChatWindow({
     const store = useChatStore.getState()
     const currentActive = store.activeSessionIds[activeWorktreeId]
     const sessions = sessionsData.sessions
+    if (!sessions) return
     const firstSession = sessions[0]
 
     // If no active session in store, or it doesn't exist in loaded sessions
@@ -392,7 +393,7 @@ export function ChatWindow({
   }, [sessionsData, activeWorktreeId, isSessionsFetching, uiStateInitialized])
 
   // Use backend's active session if store doesn't have one yet
-  if (!activeSessionId && sessionsData?.sessions.length) {
+  if (!activeSessionId && sessionsData?.sessions?.length) {
     activeSessionId =
       sessionsData.active_session_id ?? sessionsData.sessions[0]?.id
   }
@@ -2248,6 +2249,7 @@ export function ChatWindow({
 
   return (
     <ErrorBoundary
+      resetKeys={[activeWorktreeId]}
       onError={(error, errorInfo) => {
         logger.error('ChatWindow crashed', {
           error: error.message,

--- a/src/components/chat/toolbar/DockBurgerButton.tsx
+++ b/src/components/chat/toolbar/DockBurgerButton.tsx
@@ -132,7 +132,7 @@ export function DockBurgerButton({
         ...chatQueryKeys.sessions(worktreeId),
         'with-counts',
       ])
-    const session = cached?.sessions.find(s => s.id === sessionId)
+    const session = cached?.sessions?.find(s => s.id === sessionId)
     return session ? getResumeCommand(session) : null
   }, [queryClient])
 

--- a/src/components/projects/WorktreeDropdownMenu.tsx
+++ b/src/components/projects/WorktreeDropdownMenu.tsx
@@ -129,7 +129,7 @@ export function WorktreeDropdownMenu({
     (alerts?.length ?? 0) +
     (advisories?.filter(a => a.state === 'draft' || a.state === 'triage')
       .length ?? 0)
-  const workflowRunCount = workflowRuns?.runs.length ?? 0
+  const workflowRunCount = workflowRuns?.runs?.length ?? 0
   const failedWorkflowCount = workflowRuns?.failedCount ?? 0
   const isMobile = useIsMobile()
   const hasDiff = uncommittedAdded > 0 || uncommittedRemoved > 0

--- a/src/components/shared/FailedRunsBadge.tsx
+++ b/src/components/shared/FailedRunsBadge.tsx
@@ -34,7 +34,7 @@ export function FailedRunsBadge({
     staleTime: BADGE_STALE_TIME,
   })
 
-  const totalRuns = result?.runs.length ?? 0
+  const totalRuns = result?.runs?.length ?? 0
   const failedCount = result?.failedCount ?? 0
 
   const handleClick = useCallback(

--- a/src/components/shared/WorkflowRunsModal.tsx
+++ b/src/components/shared/WorkflowRunsModal.tsx
@@ -515,7 +515,7 @@ export function WorkflowRunsModal() {
         // Ignore — we'll create a new session below
       }
 
-      const emptySession = existingSessions?.sessions.find(
+      const emptySession = existingSessions?.sessions?.find(
         s =>
           !s.archived_at && (s.message_count === 0 || s.message_count == null)
       )

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -10,11 +10,28 @@ interface Props {
     resetErrorBoundary: () => void
   }) => ReactNode
   onError?: (error: Error, errorInfo: React.ErrorInfo) => void
+  /**
+   * When any value in this array changes (Object.is comparison), the boundary
+   * auto-resets if it is currently in the error state. Lets parents recover
+   * from a render crash by changing identity (e.g. tab id) without forcing a
+   * full remount of the children.
+   */
+  resetKeys?: unknown[]
 }
 
 interface State {
   hasError: boolean
   error: Error | null
+}
+
+function shallowDiffer(prev: unknown[] | undefined, next: unknown[] | undefined): boolean {
+  if (prev === next) return false
+  if (!prev || !next) return true
+  if (prev.length !== next.length) return true
+  for (let i = 0; i < prev.length; i++) {
+    if (!Object.is(prev[i], next[i])) return true
+  }
+  return false
 }
 
 export class ErrorBoundary extends Component<Props, State> {
@@ -30,6 +47,15 @@ export class ErrorBoundary extends Component<Props, State> {
   override componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     console.error('ErrorBoundary caught an error:', error, errorInfo)
     this.props.onError?.(error, errorInfo)
+  }
+
+  override componentDidUpdate(prevProps: Props): void {
+    if (
+      this.state.hasError &&
+      shallowDiffer(prevProps.resetKeys, this.props.resetKeys)
+    ) {
+      this.handleReset()
+    }
   }
 
   handleReset = (): void => {

--- a/src/components/ui/floating-dock.tsx
+++ b/src/components/ui/floating-dock.tsx
@@ -275,7 +275,7 @@ export function FloatingDock() {
         ...chatQueryKeys.sessions(currentWorktreeId),
         'with-counts',
       ])
-    const session = cached?.sessions.find(s => s.id === activeSessionId)
+    const session = cached?.sessions?.find(s => s.id === activeSessionId)
     return session ? getResumeCommand(session) : null
   }, [queryClient])
 


### PR DESCRIPTION
## Summary

Fixes #347 — UI breaking completely when API is down, auth fails, or other async exceptions occur.

- Add global `unhandledrejection` and `error` handlers in `App.tsx`; log and toast unexpected errors, suppress already-surfaced auth messages, call `event.preventDefault()` to stop silent crashes
- Add `resetKeys` prop to `ErrorBoundary` so boundary auto-resets when tab/worktree id changes — switching tabs now recovers from a crashed pane without full remount
- Pass `resetKeys={[activeWorktreeId]}` to `ChatWindow`'s `ErrorBoundary`
- Guard `sessions` array accesses with optional chaining (`?.`) in: `ChatWindow`, `DockBurgerButton`, `FloatingDock`, `WorktreeDropdownMenu`, `FailedRunsBadge`, `WorkflowRunsModal` — prevents TypeError when API returns unexpected shape


---

Fixes #347