### PR TITLE
Middle-click closes session tabs

### DIFF
--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type MouseEvent,
   type RefObject,
 } from 'react'
 import {
@@ -517,6 +518,46 @@ export function SessionChatModal({
     pendingCloseAction.current = null
     setCloseConfirmOpen(false)
   }, [])
+
+  const removeSessionTab = useCallback(
+    (session: Session) => {
+      const activeSessions = sessions.filter(s => !s.archived_at)
+      if (activeSessions.length <= 1) {
+        const action = () => {
+          handleDeleteSession(session.id)
+          onClose()
+        }
+        const sessionIsEmpty = !session.message_count
+        if (preferences?.confirm_session_close !== false && !sessionIsEmpty) {
+          pendingCloseAction.current = action
+          setCloseConfirmOpen(true)
+        } else {
+          action()
+        }
+      } else {
+        selectVisualNeighbor(session.id)
+        handleArchiveSession(session.id)
+      }
+    },
+    [
+      sessions,
+      handleDeleteSession,
+      onClose,
+      preferences?.confirm_session_close,
+      selectVisualNeighbor,
+      handleArchiveSession,
+    ]
+  )
+
+  const handleTabAuxClick = useCallback(
+    (e: MouseEvent<HTMLButtonElement>, session: Session) => {
+      if (e.button !== 1) return
+      e.preventDefault()
+      e.stopPropagation()
+      removeSessionTab(session)
+    },
+    [removeSessionTab]
+  )
 
   useEffect(() => {
     if (!isOpen) return
@@ -1238,6 +1279,7 @@ export function SessionChatModal({
                           <button
                             data-session-id={session.id}
                             onClick={() => handleTabClick(session.id)}
+                            onAuxClick={e => handleTabAuxClick(e, session)}
                             onDoubleClick={() =>
                               handleStartRenameImmediate(
                                 session.id,
@@ -1298,30 +1340,7 @@ export function SessionChatModal({
                                 }
                                 onClick={e => {
                                   e.stopPropagation()
-                                  const activeSessions = sessions.filter(
-                                    s => !s.archived_at
-                                  )
-                                  if (activeSessions.length <= 1) {
-                                    const action = () => {
-                                      handleDeleteSession(session.id)
-                                      onClose()
-                                    }
-                                    const sessionIsEmpty =
-                                      !session.message_count
-                                    if (
-                                      preferences?.confirm_session_close !==
-                                        false &&
-                                      !sessionIsEmpty
-                                    ) {
-                                      pendingCloseAction.current = action
-                                      setCloseConfirmOpen(true)
-                                    } else {
-                                      action()
-                                    }
-                                  } else {
-                                    selectVisualNeighbor(session.id)
-                                    handleArchiveSession(session.id)
-                                  }
+                                  removeSessionTab(session)
                                 }}
                                 className="ml-0.5 opacity-60 sm:opacity-0 sm:group-hover/tab:opacity-60 hover:!opacity-100"
                                 size="xs"


### PR DESCRIPTION
## Summary
- close session tabs on middle mouse click
- share existing remove-session behavior with dismiss button

https://github.com/user-attachments/assets/d8136499-86f5-4f6e-b478-459ade14da1b


## Validation
- bun run typecheck

---
AI assisted development note:
The code for this PR was generated using Codex 5.5 on low reasoning under careful human supervision. The changes have been verified and tested manually by a human.

The following prompts were used:
```
I want the tabs under a session to be closable via a middle mouse click in addition to the existing cmd + w shortcut and the “Remove session” button.
```

```
make sure to read @CONTRIBUTING.md and to follow the instructions there
```