### PR TITLE
Format chat durations as seconds or mm:ss

### DIFF
--- a/src/components/chat/MessageItem.test.tsx
+++ b/src/components/chat/MessageItem.test.tsx
@@ -338,4 +338,16 @@ describe('MessageItem', () => {
 
     expect(screen.getByText('Raptors')).toBeVisible()
   })
+
+  it('renders assistant duration in mm:ss format when minutes are non-zero', () => {
+    render(<MessageItem {...baseProps} durationMs={145_000} />)
+
+    expect(screen.getByText('02:25')).toBeVisible()
+  })
+
+  it('renders assistant duration as seconds only when under a minute', () => {
+    render(<MessageItem {...baseProps} durationMs={23_000} />)
+
+    expect(screen.getByText('23s')).toBeVisible()
+  })
 })

--- a/src/components/chat/time-utils.test.ts
+++ b/src/components/chat/time-utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { formatDuration } from './time-utils'
+
+describe('formatDuration', () => {
+  it('formats sub-minute durations as seconds only', () => {
+    expect(formatDuration(0)).toBe('0s')
+    expect(formatDuration(23_999)).toBe('23s')
+  })
+
+  it('formats minute boundaries as mm:ss', () => {
+    expect(formatDuration(60_000)).toBe('01:00')
+    expect(formatDuration(145_000)).toBe('02:25')
+  })
+})

--- a/src/components/chat/time-utils.ts
+++ b/src/components/chat/time-utils.ts
@@ -1,7 +1,13 @@
 /**
- * Format milliseconds as seconds string.
- * Examples: "0s", "23s", "145s"
+ * Format milliseconds as seconds when under a minute, otherwise mm:ss.
+ * Examples: "0s", "23s", "02:25"
  */
 export function formatDuration(ms: number): string {
-  return `${Math.floor(ms / 1000)}s`
+  const totalSeconds = Math.floor(ms / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+
+  if (minutes === 0) return `${seconds}s`
+
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
 }


### PR DESCRIPTION
## Summary
- keep durations under one minute displayed as seconds only
- display durations of one minute or more in mm:ss format
- add tests for the formatter and MessageItem rendering

## Testing
- bun run test:run src/components/chat/time-utils.test.ts src/components/chat/MessageItem.test.tsx