### PR TITLE
fix(terminal): handle split multi-byte UTF-8 codepoints in PTY reader

### DIFF
--- a/src-tauri/src/terminal/pty.rs
+++ b/src-tauri/src/terminal/pty.rs
@@ -161,21 +161,61 @@ pub fn spawn_terminal(
         log::error!("Failed to emit terminal:started event: {e}");
     }
 
-    // Spawn reader thread
+    // Spawn reader thread.
+    //
+    // Streaming UTF-8 decode: a `read()` can split a multi-byte codepoint at
+    // the buffer boundary. `from_utf8_lossy` would emit `U+FFFD` for the split
+    // bytes — corrupting valid output. Instead we carry up to 3 trailing bytes
+    // of an incomplete codepoint into the next read. Genuine invalid sequences
+    // still produce one `U+FFFD` per bad sequence, matching `from_utf8_lossy`.
     let app_clone = app.clone();
     let terminal_id_clone = terminal_id.clone();
     thread::spawn(move || {
-        let mut buf = [0u8; 4096];
+        const BUF_SIZE: usize = 4096;
+        let mut buf = [0u8; BUF_SIZE];
+        // Bytes carried from previous read (incomplete UTF-8 prefix). Max 3.
+        let mut carry: [u8; 3] = [0; 3];
+        let mut carry_len: usize = 0;
         loop {
-            match reader.read(&mut buf) {
+            // Stage carry at start of buf; read after it. Zero-alloc combine.
+            buf[..carry_len].copy_from_slice(&carry[..carry_len]);
+            let read_n = match reader.read(&mut buf[carry_len..]) {
                 Ok(0) => {
-                    // EOF - terminal closed
                     log::trace!("Terminal EOF for: {terminal_id_clone}");
+                    if carry_len > 0 {
+                        // Drain remaining carry as replacement chars (one per
+                        // dangling byte — matches `from_utf8_lossy` end-of-stream).
+                        let mut s = String::with_capacity(carry_len * 3);
+                        for _ in 0..carry_len {
+                            s.push('\u{FFFD}');
+                        }
+                        let event = TerminalOutputEvent {
+                            terminal_id: terminal_id_clone.clone(),
+                            data: s,
+                        };
+                        let _ = app_clone.emit_all_owned("terminal:output", event);
+                    }
                     break;
                 }
-                Ok(n) => {
-                    // Convert bytes to string (lossy conversion for non-UTF8)
-                    let data = String::from_utf8_lossy(&buf[..n]).to_string();
+                Ok(n) => n,
+                Err(e) => {
+                    log::error!("Error reading from terminal: {e}");
+                    break;
+                }
+            };
+            let total = carry_len + read_n;
+            carry_len = 0;
+
+            // Decode in place. Fast path: whole buf valid UTF-8 → zero-alloc
+            // (we hand the underlying bytes straight to a new String via
+            // copy_from_slice into a Vec sized exactly to total).
+            let bytes = &buf[..total];
+            match std::str::from_utf8(bytes) {
+                Ok(_) => {
+                    // SAFETY: validated above.
+                    let data = unsafe {
+                        String::from_utf8_unchecked(bytes.to_vec())
+                    };
                     let event = TerminalOutputEvent {
                         terminal_id: terminal_id_clone.clone(),
                         data,
@@ -184,9 +224,56 @@ pub fn spawn_terminal(
                         log::error!("Failed to emit terminal:output event: {e}");
                     }
                 }
-                Err(e) => {
-                    log::error!("Error reading from terminal: {e}");
-                    break;
+                Err(first_err) => {
+                    // Slow path: contains invalid bytes or incomplete tail.
+                    // Build output with one allocation sized to input.
+                    let mut out = String::with_capacity(total);
+                    let mut cursor = 0usize;
+                    let mut err = first_err;
+                    loop {
+                        let valid_up_to = err.valid_up_to();
+                        // SAFETY: from_utf8 verified [cursor..cursor+valid_up_to].
+                        out.push_str(unsafe {
+                            std::str::from_utf8_unchecked(
+                                &bytes[cursor..cursor + valid_up_to],
+                            )
+                        });
+                        match err.error_len() {
+                            None => {
+                                // Incomplete tail — stash for next read.
+                                let tail_start = cursor + valid_up_to;
+                                let tail_len = total - tail_start;
+                                debug_assert!(tail_len <= 3);
+                                carry[..tail_len]
+                                    .copy_from_slice(&bytes[tail_start..total]);
+                                carry_len = tail_len;
+                                break;
+                            }
+                            Some(bad_len) => {
+                                out.push('\u{FFFD}');
+                                cursor += valid_up_to + bad_len;
+                                if cursor >= total {
+                                    break;
+                                }
+                                match std::str::from_utf8(&bytes[cursor..]) {
+                                    Ok(s) => {
+                                        out.push_str(s);
+                                        break;
+                                    }
+                                    Err(e) => err = e,
+                                }
+                            }
+                        }
+                    }
+                    if !out.is_empty() {
+                        let event = TerminalOutputEvent {
+                            terminal_id: terminal_id_clone.clone(),
+                            data: out,
+                        };
+                        if let Err(e) = app_clone.emit_all_owned("terminal:output", event) {
+                            log::error!("Failed to emit terminal:output event: {e}");
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

PTY reader was using `String::from_utf8_lossy` on raw 4096-byte buffer reads. When a multi-byte UTF-8 codepoint was split across two reads (e.g. emoji, CJK, accented chars landing on the buffer boundary), the trailing bytes of the first chunk and the leading bytes of the next chunk were each individually invalid UTF-8 — so `from_utf8_lossy` replaced them with `U+FFFD` (�), corrupting otherwise valid terminal output.

## Fix

Streaming UTF-8 decode in `src-tauri/src/terminal/pty.rs`:

- **Carry incomplete tail**: up to 3 trailing bytes of an unfinished codepoint are stashed and prepended to the next read. The carry is staged at the start of the buffer; the read writes after it — zero-allocation combine.
- **Fast path**: when the combined buffer is fully valid UTF-8, hand bytes straight into a `String` with no scanning/replacement.
- **Slow path**: genuine invalid sequences still produce one `U+FFFD` per bad sequence (matching `from_utf8_lossy` behavior), with a single allocation sized to the input.
- **EOF drain**: any dangling carry at EOF emits one `U+FFFD` per byte, matching `from_utf8_lossy` end-of-stream semantics.

## Repro

Run a command emitting non-ASCII output that produces enough volume to land a codepoint on a 4096-byte boundary (e.g. `cat large-utf8-file`, output containing emoji or CJK at high throughput). Before the fix you'd intermittently see � replacing valid characters; after the fix output is clean.

## Test plan

- [ ] Run a terminal command outputting CJK / emoji at volume; confirm no `U+FFFD` artifacts
- [ ] Run a command emitting genuinely invalid bytes (e.g. `printf '\xff\xfe'`); confirm `U+FFFD` still appears
- [ ] Verify EOF flush: short-lived process emitting incomplete trailing bytes shows `U+FFFD` for those bytes
- [ ] Smoke test ASCII-only output for regressions (fast path)
