### PR TITLE
feat(coderabbit): add CLI review integration

### DIFF
--- a/docs/developer/coderabbit-cli.md
+++ b/docs/developer/coderabbit-cli.md
@@ -1,0 +1,20 @@
+# CodeRabbit CLI Integration
+
+Jean treats CodeRabbit as a helper CLI for secondary code review, not as a chat backend.
+
+## Settings
+
+The General preferences pane exposes CodeRabbit CLI status, install, login, update, source selection, and managed-install deletion.
+
+- Jean-managed binaries live in app data under `coderabbit-cli/`.
+- System PATH detection excludes the Jean-managed binary.
+- Login opens the terminal modal with `coderabbit auth login`.
+
+## Review flow
+
+Clicking Review opens a chooser:
+
+- Jean AI review: existing `run_review_with_ai` path.
+- CodeRabbit review: `run_coderabbit_review`, which runs `coderabbit review --agent --dir <worktree>`.
+
+The backend parses CodeRabbit JSONL events into the existing `ReviewResponse` shape so `ReviewResultsPanel` and Fix actions can be reused.

--- a/src-tauri/src/coderabbit_cli/commands.rs
+++ b/src-tauri/src/coderabbit_cli/commands.rs
@@ -1,0 +1,285 @@
+//! Tauri commands for CodeRabbit CLI management.
+
+use crate::http_server::EmitExt;
+use crate::platform::silent_command;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tauri::AppHandle;
+
+use super::config::{
+    ensure_coderabbit_cli_dir, get_coderabbit_binary_path, get_coderabbit_cli_dir,
+    resolve_coderabbit_binary,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeRabbitCliStatus {
+    pub installed: bool,
+    pub version: Option<String>,
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeRabbitAuthStatus {
+    pub authenticated: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeRabbitPathDetection {
+    pub found: bool,
+    pub path: Option<String>,
+    pub version: Option<String>,
+    pub package_manager: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CodeRabbitInstallProgress {
+    pub stage: String,
+    pub message: String,
+    pub percent: u8,
+}
+
+fn emit_progress(app: &AppHandle, stage: &str, message: &str, percent: u8) {
+    let _ = app.emit_all(
+        "coderabbit-cli:install-progress",
+        &CodeRabbitInstallProgress {
+            stage: stage.to_string(),
+            message: message.to_string(),
+            percent,
+        },
+    );
+}
+
+fn parse_version(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    trimmed
+        .split_whitespace()
+        .find(|part| part.chars().any(|c| c.is_ascii_digit()) && part.contains('.'))
+        .map(|s| s.trim_start_matches('v').to_string())
+        .or_else(|| Some(trimmed.to_string()))
+}
+
+fn get_version(binary: &std::path::Path) -> Option<String> {
+    let output = silent_command(binary).arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_version(&String::from_utf8_lossy(&output.stdout))
+}
+
+#[tauri::command]
+pub async fn check_coderabbit_cli_installed(app: AppHandle) -> Result<CodeRabbitCliStatus, String> {
+    let binary_path = resolve_coderabbit_binary(&app);
+    if !binary_path.exists() {
+        return Ok(CodeRabbitCliStatus {
+            installed: false,
+            version: None,
+            path: None,
+        });
+    }
+
+    Ok(CodeRabbitCliStatus {
+        installed: true,
+        version: get_version(&binary_path),
+        path: Some(binary_path.to_string_lossy().to_string()),
+    })
+}
+
+#[tauri::command]
+pub async fn detect_coderabbit_in_path(app: AppHandle) -> Result<CodeRabbitPathDetection, String> {
+    let jean_managed_path = get_coderabbit_binary_path(&app)
+        .ok()
+        .and_then(|p| std::fs::canonicalize(&p).ok());
+    let which_cmd = if cfg!(target_os = "windows") {
+        "where"
+    } else {
+        "which"
+    };
+    let output = match silent_command(which_cmd).arg("coderabbit").output() {
+        Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string(),
+        _ => String::new(),
+    };
+
+    if output.is_empty() {
+        return Ok(CodeRabbitPathDetection {
+            found: false,
+            path: None,
+            version: None,
+            package_manager: None,
+        });
+    }
+
+    let found_path = std::path::PathBuf::from(&output);
+    if let Some(ref jean_path) = jean_managed_path {
+        if let Ok(canonical_found) = std::fs::canonicalize(&found_path) {
+            if canonical_found == *jean_path {
+                return Ok(CodeRabbitPathDetection {
+                    found: false,
+                    path: None,
+                    version: None,
+                    package_manager: None,
+                });
+            }
+        }
+    }
+
+    let version = get_version(&found_path);
+    let package_manager = crate::platform::detect_package_manager(&found_path);
+
+    Ok(CodeRabbitPathDetection {
+        found: true,
+        path: Some(output),
+        version,
+        package_manager,
+    })
+}
+
+#[tauri::command]
+pub async fn check_coderabbit_cli_auth(app: AppHandle) -> Result<CodeRabbitAuthStatus, String> {
+    let binary_path = resolve_coderabbit_binary(&app);
+    if !binary_path.exists() {
+        return Ok(CodeRabbitAuthStatus {
+            authenticated: false,
+            error: Some("CodeRabbit CLI not installed".to_string()),
+        });
+    }
+
+    let output = tokio::time::timeout(
+        Duration::from_secs(10),
+        tokio::task::spawn_blocking(move || {
+            silent_command(&binary_path)
+                .args(["auth", "status", "--agent"])
+                .output()
+        }),
+    )
+    .await
+    .map_err(|_| "CodeRabbit auth status timed out".to_string())?
+    .map_err(|e| format!("Failed to join auth status task: {e}"))?
+    .map_err(|e| format!("Failed to check CodeRabbit auth status: {e}"))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if output.status.success() {
+        let lower = stdout.to_lowercase();
+        let authenticated = stdout.lines().any(|line| {
+            serde_json::from_str::<serde_json::Value>(line)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("authenticated")
+                        .and_then(|v| v.as_bool())
+                        .or_else(|| value.get("loggedIn").and_then(|v| v.as_bool()))
+                        .or_else(|| value.get("logged_in").and_then(|v| v.as_bool()))
+                })
+                .unwrap_or(false)
+        }) || lower.contains("authenticated")
+            || lower.contains("logged in");
+        return Ok(CodeRabbitAuthStatus {
+            authenticated: authenticated || stdout.trim().is_empty(),
+            error: None,
+        });
+    }
+
+    Ok(CodeRabbitAuthStatus {
+        authenticated: false,
+        error: Some(if stderr.is_empty() { stdout } else { stderr }),
+    })
+}
+
+#[tauri::command]
+pub async fn install_coderabbit_cli(app: AppHandle) -> Result<(), String> {
+    if cfg!(target_os = "windows") {
+        return Err("CodeRabbit CLI install script currently supports macOS and Linux. Install CodeRabbit in WSL or add it to PATH.".to_string());
+    }
+
+    let cli_dir = ensure_coderabbit_cli_dir(&app)?;
+    emit_progress(
+        &app,
+        "starting",
+        "Preparing CodeRabbit CLI installation...",
+        0,
+    );
+    emit_progress(
+        &app,
+        "downloading",
+        "Running official CodeRabbit installer...",
+        25,
+    );
+
+    let script = "curl -fsSL https://cli.coderabbit.ai/install.sh | sh";
+    let output = silent_command("sh")
+        .arg("-c")
+        .arg(script)
+        .env("CODERABBIT_INSTALL_DIR", &cli_dir)
+        .output()
+        .map_err(|e| format!("Failed to run CodeRabbit installer: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        return Err(format!(
+            "CodeRabbit installer failed: {}",
+            if stderr.is_empty() { stdout } else { stderr }
+        ));
+    }
+
+    emit_progress(&app, "verifying", "Verifying CodeRabbit CLI...", 85);
+    let binary_path = get_coderabbit_binary_path(&app)?;
+    if !binary_path.exists() {
+        return Err(format!(
+            "CodeRabbit installer completed but binary was not found at {}",
+            binary_path.display()
+        ));
+    }
+
+    let verify = silent_command(&binary_path)
+        .arg("--version")
+        .output()
+        .map_err(|e| format!("Failed to verify CodeRabbit CLI: {e}"))?;
+    if !verify.status.success() {
+        return Err("CodeRabbit CLI verification failed".to_string());
+    }
+
+    emit_progress(&app, "complete", "CodeRabbit CLI installed.", 100);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn uninstall_coderabbit_cli(app: AppHandle) -> Result<(), String> {
+    let cli_dir = get_coderabbit_cli_dir(&app)?;
+    if cli_dir.exists() {
+        std::fs::remove_dir_all(&cli_dir)
+            .map_err(|e| format!("Failed to remove CodeRabbit CLI directory: {e}"))?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn update_coderabbit_cli(app: AppHandle) -> Result<(), String> {
+    let binary_path = resolve_coderabbit_binary(&app);
+    if !binary_path.exists() {
+        return Err("CodeRabbit CLI not installed".to_string());
+    }
+    let output = silent_command(&binary_path)
+        .arg("update")
+        .output()
+        .map_err(|e| format!("Failed to update CodeRabbit CLI: {e}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        Err(if stderr.is_empty() {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        } else {
+            stderr
+        })
+    }
+}

--- a/src-tauri/src/coderabbit_cli/config.rs
+++ b/src-tauri/src/coderabbit_cli/config.rs
@@ -1,0 +1,68 @@
+//! Configuration and path management for the CodeRabbit CLI.
+
+use crate::platform::silent_command;
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+pub const CODERABBIT_CLI_DIR_NAME: &str = "coderabbit-cli";
+
+#[cfg(windows)]
+pub const CODERABBIT_BINARY_NAME: &str = "coderabbit.exe";
+#[cfg(not(windows))]
+pub const CODERABBIT_BINARY_NAME: &str = "coderabbit";
+
+pub fn get_coderabbit_cli_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {e}"))?;
+    Ok(app_data_dir.join(CODERABBIT_CLI_DIR_NAME))
+}
+
+pub fn get_coderabbit_binary_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(get_coderabbit_cli_dir(app)?.join(CODERABBIT_BINARY_NAME))
+}
+
+pub fn ensure_coderabbit_cli_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let cli_dir = get_coderabbit_cli_dir(app)?;
+    std::fs::create_dir_all(&cli_dir)
+        .map_err(|e| format!("Failed to create CodeRabbit CLI directory: {e}"))?;
+    Ok(cli_dir)
+}
+
+pub fn resolve_coderabbit_binary(app: &AppHandle) -> PathBuf {
+    let use_path = crate::get_preferences_path(app)
+        .ok()
+        .and_then(|prefs_path| std::fs::read_to_string(prefs_path).ok())
+        .and_then(|contents| serde_json::from_str::<crate::AppPreferences>(&contents).ok())
+        .map(|prefs| prefs.coderabbit_cli_source == "path")
+        .unwrap_or(false);
+
+    if use_path {
+        let which_cmd = if cfg!(target_os = "windows") {
+            "where"
+        } else {
+            "which"
+        };
+        if let Ok(output) = silent_command(which_cmd).arg("coderabbit").output() {
+            if output.status.success() {
+                let path_str = String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if !path_str.is_empty() {
+                    let path = PathBuf::from(&path_str);
+                    if path.exists() {
+                        return path;
+                    }
+                }
+            }
+        }
+        log::warn!("coderabbit_cli_source is 'path' but coderabbit was not found in PATH; falling back to Jean-managed binary");
+    }
+
+    get_coderabbit_binary_path(app)
+        .unwrap_or_else(|_| PathBuf::from(CODERABBIT_CLI_DIR_NAME).join(CODERABBIT_BINARY_NAME))
+}

--- a/src-tauri/src/coderabbit_cli/mod.rs
+++ b/src-tauri/src/coderabbit_cli/mod.rs
@@ -1,0 +1,7 @@
+//! CodeRabbit CLI management module.
+
+mod commands;
+mod config;
+
+pub use commands::*;
+pub use config::resolve_coderabbit_binary;

--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -342,6 +342,20 @@ pub async fn dispatch_command(
             .await?;
             to_value(result)
         }
+
+        "run_coderabbit_review" => {
+            let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
+            let review_run_id: Option<String> = field_opt(&args, "reviewRunId", "review_run_id")?;
+            let review_type: Option<String> = field_opt(&args, "reviewType", "review_type")?;
+            let result = crate::projects::run_coderabbit_review(
+                app.clone(),
+                worktree_path,
+                review_run_id,
+                review_type,
+            )
+            .await?;
+            to_value(result)
+        }
         "revert_last_local_commit" => {
             let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
             let result = crate::projects::revert_last_local_commit(worktree_path).await?;
@@ -1929,6 +1943,31 @@ pub async fn dispatch_command(
             crate::gh_cli::uninstall_gh_cli(app.clone()).await?;
             Ok(Value::Null)
         }
+
+        "check_coderabbit_cli_installed" => {
+            let result = crate::coderabbit_cli::check_coderabbit_cli_installed(app.clone()).await?;
+            to_value(result)
+        }
+        "detect_coderabbit_in_path" => {
+            let result = crate::coderabbit_cli::detect_coderabbit_in_path(app.clone()).await?;
+            to_value(result)
+        }
+        "check_coderabbit_cli_auth" => {
+            let result = crate::coderabbit_cli::check_coderabbit_cli_auth(app.clone()).await?;
+            to_value(result)
+        }
+        "install_coderabbit_cli" => {
+            crate::coderabbit_cli::install_coderabbit_cli(app.clone()).await?;
+            Ok(Value::Null)
+        }
+        "uninstall_coderabbit_cli" => {
+            crate::coderabbit_cli::uninstall_coderabbit_cli(app.clone()).await?;
+            Ok(Value::Null)
+        }
+        "update_coderabbit_cli" => {
+            crate::coderabbit_cli::update_coderabbit_cli(app.clone()).await?;
+            Ok(Value::Null)
+        }
         "run_cli_path_update" => {
             let command: String = from_field(&args, "command")?;
             let cli_args: Vec<String> = from_field(&args, "args")?;
@@ -1999,6 +2038,7 @@ pub async fn dispatch_command(
             crate::codex_cli::uninstall_codex_cli(app.clone()).await?;
             Ok(Value::Null)
         }
+
         "approve_codex_command" => {
             let session_id: String = field(&args, "sessionId", "session_id")?;
             let rpc_id: u64 = field(&args, "rpcId", "rpc_id")?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod browser;
 mod chat;
 mod claude_cli;
 mod cli_update;
+mod coderabbit_cli;
 mod codex_cli;
 mod cursor_cli;
 mod gh_cli;
@@ -242,6 +243,8 @@ pub struct AppPreferences {
     pub opencode_cli_source: String, // OpenCode CLI source: "jean" (managed) or "path" (system PATH)
     #[serde(default = "default_cli_source")]
     pub gh_cli_source: String, // GitHub CLI source: "jean" (managed) or "path" (system PATH)
+    #[serde(default = "default_cli_source")]
+    pub coderabbit_cli_source: String, // CodeRabbit CLI source: "jean" (managed) or "path" (system PATH)
     #[serde(default)]
     pub expand_tool_calls_by_default: bool, // Expand all tool call collapsibles by default (default: false)
     #[serde(default = "default_auto_update_ai_backends")]
@@ -1499,6 +1502,7 @@ impl Default for AppPreferences {
             codex_cli_source: default_cli_source(),
             opencode_cli_source: default_cli_source(),
             gh_cli_source: default_cli_source(),
+            coderabbit_cli_source: default_cli_source(),
             expand_tool_calls_by_default: false,
             auto_update_ai_backends: default_auto_update_ai_backends(),
         }
@@ -3164,6 +3168,7 @@ pub fn run() {
             projects::create_commit_with_ai,
             projects::revert_last_local_commit,
             projects::run_review_with_ai,
+            projects::run_coderabbit_review,
             projects::cancel_review_with_ai,
             projects::list_github_releases,
             projects::generate_release_notes,
@@ -3395,6 +3400,13 @@ pub fn run() {
             codex_cli::get_available_codex_versions,
             codex_cli::install_codex_cli,
             codex_cli::uninstall_codex_cli,
+            // CodeRabbit CLI management commands
+            coderabbit_cli::check_coderabbit_cli_installed,
+            coderabbit_cli::detect_coderabbit_in_path,
+            coderabbit_cli::check_coderabbit_cli_auth,
+            coderabbit_cli::install_coderabbit_cli,
+            coderabbit_cli::uninstall_coderabbit_cli,
+            coderabbit_cli::update_coderabbit_cli,
             // Cursor CLI management commands
             cursor_cli::check_cursor_cli_installed,
             cursor_cli::detect_cursor_in_path,

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -46,6 +46,7 @@ use super::types::{
     WorktreeUnarchivedEvent,
 };
 use crate::claude_cli::resolve_cli_binary;
+use crate::coderabbit_cli::resolve_coderabbit_binary;
 use crate::codex_cli::resolve_cli_binary as resolve_codex_cli_binary;
 use crate::gh_cli::config::resolve_gh_binary;
 use crate::http_server::EmitExt;
@@ -7471,6 +7472,247 @@ pub async fn run_review_with_ai(
     );
 
     Ok(response)
+}
+
+fn map_coderabbit_severity(severity: &str) -> String {
+    match severity {
+        "critical" => "critical".to_string(),
+        "major" | "minor" => "warning".to_string(),
+        "trivial" | "info" => "suggestion".to_string(),
+        _ => "suggestion".to_string(),
+    }
+}
+
+fn coderabbit_title(instructions: &str) -> String {
+    let first = instructions
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or("CodeRabbit finding")
+        .trim();
+    let sentence = first.split('.').next().unwrap_or(first).trim();
+    let mut title: String = sentence.chars().take(80).collect();
+    if title.is_empty() {
+        title = "CodeRabbit finding".to_string();
+    }
+    title
+}
+
+fn parse_coderabbit_review_output(output: &str) -> Result<ReviewResponse, String> {
+    let mut findings = Vec::new();
+    let mut status_messages = Vec::new();
+    let mut errors = Vec::new();
+
+    for line in output.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = match serde_json::from_str(line) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        let event_type = value.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        match event_type {
+            "finding" => {
+                let severity = value
+                    .get("severity")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("info");
+                let file = value
+                    .get("fileName")
+                    .or_else(|| value.get("file"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let instructions = value
+                    .get("codegenInstructions")
+                    .or_else(|| value.get("description"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("CodeRabbit reported a finding.")
+                    .to_string();
+                let suggestion = value
+                    .get("suggestions")
+                    .and_then(|v| v.as_array())
+                    .and_then(|arr| {
+                        let joined = arr
+                            .iter()
+                            .filter_map(|item| {
+                                item.as_str().map(str::to_string).or_else(|| {
+                                    if item.is_null() {
+                                        None
+                                    } else {
+                                        Some(item.to_string())
+                                    }
+                                })
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n\n");
+                        if joined.trim().is_empty() {
+                            None
+                        } else {
+                            Some(joined)
+                        }
+                    });
+                findings.push(ReviewFinding {
+                    severity: map_coderabbit_severity(severity),
+                    file,
+                    line: None,
+                    title: coderabbit_title(&instructions),
+                    description: instructions.clone(),
+                    suggestion: suggestion.or(Some(instructions)),
+                });
+            }
+            "status" => {
+                if let Some(status) = value.get("status").and_then(|v| v.as_str()) {
+                    status_messages.push(status.to_string());
+                }
+            }
+            "error" => {
+                let message = value
+                    .get("message")
+                    .or_else(|| value.get("error"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Unknown CodeRabbit error")
+                    .to_string();
+                errors.push(message);
+            }
+            _ => {}
+        }
+    }
+
+    if findings.is_empty() && !errors.is_empty() {
+        return Err(errors.join("; "));
+    }
+
+    let critical_or_warning = findings
+        .iter()
+        .any(|f| f.severity == "critical" || f.severity == "warning");
+    let approval_status = if critical_or_warning {
+        "changes_requested"
+    } else if findings.is_empty() {
+        "approved"
+    } else {
+        "needs_discussion"
+    }
+    .to_string();
+
+    let summary = if findings.is_empty() {
+        "CodeRabbit review completed with no findings.".to_string()
+    } else {
+        let critical = findings.iter().filter(|f| f.severity == "critical").count();
+        let warning = findings.iter().filter(|f| f.severity == "warning").count();
+        let suggestion = findings
+            .iter()
+            .filter(|f| f.severity == "suggestion")
+            .count();
+        format!(
+            "CodeRabbit review completed with {} finding(s): {} critical, {} warning, {} suggestion.",
+            findings.len(), critical, warning, suggestion
+        )
+    };
+
+    Ok(ReviewResponse {
+        summary,
+        findings,
+        approval_status,
+    })
+}
+
+/// Run CodeRabbit CLI review on the current worktree.
+#[tauri::command]
+pub async fn run_coderabbit_review(
+    app: AppHandle,
+    worktree_path: String,
+    review_run_id: Option<String>,
+    review_type: Option<String>,
+) -> Result<ReviewResponse, String> {
+    log::trace!("Running CodeRabbit review for: {worktree_path}");
+
+    let binary_path = resolve_coderabbit_binary(&app);
+    if !binary_path.exists() {
+        return Err("CodeRabbit CLI not installed".to_string());
+    }
+
+    let mut cmd = silent_command(&binary_path);
+    cmd.args(["review", "--agent", "--dir", &worktree_path]);
+    if let Some(review_type) = review_type
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        cmd.args(["--type", review_type]);
+    }
+    cmd.current_dir(&worktree_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to spawn CodeRabbit CLI: {e}"))?;
+    let pid = child.id();
+    if let Some(run_id) = review_run_id.as_deref() {
+        register_review_process(run_id, pid);
+    }
+
+    let output_result = tokio::task::spawn_blocking(move || child.wait_with_output())
+        .await
+        .map_err(|e| format!("Failed to join CodeRabbit review task: {e}"))?;
+    let cancelled = review_run_id
+        .as_deref()
+        .map(|run_id| take_review_process_pid(run_id).is_none())
+        .unwrap_or(false);
+
+    let output = match output_result {
+        Ok(output) => output,
+        Err(e) => {
+            if cancelled {
+                return Err("Review cancelled".to_string());
+            }
+            return Err(format!("Failed to wait for CodeRabbit CLI: {e}"));
+        }
+    };
+
+    if let Some(run_id) = review_run_id.as_deref() {
+        let _ = take_review_process_pid(run_id);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    if !output.status.success() {
+        if cancelled {
+            return Err("Review cancelled".to_string());
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(format!(
+            "CodeRabbit CLI failed (exit {}): {}{}",
+            output.status,
+            stderr,
+            if stdout.trim().is_empty() {
+                String::new()
+            } else {
+                format!("\n{}", stdout.trim())
+            }
+        ));
+    }
+
+    parse_coderabbit_review_output(&stdout)
+}
+
+#[cfg(test)]
+mod coderabbit_review_tests {
+    use super::*;
+
+    #[test]
+    fn parses_agent_findings() {
+        let output = r#"{"type":"review_context","reviewType":"all"}
+{"type":"status","phase":"analyzing","status":"reviewing"}
+{"type":"finding","severity":"major","fileName":"src/App.tsx","codegenInstructions":"Fix the null check before accessing value.","suggestions":["if (!value) return null;"]}
+{"type":"finding","severity":"trivial","fileName":"README.md","codegenInstructions":"Improve wording.","suggestions":[]}
+{"type":"complete"}"#;
+        let parsed = parse_coderabbit_review_output(output).unwrap();
+        assert_eq!(parsed.findings.len(), 2);
+        assert_eq!(parsed.findings[0].severity, "warning");
+        assert_eq!(parsed.findings[1].severity, "suggestion");
+        assert_eq!(parsed.approval_status, "changes_requested");
+    }
 }
 
 /// Cancel a running AI review request by review_run_id.

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -108,6 +108,7 @@ import { ChatInput } from './ChatInput'
 import { SessionDebugPanel } from './SessionDebugPanel'
 import { ChatToolbar } from './ChatToolbar'
 import { ReviewResultsPanel } from './ReviewResultsPanel'
+import { ReviewMethodModal } from './ReviewMethodModal'
 import { QueuedMessagesList } from './QueuedMessageItem'
 import { FloatingButtons } from './FloatingButtons'
 import { PlanDialog } from './PlanDialog'
@@ -1793,6 +1794,7 @@ export function ChatWindow({
     handlePush,
     handleOpenPr,
     handleReview,
+    handleCodeRabbitReview,
     handleMerge,
     handleMergePr,
     handleResolveConflicts,
@@ -1941,6 +1943,8 @@ export function ChatWindow({
     cliVersion: cliStatus?.version ?? null,
     worktreeProjectId: worktree?.project_id,
   })
+
+  const [reviewMethodModalOpen, setReviewMethodModalOpen] = useState(false)
 
   // Linked projects modal state
   const linkedProjectsModalOpen = useUIStore(
@@ -2323,6 +2327,12 @@ export function ChatWindow({
       )}
     >
       <div className="flex h-full w-full min-w-0 flex-col overflow-hidden">
+        <ReviewMethodModal
+          open={reviewMethodModalOpen}
+          onOpenChange={setReviewMethodModalOpen}
+          onAiReview={handleReview}
+          onCodeRabbitReview={handleCodeRabbitReview}
+        />
         {showReviewFullWidth && activeSessionId ? (
           <div className="flex-1 min-h-0">
             <ReviewResultsPanel
@@ -2989,7 +2999,7 @@ export function ChatWindow({
                                 onCommit={handleCommit}
                                 onCommitAndPush={handleCommitAndPushWithPicker}
                                 onOpenPr={handleOpenPr}
-                                onReview={() => handleReview()}
+                                onReview={() => setReviewMethodModalOpen(true)}
                                 onMerge={handleMerge}
                                 onMergePr={handleMergePr}
                                 onResolvePrConflicts={handleResolvePrConflicts}

--- a/src/components/chat/ReviewMethodModal.tsx
+++ b/src/components/chat/ReviewMethodModal.tsx
@@ -1,0 +1,140 @@
+import { Bot, Loader2, Rabbit } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useCodeRabbitCliStatus } from '@/services/coderabbit-cli'
+import { useUIStore } from '@/store/ui-store'
+import { cn } from '@/lib/utils'
+
+interface ReviewMethodModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onAiReview: () => void
+  onCodeRabbitReview: () => void
+}
+
+export function ReviewMethodModal({
+  open,
+  onOpenChange,
+  onAiReview,
+  onCodeRabbitReview,
+}: ReviewMethodModalProps) {
+  const { data: coderabbitStatus, isLoading } = useCodeRabbitCliStatus({
+    enabled: open,
+  })
+  const openPreferencesPane = useUIStore(state => state.openPreferencesPane)
+  const codeRabbitReady = Boolean(coderabbitStatus?.installed)
+
+  const choose = (handler: () => void) => {
+    onOpenChange(false)
+    handler()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[min(360px,calc(100vw-32px))] gap-3 p-4 sm:max-w-[360px]">
+        <DialogHeader className="space-y-1 pr-6">
+          <DialogTitle className="text-base font-semibold">
+            Review with
+          </DialogTitle>
+          <DialogDescription className="text-xs leading-5">
+            Choose the reviewer for this worktree.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-2">
+          <ReviewChoice
+            icon={<Bot className="size-4" />}
+            title="Jean"
+            subtitle="Uses your configured review backend"
+            badge="Default"
+            onClick={() => choose(onAiReview)}
+          />
+
+          <ReviewChoice
+            icon={
+              isLoading ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Rabbit className="size-4" />
+              )
+            }
+            title="CodeRabbit"
+            subtitle={
+              codeRabbitReady
+                ? 'Runs coderabbit review'
+                : 'Install or select in Settings'
+            }
+            disabled={isLoading || !codeRabbitReady}
+            onClick={() => choose(onCodeRabbitReview)}
+          />
+        </div>
+
+        {!codeRabbitReady && !isLoading && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 justify-start px-2 text-xs text-muted-foreground"
+            onClick={() => {
+              onOpenChange(false)
+              openPreferencesPane('general')
+            }}
+          >
+            Open CodeRabbit settings
+          </Button>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ReviewChoice({
+  icon,
+  title,
+  subtitle,
+  badge,
+  disabled,
+  onClick,
+}: {
+  icon: React.ReactNode
+  title: string
+  subtitle: string
+  badge?: string
+  disabled?: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        'flex w-full items-center gap-3 rounded-lg border border-border/70 bg-muted/25 px-3 py-2.5 text-left transition-colors',
+        'hover:border-border hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        disabled && 'cursor-not-allowed opacity-50 hover:bg-muted/25'
+      )}
+    >
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background text-muted-foreground">
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-2 text-sm font-medium leading-none">
+          {title}
+          {badge && (
+            <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+              {badge}
+            </span>
+          )}
+        </span>
+        <span className="mt-1 block truncate text-xs text-muted-foreground">
+          {subtitle}
+        </span>
+      </span>
+    </button>
+  )
+}

--- a/src/components/chat/hooks/useGitOperations.ts
+++ b/src/components/chat/hooks/useGitOperations.ts
@@ -79,8 +79,10 @@ interface UseGitOperationsReturn {
   handlePush: (remote?: string) => Promise<void>
   /** Creates PR with AI-generated title and description */
   handleOpenPr: () => Promise<void>
-  /** Runs AI code review. If existingSessionId is provided, stores results on that session instead of creating a new one. */
-  handleReview: (existingSessionId?: string) => Promise<void>
+  /** Runs AI code review. */
+  handleReview: () => Promise<void>
+  /** Runs CodeRabbit CLI code review. */
+  handleCodeRabbitReview: () => Promise<void>
   /** Validates and shows merge options dialog */
   handleMerge: () => Promise<void>
   /** Merges open PR on GitHub then archives/deletes worktree */
@@ -520,180 +522,206 @@ export function useGitOperations({
   // Handle Review - runs AI code review in background
   // If existingSessionId is provided, stores results on that session (in-place review from ChatWindow)
   // Creates a new session and stores review results in it
-  const handleReview = useCallback(async () => {
-    if (!activeWorktreeId || !activeWorktreePath) return
+  const runReview = useCallback(
+    async (source: 'ai' | 'coderabbit') => {
+      if (!activeWorktreeId || !activeWorktreePath) return
 
-    const { setWorktreeLoading, clearWorktreeLoading } = useChatStore.getState()
-    setWorktreeLoading(activeWorktreeId, 'review')
-    const branch = worktree?.branch ?? ''
-    const projectName = project?.name ?? 'project'
-    const worktreeName = worktree?.name ?? branch
-    const reviewTarget = `${projectName}/${worktreeName}`
-    const reviewRunId = generateId()
-    let cancelRequested = false
-    const toastId = toast.loading(`Reviewing ${reviewTarget}...`, {
-      cancel: {
-        label: 'Cancel',
-        onClick: () => {
-          cancelRequested = true
-          toast.loading(`Cancelling review for ${reviewTarget}...`, {
-            id: toastId,
-          })
-          invoke<boolean>('cancel_review_with_ai', { reviewRunId })
-            .then(cancelled => {
-              if (cancelled) {
-                toast.info(`Review cancelled for ${reviewTarget}`, {
+      const { setWorktreeLoading, clearWorktreeLoading } =
+        useChatStore.getState()
+      setWorktreeLoading(activeWorktreeId, 'review')
+      const branch = worktree?.branch ?? ''
+      const projectName = project?.name ?? 'project'
+      const worktreeName = worktree?.name ?? branch
+      const reviewTarget = `${projectName}/${worktreeName}`
+      const reviewRunId = generateId()
+      let cancelRequested = false
+      const reviewLabel =
+        source === 'coderabbit' ? 'CodeRabbit review' : 'Review'
+      const toastId = toast.loading(`${reviewLabel} for ${reviewTarget}...`, {
+        cancel: {
+          label: 'Cancel',
+          onClick: () => {
+            cancelRequested = true
+            toast.loading(`Cancelling review for ${reviewTarget}...`, {
+              id: toastId,
+            })
+            invoke<boolean>('cancel_review_with_ai', { reviewRunId })
+              .then(cancelled => {
+                if (cancelled) {
+                  toast.info(`Review cancelled for ${reviewTarget}`, {
+                    id: toastId,
+                  })
+                } else {
+                  toast.info(`No active review to cancel for ${reviewTarget}`, {
+                    id: toastId,
+                  })
+                }
+              })
+              .catch(error => {
+                toast.error(`Failed to cancel review: ${error}`, {
                   id: toastId,
                 })
-              } else {
-                toast.info(`No active review to cancel for ${reviewTarget}`, {
-                  id: toastId,
-                })
-              }
-            })
-            .catch(error => {
-              toast.error(`Failed to cancel review: ${error}`, { id: toastId })
-            })
-        },
-      },
-    })
-
-    // Fire-and-forget: detect and link PR if not already linked
-    if (!worktree?.pr_number) {
-      invoke<DetectPrResponse | null>('detect_and_link_pr', {
-        worktreeId: activeWorktreeId,
-        worktreePath: activeWorktreePath,
-      })
-        .then(result => {
-          if (result && worktree?.project_id) {
-            queryClient.invalidateQueries({
-              queryKey: projectsQueryKeys.worktrees(worktree.project_id),
-            })
-            queryClient.invalidateQueries({
-              queryKey: [
-                ...projectsQueryKeys.all,
-                'worktree',
-                activeWorktreeId,
-              ],
-            })
-          }
-        })
-        .catch(() => {
-          /* noop - PR detection is best-effort */
-        })
-    }
-
-    try {
-      const result = await invoke<ReviewResponse>('run_review_with_ai', {
-        worktreePath: activeWorktreePath,
-        customPrompt: preferences?.magic_prompts?.code_review,
-        model: preferences?.magic_prompt_models?.code_review_model,
-        customProfileName: resolveMagicPromptProvider(
-          preferences?.magic_prompt_providers,
-          'code_review_provider',
-          preferences?.default_provider
-        ),
-        reasoningEffort:
-          preferences?.magic_prompt_efforts?.code_review_effort ?? null,
-        reviewRunId,
-      })
-
-      // Always create a new session for the review
-      const newSession = await invoke<Session>('create_session', {
-        worktreeId: activeWorktreeId,
-        worktreePath: activeWorktreePath,
-        name: 'Code Review',
-      })
-      const targetSessionId = newSession.id
-
-      // Store review results in Zustand (session-scoped, auto-opens sidebar)
-      const {
-        setReviewResults,
-        setActiveSession,
-        clearActiveWorktree,
-        copySessionSettings,
-        activeSessionIds,
-      } = useChatStore.getState()
-      const currentReviewSessionId = activeSessionIds[activeWorktreeId]
-      setReviewResults(targetSessionId, result)
-
-      // Inherit model/mode/thinking settings from current session
-      if (currentReviewSessionId)
-        copySessionSettings(currentReviewSessionId, targetSessionId)
-
-      // Navigate to ProjectCanvasView and open the review session
-      setActiveSession(activeWorktreeId, targetSessionId)
-      useProjectsStore.getState().selectWorktree(activeWorktreeId)
-      clearActiveWorktree()
-      useUIStore
-        .getState()
-        .markWorktreeForAutoOpenSession(activeWorktreeId, targetSessionId)
-
-      // Persist review results to session file
-      invoke('update_session_state', {
-        worktreeId: activeWorktreeId,
-        worktreePath: activeWorktreePath,
-        sessionId: targetSessionId,
-        reviewResults: result,
-      }).catch(() => {
-        /* noop - best effort persist */
-      })
-
-      // Invalidate sessions query to refresh tab bar
-      queryClient.invalidateQueries({
-        queryKey: chatQueryKeys.sessions(activeWorktreeId),
-      })
-
-      const findingCount = result.findings.length
-      toast.success(
-        `Review done on ${projectName}/${worktreeName} (${findingCount} findings)`,
-        {
-          id: toastId,
-          action: {
-            label: 'Open',
-            onClick: () => {
-              if (!activeWorktreePath) return
-              const { setActiveSession, clearActiveWorktree } =
-                useChatStore.getState()
-              useProjectsStore.getState().selectWorktree(activeWorktreeId)
-              clearActiveWorktree()
-              setActiveSession(activeWorktreeId, targetSessionId)
-              useUIStore
-                .getState()
-                .markWorktreeForAutoOpenSession(
-                  activeWorktreeId,
-                  targetSessionId
-                )
-            },
+              })
           },
-        }
-      )
-    } catch (error) {
-      const errorString = String(error)
-      const cancelled =
-        cancelRequested ||
-        errorString.toLowerCase().includes('cancelled') ||
-        errorString.toLowerCase().includes('canceled')
-      if (cancelled) {
-        toast.info(`Review cancelled for ${reviewTarget}`, { id: toastId })
-      } else {
-        toast.error(`Failed to review: ${error}`, { id: toastId })
+        },
+      })
+
+      // Fire-and-forget: detect and link PR if not already linked
+      if (!worktree?.pr_number) {
+        invoke<DetectPrResponse | null>('detect_and_link_pr', {
+          worktreeId: activeWorktreeId,
+          worktreePath: activeWorktreePath,
+        })
+          .then(result => {
+            if (result && worktree?.project_id) {
+              queryClient.invalidateQueries({
+                queryKey: projectsQueryKeys.worktrees(worktree.project_id),
+              })
+              queryClient.invalidateQueries({
+                queryKey: [
+                  ...projectsQueryKeys.all,
+                  'worktree',
+                  activeWorktreeId,
+                ],
+              })
+            }
+          })
+          .catch(() => {
+            /* noop - PR detection is best-effort */
+          })
       }
-    } finally {
-      clearWorktreeLoading(activeWorktreeId)
-    }
-  }, [
-    activeWorktreeId,
-    activeWorktreePath,
-    worktree,
-    project?.name,
-    queryClient,
-    preferences?.magic_prompts?.code_review,
-    preferences?.magic_prompt_models?.code_review_model,
-    preferences?.magic_prompt_providers,
-    preferences?.default_provider,
-    preferences?.magic_prompt_efforts?.code_review_effort,
-  ])
+
+      try {
+        const result = await invoke<ReviewResponse>(
+          source === 'coderabbit'
+            ? 'run_coderabbit_review'
+            : 'run_review_with_ai',
+          source === 'coderabbit'
+            ? {
+                worktreePath: activeWorktreePath,
+                reviewRunId,
+                reviewType: 'all',
+              }
+            : {
+                worktreePath: activeWorktreePath,
+                customPrompt: preferences?.magic_prompts?.code_review,
+                model: preferences?.magic_prompt_models?.code_review_model,
+                customProfileName: resolveMagicPromptProvider(
+                  preferences?.magic_prompt_providers,
+                  'code_review_provider',
+                  preferences?.default_provider
+                ),
+                reasoningEffort:
+                  preferences?.magic_prompt_efforts?.code_review_effort ?? null,
+                reviewRunId,
+              }
+        )
+
+        // Always create a new session for the review
+        const newSession = await invoke<Session>('create_session', {
+          worktreeId: activeWorktreeId,
+          worktreePath: activeWorktreePath,
+          name: 'Code Review',
+        })
+        const targetSessionId = newSession.id
+
+        // Store review results in Zustand (session-scoped, auto-opens sidebar)
+        const {
+          setReviewResults,
+          setActiveSession,
+          clearActiveWorktree,
+          copySessionSettings,
+          activeSessionIds,
+        } = useChatStore.getState()
+        const currentReviewSessionId = activeSessionIds[activeWorktreeId]
+        setReviewResults(targetSessionId, result)
+
+        // Inherit model/mode/thinking settings from current session
+        if (currentReviewSessionId)
+          copySessionSettings(currentReviewSessionId, targetSessionId)
+
+        // Navigate to ProjectCanvasView and open the review session
+        setActiveSession(activeWorktreeId, targetSessionId)
+        useProjectsStore.getState().selectWorktree(activeWorktreeId)
+        clearActiveWorktree()
+        useUIStore
+          .getState()
+          .markWorktreeForAutoOpenSession(activeWorktreeId, targetSessionId)
+
+        // Persist review results to session file
+        invoke('update_session_state', {
+          worktreeId: activeWorktreeId,
+          worktreePath: activeWorktreePath,
+          sessionId: targetSessionId,
+          reviewResults: result,
+        }).catch(() => {
+          /* noop - best effort persist */
+        })
+
+        // Invalidate sessions query to refresh tab bar
+        queryClient.invalidateQueries({
+          queryKey: chatQueryKeys.sessions(activeWorktreeId),
+        })
+
+        const findingCount = result.findings.length
+        toast.success(
+          `${source === 'coderabbit' ? 'CodeRabbit review' : 'Review'} done on ${projectName}/${worktreeName} (${findingCount} findings)`,
+          {
+            id: toastId,
+            action: {
+              label: 'Open',
+              onClick: () => {
+                if (!activeWorktreePath) return
+                const { setActiveSession, clearActiveWorktree } =
+                  useChatStore.getState()
+                useProjectsStore.getState().selectWorktree(activeWorktreeId)
+                clearActiveWorktree()
+                setActiveSession(activeWorktreeId, targetSessionId)
+                useUIStore
+                  .getState()
+                  .markWorktreeForAutoOpenSession(
+                    activeWorktreeId,
+                    targetSessionId
+                  )
+              },
+            },
+          }
+        )
+      } catch (error) {
+        const errorString = String(error)
+        const cancelled =
+          cancelRequested ||
+          errorString.toLowerCase().includes('cancelled') ||
+          errorString.toLowerCase().includes('canceled')
+        if (cancelled) {
+          toast.info(`Review cancelled for ${reviewTarget}`, { id: toastId })
+        } else {
+          toast.error(`Failed to review: ${error}`, { id: toastId })
+        }
+      } finally {
+        clearWorktreeLoading(activeWorktreeId)
+      }
+    },
+    [
+      activeWorktreeId,
+      activeWorktreePath,
+      worktree,
+      project?.name,
+      queryClient,
+      preferences?.magic_prompts?.code_review,
+      preferences?.magic_prompt_models?.code_review_model,
+      preferences?.magic_prompt_providers,
+      preferences?.default_provider,
+      preferences?.magic_prompt_efforts?.code_review_effort,
+    ]
+  )
+
+  const handleReview = useCallback(() => runReview('ai'), [runReview])
+
+  const handleCodeRabbitReview = useCallback(
+    () => runReview('coderabbit'),
+    [runReview]
+  )
 
   // Handle Merge - validates and shows merge options dialog
   const handleMerge = useCallback(async () => {
@@ -1147,6 +1175,7 @@ ${resolveInstructions}`
     handlePush,
     handleOpenPr,
     handleReview,
+    handleCodeRabbitReview,
     handleMerge,
     handleMergePr,
     handleResolveConflicts,

--- a/src/components/magic/MagicModal.tsx
+++ b/src/components/magic/MagicModal.tsx
@@ -87,6 +87,7 @@ import {
   OPENCODE_MODEL_OPTIONS,
 } from '@/components/chat/toolbar/toolbar-options'
 import { formatOpencodeModelLabel } from '@/components/chat/toolbar/toolbar-utils'
+import { ReviewMethodModal } from '@/components/chat/ReviewMethodModal'
 
 type MagicOption =
   | 'save-context'
@@ -366,6 +367,7 @@ export function MagicModal() {
   const [customInvestigateModel, setCustomInvestigateModel] =
     useState<string>('sonnet')
   const [resolveDialogOpen, setResolveDialogOpen] = useState(false)
+  const [reviewMethodDialogOpen, setReviewMethodDialogOpen] = useState(false)
   const [resolveSelectionMode, setResolveSelectionMode] =
     useState<ResolveSelectionMode>('settings-default')
   const [customResolveBackend, setCustomResolveBackend] =
@@ -789,7 +791,8 @@ export function MagicModal() {
   const executeGitDirectly = useCallback(
     async (
       option: MagicOption,
-      override?: { backend: CliBackend; model: string }
+      override?: { backend: CliBackend; model: string },
+      reviewSource: 'ai' | 'coderabbit' = 'ai'
     ) => {
       if (!selectedWorktreeId || !worktree?.path) return
 
@@ -1258,19 +1261,31 @@ ${resolveInstructions}`
           }
 
           try {
-            const result = await invoke<ReviewResponse>('run_review_with_ai', {
-              worktreePath: worktree.path,
-              customPrompt: preferences?.magic_prompts?.code_review,
-              model: preferences?.magic_prompt_models?.code_review_model,
-              customProfileName: resolveMagicPromptProvider(
-                preferences?.magic_prompt_providers,
-                'code_review_provider',
-                preferences?.default_provider
-              ),
-              reasoningEffort:
-                preferences?.magic_prompt_efforts?.code_review_effort ?? null,
-              reviewRunId,
-            })
+            const result = await invoke<ReviewResponse>(
+              reviewSource === 'coderabbit'
+                ? 'run_coderabbit_review'
+                : 'run_review_with_ai',
+              reviewSource === 'coderabbit'
+                ? {
+                    worktreePath: worktree.path,
+                    reviewRunId,
+                    reviewType: 'all',
+                  }
+                : {
+                    worktreePath: worktree.path,
+                    customPrompt: preferences?.magic_prompts?.code_review,
+                    model: preferences?.magic_prompt_models?.code_review_model,
+                    customProfileName: resolveMagicPromptProvider(
+                      preferences?.magic_prompt_providers,
+                      'code_review_provider',
+                      preferences?.default_provider
+                    ),
+                    reasoningEffort:
+                      preferences?.magic_prompt_efforts?.code_review_effort ??
+                      null,
+                    reviewRunId,
+                  }
+            )
 
             const newSession = await invoke<Session>('create_session', {
               worktreeId: selectedWorktreeId,
@@ -1315,7 +1330,7 @@ ${resolveInstructions}`
 
             const findingCount = result.findings.length
             toast.success(
-              `Review done on ${reviewTarget} (${findingCount} findings)`,
+              `${reviewSource === 'coderabbit' ? 'CodeRabbit review' : 'Review'} done on ${reviewTarget} (${findingCount} findings)`,
               {
                 id: toastId,
                 action: {
@@ -1409,6 +1424,17 @@ ${resolveInstructions}`
     async (option: MagicOption) => {
       // Block disabled options on canvas
       if (isOnCanvas && !CANVAS_ALLOWED_OPTIONS.has(option)) {
+        return
+      }
+
+      if (option === 'review') {
+        if (!selectedWorktreeId || !worktree?.path) {
+          notify('No worktree selected', undefined, { type: 'error' })
+          setMagicModalOpen(false)
+          return
+        }
+        setMagicModalOpen(false)
+        setReviewMethodDialogOpen(true)
         return
       }
 
@@ -1637,6 +1663,14 @@ ${resolveInstructions}`
 
   return (
     <>
+      <ReviewMethodModal
+        open={reviewMethodDialogOpen}
+        onOpenChange={setReviewMethodDialogOpen}
+        onAiReview={() => executeGitDirectly('review', undefined, 'ai')}
+        onCodeRabbitReview={() =>
+          executeGitDirectly('review', undefined, 'coderabbit')
+        }
+      />
       <Dialog open={magicModalOpen} onOpenChange={handleOpenChange}>
         <DialogContent
           ref={contentRef}

--- a/src/components/preferences/CliLoginModal.tsx
+++ b/src/components/preferences/CliLoginModal.tsx
@@ -16,6 +16,7 @@ import { ghCliQueryKeys } from '@/services/gh-cli'
 import { codexCliQueryKeys } from '@/services/codex-cli'
 import { opencodeCliQueryKeys } from '@/services/opencode-cli'
 import { cursorCliQueryKeys } from '@/services/cursor-cli'
+import { coderabbitCliQueryKeys } from '@/services/coderabbit-cli'
 import { githubQueryKeys } from '@/services/github'
 import {
   Dialog,
@@ -61,7 +62,14 @@ export function CliLoginModal() {
 }
 
 interface CliLoginModalContentProps {
-  cliType: 'claude' | 'gh' | 'codex' | 'opencode' | 'cursor' | null
+  cliType:
+    | 'claude'
+    | 'gh'
+    | 'codex'
+    | 'opencode'
+    | 'cursor'
+    | 'coderabbit'
+    | null
   command: string
   commandArgs: string[] | null
   action: 'login' | 'update' | 'install'
@@ -90,11 +98,13 @@ function CliLoginModalContent({
       ? 'Claude CLI'
       : cliType === 'codex'
         ? 'Codex CLI'
-        : cliType === 'opencode'
-          ? 'OpenCode CLI'
-          : cliType === 'cursor'
-            ? 'Cursor CLI'
-            : 'GitHub CLI'
+        : cliType === 'coderabbit'
+          ? 'CodeRabbit CLI'
+          : cliType === 'opencode'
+            ? 'OpenCode CLI'
+            : cliType === 'cursor'
+              ? 'Cursor CLI'
+              : 'GitHub CLI'
   const cliTitle =
     cliType === 'cursor' ? (
       <span className="inline-flex items-center gap-2">
@@ -224,6 +234,10 @@ function CliLoginModalContent({
           queryClient.invalidateQueries({ queryKey: opencodeCliQueryKeys.all })
         } else if (cliType === 'cursor') {
           queryClient.invalidateQueries({ queryKey: cursorCliQueryKeys.all })
+        } else if (cliType === 'coderabbit') {
+          queryClient.invalidateQueries({
+            queryKey: coderabbitCliQueryKeys.all,
+          })
         }
 
         // Dismiss any lingering update toast for this CLI type

--- a/src/components/preferences/PreferencesDialog.test.tsx
+++ b/src/components/preferences/PreferencesDialog.test.tsx
@@ -30,6 +30,10 @@ vi.mock('./panes/GitHubPane', () => ({
   GitHubPane: () => <div>GitHub CLI pane</div>,
 }))
 
+vi.mock('./panes/CodeRabbitPane', () => ({
+  CodeRabbitPane: () => <div>CodeRabbit CLI pane</div>,
+}))
+
 vi.mock('./panes/AppearancePane', () => ({
   AppearancePane: () => <div>Appearance pane</div>,
 }))
@@ -140,6 +144,7 @@ describe('PreferencesDialog', () => {
       'OpenCode',
       'Cursor',
       'GitHub CLI',
+      'CodeRabbit CLI',
       'Magic Prompts',
       'Opinionated',
       'Providers',

--- a/src/components/preferences/PreferencesDialog.tsx
+++ b/src/components/preferences/PreferencesDialog.tsx
@@ -11,6 +11,7 @@ import {
   FlaskConical,
   Globe,
   Github,
+  Rabbit,
   Sparkles,
   type LucideIcon,
 } from 'lucide-react'
@@ -60,6 +61,7 @@ import { CodexPane } from './panes/CodexPane'
 import { OpenCodePane } from './panes/OpenCodePane'
 import { CursorPane } from './panes/CursorPane'
 import { GitHubPane } from './panes/GitHubPane'
+import { CodeRabbitPane } from './panes/CodeRabbitPane'
 import { AppearancePane } from './panes/AppearancePane'
 import { KeybindingsPane } from './panes/KeybindingsPane'
 import { MagicPromptsPane } from './panes/MagicPromptsPane'
@@ -140,6 +142,12 @@ const navigationEntries: (NavigationItem | NavigationSeparator)[] = [
     name: 'GitHub CLI',
     icon: Github,
   },
+  {
+    type: 'item',
+    id: 'coderabbit',
+    name: 'CodeRabbit CLI',
+    icon: Rabbit,
+  },
   { type: 'separator', id: 'backend-separator' },
   {
     type: 'item',
@@ -206,6 +214,7 @@ const paneIconMap: Record<PreferencePane, LucideIcon> = {
   opencode: OpenCodeIcon,
   cursor: CursorIcon,
   github: Github,
+  coderabbit: Rabbit,
   opinionated: Sparkles,
   providers: Blocks,
   usage: BarChart3,
@@ -232,6 +241,8 @@ const getPaneTitle = (pane: PreferencePane): string => {
       return 'Cursor'
     case 'github':
       return 'GitHub CLI'
+    case 'coderabbit':
+      return 'CodeRabbit CLI'
     case 'appearance':
       return 'Appearance'
     case 'keybindings':
@@ -776,6 +787,11 @@ export function PreferencesDialog() {
               {activePane === 'github' && (
                 <div id="pref-pane-github">
                   <GitHubPane />
+                </div>
+              )}
+              {activePane === 'coderabbit' && (
+                <div id="pref-pane-coderabbit">
+                  <CodeRabbitPane />
                 </div>
               )}
               {activePane === 'appearance' && (

--- a/src/components/preferences/panes/CodeRabbitPane.tsx
+++ b/src/components/preferences/panes/CodeRabbitPane.tsx
@@ -1,0 +1,5 @@
+import { GeneralPane } from './GeneralPane'
+
+export function CodeRabbitPane() {
+  return <GeneralPane scope="coderabbit" />
+}

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -50,6 +50,14 @@ import {
   useCodexPathDetection,
 } from '@/services/codex-cli'
 import {
+  useCodeRabbitCliStatus,
+  useCodeRabbitCliAuth,
+  useCodeRabbitPathDetection,
+  useInstallCodeRabbitCli,
+  useUpdateCodeRabbitCli,
+  coderabbitCliQueryKeys,
+} from '@/services/coderabbit-cli'
+import {
   useOpenCodeCliStatus,
   useOpenCodeCliAuth,
   useAvailableOpencodeModels,
@@ -69,6 +77,7 @@ import {
 import type { ClaudeAuthStatus } from '@/types/claude-cli'
 import type { GhAuthStatus } from '@/types/gh-cli'
 import type { CodexAuthStatus } from '@/types/codex-cli'
+import type { CodeRabbitAuthStatus } from '@/types/coderabbit-cli'
 import type { OpenCodeAuthStatus } from '@/types/opencode-cli'
 import type { CursorAuthStatus } from '@/types/cursor-cli'
 import {
@@ -173,6 +182,7 @@ type PreferencesPaneScope =
   | 'opencode'
   | 'cursor'
   | 'github'
+  | 'coderabbit'
 
 export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
   scope = 'general',
@@ -184,7 +194,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
   const [showDeleteAllDialog, setShowDeleteAllDialog] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [deleteCliTarget, setDeleteCliTarget] = useState<
-    'claude' | 'codex' | 'opencode' | 'gh' | null
+    'claude' | 'codex' | 'opencode' | 'gh' | 'coderabbit' | null
   >(null)
   const [isDeletingCli, setIsDeletingCli] = useState(false)
 
@@ -193,6 +203,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
   const { data: codexPathDetection } = useCodexPathDetection()
   const { data: opencodePathDetection } = useOpenCodePathDetection()
   const { data: ghPathDetection } = useGhPathDetection()
+  const { data: coderabbitPathDetection } = useCodeRabbitPathDetection()
   const { data: cursorPathDetection } = useCursorPathDetection()
 
   // CLI status hooks
@@ -227,6 +238,11 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
     !!codexStatus?.version &&
     !!codexLatestStable &&
     isNewerVersion(codexLatestStable.version, codexStatus.version)
+  const { data: coderabbitStatus, isLoading: isCodeRabbitLoading } =
+    useCodeRabbitCliStatus()
+  const isCodeRabbitPathSource = preferences?.coderabbit_cli_source === 'path'
+  const installCodeRabbitCli = useInstallCodeRabbitCli()
+  const updateCodeRabbitCli = useUpdateCodeRabbitCli()
   const { data: opencodeStatus, isLoading: isOpenCodeLoading } =
     useOpenCodeCliStatus()
   const isOpencodePathSource = preferences?.opencode_cli_source === 'path'
@@ -252,6 +268,10 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
   const { data: codexAuth, isLoading: isCodexAuthLoading } = useCodexCliAuth({
     enabled: !!codexStatus?.installed,
   })
+  const { data: coderabbitAuth, isLoading: isCodeRabbitAuthLoading } =
+    useCodeRabbitCliAuth({
+      enabled: !!coderabbitStatus?.installed,
+    })
   const { data: opencodeAuth, isLoading: isOpenCodeAuthLoading } =
     useOpenCodeCliAuth({
       enabled: !!opencodeStatus?.installed,
@@ -275,6 +295,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
     gh: preferences?.gh_cli_source,
     codex: preferences?.codex_cli_source,
     opencode: preferences?.opencode_cli_source,
+    coderabbit: preferences?.coderabbit_cli_source,
   })
   useEffect(() => {
     const cur = {
@@ -282,6 +303,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
       gh: preferences?.gh_cli_source,
       codex: preferences?.codex_cli_source,
       opencode: preferences?.opencode_cli_source,
+      coderabbit: preferences?.coderabbit_cli_source,
     }
     if (cur.claude !== prevSources.current.claude) {
       queryClient.invalidateQueries({ queryKey: claudeCliQueryKeys.status() })
@@ -295,12 +317,18 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
     if (cur.opencode !== prevSources.current.opencode) {
       queryClient.invalidateQueries({ queryKey: opencodeCliQueryKeys.status() })
     }
+    if (cur.coderabbit !== prevSources.current.coderabbit) {
+      queryClient.invalidateQueries({
+        queryKey: coderabbitCliQueryKeys.status(),
+      })
+    }
     prevSources.current = cur
   }, [
     preferences?.claude_cli_source,
     preferences?.gh_cli_source,
     preferences?.codex_cli_source,
     preferences?.opencode_cli_source,
+    preferences?.coderabbit_cli_source,
     queryClient,
   ])
 
@@ -320,6 +348,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
   const [checkingClaudeAuth, setCheckingClaudeAuth] = useState(false)
   const [checkingGhAuth, setCheckingGhAuth] = useState(false)
   const [checkingCodexAuth, setCheckingCodexAuth] = useState(false)
+  const [checkingCodeRabbitAuth, setCheckingCodeRabbitAuth] = useState(false)
   const [checkingOpenCodeAuth, setCheckingOpenCodeAuth] = useState(false)
   const [checkingCursorAuth, setCheckingCursorAuth] = useState(false)
   const [openCodeModelPopoverOpen, setOpenCodeModelPopoverOpen] =
@@ -484,6 +513,21 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
     }
   }
 
+  const handleCodeRabbitSourceChange = (value: 'jean' | 'path') => {
+    if (preferences) {
+      patchPreferences.mutate(
+        { coderabbit_cli_source: value },
+        {
+          onSuccess: () => {
+            queryClient.invalidateQueries({
+              queryKey: coderabbitCliQueryKeys.all,
+            })
+          },
+        }
+      )
+    }
+  }
+
   const handleOpencodeSourceChange = (value: 'jean' | 'path') => {
     if (preferences) {
       patchPreferences.mutate(
@@ -510,6 +554,10 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
         cmd: 'uninstall_opencode_cli' as const,
       },
       gh: { name: 'GitHub CLI', cmd: 'uninstall_gh_cli' as const },
+      coderabbit: {
+        name: 'CodeRabbit CLI',
+        cmd: 'uninstall_coderabbit_cli' as const,
+      },
     }
     const { name, cmd } = labelMap[target]
     setIsDeletingCli(true)
@@ -523,7 +571,9 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
             ? 'codex_cli_source'
             : target === 'opencode'
               ? 'opencode_cli_source'
-              : 'gh_cli_source'
+              : target === 'gh'
+                ? 'gh_cli_source'
+                : 'coderabbit_cli_source'
       await new Promise<void>((resolve, reject) => {
         patchPreferences.mutate(
           { [sourceKey]: 'path' } as Partial<AppPreferences>,
@@ -540,7 +590,9 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
             ? codexCliQueryKeys.all
             : target === 'opencode'
               ? opencodeCliQueryKeys.all
-              : ghCliQueryKeys.all
+              : target === 'gh'
+                ? ghCliQueryKeys.all
+                : coderabbitCliQueryKeys.all
       queryClient.invalidateQueries({ queryKey: queryKeys })
       const pathFound =
         target === 'claude'
@@ -549,7 +601,9 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
             ? codexPathDetection?.found
             : target === 'opencode'
               ? opencodePathDetection?.found
-              : ghPathDetection?.found
+              : target === 'gh'
+                ? ghPathDetection?.found
+                : coderabbitPathDetection?.found
       if (pathFound) {
         toast.success(`Jean-managed ${name} removed. Using system PATH.`, {
           id: toastId,
@@ -879,6 +933,29 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
     openCliLoginModal('codex', codexStatus.path, ['login'])
   }, [codexStatus?.path, openCliLoginModal, queryClient])
 
+  const handleCodeRabbitLogin = useCallback(async () => {
+    if (!coderabbitStatus?.path) return
+
+    setCheckingCodeRabbitAuth(true)
+    try {
+      await queryClient.invalidateQueries({
+        queryKey: coderabbitCliQueryKeys.auth(),
+      })
+      const result = await queryClient.fetchQuery<CodeRabbitAuthStatus>({
+        queryKey: coderabbitCliQueryKeys.auth(),
+      })
+
+      if (result?.authenticated) {
+        toast.success('CodeRabbit CLI is already authenticated')
+        return
+      }
+    } finally {
+      setCheckingCodeRabbitAuth(false)
+    }
+
+    openCliLoginModal('coderabbit', coderabbitStatus.path, ['auth', 'login'])
+  }, [coderabbitStatus?.path, openCliLoginModal, queryClient])
+
   const handleOpenCodeLogin = useCallback(async () => {
     if (!opencodeStatus?.path) return
 
@@ -922,6 +999,11 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
     if (!opencodeStatus?.path) return
     openCliLoginModal('opencode', opencodeStatus.path, ['auth', 'login'])
   }, [opencodeStatus?.path, openCliLoginModal])
+
+  const handleCodeRabbitRelogin = useCallback(() => {
+    if (!coderabbitStatus?.path) return
+    openCliLoginModal('coderabbit', coderabbitStatus.path, ['auth', 'login'])
+  }, [coderabbitStatus?.path, openCliLoginModal])
 
   const handleCursorLogin = useCallback(async () => {
     if (!cursorStatus?.path) return
@@ -1294,6 +1376,161 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
                         size="sm"
                         className="text-destructive hover:text-destructive"
                         onClick={() => setDeleteCliTarget('gh')}
+                      >
+                        Delete managed install
+                      </Button>
+                    )}
+                </div>
+              </InlineField>
+            )}
+          </div>
+        </SettingsSection>
+      )}
+
+      {hasBackend() && scope === 'coderabbit' && (
+        <SettingsSection
+          title="CodeRabbit CLI"
+          anchorId="pref-coderabbit-section-cli"
+          actions={
+            coderabbitStatus?.installed ? (
+              checkingCodeRabbitAuth || isCodeRabbitAuthLoading ? (
+                <span className="text-sm text-muted-foreground flex items-center gap-2">
+                  <Loader2 className="size-3 animate-spin" />
+                  Checking...
+                </span>
+              ) : coderabbitAuth?.authenticated ? (
+                <span className="text-sm text-muted-foreground flex items-center gap-2">
+                  Logged in
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleCodeRabbitRelogin}
+                  >
+                    Relogin
+                  </Button>
+                </span>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleCodeRabbitLogin}
+                >
+                  Login
+                </Button>
+              )
+            ) : (
+              <span className="text-sm text-muted-foreground">
+                Not installed
+              </span>
+            )
+          }
+        >
+          <div className="space-y-4">
+            <InlineField
+              label={coderabbitStatus?.installed ? 'Version' : 'Status'}
+              description={
+                coderabbitStatus?.installed
+                  ? 'Enables secondary CodeRabbit code reviews'
+                  : 'Optional — enables secondary CodeRabbit code reviews'
+              }
+            >
+              {isCodeRabbitLoading || installCodeRabbitCli.isPending ? (
+                <Loader2 className="size-4 animate-spin text-muted-foreground" />
+              ) : coderabbitStatus?.installed ? (
+                <div className="flex items-center gap-2">
+                  <span className="text-sm">
+                    {coderabbitStatus.version ?? 'Installed'}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={updateCodeRabbitCli.isPending}
+                    onClick={() => {
+                      if (isCodeRabbitPathSource) {
+                        const action = getPathUpdateAction(
+                          coderabbitStatus.path,
+                          coderabbitPathDetection?.package_manager,
+                          'coderabbit',
+                          ['update']
+                        )
+                        if (action) {
+                          openCliLoginModal(
+                            'coderabbit',
+                            action[0],
+                            action[1],
+                            'update'
+                          )
+                          return
+                        }
+                      }
+                      updateCodeRabbitCli.mutate()
+                    }}
+                  >
+                    {updateCodeRabbitCli.isPending ? 'Updating...' : 'Update'}
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  className="w-full sm:w-40"
+                  disabled={installCodeRabbitCli.isPending}
+                  onClick={() => installCodeRabbitCli.mutate()}
+                >
+                  {installCodeRabbitCli.isPending ? 'Installing...' : 'Install'}
+                </Button>
+              )}
+            </InlineField>
+            {(coderabbitStatus?.installed ||
+              coderabbitPathDetection?.found) && (
+              <InlineField
+                label="Source"
+                description={
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={() =>
+                          handleCopyPath(
+                            preferences?.coderabbit_cli_source === 'path'
+                              ? coderabbitPathDetection?.path
+                              : coderabbitStatus?.path
+                          )
+                        }
+                        className="text-left hover:underline cursor-pointer"
+                      >
+                        {preferences?.coderabbit_cli_source === 'path'
+                          ? (coderabbitPathDetection?.path ?? 'System PATH')
+                          : (coderabbitStatus?.path ?? 'Not installed')}
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>Click to copy path</TooltipContent>
+                  </Tooltip>
+                }
+              >
+                <div className="flex items-center gap-2">
+                  <Select
+                    value={preferences?.coderabbit_cli_source ?? 'jean'}
+                    onValueChange={handleCodeRabbitSourceChange}
+                  >
+                    <SelectTrigger className="w-96">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="jean">Jean (managed)</SelectItem>
+                      <SelectItem
+                        value="path"
+                        disabled={!coderabbitPathDetection?.found}
+                      >
+                        System PATH
+                        {!coderabbitPathDetection?.found && ' (not found)'}
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  {preferences?.coderabbit_cli_source === 'jean' &&
+                    coderabbitStatus?.installed && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => setDeleteCliTarget('coderabbit')}
                       >
                         Delete managed install
                       </Button>
@@ -3148,7 +3385,9 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
                   ? 'Codex CLI'
                   : deleteCliTarget === 'opencode'
                     ? 'OpenCode CLI'
-                    : 'GitHub CLI'}
+                    : deleteCliTarget === 'coderabbit'
+                      ? 'CodeRabbit CLI'
+                      : 'GitHub CLI'}
               ?
             </AlertDialogTitle>
             <AlertDialogDescription>
@@ -3162,7 +3401,9 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
                         ? opencodePathDetection?.found
                         : deleteCliTarget === 'gh'
                           ? ghPathDetection?.found
-                          : false
+                          : deleteCliTarget === 'coderabbit'
+                            ? coderabbitPathDetection?.found
+                            : false
                 return pathFound
                   ? 'The Jean-managed binary will be removed and the source will switch to System PATH. You can reinstall it later from this page.'
                   : 'The Jean-managed binary will be removed. No System PATH version was detected, so this backend will be unavailable until you reinstall it.'

--- a/src/components/preferences/preferences-search.test.ts
+++ b/src/components/preferences/preferences-search.test.ts
@@ -10,6 +10,7 @@ const nativeOnlyEntryIds = [
   'opencode-cli',
   'cursor-cli',
   'github-cli',
+  'coderabbit-cli',
   'general-troubleshooting',
   'web-access-server',
   'web-access-authentication',
@@ -73,6 +74,9 @@ describe('preferences search index', () => {
     expect(searchPreferenceEntries('opencode login')[0]?.pane).toBe('opencode')
     expect(searchPreferenceEntries('cursor model')[0]?.pane).toBe('cursor')
     expect(searchPreferenceEntries('github login')[0]?.pane).toBe('github')
+    expect(searchPreferenceEntries('coderabbit login')[0]?.pane).toBe(
+      'coderabbit'
+    )
   })
 
   it('returns relevant appearance hits for font queries', () => {

--- a/src/components/preferences/preferences-search.ts
+++ b/src/components/preferences/preferences-search.ts
@@ -78,6 +78,15 @@ const paneEntries: PreferenceSearchEntry[] = [
     anchorId: 'pref-pane-github',
   },
   {
+    id: 'pane-coderabbit',
+    pane: 'coderabbit',
+    paneTitle: 'CodeRabbit CLI',
+    type: 'pane',
+    title: 'CodeRabbit CLI Settings',
+    keywords: ['coderabbit', 'coderabbit cli', 'coderabbit login'],
+    anchorId: 'pref-pane-coderabbit',
+  },
+  {
     id: 'pane-providers',
     pane: 'providers',
     paneTitle: 'Providers',
@@ -208,6 +217,22 @@ const sectionEntries: PreferenceSearchEntry[] = [
     ],
     anchorId: 'pref-claude-section-settings',
     fallbackAnchorId: 'pref-pane-claude',
+  },
+  {
+    id: 'coderabbit-cli',
+    pane: 'coderabbit',
+    paneTitle: 'CodeRabbit CLI',
+    type: 'section',
+    title: 'CodeRabbit CLI',
+    sectionTitle: 'CodeRabbit CLI',
+    keywords: [
+      'coderabbit',
+      'install coderabbit',
+      'coderabbit login',
+      'code review',
+    ],
+    anchorId: 'pref-coderabbit-section-cli',
+    fallbackAnchorId: 'pref-pane-coderabbit',
   },
   {
     id: 'codex-cli',
@@ -547,6 +572,7 @@ const sectionEntries: PreferenceSearchEntry[] = [
 
 const nativeOnlySectionIds = new Set([
   'claude-cli',
+  'coderabbit-cli',
   'codex-cli',
   'opencode-cli',
   'cursor-cli',

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -593,6 +593,8 @@ class WsTransport {
     'install_codex_cli',
     'install_opencode_cli',
     'install_gh_cli',
+    'install_coderabbit_cli',
+    'run_coderabbit_review',
   ])
   private static readonly LONG_TIMEOUT = 30 * 60_000
   private static readonly DEFAULT_TIMEOUT = 60_000

--- a/src/services/coderabbit-cli.ts
+++ b/src/services/coderabbit-cli.ts
@@ -1,0 +1,162 @@
+/** CodeRabbit CLI management service. */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { hasBackend } from '@/lib/environment'
+import { invoke, listen, useWsConnectionStatus } from '@/lib/transport'
+import { logger } from '@/lib/logger'
+import type {
+  CodeRabbitAuthStatus,
+  CodeRabbitCliStatus,
+  CodeRabbitInstallProgress,
+  CodeRabbitPathDetection,
+} from '@/types/coderabbit-cli'
+
+const isTauri = hasBackend
+
+export const coderabbitCliQueryKeys = {
+  all: ['coderabbit-cli'] as const,
+  status: () => [...coderabbitCliQueryKeys.all, 'status'] as const,
+  auth: () => [...coderabbitCliQueryKeys.all, 'auth'] as const,
+  pathDetection: () =>
+    [...coderabbitCliQueryKeys.all, 'path-detection'] as const,
+}
+
+export function useCodeRabbitPathDetection(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: coderabbitCliQueryKeys.pathDetection(),
+    queryFn: async (): Promise<CodeRabbitPathDetection> => {
+      if (!isTauri()) {
+        return {
+          found: false,
+          path: null,
+          version: null,
+          package_manager: null,
+        }
+      }
+      try {
+        return invoke<CodeRabbitPathDetection>('detect_coderabbit_in_path')
+      } catch (error) {
+        logger.debug('CodeRabbit PATH detection failed', { error })
+        return {
+          found: false,
+          path: null,
+          version: null,
+          package_manager: null,
+        }
+      }
+    },
+    enabled: options?.enabled ?? true,
+    staleTime: 1000 * 60 * 30,
+    gcTime: 1000 * 60 * 60,
+  })
+}
+
+export function useCodeRabbitCliStatus(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: coderabbitCliQueryKeys.status(),
+    queryFn: async (): Promise<CodeRabbitCliStatus> => {
+      if (!isTauri()) return { installed: false, version: null, path: null }
+      try {
+        return invoke<CodeRabbitCliStatus>('check_coderabbit_cli_installed')
+      } catch (error) {
+        logger.error('Failed to check CodeRabbit CLI status', { error })
+        return { installed: false, version: null, path: null }
+      }
+    },
+    enabled: options?.enabled ?? true,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+    refetchInterval: 1000 * 60 * 60,
+  })
+}
+
+export function useCodeRabbitCliAuth(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: coderabbitCliQueryKeys.auth(),
+    queryFn: async (): Promise<CodeRabbitAuthStatus> => {
+      if (!isTauri())
+        return { authenticated: false, error: 'Not in Tauri context' }
+      try {
+        return invoke<CodeRabbitAuthStatus>('check_coderabbit_cli_auth')
+      } catch (error) {
+        logger.error('Failed to check CodeRabbit CLI auth', { error })
+        return { authenticated: false, error: String(error) }
+      }
+    },
+    enabled: options?.enabled ?? true,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+  })
+}
+
+export function useInstallCodeRabbitCli() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async () => {
+      await invoke('install_coderabbit_cli')
+    },
+    retry: false,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: coderabbitCliQueryKeys.all })
+      toast.success('CodeRabbit CLI installed successfully')
+    },
+    onError: error => {
+      logger.error('Failed to install CodeRabbit CLI', { error })
+      toast.error('Failed to install CodeRabbit CLI', {
+        description: String(error),
+      })
+    },
+  })
+}
+
+export function useUpdateCodeRabbitCli() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async () => {
+      await invoke('update_coderabbit_cli')
+    },
+    retry: false,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: coderabbitCliQueryKeys.all })
+      toast.success('CodeRabbit CLI updated')
+    },
+    onError: error => {
+      logger.error('Failed to update CodeRabbit CLI', { error })
+      toast.error('Failed to update CodeRabbit CLI', {
+        description: String(error),
+      })
+    },
+  })
+}
+
+export function useCodeRabbitInstallProgress(): [
+  CodeRabbitInstallProgress | null,
+  () => void,
+] {
+  const [progress, setProgress] = useState<CodeRabbitInstallProgress | null>(
+    null
+  )
+  const wsConnected = useWsConnectionStatus()
+  const resetProgress = useCallback(() => setProgress(null), [])
+
+  useEffect(() => {
+    if (!isTauri()) return
+    let unlistenFn: (() => void) | null = null
+    const setup = async () => {
+      unlistenFn = await listen<CodeRabbitInstallProgress>(
+        'coderabbit-cli:install-progress',
+        event => setProgress(event.payload)
+      )
+    }
+    setup().catch(error =>
+      logger.error('Failed to listen for CodeRabbit install progress', {
+        error,
+      })
+    )
+    return () => unlistenFn?.()
+  }, [wsConnected])
+
+  return [progress, resetProgress]
+}

--- a/src/store/ui-store.ts
+++ b/src/store/ui-store.ts
@@ -8,6 +8,7 @@ export type PreferencePane =
   | 'opencode'
   | 'cursor'
   | 'github'
+  | 'coderabbit'
   | 'appearance'
   | 'keybindings'
   | 'magic-prompts'
@@ -21,7 +22,13 @@ export type PreferencePane =
 
 export type OnboardingStartStep = 'claude' | 'gh' | null
 
-export type CliUpdateModalType = 'claude' | 'gh' | 'codex' | 'opencode' | null
+export type CliUpdateModalType =
+  | 'claude'
+  | 'gh'
+  | 'codex'
+  | 'opencode'
+  | 'coderabbit'
+  | null
 
 export type CliLoginModalType =
   | 'claude'
@@ -29,6 +36,7 @@ export type CliLoginModalType =
   | 'codex'
   | 'opencode'
   | 'cursor'
+  | 'coderabbit'
   | null
 
 interface UIState {
@@ -140,10 +148,12 @@ interface UIState {
     projectPath?: string | null,
     branch?: string | null
   ) => void
-  openCliUpdateModal: (type: 'claude' | 'gh' | 'codex' | 'opencode') => void
+  openCliUpdateModal: (
+    type: 'claude' | 'gh' | 'codex' | 'opencode' | 'coderabbit'
+  ) => void
   closeCliUpdateModal: () => void
   openCliLoginModal: (
-    type: 'claude' | 'gh' | 'codex' | 'opencode' | 'cursor',
+    type: 'claude' | 'gh' | 'codex' | 'opencode' | 'cursor' | 'coderabbit',
     command: string,
     commandArgs?: string[],
     action?: 'login' | 'update' | 'install'

--- a/src/types/coderabbit-cli.ts
+++ b/src/types/coderabbit-cli.ts
@@ -1,0 +1,25 @@
+/** Types for CodeRabbit CLI management. */
+
+export interface CodeRabbitCliStatus {
+  installed: boolean
+  version: string | null
+  path: string | null
+}
+
+export interface CodeRabbitAuthStatus {
+  authenticated: boolean
+  error: string | null
+}
+
+export interface CodeRabbitPathDetection {
+  found: boolean
+  path: string | null
+  version: string | null
+  package_manager: string | null
+}
+
+export interface CodeRabbitInstallProgress {
+  stage: 'starting' | 'downloading' | 'installing' | 'verifying' | 'complete'
+  message: string
+  percent: number
+}

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -984,6 +984,7 @@ export interface AppPreferences {
   codex_cli_source: 'jean' | 'path' // Codex CLI source: 'jean' (managed) or 'path' (system PATH)
   opencode_cli_source: 'jean' | 'path' // OpenCode CLI source: 'jean' (managed) or 'path' (system PATH)
   gh_cli_source: 'jean' | 'path' // GitHub CLI source: 'jean' (managed) or 'path' (system PATH)
+  coderabbit_cli_source?: 'jean' | 'path' // CodeRabbit CLI source: 'jean' (managed) or 'path' (system PATH)
   expand_tool_calls_by_default: boolean // Expand all tool call collapsibles by default
   auto_update_ai_backends: boolean // Auto-install CLI updates in background when a new version is detected
 }
@@ -1717,6 +1718,7 @@ export const defaultPreferences: AppPreferences = {
   codex_cli_source: 'jean', // Default: Jean-managed
   opencode_cli_source: 'jean', // Default: Jean-managed
   gh_cli_source: 'jean', // Default: Jean-managed
+  coderabbit_cli_source: 'jean', // Default: Jean-managed
   expand_tool_calls_by_default: false, // Default: collapsed
   auto_update_ai_backends: true, // Default: auto-update AI backends in the background
 }


### PR DESCRIPTION
## Summary
- Add CodeRabbit CLI management across Tauri and preferences, including install, update, uninstall, PATH detection, auth checks, and source selection.
- Add a review method chooser so users can run either Jean AI review or CodeRabbit review from chat and Magic flows.
- Implement `run_coderabbit_review` to execute `coderabbit review --agent`, parse JSONL findings into the existing review result format, and reuse review result/fix UI.
- Document the CodeRabbit CLI integration and add preference search/test coverage for the new pane.

## Testing
- Added parser unit coverage for CodeRabbit agent findings.
- Updated preferences dialog/search tests for the new CodeRabbit CLI pane.