### PR TITLE
fix: gate RunEvent::Reopen on macos

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3853,6 +3853,7 @@ pub fn run() {
                 }
                 chat::codex_server::shutdown_server();
             }
+            #[cfg(target_os = "macos")]
             tauri::RunEvent::Reopen { .. } => {
                 if let Some(window) = app_handle.get_webview_window("main") {
                     let _ = window.show();


### PR DESCRIPTION
`RunEvent::Reopen` is a macOS-only variant in Tauri 2, so the match arm fails to compile on Linux and Windows; this caused the `v0.1.48` release workflow to ship only macOS bundles.