### PR TITLE
feat(toolbar): add desktop Magic button

### DIFF
--- a/src/components/chat/toolbar/DesktopToolbarControls.test.tsx
+++ b/src/components/chat/toolbar/DesktopToolbarControls.test.tsx
@@ -127,6 +127,23 @@ describe('DesktopToolbarControls', () => {
     expect(onSetExecutionMode).toHaveBeenCalledWith('build')
   })
 
+  it('shows a desktop Magic button that opens the magic modal', async () => {
+    const user = userEvent.setup()
+    const onOpenMagicModal = vi.fn()
+
+    renderDesktopToolbarControls({ onOpenMagicModal })
+
+    await user.click(screen.getByRole('button', { name: /magic/i }))
+
+    expect(onOpenMagicModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the desktop Magic button while questions are pending', () => {
+    renderDesktopToolbarControls({ hasPendingQuestions: true })
+
+    expect(screen.getByRole('button', { name: /magic/i })).toBeDisabled()
+  })
+
   it('hides Claude-only Max effort for Codex', () => {
     renderDesktopToolbarControls({
       isCodex: true,

--- a/src/components/chat/toolbar/DesktopToolbarControls.tsx
+++ b/src/components/chat/toolbar/DesktopToolbarControls.tsx
@@ -7,6 +7,7 @@ import {
   GitPullRequest,
   Shield,
   ShieldAlert,
+  Wand2,
 } from 'lucide-react'
 import { useCallback } from 'react'
 import { Kbd } from '@/components/ui/kbd'
@@ -167,7 +168,7 @@ export function DesktopToolbarControls({
   setProviderDropdownOpen,
   setThinkingDropdownOpen,
   onMcpDropdownOpenChange: _onMcpDropdownOpenChange,
-  onOpenMagicModal: _onOpenMagicModal,
+  onOpenMagicModal,
   onOpenProjectSettings: _onOpenProjectSettings,
   onResolvePrConflicts,
   onLoadContext,
@@ -218,6 +219,21 @@ export function DesktopToolbarControls({
         activeMcpCount={activeMcpCount}
         className="hidden @xl:flex"
       />
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label="Magic"
+            disabled={hasPendingQuestions}
+            className="hidden @xl:flex h-8 items-center gap-1 px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+            onClick={onOpenMagicModal}
+          >
+            <Wand2 className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Magic (⌘M)</TooltipContent>
+      </Tooltip>
 
       <div className="hidden @xl:block h-4 w-px bg-border/50" />
 


### PR DESCRIPTION
## Summary
- Add a visible Magic toolbar button on desktop layouts next to the existing dock controls.
- Wire the button to open the Magic modal and show the existing `⌘M` shortcut in a tooltip.
- Disable the desktop Magic button while pending questions are active.
- Add toolbar tests covering modal opening and disabled state.

Fixes #369

---

Fixes #369