### PR TITLE
[codex] fix OpenCode cancel cleanup

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,7 +50,7 @@ portable-pty = "0.8"  # For terminal/PTY support
 which = "7"           # For cross-platform executable detection
 axum = { version = "0.8", features = ["ws"] }  # HTTP server + WebSocket
 tower-http = { version = "0.6", features = ["cors", "fs", "compression-br", "compression-gzip"] }  # CORS + static files + response compression
-tokio = { version = "1", features = ["sync", "macros", "net", "io-util", "fs", "rt-multi-thread"] }  # Channel for WS broadcast
+tokio = { version = "1", features = ["sync", "macros", "net", "io-util", "fs", "rt-multi-thread", "time"] }  # Channel for WS broadcast
 futures-util = "0.3"  # Stream utilities for WebSocket split
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }  # Image resize/compression on paste
 arboard = { version = "3", features = ["wayland-data-control"] }  # Native clipboard image read (Linux WebKitGTK fallback)

--- a/src-tauri/src/chat/opencode.rs
+++ b/src-tauri/src/chat/opencode.rs
@@ -6,6 +6,7 @@ use base64::{engine::general_purpose::STANDARD, Engine};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -280,6 +281,7 @@ const OPENCODE_SSE_MAX_RECONNECT_DELAY: Duration = Duration::from_secs(5);
 const OPENCODE_SSE_SHORT_LIVED_THRESHOLD: Duration = Duration::from_secs(2);
 const OPENCODE_SSE_MAX_SHORT_LIVED_DISCONNECTS: u32 = 3;
 const OPENCODE_SSE_DISABLED_COOLDOWN: Duration = Duration::from_secs(60);
+const OPENCODE_HTTP_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 fn shared_sse_reconnect_delay(short_lived_disconnects: u32) -> Duration {
     if short_lived_disconnects == 0 {
@@ -1811,6 +1813,148 @@ fn process_shared_sse_event(
     }
 }
 
+async fn await_opencode_http_or_cancel<F, T>(
+    future: F,
+    cancelled: Arc<AtomicBool>,
+    opencode_session_id: String,
+    working_dir: String,
+) -> Option<T>
+where
+    F: Future<Output = T>,
+{
+    if cancelled.load(Ordering::SeqCst) {
+        super::registry::abort_opencode_session(opencode_session_id.clone(), Some(working_dir));
+        return None;
+    }
+
+    tokio::pin!(future);
+    loop {
+        tokio::select! {
+            result = &mut future => return Some(result),
+            _ = tokio::time::sleep(OPENCODE_HTTP_CANCEL_POLL_INTERVAL) => {
+                if cancelled.load(Ordering::SeqCst) {
+                    super::registry::abort_opencode_session(opencode_session_id.clone(), Some(working_dir.clone()));
+                    return None;
+                }
+            }
+        }
+    }
+}
+
+async fn sleep_or_cancel_opencode_http(
+    duration: Duration,
+    cancelled: Arc<AtomicBool>,
+    opencode_session_id: String,
+    working_dir: String,
+) -> bool {
+    await_opencode_http_or_cancel(
+        tokio::time::sleep(duration),
+        cancelled,
+        opencode_session_id,
+        working_dir,
+    )
+    .await
+    .is_none()
+}
+
+fn post_opencode_message_cancellable(
+    msg_url: String,
+    working_dir: String,
+    payload: serde_json::Value,
+    cancelled: Arc<AtomicBool>,
+    jean_session_id: String,
+    opencode_session_id: String,
+) -> Result<Option<(reqwest::StatusCode, String)>, String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("Failed to build OpenCode HTTP runtime: {e}"))?;
+
+    runtime.block_on(async move {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(1800))
+            .build()
+            .map_err(|e| format!("Failed to build OpenCode async HTTP client: {e}"))?;
+
+        let send_once = || {
+            client
+                .post(&msg_url)
+                .query(&[("directory", working_dir.as_str())])
+                .json(&payload)
+                .send()
+        };
+
+        let response = match await_opencode_http_or_cancel(
+            send_once(),
+            cancelled.clone(),
+            opencode_session_id.clone(),
+            working_dir.clone(),
+        )
+        .await
+        {
+            Some(Ok(resp)) => resp,
+            Some(Err(e)) if e.is_connect() || e.is_request() => {
+                log::warn!("OpenCode message connection error, retrying in 2s: {e}");
+                if sleep_or_cancel_opencode_http(
+                    std::time::Duration::from_secs(2),
+                    cancelled.clone(),
+                    opencode_session_id.clone(),
+                    working_dir.clone(),
+                )
+                .await
+                {
+                    return Ok(None);
+                }
+
+                match await_opencode_http_or_cancel(
+                    send_once(),
+                    cancelled.clone(),
+                    opencode_session_id.clone(),
+                    working_dir.clone(),
+                )
+                .await
+                {
+                    Some(Ok(resp)) => resp,
+                    Some(Err(e)) => return Err(format!("Failed to send OpenCode message: {e}")),
+                    None => return Ok(None),
+                }
+            }
+            Some(Err(e)) => return Err(format!("Failed to send OpenCode message: {e}")),
+            None => return Ok(None),
+        };
+
+        let status = response.status();
+        log::info!(
+            "OpenCode: POST body read start jean_session={} opencode_session={}",
+            jean_session_id,
+            opencode_session_id
+        );
+        let body_read_start = Instant::now();
+        let body = match await_opencode_http_or_cancel(
+            response.text(),
+            cancelled,
+            opencode_session_id.clone(),
+            working_dir,
+        )
+        .await
+        {
+            Some(Ok(body)) => body,
+            Some(Err(e)) => {
+                log::warn!(
+                    "OpenCode: POST body read failed jean_session={} opencode_session={} elapsed_ms={} err={e}",
+                    jean_session_id,
+                    opencode_session_id,
+                    body_read_start.elapsed().as_millis()
+                );
+                return Err(format!("Failed to read OpenCode message response: {e}"));
+            }
+            None => return Ok(None),
+        };
+
+        Ok(Some((status, body)))
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn execute_opencode_http(
     app: &tauri::AppHandle,
@@ -2006,7 +2150,6 @@ pub fn execute_opencode_http(
         payload["system"] = serde_json::Value::String(system.to_string());
     }
 
-    // Retry once on connection-level errors (server temporarily unreachable).
     let post_start = Instant::now();
     log::info!(
         "OpenCode: message POST start jean_session={} opencode_session={} url={}",
@@ -2014,41 +2157,39 @@ pub fn execute_opencode_http(
         opencode_session_id,
         msg_url
     );
-    let response = match client.post(&msg_url).query(&query).json(&payload).send() {
-        Ok(resp) => resp,
-        Err(e) if e.is_connect() || e.is_request() => {
-            log::warn!("OpenCode message connection error, retrying in 2s: {e}");
-            std::thread::sleep(std::time::Duration::from_secs(2));
-            if cancelled.load(Ordering::SeqCst) {
-                return Ok(OpenCodeResponse {
-                    content: String::new(),
-                    session_id: opencode_session_id,
-                    tool_calls: vec![],
-                    content_blocks: vec![],
-                    cancelled: true,
-                    usage: None,
-                });
-            }
-            client
-                .post(&msg_url)
-                .query(&query)
-                .json(&payload)
-                .send()
-                .map_err(|e| format!("Failed to send OpenCode message: {e}"))?
-        }
-        Err(e) => return Err(format!("Failed to send OpenCode message: {e}")),
+    let Some((status, body)) = post_opencode_message_cancellable(
+        msg_url,
+        working_dir_string.clone(),
+        payload,
+        cancelled.clone(),
+        session_id.to_string(),
+        opencode_session_id.clone(),
+    )?
+    else {
+        log::info!(
+            "OpenCode: message POST cancelled jean_session={} opencode_session={} elapsed_ms={}",
+            session_id,
+            opencode_session_id,
+            post_start.elapsed().as_millis()
+        );
+        return Ok(OpenCodeResponse {
+            content: String::new(),
+            session_id: opencode_session_id,
+            tool_calls: vec![],
+            content_blocks: vec![],
+            cancelled: true,
+            usage: None,
+        });
     };
     log::info!(
         "OpenCode: message POST finished jean_session={} opencode_session={} elapsed_ms={} status={}",
         session_id,
         opencode_session_id,
         post_start.elapsed().as_millis(),
-        response.status()
+        status
     );
 
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().unwrap_or_default();
+    if !status.is_success() {
         let error = format!("OpenCode message failed: status={status}, body={body}");
         let _ = app.emit_all(
             "chat:error",
@@ -2061,26 +2202,21 @@ pub fn execute_opencode_http(
         return Err(error);
     }
 
-    log::info!(
-        "OpenCode: POST body read start jean_session={} opencode_session={}",
-        session_id,
-        opencode_session_id
-    );
-    let body_read_start = Instant::now();
-    let response_json: serde_json::Value = response.json().map_err(|e| {
+    let body_parse_start = Instant::now();
+    let response_json: serde_json::Value = serde_json::from_str(&body).map_err(|e| {
         log::warn!(
-            "OpenCode: POST body read failed jean_session={} opencode_session={} elapsed_ms={} err={e}",
+            "OpenCode: POST body parse failed jean_session={} opencode_session={} elapsed_ms={} err={e}",
             session_id,
             opencode_session_id,
-            body_read_start.elapsed().as_millis()
+            body_parse_start.elapsed().as_millis()
         );
         format!("Failed to parse OpenCode message response: {e}")
     })?;
     log::info!(
-        "OpenCode: POST body read done jean_session={} opencode_session={} elapsed_ms={} parts={}",
+        "OpenCode: POST body parse done jean_session={} opencode_session={} elapsed_ms={} parts={}",
         session_id,
         opencode_session_id,
-        body_read_start.elapsed().as_millis(),
+        body_parse_start.elapsed().as_millis(),
         response_json
             .get("parts")
             .and_then(|v| v.as_array())
@@ -2775,5 +2911,29 @@ mod tests {
             "parts": [{"type": "text", "text": "hello"}]
         });
         assert_eq!(extract_opencode_error_message(&body), None);
+    }
+
+    #[test]
+    fn await_opencode_http_or_cancel_returns_none_when_cancelled() {
+        std::thread::spawn(|| {
+            let cancelled = Arc::new(AtomicBool::new(true));
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            let start = Instant::now();
+            let result = runtime.block_on(await_opencode_http_or_cancel(
+                std::future::pending::<()>(),
+                cancelled,
+                "opencode-session".to_string(),
+                "/tmp".to_string(),
+            ));
+
+            assert!(result.is_none());
+            assert!(start.elapsed() < Duration::from_millis(50));
+        })
+        .join()
+        .unwrap();
     }
 }

--- a/src-tauri/src/chat/registry.rs
+++ b/src-tauri/src/chat/registry.rs
@@ -145,6 +145,39 @@ pub fn update_cancel_flag_context(
     }
 }
 
+/// Fire-and-forget server-side abort for a running OpenCode session.
+///
+/// OpenCode exposes `POST /session/{id}/abort`. Jean still keeps a local
+/// cancellation flag so the in-process request can return promptly even if
+/// the server abort request is slow or fails.
+pub fn abort_opencode_session(opencode_session_id: String, working_dir: Option<String>) {
+    std::thread::spawn(move || {
+        let Some(base_url) = crate::opencode_server::get_current_url() else {
+            log::warn!("OpenCode: no server URL available for abort");
+            return;
+        };
+
+        let abort_url = format!("{base_url}/session/{opencode_session_id}/abort");
+        log::info!("OpenCode: sending abort to {abort_url}");
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build();
+        match client {
+            Ok(c) => {
+                let mut request = c.post(&abort_url);
+                if let Some(dir) = working_dir {
+                    request = request.query(&[("directory", dir)]);
+                }
+                match request.send() {
+                    Ok(resp) => log::info!("OpenCode abort response: status={}", resp.status()),
+                    Err(e) => log::warn!("OpenCode abort request failed: {e}"),
+                }
+            }
+            Err(e) => log::warn!("OpenCode abort client build failed: {e}"),
+        }
+    });
+}
+
 /// Register a Codex app-server turn for a session.
 /// Returns `false` if the session was already pending cancellation.
 pub fn register_codex_turn(session_id: String, thread_id: String, turn_id: String) -> bool {
@@ -265,6 +298,23 @@ mod tests {
 
         clear_registries();
     }
+
+    #[test]
+    fn cleanup_session_registrations_clears_opencode_active_flag() {
+        clear_registries();
+
+        assert!(register_cancel_flag(
+            "opencode-session".to_string(),
+            Arc::new(AtomicBool::new(false))
+        ));
+        assert!(is_session_actively_managed("opencode-session"));
+
+        cleanup_session_registrations("opencode-session");
+
+        assert!(!is_session_actively_managed("opencode-session"));
+
+        clear_registries();
+    }
 }
 
 /// Cancel a running Claude process for a session by sending SIGKILL to the process group
@@ -369,39 +419,10 @@ pub fn cancel_process(
         entry.flag.store(true, Ordering::SeqCst);
 
         // Fire-and-forget: call the OpenCode interrupt endpoint to abort server-side processing.
-        // This makes the in-flight blocking POST return immediately.
+        // The in-process OpenCode request also watches the cancel flag and drops
+        // its HTTP future so Jean can unregister the session promptly.
         if let Some(oc_sid) = entry.opencode_session_id {
-            if let Some(base_url) = crate::opencode_server::get_current_url() {
-                // sst/opencode renamed the endpoint to `/abort` in v1.14.x (HttpApi migration).
-                let interrupt_url = format!("{base_url}/session/{oc_sid}/abort");
-                let working_dir = entry.working_dir.clone();
-                std::thread::spawn(move || {
-                    log::info!("OpenCode: sending interrupt to {interrupt_url}");
-                    let client = reqwest::blocking::Client::builder()
-                        .timeout(std::time::Duration::from_secs(5))
-                        .build();
-                    match client {
-                        Ok(c) => {
-                            let mut request = c.post(&interrupt_url);
-                            if let Some(dir) = working_dir {
-                                request = request.query(&[("directory", dir)]);
-                            }
-                            match request.send() {
-                                Ok(resp) => {
-                                    log::info!(
-                                        "OpenCode interrupt response: status={}",
-                                        resp.status()
-                                    )
-                                }
-                                Err(e) => log::warn!("OpenCode interrupt request failed: {e}"),
-                            }
-                        }
-                        Err(e) => log::warn!("OpenCode interrupt client build failed: {e}"),
-                    }
-                });
-            } else {
-                log::warn!("OpenCode: no server URL available for interrupt");
-            }
+            abort_opencode_session(oc_sid, entry.working_dir.clone());
         }
 
         // Mark run as cancelled immediately (before HTTP call returns)
@@ -512,26 +533,9 @@ pub fn cancel_process_if_running(
         log::trace!("OpenCode session {session_id} is running, setting cancel flag");
         entry.flag.store(true, Ordering::SeqCst);
 
-        // Fire-and-forget interrupt
+        // Fire-and-forget abort
         if let Some(oc_sid) = entry.opencode_session_id {
-            if let Some(base_url) = crate::opencode_server::get_current_url() {
-                // sst/opencode renamed the endpoint to `/abort` in v1.14.x (HttpApi migration).
-                let interrupt_url = format!("{base_url}/session/{oc_sid}/abort");
-                let working_dir = entry.working_dir.clone();
-                std::thread::spawn(move || {
-                    log::info!("OpenCode: sending interrupt to {interrupt_url}");
-                    let client = reqwest::blocking::Client::builder()
-                        .timeout(std::time::Duration::from_secs(5))
-                        .build();
-                    if let Ok(c) = client {
-                        let mut request = c.post(&interrupt_url);
-                        if let Some(dir) = working_dir {
-                            request = request.query(&[("directory", dir)]);
-                        }
-                        let _ = request.send();
-                    }
-                });
-            }
+            abort_opencode_session(oc_sid, entry.working_dir.clone());
         }
 
         if let Err(e) = run_log::mark_running_run_cancelled(app, session_id) {


### PR DESCRIPTION
## Summary

- make the OpenCode `/session/{id}/message` POST locally cancellable from Jean
- keep sending OpenCode's server-side `/abort` request, now via a centralized helper
- add regression coverage for OpenCode cancellation cleanup and cancel polling

## Root cause

OpenCode sends prompts through a long-running HTTP POST. When the UI cancelled a run, Jean emitted `chat:cancelled` and set the OpenCode cancel flag, but registry cleanup could not run until the blocking POST returned. The session stayed in `CANCEL_FLAGS`, so the next prompt hit Jean's duplicate-send guard and failed with `Session already has an active request`.

## Validation

- `bun run build`
- `cargo test --manifest-path src-tauri/Cargo.toml await_opencode_http_or_cancel_returns_none_when_cancelled`
- `cargo test --manifest-path src-tauri/Cargo.toml cleanup_session_registrations_clears_opencode_active_flag`
- `git diff --check && cargo fmt --manifest-path src-tauri/Cargo.toml --check`

Fixes #375
