### PR TITLE
fix(tauri): gate reopen handling to macOS

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3870,6 +3870,7 @@ pub fn run() {
                 }
                 chat::codex_server::shutdown_server();
             }
+            #[cfg(target_os = "macos")]
             tauri::RunEvent::Reopen { .. } => {
                 if let Some(window) = app_handle.get_webview_window("main") {
                     let _ = window.show();


### PR DESCRIPTION
## Summary
- Restricts `tauri::RunEvent::Reopen` handling to macOS builds only.
- Prevents platform-specific reopen event handling from affecting non-macOS Tauri targets.

## Breaking Changes
- None