### PR TITLE
feat(auto-fix): add automated issue fixing scheduler

### DIFF
--- a/docs/developer/architecture-guide.md
+++ b/docs/developer/architecture-guide.md
@@ -100,7 +100,7 @@ Additional systems (no dedicated docs yet):
   backend-owned history from local stores where stable (`~/.codex/sessions/**`
   and `~/.claude/projects/<escaped-cwd>/**`) and imports a chosen history row as
   a Jean terminal session running the backend's native resume command.
-- **Background Tasks** - Git/PR polling with focus-aware intervals (`src-tauri/src/background_tasks/`); Auto Fix issue polling/planning/yolo handoff (`src-tauri/src/auto_fix/`)
+- **Background Tasks** - Git/PR polling with focus-aware intervals (`src-tauri/src/background_tasks/`); Auto Fix issue polling/planning/yolo handoff and scheduler active-hours window via `chrono` local time with midnight-crossing support (`src-tauri/src/auto_fix/`)
 - **HTTP Server** - Embedded Axum server + WebSocket for headless/web mode (`src-tauri/src/http_server/`)
 - **Diagnostics** - CPU/memory monitoring panel (`src-tauri/src/diagnostics/`)
 - **MCP** - Model Context Protocol server integration with per-project overrides (`src/services/mcp.ts`)

--- a/docs/developer/architecture-guide.md
+++ b/docs/developer/architecture-guide.md
@@ -100,7 +100,7 @@ Additional systems (no dedicated docs yet):
   backend-owned history from local stores where stable (`~/.codex/sessions/**`
   and `~/.claude/projects/<escaped-cwd>/**`) and imports a chosen history row as
   a Jean terminal session running the backend's native resume command.
-- **Background Tasks** - Git/PR polling with focus-aware intervals (`src-tauri/src/background_tasks/`)
+- **Background Tasks** - Git/PR polling with focus-aware intervals (`src-tauri/src/background_tasks/`); Auto Fix issue polling/planning/yolo handoff (`src-tauri/src/auto_fix/`)
 - **HTTP Server** - Embedded Axum server + WebSocket for headless/web mode (`src-tauri/src/http_server/`)
 - **Diagnostics** - CPU/memory monitoring panel (`src-tauri/src/diagnostics/`)
 - **MCP** - Model Context Protocol server integration with per-project overrides (`src/services/mcp.ts`)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2494,6 +2494,7 @@ dependencies = [
  "arboard",
  "axum",
  "base64 0.22.1",
+ "chrono",
  "dirs 5.0.1",
  "flate2",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,6 +55,7 @@ futures-util = "0.3"  # Stream utilities for WebSocket split
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }  # Image resize/compression on paste
 arboard = { version = "3", features = ["wayland-data-control"] }  # Native clipboard image read (Linux WebKitGTK fallback)
 if-addrs = "0.13"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }  # Local machine time for Auto Fix active-hours window
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/src/auto_fix/mod.rs
+++ b/src-tauri/src/auto_fix/mod.rs
@@ -1,0 +1,2 @@
+pub mod scheduler;
+pub mod types;

--- a/src-tauri/src/auto_fix/scheduler.rs
+++ b/src-tauri/src/auto_fix/scheduler.rs
@@ -564,7 +564,15 @@ async fn approve_plan_and_start_yolo(
     Ok(())
 }
 
+fn clear_pending_auto_yolo_for_project(project_id: &str) {
+    pending_yolo()
+        .lock()
+        .expect("pending auto yolo mutex")
+        .retain(|_, entry| entry.project_id != project_id);
+}
+
 fn emit_auto_fix_stopped(app: &AppHandle, project: &Project, backend: &str, error: &str) {
+    clear_pending_auto_yolo_for_project(&project.id);
     disable_project_auto_fix(app, &project.id);
     let event = AutoFixStoppedEvent {
         project_id: project.id.clone(),
@@ -667,6 +675,40 @@ mod tests {
 
         clear_auto_yolo_in_flight(&mut in_flight, "session-1");
         assert!(mark_auto_yolo_in_flight(&mut in_flight, "session-1"));
+    }
+
+    #[test]
+    fn clears_pending_auto_yolo_entries_for_stopped_project() {
+        let entry_for_stopped_project = PendingAutoYolo {
+            project_id: "project-1".to_string(),
+            project_name: "Project 1".to_string(),
+            worktree_id: "worktree-1".to_string(),
+            worktree_path: "/tmp/worktree-1".to_string(),
+            session_id: "session-1".to_string(),
+            backend: "claude".to_string(),
+            model: None,
+        };
+        let entry_for_other_project = PendingAutoYolo {
+            project_id: "project-2".to_string(),
+            project_name: "Project 2".to_string(),
+            worktree_id: "worktree-2".to_string(),
+            worktree_path: "/tmp/worktree-2".to_string(),
+            session_id: "session-2".to_string(),
+            backend: "claude".to_string(),
+            model: None,
+        };
+        {
+            let mut pending = pending_yolo().lock().expect("pending auto yolo mutex");
+            pending.clear();
+            pending.insert("session-1".to_string(), entry_for_stopped_project);
+            pending.insert("session-2".to_string(), entry_for_other_project);
+        }
+
+        clear_pending_auto_yolo_for_project("project-1");
+
+        let pending = pending_yolo().lock().expect("pending auto yolo mutex");
+        assert!(!pending.contains_key("session-1"));
+        assert!(pending.contains_key("session-2"));
     }
 
     #[test]

--- a/src-tauri/src/auto_fix/scheduler.rs
+++ b/src-tauri/src/auto_fix/scheduler.rs
@@ -1,0 +1,711 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use tauri::AppHandle;
+
+use super::types::{AutoFixIssueCandidate, AutoFixStoppedEvent};
+use crate::chat::types::{EffortLevel, ThinkingLevel};
+use crate::http_server::EmitExt;
+use crate::projects::github_issues::{GitHubComment, IssueContext};
+use crate::projects::types::{Project, ProjectAutoFixSettings, Worktree, WorktreeOrigin};
+
+const AUTO_FIX_TICK_SECONDS: u64 = 10;
+const AUTO_YOLO_WATCH_SECONDS: u64 = 2;
+const AUTO_YOLO_WATCH_ATTEMPTS: usize = 900; // 30 minutes
+
+#[derive(Debug, Clone)]
+struct PendingAutoYolo {
+    project_id: String,
+    project_name: String,
+    worktree_id: String,
+    worktree_path: String,
+    session_id: String,
+    backend: String,
+    model: Option<String>,
+}
+
+static LAST_PROJECT_CHECKS: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+static PENDING_YOLO: OnceLock<Mutex<HashMap<String, PendingAutoYolo>>> = OnceLock::new();
+static YOLO_IN_FLIGHT: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn last_project_checks() -> &'static Mutex<HashMap<String, u64>> {
+    LAST_PROJECT_CHECKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn pending_yolo() -> &'static Mutex<HashMap<String, PendingAutoYolo>> {
+    PENDING_YOLO.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn auto_yolo_in_flight() -> &'static Mutex<HashSet<String>> {
+    YOLO_IN_FLIGHT.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+fn mark_auto_yolo_in_flight(in_flight: &mut HashSet<String>, session_id: &str) -> bool {
+    in_flight.insert(session_id.to_string())
+}
+
+fn clear_auto_yolo_in_flight(in_flight: &mut HashSet<String>, session_id: &str) {
+    in_flight.remove(session_id);
+}
+
+fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+pub fn select_issue_numbers_to_start(
+    issues: &[AutoFixIssueCandidate],
+    handled_issue_numbers: &HashSet<u32>,
+    limit: usize,
+) -> Vec<u32> {
+    issues
+        .iter()
+        .filter(|issue| !handled_issue_numbers.contains(&issue.number))
+        .take(limit)
+        .map(|issue| issue.number)
+        .collect()
+}
+
+pub fn is_backend_quota_or_auth_error(error: &str) -> bool {
+    let lower = error.to_lowercase();
+    lower.contains("quota")
+        || lower.contains("rate limit")
+        || lower.contains("usage limit")
+        || lower.contains("out of tokens")
+        || lower.contains("token expired")
+        || lower.contains("not authenticated")
+        || lower.contains("authrequired")
+}
+
+pub fn start_auto_fix_scheduler(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            run_auto_yolo_watch(&app).await;
+            run_auto_fix_scan(&app).await;
+            tokio::time::sleep(Duration::from_secs(AUTO_FIX_TICK_SECONDS)).await;
+        }
+    });
+}
+
+async fn run_auto_fix_scan(app: &AppHandle) {
+    let data = match crate::projects::storage::load_projects_data(app) {
+        Ok(data) => data,
+        Err(err) => {
+            log::warn!("Mr. Robot: failed to load projects data: {err}");
+            return;
+        }
+    };
+
+    for project in data.projects.iter().filter(|project| !project.is_folder) {
+        let Some(settings) = project.auto_fix_settings.clone() else {
+            continue;
+        };
+        if !settings.enabled {
+            continue;
+        }
+        if !auto_fix_active_now(&settings) {
+            continue;
+        }
+        if !project_due(project, &settings) {
+            continue;
+        }
+
+        let project_worktrees: Vec<Worktree> = data
+            .worktrees
+            .iter()
+            .filter(|worktree| worktree.project_id == project.id)
+            .cloned()
+            .collect();
+        let active_auto_fix = project_worktrees
+            .iter()
+            .filter(|worktree| {
+                worktree.archived_at.is_none()
+                    && matches!(worktree.origin, Some(WorktreeOrigin::AutoFix))
+            })
+            .count();
+        let max_parallel = settings.max_parallel_worktrees.max(1) as usize;
+        if active_auto_fix >= max_parallel {
+            continue;
+        }
+
+        let capacity = max_parallel - active_auto_fix;
+        let limit = (settings.issue_limit.max(1) as usize).min(capacity);
+        let handled: HashSet<u32> = project_worktrees
+            .iter()
+            .filter_map(|worktree| worktree.issue_number)
+            .collect();
+
+        let issues = match crate::projects::github_issues::list_github_issues(
+            app.clone(),
+            project.path.clone(),
+            Some("open".to_string()),
+        )
+        .await
+        {
+            Ok(result) => result
+                .issues
+                .into_iter()
+                .map(|issue| AutoFixIssueCandidate {
+                    number: issue.number,
+                })
+                .collect::<Vec<_>>(),
+            Err(err) => {
+                log::warn!(
+                    "Mr. Robot: failed to list issues for {}: {err}",
+                    project.name
+                );
+                continue;
+            }
+        };
+
+        for issue_number in select_issue_numbers_to_start(&issues, &handled, limit) {
+            let app_clone = app.clone();
+            let project_clone = project.clone();
+            let settings_clone = settings.clone();
+            tauri::async_runtime::spawn(async move {
+                if let Err(err) =
+                    start_issue_auto_fix(&app_clone, &project_clone, &settings_clone, issue_number)
+                        .await
+                {
+                    log::warn!(
+                        "Mr. Robot: issue #{issue_number} failed for {}: {err}",
+                        project_clone.name
+                    );
+                    if is_backend_quota_or_auth_error(&err) {
+                        emit_auto_fix_stopped(
+                            &app_clone,
+                            &project_clone,
+                            &settings_clone.planning_backend,
+                            &err,
+                        );
+                    }
+                }
+            });
+        }
+    }
+}
+
+fn within_active_window(start: u8, end: u8, hour: u8) -> bool {
+    if start == end {
+        return true; // empty/full = no restriction
+    }
+    if start < end {
+        hour >= start && hour < end
+    } else {
+        hour >= start || hour < end // crosses midnight (e.g. 20->8)
+    }
+}
+
+fn auto_fix_active_now(settings: &ProjectAutoFixSettings) -> bool {
+    if !settings.active_hours_enabled {
+        return true;
+    }
+    use chrono::Timelike;
+    let hour = chrono::Local::now().hour() as u8;
+    within_active_window(settings.active_hours_start, settings.active_hours_end, hour)
+}
+
+fn should_queue_auto_yolo(settings: &ProjectAutoFixSettings) -> bool {
+    settings.auto_yolo_enabled
+}
+
+fn project_due(project: &Project, settings: &ProjectAutoFixSettings) -> bool {
+    let now = now_unix_secs();
+    let interval = settings.interval_minutes.max(1) * 60;
+    let mut checks = last_project_checks().lock().expect("auto fix checks mutex");
+    let last = checks.get(&project.id).copied().unwrap_or(0);
+    if now.saturating_sub(last) < interval {
+        return false;
+    }
+    checks.insert(project.id.clone(), now);
+    true
+}
+
+async fn start_issue_auto_fix(
+    app: &AppHandle,
+    project: &Project,
+    settings: &ProjectAutoFixSettings,
+    issue_number: u32,
+) -> Result<(), String> {
+    let issue = crate::projects::github_issues::get_github_issue(
+        app.clone(),
+        project.path.clone(),
+        issue_number,
+    )
+    .await?;
+    let comments: Vec<GitHubComment> = issue.comments;
+    let issue_context = IssueContext {
+        number: issue.number,
+        title: issue.title,
+        body: issue.body,
+        comments,
+    };
+
+    let pending_worktree = crate::projects::create_worktree(
+        app.clone(),
+        project.id.clone(),
+        None,
+        Some(issue_context),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(false),
+        Some("auto_fix".to_string()),
+    )
+    .await?;
+
+    let ready_worktree = wait_for_worktree_ready(app, &pending_worktree.id).await?;
+    let prompt = format!(
+        "Investigate GitHub issue #{issue_number}. Create a focused implementation plan for fixing it. Do not implement yet; stop in plan mode and wait for approval."
+    );
+    let model = settings
+        .planning_model
+        .clone()
+        .unwrap_or_else(|| default_model_for_backend(&settings.planning_backend));
+
+    let result = crate::jean_mcp_core::start_background_investigation_impl(
+        app,
+        ready_worktree.id.clone(),
+        ready_worktree.path.clone(),
+        prompt,
+        model,
+        settings.planning_backend.clone(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some("auto_fix".to_string()),
+    )
+    .await?;
+
+    if !should_queue_auto_yolo(settings) {
+        return Ok(());
+    }
+
+    let pending_session_id = result.session_id.clone();
+    pending_yolo()
+        .lock()
+        .expect("pending auto yolo mutex")
+        .insert(
+            pending_session_id.clone(),
+            PendingAutoYolo {
+                project_id: project.id.clone(),
+                project_name: project.name.clone(),
+                worktree_id: ready_worktree.id,
+                worktree_path: ready_worktree.path,
+                session_id: result.session_id,
+                backend: settings.yolo_backend.clone(),
+                model: settings.yolo_model.clone(),
+            },
+        );
+    spawn_pending_auto_yolo_watch(app.clone(), pending_session_id);
+
+    Ok(())
+}
+
+async fn wait_for_worktree_ready(app: &AppHandle, worktree_id: &str) -> Result<Worktree, String> {
+    for _ in 0..30 {
+        if let Ok(worktree) =
+            crate::projects::get_worktree(app.clone(), worktree_id.to_string()).await
+        {
+            return Ok(worktree);
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    Err(format!(
+        "Timed out waiting for Mr. Robot worktree {worktree_id} to be ready"
+    ))
+}
+
+async fn run_auto_yolo_watch(app: &AppHandle) {
+    let pending_session_ids: Vec<String> = pending_yolo()
+        .lock()
+        .expect("pending auto yolo mutex")
+        .keys()
+        .cloned()
+        .collect();
+
+    for session_id in pending_session_ids {
+        try_start_auto_yolo_if_ready(app, &session_id).await;
+    }
+}
+
+fn spawn_pending_auto_yolo_watch(app: AppHandle, session_id: String) {
+    tauri::async_runtime::spawn(async move {
+        for _ in 0..AUTO_YOLO_WATCH_ATTEMPTS {
+            if !pending_yolo()
+                .lock()
+                .expect("pending auto yolo mutex")
+                .contains_key(&session_id)
+            {
+                return;
+            }
+            if auto_yolo_in_flight()
+                .lock()
+                .expect("auto yolo in flight mutex")
+                .contains(&session_id)
+            {
+                return;
+            }
+
+            try_start_auto_yolo_if_ready(&app, &session_id).await;
+
+            tokio::time::sleep(Duration::from_secs(AUTO_YOLO_WATCH_SECONDS)).await;
+        }
+    });
+}
+
+async fn try_start_auto_yolo_if_ready(app: &AppHandle, session_id: &str) {
+    let Some(entry) = pending_yolo()
+        .lock()
+        .expect("pending auto yolo mutex")
+        .get(session_id)
+        .cloned()
+    else {
+        return;
+    };
+
+    let Ok(status) = crate::chat::get_session_status(app.clone(), entry.session_id.clone()).await
+    else {
+        return;
+    };
+    if status
+        .get("waitingForInputType")
+        .and_then(|value| value.as_str())
+        != Some("plan")
+    {
+        return;
+    }
+
+    {
+        let mut in_flight = auto_yolo_in_flight()
+            .lock()
+            .expect("auto yolo in flight mutex");
+        if !mark_auto_yolo_in_flight(&mut in_flight, &entry.session_id) {
+            return;
+        }
+    }
+
+    pending_yolo()
+        .lock()
+        .expect("pending auto yolo mutex")
+        .remove(&entry.session_id);
+    spawn_auto_yolo_start(app.clone(), entry);
+}
+
+fn spawn_auto_yolo_start(app: AppHandle, entry: PendingAutoYolo) {
+    tauri::async_runtime::spawn(async move {
+        let result = approve_plan_and_start_yolo(&app, &entry).await;
+        clear_auto_yolo_in_flight(
+            &mut auto_yolo_in_flight()
+                .lock()
+                .expect("auto yolo in flight mutex"),
+            &entry.session_id,
+        );
+
+        if let Err(err) = result {
+            log::warn!("Mr. Robot: yolo start failed: {err}");
+            if is_backend_quota_or_auth_error(&err) {
+                let project = project_from_pending_auto_yolo(&entry);
+                emit_auto_fix_stopped(&app, &project, &entry.backend, &err);
+            } else {
+                let session_id = entry.session_id.clone();
+                pending_yolo()
+                    .lock()
+                    .expect("pending auto yolo mutex")
+                    .insert(entry.session_id.clone(), entry);
+                spawn_pending_auto_yolo_watch(app.clone(), session_id);
+            }
+        }
+    });
+}
+
+fn project_from_pending_auto_yolo(entry: &PendingAutoYolo) -> Project {
+    Project {
+        id: entry.project_id.clone(),
+        name: entry.project_name.clone(),
+        path: String::new(),
+        default_branch: String::new(),
+        added_at: 0,
+        order: 0,
+        parent_id: None,
+        is_folder: false,
+        avatar_path: None,
+        default_avatar_path: None,
+        enabled_mcp_servers: None,
+        known_mcp_servers: Vec::new(),
+        custom_system_prompt: None,
+        default_provider: None,
+        default_backend: None,
+        worktrees_dir: None,
+        linear_api_key: None,
+        linear_team_id: None,
+        linked_project_ids: Vec::new(),
+        auto_fix_settings: None,
+    }
+}
+
+async fn approve_plan_and_start_yolo(
+    app: &AppHandle,
+    entry: &PendingAutoYolo,
+) -> Result<(), String> {
+    let session = crate::chat::get_session(
+        app.clone(),
+        entry.worktree_id.clone(),
+        entry.worktree_path.clone(),
+        entry.session_id.clone(),
+        Some(20),
+    )
+    .await?;
+    if let Some(message_id) = session.pending_plan_message_id.clone() {
+        crate::chat::mark_plan_approved(
+            app.clone(),
+            entry.worktree_id.clone(),
+            entry.worktree_path.clone(),
+            entry.session_id.clone(),
+            message_id,
+        )
+        .await?;
+    }
+
+    let model = entry
+        .model
+        .clone()
+        .unwrap_or_else(|| default_model_for_backend(&entry.backend));
+    crate::chat::set_session_backend(
+        app.clone(),
+        entry.worktree_id.clone(),
+        entry.worktree_path.clone(),
+        entry.session_id.clone(),
+        entry.backend.clone(),
+    )
+    .await?;
+    crate::chat::set_session_model(
+        app.clone(),
+        entry.worktree_id.clone(),
+        entry.worktree_path.clone(),
+        entry.session_id.clone(),
+        model.clone(),
+    )
+    .await?;
+
+    crate::chat::update_session_state(
+        app.clone(),
+        entry.worktree_id.clone(),
+        entry.worktree_path.clone(),
+        entry.session_id.clone(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(false),
+        Some(false),
+        Some(None),
+        None,
+        Some(None),
+        None,
+        None,
+        None,
+        None,
+        Some(Some("yolo".to_string())),
+        None,
+    )
+    .await?;
+    let _ = crate::chat::broadcast_session_setting(
+        app.clone(),
+        entry.session_id.clone(),
+        "executionMode".to_string(),
+        "yolo".to_string(),
+    )
+    .await;
+    let _ = crate::chat::broadcast_session_setting(
+        app.clone(),
+        entry.session_id.clone(),
+        "waitingForInput".to_string(),
+        "false".to_string(),
+    )
+    .await;
+
+    crate::chat::send_chat_message(
+        app.clone(),
+        entry.session_id.clone(),
+        entry.worktree_id.clone(),
+        entry.worktree_path.clone(),
+        "[Mr. Robot Yolo]\nPlan approved automatically. Begin a new yolo execution turn now. Execute the approved plan, implement the fixes immediately, and do not continue planning or ask for confirmation."
+            .to_string(),
+        Some(model),
+        Some("yolo".to_string()),
+        Some(ThinkingLevel::Off),
+        Some(EffortLevel::Medium),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(entry.backend.clone()),
+    )
+    .await?;
+
+    Ok(())
+}
+
+fn emit_auto_fix_stopped(app: &AppHandle, project: &Project, backend: &str, error: &str) {
+    disable_project_auto_fix(app, &project.id);
+    let event = AutoFixStoppedEvent {
+        project_id: project.id.clone(),
+        project_name: project.name.clone(),
+        backend: backend.to_string(),
+        error: error.to_string(),
+    };
+    if let Err(err) = app.emit_all("auto-fix:stopped", &event) {
+        log::warn!("Mr. Robot: failed to emit stop notification: {err}");
+    }
+}
+
+fn disable_project_auto_fix(app: &AppHandle, project_id: &str) {
+    let Ok(mut data) = crate::projects::storage::load_projects_data(app) else {
+        return;
+    };
+    let Some(project) = data.find_project_mut(project_id) else {
+        return;
+    };
+    let Some(settings) = project.auto_fix_settings.as_mut() else {
+        return;
+    };
+    settings.enabled = false;
+    if let Err(err) = crate::projects::storage::save_projects_data(app, &data) {
+        log::warn!("Mr. Robot: failed to disable project setting: {err}");
+    }
+}
+
+fn default_model_for_backend(backend: &str) -> String {
+    match backend {
+        "codex" => "gpt-5.3-codex".to_string(),
+        "opencode" => "opencode/gpt-5.3-codex".to_string(),
+        "cursor" => "auto".to_string(),
+        _ => "claude-opus-4-8[1m]".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skips_handled_issues_and_respects_limit() {
+        let issues = vec![
+            AutoFixIssueCandidate { number: 1 },
+            AutoFixIssueCandidate { number: 2 },
+            AutoFixIssueCandidate { number: 3 },
+            AutoFixIssueCandidate { number: 4 },
+        ];
+        let handled = HashSet::from([2, 4]);
+
+        let selected = select_issue_numbers_to_start(&issues, &handled, 2);
+
+        assert_eq!(selected, vec![1, 3]);
+    }
+
+    #[test]
+    fn active_window_same_day() {
+        assert!(within_active_window(8, 17, 8));
+        assert!(within_active_window(8, 17, 12));
+        assert!(!within_active_window(8, 17, 17));
+        assert!(!within_active_window(8, 17, 7));
+        assert!(!within_active_window(8, 17, 20));
+    }
+
+    #[test]
+    fn active_window_crosses_midnight() {
+        assert!(within_active_window(20, 8, 22));
+        assert!(within_active_window(20, 8, 2));
+        assert!(within_active_window(20, 8, 20));
+        assert!(!within_active_window(20, 8, 8));
+        assert!(!within_active_window(20, 8, 12));
+    }
+
+    #[test]
+    fn active_window_equal_bounds_always_active() {
+        assert!(within_active_window(0, 0, 0));
+        assert!(within_active_window(9, 9, 23));
+    }
+
+    #[test]
+    fn detects_backend_quota_or_auth_errors() {
+        assert!(is_backend_quota_or_auth_error(
+            "Codex token expired. Run `codex` to log in again."
+        ));
+        assert!(is_backend_quota_or_auth_error(
+            "Claude usage limit reached for this plan"
+        ));
+        assert!(!is_backend_quota_or_auth_error(
+            "worktree path already exists"
+        ));
+    }
+
+    #[test]
+    fn auto_yolo_in_flight_guard_prevents_duplicate_starts() {
+        let mut in_flight = HashSet::new();
+
+        assert!(mark_auto_yolo_in_flight(&mut in_flight, "session-1"));
+        assert!(!mark_auto_yolo_in_flight(&mut in_flight, "session-1"));
+
+        clear_auto_yolo_in_flight(&mut in_flight, "session-1");
+        assert!(mark_auto_yolo_in_flight(&mut in_flight, "session-1"));
+    }
+
+    #[test]
+    fn does_not_queue_yolo_when_plan_only_is_enabled() {
+        let settings = ProjectAutoFixSettings {
+            enabled: true,
+            interval_minutes: 15,
+            issue_limit: 1,
+            max_parallel_worktrees: 1,
+            planning_backend: "claude".to_string(),
+            planning_model: None,
+            auto_yolo_enabled: false,
+            yolo_backend: "claude".to_string(),
+            yolo_model: None,
+            active_hours_enabled: false,
+            active_hours_start: 20,
+            active_hours_end: 8,
+        };
+
+        assert!(!should_queue_auto_yolo(&settings));
+    }
+
+    #[test]
+    fn queues_yolo_when_enabled() {
+        let settings = ProjectAutoFixSettings {
+            enabled: true,
+            interval_minutes: 15,
+            issue_limit: 1,
+            max_parallel_worktrees: 1,
+            planning_backend: "claude".to_string(),
+            planning_model: None,
+            auto_yolo_enabled: true,
+            yolo_backend: "claude".to_string(),
+            yolo_model: None,
+            active_hours_enabled: false,
+            active_hours_start: 20,
+            active_hours_end: 8,
+        };
+
+        assert!(should_queue_auto_yolo(&settings));
+    }
+}

--- a/src-tauri/src/auto_fix/types.rs
+++ b/src-tauri/src/auto_fix/types.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AutoFixStoppedEvent {
+    pub project_id: String,
+    pub project_name: String,
+    pub backend: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct AutoFixIssueCandidate {
+    pub number: u32,
+}

--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -1617,6 +1617,7 @@ pub async fn restore_session_with_base(
         pr_push_remote: None,
         pr_push_branch: None,
         order: 0,
+        origin: None,
         labels: Vec::new(),
         label: None,
         archived_at: None,
@@ -1936,6 +1937,7 @@ pub async fn set_sessions_last_opened_bulk(
 /// 5. Adds the assistant response
 /// 6. Saves the updated session
 /// 7. Returns the assistant message
+///
 /// Persist a salvaged resume/session ID onto the correct backend field.
 /// Used by the thread-error/thread-panic recovery paths so the next send can
 /// resume the conversation instead of starting fresh.

--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -242,7 +242,7 @@ pub async fn dispatch_command(
             let linked_project_ids: Option<Vec<String>> =
                 field_opt(&args, "linkedProjectIds", "linked_project_ids")?;
             let auto_fix_settings: Option<Option<crate::projects::types::ProjectAutoFixSettings>> =
-                field_opt(&args, "autoFixSettings", "auto_fix_settings")?;
+                field_nullable_option(&args, "autoFixSettings", "auto_fix_settings")?;
             let result = crate::projects::update_project_settings(
                 app.clone(),
                 project_id,
@@ -3037,6 +3037,26 @@ fn field_opt<T: serde::de::DeserializeOwned>(
     from_field_opt(args, snake)
 }
 
+/// Try camelCase field first, then snake_case. For optional nullable fields.
+fn field_nullable_option<T: serde::de::DeserializeOwned>(
+    args: &Value,
+    camel: &str,
+    snake: &str,
+) -> Result<Option<Option<T>>, String> {
+    let (field_name, value) = match args.get(camel).or_else(|| args.get(snake)) {
+        None => return Ok(None),
+        Some(value) if args.get(camel).is_some() => (camel, value),
+        Some(value) => (snake, value),
+    };
+
+    match value {
+        Value::Null => Ok(Some(None)),
+        value => serde_json::from_value(value.clone())
+            .map(|value| Some(Some(value)))
+            .map_err(|e| format!("Invalid field '{field_name}': {e}")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3123,6 +3143,40 @@ mod tests {
                 terminal_id: "term-1".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn field_nullable_option_preserves_missing_null_and_value() {
+        type Settings = crate::projects::types::ProjectAutoFixSettings;
+
+        let missing: Option<Option<Settings>> =
+            field_nullable_option(&json!({}), "autoFixSettings", "auto_fix_settings").unwrap();
+        assert_eq!(missing, None);
+
+        let explicit_null: Option<Option<Settings>> = field_nullable_option(
+            &json!({ "autoFixSettings": null }),
+            "autoFixSettings",
+            "auto_fix_settings",
+        )
+        .unwrap();
+        assert_eq!(explicit_null, Some(None));
+
+        let value: Option<Option<Settings>> = field_nullable_option(
+            &json!({
+                "auto_fix_settings": {
+                    "enabled": true,
+                    "interval_minutes": 30,
+                    "issue_limit": 4,
+                    "max_parallel_worktrees": 2,
+                    "planning_backend": "claude",
+                    "yolo_backend": "codex"
+                }
+            }),
+            "autoFixSettings",
+            "auto_fix_settings",
+        )
+        .unwrap();
+        assert_eq!(value.unwrap().unwrap().issue_limit, 4);
     }
 
     #[test]

--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -187,6 +187,7 @@ pub async fn dispatch_command(
             let linear_context = field_opt(&args, "linearContext", "linear_context")?;
             let custom_name = field_opt(&args, "customName", "custom_name")?;
             let auto_open_in_jean = field_opt(&args, "autoOpenInJean", "auto_open_in_jean")?;
+            let origin = field_opt(&args, "origin", "origin")?;
             let result = crate::projects::create_worktree(
                 app.clone(),
                 project_id,
@@ -198,6 +199,7 @@ pub async fn dispatch_command(
                 linear_context,
                 custom_name,
                 auto_open_in_jean,
+                origin,
             )
             .await?;
             // No cache invalidation here — worktree creation uses event-based sync
@@ -239,6 +241,8 @@ pub async fn dispatch_command(
                 field_opt(&args, "linearTeamId", "linear_team_id")?;
             let linked_project_ids: Option<Vec<String>> =
                 field_opt(&args, "linkedProjectIds", "linked_project_ids")?;
+            let auto_fix_settings: Option<Option<crate::projects::types::ProjectAutoFixSettings>> =
+                field_opt(&args, "autoFixSettings", "auto_fix_settings")?;
             let result = crate::projects::update_project_settings(
                 app.clone(),
                 project_id,
@@ -253,6 +257,7 @@ pub async fn dispatch_command(
                 linear_api_key,
                 linear_team_id,
                 linked_project_ids,
+                auto_fix_settings,
             )
             .await?;
             emit_cache_invalidation(app, &["projects"]);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ use tauri::{AppHandle, Emitter, Manager};
 #[cfg(target_os = "macos")]
 use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
 
+mod auto_fix;
 mod background_tasks;
 mod browser;
 mod chat;
@@ -3672,6 +3673,7 @@ pub fn run() {
             let task_manager = background_tasks::BackgroundTaskManager::new(app.handle().clone());
             task_manager.start();
             app.manage(task_manager);
+            auto_fix::scheduler::start_auto_fix_scheduler(app.handle().clone());
             log::trace!("Background task manager initialized");
 
             // Initialize HTTP server infrastructure

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -1020,11 +1020,7 @@ pub async fn create_worktree(
     log::trace!("Creating worktree for project: {project_id}");
 
     let auto_open_in_jean = auto_open_in_jean.unwrap_or(true);
-    let worktree_origin = match origin.as_deref() {
-        Some("auto_fix") => Some(WorktreeOrigin::AutoFix),
-        Some("manual") | None => None,
-        Some(other) => return Err(format!("Unsupported worktree origin: {other}")),
-    };
+    let worktree_origin = parse_worktree_origin(origin.as_deref())?;
 
     let data = load_projects_data(&app)?;
 
@@ -1872,6 +1868,15 @@ pub async fn create_worktree(
 
     log::trace!("Returning pending worktree: {}", pending_worktree.name);
     Ok(pending_worktree)
+}
+
+fn parse_worktree_origin(origin: Option<&str>) -> Result<Option<WorktreeOrigin>, String> {
+    match origin {
+        Some("auto_fix") => Ok(Some(WorktreeOrigin::AutoFix)),
+        Some("manual") => Ok(Some(WorktreeOrigin::Manual)),
+        None => Ok(None),
+        Some(other) => Err(format!("Unsupported worktree origin: {other}")),
+    }
 }
 
 /// Create a worktree from an existing branch (runs in background)
@@ -11089,6 +11094,14 @@ pub async fn revert_last_local_commit(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_worktree_origin_preserves_manual_origin() {
+        assert_eq!(
+            parse_worktree_origin(Some("manual")),
+            Ok(Some(WorktreeOrigin::Manual))
+        );
+    }
 
     #[test]
     fn extract_json_object_plain() {

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -39,11 +39,11 @@ use super::release_notes::{
 };
 use super::storage::{get_project_worktrees_dir, load_projects_data, save_projects_data};
 use super::types::{
-    JeanConfig, MergeType, Project, SessionType, Worktree, WorktreeArchivedEvent,
-    WorktreeBranchExistsEvent, WorktreeCreateErrorEvent, WorktreeCreatedEvent,
-    WorktreeCreatingEvent, WorktreeDeleteErrorEvent, WorktreeDeletedEvent, WorktreeDeletingEvent,
-    WorktreePathExistsEvent, WorktreePermanentlyDeletedEvent, WorktreeSetupCompleteEvent,
-    WorktreeUnarchivedEvent,
+    JeanConfig, MergeType, Project, ProjectAutoFixSettings, SessionType, Worktree,
+    WorktreeArchivedEvent, WorktreeBranchExistsEvent, WorktreeCreateErrorEvent,
+    WorktreeCreatedEvent, WorktreeCreatingEvent, WorktreeDeleteErrorEvent, WorktreeDeletedEvent,
+    WorktreeDeletingEvent, WorktreeOrigin, WorktreePathExistsEvent,
+    WorktreePermanentlyDeletedEvent, WorktreeSetupCompleteEvent, WorktreeUnarchivedEvent,
 };
 use crate::chat::types::LabelData;
 use crate::claude_cli::resolve_cli_binary;
@@ -496,6 +496,7 @@ pub async fn add_project(
         linear_api_key: None,
         linear_team_id: None,
         linked_project_ids: Vec::new(),
+        auto_fix_settings: None,
     };
 
     data.add_project(project.clone());
@@ -654,6 +655,7 @@ pub async fn init_project(
         linear_api_key: None,
         linear_team_id: None,
         linked_project_ids: Vec::new(),
+        auto_fix_settings: None,
     };
 
     data.add_project(project.clone());
@@ -709,6 +711,7 @@ pub async fn clone_project(
         linear_api_key: None,
         linear_team_id: None,
         linked_project_ids: Vec::new(),
+        auto_fix_settings: None,
     };
 
     data.add_project(project.clone());
@@ -1000,6 +1003,7 @@ fn truncate_utf8(input: &str, max_bytes: usize) -> (String, bool) {
 /// - `worktree:created` - Emitted when creation completes successfully
 /// - `worktree:error` - Emitted if creation fails
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn create_worktree(
     app: AppHandle,
     project_id: String,
@@ -1011,10 +1015,16 @@ pub async fn create_worktree(
     linear_context: Option<LinearIssueContext>,
     custom_name: Option<String>,
     auto_open_in_jean: Option<bool>,
+    origin: Option<String>,
 ) -> Result<Worktree, String> {
     log::trace!("Creating worktree for project: {project_id}");
 
     let auto_open_in_jean = auto_open_in_jean.unwrap_or(true);
+    let worktree_origin = match origin.as_deref() {
+        Some("auto_fix") => Some(WorktreeOrigin::AutoFix),
+        Some("manual") | None => None,
+        Some(other) => return Err(format!("Unsupported worktree origin: {other}")),
+    };
 
     let data = load_projects_data(&app)?;
 
@@ -1151,6 +1161,7 @@ pub async fn create_worktree(
         issue_number: issue_context.as_ref().map(|ctx| ctx.number as u64),
         security_alert_number: security_context.as_ref().map(|ctx| ctx.number as u64),
         advisory_ghsa_id: advisory_context.as_ref().map(|ctx| ctx.ghsa_id.clone()),
+        origin: worktree_origin.clone(),
         auto_open_in_jean,
     };
     if let Err(e) = app.emit_all("worktree:creating", &creating_event) {
@@ -1198,6 +1209,7 @@ pub async fn create_worktree(
         pr_push_remote: None,
         pr_push_branch: None,
         order: 0, // Placeholder, actual order is set in background thread
+        origin: worktree_origin.clone(),
         archived_at: None,
         labels: Vec::new(),
         label: None,
@@ -1218,6 +1230,7 @@ pub async fn create_worktree(
     let security_context_clone = security_context.clone();
     let advisory_context_clone = advisory_context.clone();
     let linear_context_clone = linear_context.clone();
+    let worktree_origin_clone = worktree_origin.clone();
 
     // Spawn background thread for git operations
     thread::spawn(move || {
@@ -1754,6 +1767,7 @@ pub async fn create_worktree(
                     pr_push_remote: None,
                     pr_push_branch: None,
                     order: max_order + 1,
+                    origin: worktree_origin_clone.clone(),
                     archived_at: None,
                     labels: Vec::new(),
                     label: None,
@@ -1917,6 +1931,7 @@ pub async fn create_worktree_from_existing_branch(
         issue_number: issue_context.as_ref().map(|ctx| ctx.number as u64),
         security_alert_number: security_context.as_ref().map(|ctx| ctx.number as u64),
         advisory_ghsa_id: advisory_context.as_ref().map(|ctx| ctx.ghsa_id.clone()),
+        origin: None,
         auto_open_in_jean,
     };
     if let Err(e) = app.emit_all("worktree:creating", &creating_event) {
@@ -1964,6 +1979,7 @@ pub async fn create_worktree_from_existing_branch(
         pr_push_remote: None,
         pr_push_branch: None,
         order: 0, // Placeholder, actual order is set in background thread
+        origin: None,
         archived_at: None,
         labels: Vec::new(),
         label: None,
@@ -2352,6 +2368,7 @@ pub async fn create_worktree_from_existing_branch(
                     pr_push_remote: None,
                     pr_push_branch: None,
                     order: max_order + 1,
+                    origin: None,
                     archived_at: None,
                     labels: Vec::new(),
                     label: None,
@@ -2543,6 +2560,7 @@ pub async fn checkout_pr(
         issue_number: None,
         security_alert_number: None,
         advisory_ghsa_id: None,
+        origin: None,
         auto_open_in_jean: true,
     };
     if let Err(e) = app.emit_all("worktree:creating", &creating_event) {
@@ -2587,6 +2605,7 @@ pub async fn checkout_pr(
         pr_push_remote: None,
         pr_push_branch: None,
         order: 0, // Will be updated in background thread
+        origin: None,
         archived_at: None,
         labels: Vec::new(),
         label: None,
@@ -2911,6 +2930,7 @@ pub async fn checkout_pr(
                     pr_push_remote: None,
                     pr_push_branch: None,
                     order: max_order + 1,
+                    origin: None,
                     archived_at: None,
                     labels: Vec::new(),
                     label: None,
@@ -3249,6 +3269,7 @@ pub async fn create_base_session(app: AppHandle, project_id: String) -> Result<W
         pr_push_remote: None,
         pr_push_branch: None,
         order: 0, // Base sessions are always first
+        origin: None,
         archived_at: None,
         labels: Vec::new(),
         label: None,
@@ -3663,6 +3684,7 @@ pub async fn import_worktree(
         pr_push_remote: None,
         pr_push_branch: None,
         order: max_order + 1,
+        origin: None,
         archived_at: None,
         labels: Vec::new(),
         label: None,
@@ -4707,6 +4729,7 @@ pub async fn update_project_settings(
     linear_api_key: Option<String>,
     linear_team_id: Option<String>,
     linked_project_ids: Option<Vec<String>>,
+    auto_fix_settings: Option<Option<ProjectAutoFixSettings>>,
 ) -> Result<Project, String> {
     log::trace!("Updating settings for project: {project_id}");
 
@@ -4784,6 +4807,11 @@ pub async fn update_project_settings(
         } else {
             Some(team_id)
         };
+    }
+
+    if let Some(settings) = auto_fix_settings {
+        log::trace!("Updating Mr. Robot settings: {settings:?}");
+        project.auto_fix_settings = settings;
     }
 
     // Handle linked_project_ids with bidirectional sync
@@ -9943,6 +9971,7 @@ pub async fn create_folder(
         linear_api_key: None,
         linear_team_id: None,
         linked_project_ids: Vec::new(),
+        auto_fix_settings: None,
     };
 
     data.add_project(folder.clone());
@@ -11238,6 +11267,7 @@ mod tests {
             linear_api_key: None,
             linear_team_id: None,
             linked_project_ids: Vec::new(),
+            auto_fix_settings: None,
         };
 
         attach_default_avatar(&mut project);

--- a/src-tauri/src/projects/types.rs
+++ b/src-tauri/src/projects/types.rs
@@ -13,6 +13,37 @@ pub enum SessionType {
     Base,
 }
 
+/// Origin/category for a worktree.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorktreeOrigin {
+    Manual,
+    AutoFix,
+}
+
+/// Per-project automated issue fixing settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ProjectAutoFixSettings {
+    pub enabled: bool,
+    pub interval_minutes: u64,
+    pub issue_limit: u32,
+    pub max_parallel_worktrees: u32,
+    pub planning_backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub planning_model: Option<String>,
+    #[serde(default)]
+    pub auto_yolo_enabled: bool,
+    pub yolo_backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub yolo_model: Option<String>,
+    #[serde(default)]
+    pub active_hours_enabled: bool,
+    #[serde(default)]
+    pub active_hours_start: u8, // 0-23 local hour, inclusive
+    #[serde(default)]
+    pub active_hours_end: u8, // 0-23 local hour, exclusive
+}
+
 /// Type of merge operation for merging worktree to base
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -126,6 +157,9 @@ pub struct Project {
     /// IDs of linked projects for cross-project context sharing
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub linked_project_ids: Vec<String>,
+    /// Per-project automated issue fixing settings.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_fix_settings: Option<ProjectAutoFixSettings>,
 }
 
 /// A git worktree created for a project
@@ -231,6 +265,9 @@ pub struct Worktree {
     /// Display order within project (lower = higher in list, base sessions ignore this)
     #[serde(default)]
     pub order: u32,
+    /// Worktree origin/category.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin: Option<WorktreeOrigin>,
     /// User-assigned labels with colors (e.g. "In Progress").
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub labels: Vec<LabelData>,
@@ -464,6 +501,8 @@ pub struct WorktreeCreatingEvent {
     pub security_alert_number: Option<u64>,
     /// Advisory GHSA ID (if created from an advisory)
     pub advisory_ghsa_id: Option<String>,
+    /// Worktree origin/category.
+    pub origin: Option<WorktreeOrigin>,
     /// Whether Jean UI should auto-select/open this worktree when events arrive
     pub auto_open_in_jean: bool,
 }
@@ -694,5 +733,55 @@ mod label_tests {
                 { "name": "Pinned", "color": "#22c55e", "pinned": true }
             ])
         );
+    }
+
+    #[test]
+    fn project_auto_fix_settings_round_trip() {
+        let settings = ProjectAutoFixSettings {
+            enabled: true,
+            interval_minutes: 15,
+            issue_limit: 3,
+            max_parallel_worktrees: 2,
+            planning_backend: "claude".to_string(),
+            planning_model: Some("claude-opus-4-8[1m]".to_string()),
+            auto_yolo_enabled: true,
+            yolo_backend: "codex".to_string(),
+            yolo_model: Some("gpt-5.3-codex".to_string()),
+            active_hours_enabled: true,
+            active_hours_start: 20,
+            active_hours_end: 8,
+        };
+
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("\"interval_minutes\":15"));
+        let parsed: ProjectAutoFixSettings = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.issue_limit, 3);
+        assert!(parsed.auto_yolo_enabled);
+        assert_eq!(parsed.yolo_backend, "codex");
+    }
+
+    #[test]
+    fn project_auto_fix_settings_default_to_plan_only() {
+        let json = serde_json::json!({
+            "enabled": true,
+            "interval_minutes": 15,
+            "issue_limit": 3,
+            "max_parallel_worktrees": 2,
+            "planning_backend": "claude",
+            "yolo_backend": "codex"
+        });
+
+        let parsed: ProjectAutoFixSettings = serde_json::from_value(json).unwrap();
+
+        assert!(!parsed.auto_yolo_enabled);
+    }
+
+    #[test]
+    fn worktree_origin_serializes_as_auto_fix() {
+        let origin = WorktreeOrigin::AutoFix;
+        let json = serde_json::to_string(&origin).unwrap();
+
+        assert_eq!(json, "\"auto_fix\"");
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import {
   refetchInitialData,
   setAppDataDir,
   hasPreloadedData,
+  listen,
   type InitialData,
 } from '@/lib/transport'
 import { isNativeApp } from '@/lib/environment'
@@ -56,6 +57,13 @@ import {
 import { scheduleIdleWork } from './lib/idle'
 import { isWindows } from './lib/platform'
 import { checkWebClientVersion } from './lib/web-client-version'
+
+interface AutoFixStoppedEvent {
+  projectId: string
+  projectName: string
+  backend: string
+  error: string
+}
 
 /** Loading screen shown while preloading initial data (browser mode only). */
 function WebLoadingScreen() {
@@ -123,6 +131,21 @@ function App() {
   // Holds the update object so the title bar indicator can trigger install later
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const pendingUpdateRef = useRef<any>(null)
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined
+    listen<AutoFixStoppedEvent>('auto-fix:stopped', event => {
+      const { projectName, backend, error } = event.payload
+      toast.error(`Mr. Robot stopped for ${projectName}`, {
+        description: `${backend}: ${error}`,
+        duration: Infinity,
+        closeButton: true,
+      })
+    }).then(fn => {
+      unlisten = fn
+    })
+    return () => unlisten?.()
+  }, [])
 
   const installAppUpdate = useCallback(
     async (update: {

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -3223,6 +3223,7 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
                   'settingsPane' in tab ? tab.settingsPane : undefined
                 const settingsPlacement =
                   'settingsPlacement' in tab ? tab.settingsPlacement : undefined
+                const badge = 'badge' in tab ? tab.badge : undefined
                 if (settingsPane && settingsPlacement === 'inside') {
                   return (
                     <div
@@ -3243,6 +3244,18 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
                       >
                         <Icon className="h-3.5 w-3.5" />
                         <span>{tab.label}</span>
+                        {badge && (
+                          <span
+                            className={cn(
+                              'rounded border px-1 py-0 text-[9px] uppercase leading-4 tracking-wide',
+                              isActive
+                                ? 'border-primary/30 text-primary'
+                                : 'border-muted-foreground/20 text-muted-foreground'
+                            )}
+                          >
+                            {badge}
+                          </span>
+                        )}
                         <span
                           className={cn(
                             'rounded-md px-1.5 py-0.5 text-[10px] leading-none',

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -22,7 +22,6 @@ import { invoke } from '@/lib/transport'
 import { cn } from '@/lib/utils'
 import { dismissibleToast } from '@/lib/dismissible-toast'
 import {
-  type LucideIcon,
   Search,
   X,
   MoreHorizontal,
@@ -165,6 +164,15 @@ import {
   shouldDisableWorktreeTextSelection,
   shouldShowWorktreeLabelContextMenu,
 } from './worktree-label-context'
+import {
+  CANVAS_FILTER_TABS,
+  getCanvasFilterTabCount,
+  isLabelFilterTab,
+  matchesCanvasFilterTab,
+  type CanvasFilterTab,
+  type CanvasPredefinedFilterTab,
+  type CanvasPredefinedFilterTabItem,
+} from './canvas-worktree-filters'
 const GitDiffModal = lazy(() =>
   import('@/components/chat/GitDiffModal').then(mod => ({
     default: mod.GitDiffModal,
@@ -340,98 +348,18 @@ type ActiveStatus =
   | 'review'
   | null
 
-type CanvasPredefinedFilterTab =
-  | 'all'
-  | 'manual'
-  | 'issues'
-  | 'prs'
-  | 'security'
-type CanvasLabelFilterTab = `label:${string}`
-type CanvasFilterTab = CanvasPredefinedFilterTab | CanvasLabelFilterTab
-
-interface CanvasPredefinedFilterTabItem {
-  value: CanvasPredefinedFilterTab
-  label: string
-  icon: LucideIcon
-}
-
 interface CanvasLabelFilterTabItem extends PinnedWorktreeLabelTab {
-  icon: LucideIcon
+  icon: React.ComponentType<{ className?: string; style?: React.CSSProperties }>
 }
 
 type CanvasFilterTabItem =
   | CanvasPredefinedFilterTabItem
   | CanvasLabelFilterTabItem
 
-const CANVAS_FILTER_TABS: CanvasPredefinedFilterTabItem[] = [
-  { value: 'all', label: 'All', icon: Home },
-  { value: 'manual', label: 'Manual', icon: GitBranch },
-  { value: 'issues', label: 'Issues', icon: CircleDot },
-  { value: 'prs', label: 'PRs', icon: GitPullRequestArrow },
-  { value: 'security', label: 'Security', icon: ShieldAlert },
-]
-
-function isLabelFilterTab(
-  value: CanvasFilterTab
-): value is CanvasLabelFilterTab {
-  return value.startsWith('label:')
-}
-
 function isLabelFilterTabItem(
   tab: CanvasFilterTabItem
 ): tab is CanvasLabelFilterTabItem {
   return isLabelFilterTab(tab.value)
-}
-
-function isIssueWorktree(worktree: Worktree): boolean {
-  return (
-    worktree.issue_number != null || !!worktree.linear_issue_identifier?.trim()
-  )
-}
-
-function isPrWorktree(worktree: Worktree): boolean {
-  return worktree.pr_number != null
-}
-
-function isSecurityWorktree(worktree: Worktree): boolean {
-  return (
-    worktree.security_alert_number != null ||
-    !!worktree.advisory_ghsa_id?.trim()
-  )
-}
-
-function isManualWorktree(worktree: Worktree): boolean {
-  return (
-    !isBaseSession(worktree) &&
-    !isIssueWorktree(worktree) &&
-    !isPrWorktree(worktree) &&
-    !isSecurityWorktree(worktree)
-  )
-}
-
-function matchesCanvasFilterTab(
-  worktree: Worktree,
-  activeFilterTab: CanvasFilterTab
-): boolean {
-  if (isLabelFilterTab(activeFilterTab)) {
-    const labelName = activeFilterTab.slice('label:'.length).toLowerCase()
-    return getWorktreeLabels(worktree).some(
-      label => label.name.toLowerCase() === labelName
-    )
-  }
-
-  switch (activeFilterTab) {
-    case 'all':
-      return true
-    case 'manual':
-      return isManualWorktree(worktree)
-    case 'issues':
-      return isIssueWorktree(worktree)
-    case 'prs':
-      return isPrWorktree(worktree)
-    case 'security':
-      return isSecurityWorktree(worktree)
-  }
 }
 
 function getActiveStatus(cards: SessionCardData[]): ActiveStatus {
@@ -997,11 +925,12 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
     Record<CanvasPredefinedFilterTab, number>
   >(() => {
     return {
-      all: visibleWorktrees.length,
-      manual: visibleWorktrees.filter(isManualWorktree).length,
-      issues: visibleWorktrees.filter(isIssueWorktree).length,
-      prs: visibleWorktrees.filter(isPrWorktree).length,
-      security: visibleWorktrees.filter(isSecurityWorktree).length,
+      all: getCanvasFilterTabCount(visibleWorktrees, 'all'),
+      manual: getCanvasFilterTabCount(visibleWorktrees, 'manual'),
+      issues: getCanvasFilterTabCount(visibleWorktrees, 'issues'),
+      prs: getCanvasFilterTabCount(visibleWorktrees, 'prs'),
+      security: getCanvasFilterTabCount(visibleWorktrees, 'security'),
+      auto_fix: getCanvasFilterTabCount(visibleWorktrees, 'auto_fix'),
     }
   }, [visibleWorktrees])
 
@@ -3290,38 +3219,110 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
                 const count = isPinnedLabelTab
                   ? tab.count
                   : filterTabCounts[tab.value]
-                return (
-                  <button
-                    key={tab.value}
-                    type="button"
-                    role="tab"
-                    aria-selected={isActive}
-                    className={cn(
-                      'inline-flex shrink-0 items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors',
-                      isActive
-                        ? 'border-primary/30 bg-primary/10 text-primary'
-                        : 'border-transparent text-muted-foreground hover:bg-muted/60 hover:text-foreground'
-                    )}
-                    onClick={() => handleFilterTabChange(tab.value)}
-                  >
-                    <Icon
-                      className="h-3.5 w-3.5"
-                      style={
-                        isPinnedLabelTab ? { color: tab.color } : undefined
-                      }
-                    />
-                    <span>{tab.label}</span>
-                    <span
+                const settingsPane =
+                  'settingsPane' in tab ? tab.settingsPane : undefined
+                const settingsPlacement =
+                  'settingsPlacement' in tab ? tab.settingsPlacement : undefined
+                if (settingsPane && settingsPlacement === 'inside') {
+                  return (
+                    <div
+                      key={tab.value}
                       className={cn(
-                        'rounded-md px-1.5 py-0.5 text-[10px] leading-none',
+                        'inline-flex shrink-0 items-center overflow-hidden rounded-md border text-xs font-medium transition-colors',
                         isActive
-                          ? 'bg-primary/15 text-primary'
-                          : 'bg-muted text-muted-foreground'
+                          ? 'border-primary/30 bg-primary/10 text-primary'
+                          : 'border-transparent text-muted-foreground hover:bg-muted/60 hover:text-foreground'
                       )}
                     >
-                      {count}
-                    </span>
-                  </button>
+                      <button
+                        type="button"
+                        role="tab"
+                        aria-selected={isActive}
+                        className="inline-flex shrink-0 items-center gap-1.5 pl-3 py-1.5"
+                        onClick={() => handleFilterTabChange(tab.value)}
+                      >
+                        <Icon className="h-3.5 w-3.5" />
+                        <span>{tab.label}</span>
+                        <span
+                          className={cn(
+                            'rounded-md px-1.5 py-0.5 text-[10px] leading-none',
+                            isActive
+                              ? 'bg-primary/15 text-primary'
+                              : 'bg-muted text-muted-foreground'
+                          )}
+                        >
+                          {count}
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        aria-label={`Configure ${tab.label}`}
+                        title={`Configure ${tab.label}`}
+                        className={cn(
+                          'mx-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md transition-colors',
+                          isActive
+                            ? 'text-primary hover:bg-primary/15'
+                            : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                        )}
+                        onClick={() =>
+                          useProjectsStore
+                            .getState()
+                            .openProjectSettings(projectId, settingsPane)
+                        }
+                      >
+                        <Settings className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  )
+                }
+                return (
+                  <div key={tab.value} className="inline-flex shrink-0 gap-0.5">
+                    <button
+                      type="button"
+                      role="tab"
+                      aria-selected={isActive}
+                      className={cn(
+                        'inline-flex shrink-0 items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors',
+                        isActive
+                          ? 'border-primary/30 bg-primary/10 text-primary'
+                          : 'border-transparent text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+                      )}
+                      onClick={() => handleFilterTabChange(tab.value)}
+                    >
+                      <Icon
+                        className="h-3.5 w-3.5"
+                        style={
+                          isPinnedLabelTab ? { color: tab.color } : undefined
+                        }
+                      />
+                      <span>{tab.label}</span>
+                      <span
+                        className={cn(
+                          'rounded-md px-1.5 py-0.5 text-[10px] leading-none',
+                          isActive
+                            ? 'bg-primary/15 text-primary'
+                            : 'bg-muted text-muted-foreground'
+                        )}
+                      >
+                        {count}
+                      </span>
+                    </button>
+                    {settingsPane && (
+                      <button
+                        type="button"
+                        aria-label={`Configure ${tab.label}`}
+                        title={`Configure ${tab.label}`}
+                        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                        onClick={() =>
+                          useProjectsStore
+                            .getState()
+                            .openProjectSettings(projectId, settingsPane)
+                        }
+                      >
+                        <Settings className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
                 )
               })}
             </div>

--- a/src/components/dashboard/canvas-worktree-filters.test.ts
+++ b/src/components/dashboard/canvas-worktree-filters.test.ts
@@ -26,6 +26,7 @@ describe('canvas worktree filters', () => {
 
     expect(mrRobotTab?.settingsPane).toBe('auto-fix')
     expect(mrRobotTab?.settingsPlacement).toBe('inside')
+    expect(mrRobotTab?.badge).toBe('Beta')
   })
 
   it('hides auto-fix issue worktrees from All and Issues', () => {

--- a/src/components/dashboard/canvas-worktree-filters.test.ts
+++ b/src/components/dashboard/canvas-worktree-filters.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '@/types/projects'
+import {
+  CANVAS_FILTER_TABS,
+  getCanvasFilterTabCount,
+  matchesCanvasFilterTab,
+} from './canvas-worktree-filters'
+
+function worktree(overrides: Partial<Worktree>): Worktree {
+  return {
+    id: overrides.id ?? 'wt-1',
+    project_id: 'project-1',
+    name: overrides.name ?? 'worktree',
+    path: `/tmp/${overrides.name ?? 'worktree'}`,
+    branch: overrides.branch ?? 'branch',
+    created_at: 1,
+    session_type: 'worktree',
+    order: 0,
+    ...overrides,
+  }
+}
+
+describe('canvas worktree filters', () => {
+  it('marks the Mr. Robot tab as configurable from project settings', () => {
+    const mrRobotTab = CANVAS_FILTER_TABS.find(tab => tab.value === 'auto_fix')
+
+    expect(mrRobotTab?.settingsPane).toBe('auto-fix')
+    expect(mrRobotTab?.settingsPlacement).toBe('inside')
+  })
+
+  it('hides auto-fix issue worktrees from All and Issues', () => {
+    const autoFixIssue = worktree({
+      id: 'auto-fix-issue',
+      issue_number: 123,
+      origin: 'auto_fix',
+    })
+
+    expect(matchesCanvasFilterTab(autoFixIssue, 'all')).toBe(false)
+    expect(matchesCanvasFilterTab(autoFixIssue, 'issues')).toBe(false)
+    expect(matchesCanvasFilterTab(autoFixIssue, 'auto_fix')).toBe(true)
+  })
+
+  it('counts auto-fix worktrees separately from All', () => {
+    const worktrees = [
+      worktree({ id: 'manual' }),
+      worktree({ id: 'issue', issue_number: 123 }),
+      worktree({ id: 'auto', issue_number: 456, origin: 'auto_fix' }),
+    ]
+
+    expect(getCanvasFilterTabCount(worktrees, 'all')).toBe(2)
+    expect(getCanvasFilterTabCount(worktrees, 'issues')).toBe(1)
+    expect(getCanvasFilterTabCount(worktrees, 'auto_fix')).toBe(1)
+  })
+})

--- a/src/components/dashboard/canvas-worktree-filters.ts
+++ b/src/components/dashboard/canvas-worktree-filters.ts
@@ -26,6 +26,7 @@ export interface CanvasPredefinedFilterTabItem {
   icon: LucideIcon
   settingsPane?: string
   settingsPlacement?: 'inside'
+  badge?: string
 }
 
 export const CANVAS_FILTER_TABS: CanvasPredefinedFilterTabItem[] = [
@@ -40,6 +41,7 @@ export const CANVAS_FILTER_TABS: CanvasPredefinedFilterTabItem[] = [
     icon: Bot,
     settingsPane: 'auto-fix',
     settingsPlacement: 'inside',
+    badge: 'Beta',
   },
 ]
 

--- a/src/components/dashboard/canvas-worktree-filters.ts
+++ b/src/components/dashboard/canvas-worktree-filters.ts
@@ -1,0 +1,116 @@
+import type { LucideIcon } from 'lucide-react'
+import {
+  Bot,
+  CircleDot,
+  GitBranch,
+  GitPullRequestArrow,
+  Home,
+  ShieldAlert,
+} from 'lucide-react'
+import { getWorktreeLabels } from '@/lib/worktree-labels'
+import { isBaseSession, type Worktree } from '@/types/projects'
+
+export type CanvasPredefinedFilterTab =
+  | 'all'
+  | 'manual'
+  | 'issues'
+  | 'prs'
+  | 'security'
+  | 'auto_fix'
+export type CanvasLabelFilterTab = `label:${string}`
+export type CanvasFilterTab = CanvasPredefinedFilterTab | CanvasLabelFilterTab
+
+export interface CanvasPredefinedFilterTabItem {
+  value: CanvasPredefinedFilterTab
+  label: string
+  icon: LucideIcon
+  settingsPane?: string
+  settingsPlacement?: 'inside'
+}
+
+export const CANVAS_FILTER_TABS: CanvasPredefinedFilterTabItem[] = [
+  { value: 'all', label: 'All', icon: Home },
+  { value: 'manual', label: 'Manual', icon: GitBranch },
+  { value: 'issues', label: 'Issues', icon: CircleDot },
+  { value: 'prs', label: 'PRs', icon: GitPullRequestArrow },
+  { value: 'security', label: 'Security', icon: ShieldAlert },
+  {
+    value: 'auto_fix',
+    label: 'Mr. Robot',
+    icon: Bot,
+    settingsPane: 'auto-fix',
+    settingsPlacement: 'inside',
+  },
+]
+
+export function isLabelFilterTab(
+  value: CanvasFilterTab
+): value is CanvasLabelFilterTab {
+  return value.startsWith('label:')
+}
+
+export function isAutoFixWorktree(worktree: Worktree): boolean {
+  return worktree.origin === 'auto_fix'
+}
+
+export function isIssueWorktree(worktree: Worktree): boolean {
+  return (
+    worktree.issue_number != null || !!worktree.linear_issue_identifier?.trim()
+  )
+}
+
+export function isPrWorktree(worktree: Worktree): boolean {
+  return worktree.pr_number != null
+}
+
+export function isSecurityWorktree(worktree: Worktree): boolean {
+  return (
+    worktree.security_alert_number != null ||
+    !!worktree.advisory_ghsa_id?.trim()
+  )
+}
+
+export function isManualWorktree(worktree: Worktree): boolean {
+  return (
+    !isBaseSession(worktree) &&
+    !isAutoFixWorktree(worktree) &&
+    !isIssueWorktree(worktree) &&
+    !isPrWorktree(worktree) &&
+    !isSecurityWorktree(worktree)
+  )
+}
+
+export function matchesCanvasFilterTab(
+  worktree: Worktree,
+  activeFilterTab: CanvasFilterTab
+): boolean {
+  if (isLabelFilterTab(activeFilterTab)) {
+    const labelName = activeFilterTab.slice('label:'.length).toLowerCase()
+    return getWorktreeLabels(worktree).some(
+      label => label.name.toLowerCase() === labelName
+    )
+  }
+
+  switch (activeFilterTab) {
+    case 'all':
+      return !isAutoFixWorktree(worktree)
+    case 'manual':
+      return isManualWorktree(worktree)
+    case 'issues':
+      return isIssueWorktree(worktree) && !isAutoFixWorktree(worktree)
+    case 'prs':
+      return isPrWorktree(worktree) && !isAutoFixWorktree(worktree)
+    case 'security':
+      return isSecurityWorktree(worktree) && !isAutoFixWorktree(worktree)
+    case 'auto_fix':
+      return isAutoFixWorktree(worktree)
+  }
+}
+
+export function getCanvasFilterTabCount(
+  worktrees: Worktree[],
+  tab: CanvasPredefinedFilterTab
+): number {
+  return worktrees.filter(worktree => matchesCanvasFilterTab(worktree, tab))
+    .length
+}

--- a/src/components/projects/ProjectSettingsDialog.tsx
+++ b/src/components/projects/ProjectSettingsDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react'
-import { Settings, Plug, FileJson } from 'lucide-react'
+import { Bot, Settings, Plug, FileJson } from 'lucide-react'
 import { ModalCloseButton } from '@/components/ui/modal-close-button'
 import {
   Breadcrumb,
@@ -37,11 +37,13 @@ import { useProjects } from '@/services/projects'
 import { GeneralPane } from './panes/GeneralPane'
 import { McpServersPane } from './panes/McpServersPane'
 import { JeanJsonPane } from './panes/JeanJsonPane'
+import { AutoFixPane } from './panes/AutoFixPane'
 
-type ProjectSettingsPane = 'general' | 'mcp-servers' | 'jean-json'
+type ProjectSettingsPane = 'general' | 'mcp-servers' | 'jean-json' | 'auto-fix'
 
 const navigationItems = [
   { id: 'general' as const, name: 'General', icon: Settings },
+  { id: 'auto-fix' as const, name: 'Mr. Robot', icon: Bot },
   { id: 'mcp-servers' as const, name: 'MCP Servers', icon: Plug },
   { id: 'jean-json' as const, name: 'Jean.json', icon: FileJson },
 ]
@@ -50,6 +52,8 @@ const getPaneTitle = (pane: ProjectSettingsPane): string => {
   switch (pane) {
     case 'general':
       return 'General'
+    case 'auto-fix':
+      return 'Mr. Robot'
     case 'mcp-servers':
       return 'MCP Servers'
     case 'jean-json':
@@ -206,6 +210,9 @@ function ProjectSettingsDialogContent({
                       projectId={safeProjectId}
                       projectPath={projectPath}
                     />
+                  )}
+                  {activePane === 'auto-fix' && (
+                    <AutoFixPane projectId={safeProjectId} />
                   )}
                   {activePane === 'jean-json' && (
                     <JeanJsonPane

--- a/src/components/projects/panes/AutoFixPane.test.ts
+++ b/src/components/projects/panes/AutoFixPane.test.ts
@@ -1,8 +1,0 @@
-import { describe, expect, it } from 'vitest'
-import { MR_ROBOT_SETTINGS_BADGE } from './AutoFixPane'
-
-describe('AutoFixPane', () => {
-  it('labels Mr. Robot settings as beta', () => {
-    expect(MR_ROBOT_SETTINGS_BADGE).toBe('Beta')
-  })
-})

--- a/src/components/projects/panes/AutoFixPane.test.ts
+++ b/src/components/projects/panes/AutoFixPane.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { MR_ROBOT_SETTINGS_BADGE } from './AutoFixPane'
+
+describe('AutoFixPane', () => {
+  it('labels Mr. Robot settings as beta', () => {
+    expect(MR_ROBOT_SETTINGS_BADGE).toBe('Beta')
+  })
+})

--- a/src/components/projects/panes/AutoFixPane.test.tsx
+++ b/src/components/projects/panes/AutoFixPane.test.tsx
@@ -1,0 +1,191 @@
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@/test/test-utils'
+import type { Project, ProjectAutoFixSettings } from '@/types/projects'
+import {
+  AutoFixPane,
+  hasAutoFixSettingsChanges,
+  MR_ROBOT_SETTINGS_BADGE,
+} from './AutoFixPane'
+
+const mutateMock = vi.fn()
+let projectsMock: Project[] = []
+
+vi.mock('@/services/projects', () => ({
+  useProjects: () => ({ data: projectsMock }),
+  useUpdateProjectSettings: () => ({ mutate: mutateMock, isPending: false }),
+}))
+
+const baseAutoFixSettings: ProjectAutoFixSettings = {
+  enabled: false,
+  interval_minutes: 30,
+  issue_limit: 2,
+  max_parallel_worktrees: 3,
+  planning_backend: 'claude',
+  planning_model: 'haiku',
+  auto_yolo_enabled: false,
+  yolo_backend: 'claude',
+  yolo_model: null,
+  active_hours_enabled: false,
+  active_hours_start: 20,
+  active_hours_end: 8,
+}
+
+function project(
+  autoFixSettings: Partial<ProjectAutoFixSettings> = {}
+): Project {
+  return {
+    id: 'project-id',
+    name: 'Project',
+    path: '/tmp/project',
+    default_branch: 'main',
+    added_at: 1,
+    order: 1,
+    auto_fix_settings: {
+      ...baseAutoFixSettings,
+      ...autoFixSettings,
+    },
+  }
+}
+
+function renderPane() {
+  return render(<AutoFixPane projectId="project-id" />)
+}
+
+function getElementAt<T>(items: T[], index: number): T {
+  const item = items[index]
+  if (!item) throw new Error(`Expected element at index ${index}`)
+  return item
+}
+
+describe('AutoFixPane', () => {
+  beforeEach(() => {
+    mutateMock.mockReset()
+    projectsMock = [project()]
+    HTMLElement.prototype.hasPointerCapture = vi.fn()
+    HTMLElement.prototype.releasePointerCapture = vi.fn()
+    HTMLElement.prototype.scrollIntoView = vi.fn()
+  })
+
+  it('labels Mr. Robot settings as beta', () => {
+    expect(MR_ROBOT_SETTINGS_BADGE).toBe('Beta')
+  })
+
+  it('renders with project auto-fix settings', () => {
+    renderPane()
+
+    expect(screen.getByText('Mr. Robot')).toBeInTheDocument()
+    expect(screen.getByText('Mr. Robot issue sweeps')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Save settings' })
+    ).toBeInTheDocument()
+  })
+
+  it('disables save until settings change', () => {
+    renderPane()
+
+    const button = screen.getByRole('button', { name: 'Save settings' })
+    expect(button).toBeDisabled()
+
+    fireEvent.change(getElementAt(screen.getAllByRole('spinbutton'), 0), {
+      target: { value: '45' },
+    })
+
+    expect(button).not.toBeDisabled()
+  })
+
+  it('does not submit unchanged settings', () => {
+    renderPane()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save settings' }))
+
+    expect(mutateMock).not.toHaveBeenCalled()
+  })
+
+  it('detects deep settings changes', () => {
+    expect(
+      hasAutoFixSettingsChanges(baseAutoFixSettings, baseAutoFixSettings)
+    ).toBe(false)
+    expect(
+      hasAutoFixSettingsChanges(baseAutoFixSettings, {
+        ...baseAutoFixSettings,
+        interval_minutes: 45,
+      })
+    ).toBe(true)
+  })
+
+  it('saves when toggles change', async () => {
+    const user = userEvent.setup()
+    renderPane()
+
+    const switches = screen.getAllByRole('switch')
+    await user.click(getElementAt(switches, 0))
+    await user.click(getElementAt(switches, 1))
+
+    expect(mutateMock).toHaveBeenNthCalledWith(1, {
+      projectId: 'project-id',
+      autoFixSettings: expect.objectContaining({ enabled: true }),
+    })
+    expect(mutateMock).toHaveBeenNthCalledWith(2, {
+      projectId: 'project-id',
+      autoFixSettings: expect.objectContaining({
+        active_hours_enabled: true,
+      }),
+    })
+  })
+
+  it('clamps numeric inputs to at least one before saving', async () => {
+    const user = userEvent.setup()
+    renderPane()
+
+    fireEvent.change(getElementAt(screen.getAllByRole('spinbutton'), 0), {
+      target: { value: '0' },
+    })
+    await user.click(screen.getByRole('button', { name: 'Save settings' }))
+
+    expect(mutateMock).toHaveBeenCalledWith({
+      projectId: 'project-id',
+      autoFixSettings: expect.objectContaining({ interval_minutes: 1 }),
+    })
+  })
+
+  it('clears the planning model when the planning backend changes', async () => {
+    const user = userEvent.setup()
+    renderPane()
+
+    const comboboxes = screen.getAllByRole('combobox')
+    expect(getElementAt(comboboxes, 1)).toHaveTextContent('Claude Haiku')
+
+    await user.click(getElementAt(comboboxes, 0))
+    await user.click(await screen.findByRole('option', { name: 'Codex' }))
+
+    expect(getElementAt(screen.getAllByRole('combobox'), 1)).toHaveTextContent(
+      'Backend default'
+    )
+  })
+
+  it('trims model strings and saves blank models as null', async () => {
+    const user = userEvent.setup()
+    projectsMock = [
+      project({
+        planning_model: '  haiku  ',
+        yolo_model: '   ',
+      }),
+    ]
+    renderPane()
+
+    fireEvent.change(getElementAt(screen.getAllByRole('spinbutton'), 0), {
+      target: { value: '31' },
+    })
+    await user.click(screen.getByRole('button', { name: 'Save settings' }))
+
+    expect(mutateMock).toHaveBeenCalledWith({
+      projectId: 'project-id',
+      autoFixSettings: expect.objectContaining({
+        interval_minutes: 31,
+        planning_model: 'haiku',
+        yolo_model: null,
+      }),
+    })
+  })
+})

--- a/src/components/projects/panes/AutoFixPane.tsx
+++ b/src/components/projects/panes/AutoFixPane.tsx
@@ -39,6 +39,27 @@ const DEFAULT_AUTO_FIX_SETTINGS: ProjectAutoFixSettings = {
   active_hours_end: 8,
 }
 
+function normalizeAutoFixSettings(
+  settings: ProjectAutoFixSettings
+): ProjectAutoFixSettings {
+  return {
+    ...DEFAULT_AUTO_FIX_SETTINGS,
+    ...settings,
+    planning_model: settings.planning_model?.trim() || null,
+    yolo_model: settings.yolo_model?.trim() || null,
+  }
+}
+
+export function hasAutoFixSettingsChanges(
+  initialSettings: ProjectAutoFixSettings,
+  settings: ProjectAutoFixSettings
+) {
+  return (
+    JSON.stringify(normalizeAutoFixSettings(settings)) !==
+    JSON.stringify(normalizeAutoFixSettings(initialSettings))
+  )
+}
+
 const HOUR_OPTIONS = Array.from({ length: 24 }, (_, hour) => hour)
 
 function formatHour(hour: number): string {
@@ -134,6 +155,11 @@ export function AutoFixPane({ projectId }: { projectId: string }) {
     setSettings(initialSettings)
   }, [initialSettings])
 
+  const hasChanges = useMemo(
+    () => hasAutoFixSettingsChanges(initialSettings, settings),
+    [initialSettings, settings]
+  )
+
   const setNumber = (
     key: 'interval_minutes' | 'issue_limit' | 'max_parallel_worktrees',
     value: string
@@ -146,13 +172,11 @@ export function AutoFixPane({ projectId }: { projectId: string }) {
   }
 
   const saveSettings = (nextSettings = settings) => {
+    if (!hasAutoFixSettingsChanges(initialSettings, nextSettings)) return
+
     updateSettings.mutate({
       projectId,
-      autoFixSettings: {
-        ...nextSettings,
-        planning_model: nextSettings.planning_model?.trim() || null,
-        yolo_model: nextSettings.yolo_model?.trim() || null,
-      },
+      autoFixSettings: normalizeAutoFixSettings(nextSettings),
     })
   }
 
@@ -183,7 +207,7 @@ export function AutoFixPane({ projectId }: { projectId: string }) {
     const parsed = Number.parseInt(value, 10)
     setSettings(current => ({
       ...current,
-      [key]: Number.isFinite(parsed) ? parsed : 0,
+      [key]: Number.isFinite(parsed) ? Math.max(0, Math.min(23, parsed)) : 0,
     }))
   }
 
@@ -382,51 +406,52 @@ export function AutoFixPane({ projectId }: { projectId: string }) {
                 disabled={updateSettings.isPending}
               />
             </div>
-            <div
-              className={
-                settings.auto_yolo_enabled
-                  ? 'grid gap-4 sm:grid-cols-2'
-                  : 'grid gap-4 sm:grid-cols-2 opacity-50'
-              }
-            >
+            <div className="grid gap-4 sm:grid-cols-2">
               <Field label="Backend">
-                <Select
-                  value={settings.yolo_backend}
-                  disabled={!settings.auto_yolo_enabled}
-                  onValueChange={yolo_backend =>
-                    setSettings(current => ({
-                      ...current,
-                      yolo_backend,
-                      yolo_model: null,
-                    }))
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="claude">Claude</SelectItem>
-                    <SelectItem value="codex">Codex</SelectItem>
-                    <SelectItem value="opencode">OpenCode</SelectItem>
-                    <SelectItem value="cursor">Cursor</SelectItem>
-                  </SelectContent>
-                </Select>
+                <div className={settings.auto_yolo_enabled ? '' : 'opacity-50'}>
+                  <Select
+                    value={settings.yolo_backend}
+                    disabled={!settings.auto_yolo_enabled}
+                    onValueChange={yolo_backend =>
+                      setSettings(current => ({
+                        ...current,
+                        yolo_backend,
+                        yolo_model: null,
+                      }))
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="claude">Claude</SelectItem>
+                      <SelectItem value="codex">Codex</SelectItem>
+                      <SelectItem value="opencode">OpenCode</SelectItem>
+                      <SelectItem value="cursor">Cursor</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
               </Field>
               <Field label="Model">
-                <ModelSelect
-                  backend={settings.yolo_backend}
-                  value={settings.yolo_model}
-                  disabled={!settings.auto_yolo_enabled}
-                  onChange={yolo_model =>
-                    setSettings(current => ({ ...current, yolo_model }))
-                  }
-                />
+                <div className={settings.auto_yolo_enabled ? '' : 'opacity-50'}>
+                  <ModelSelect
+                    backend={settings.yolo_backend}
+                    value={settings.yolo_model}
+                    disabled={!settings.auto_yolo_enabled}
+                    onChange={yolo_model =>
+                      setSettings(current => ({ ...current, yolo_model }))
+                    }
+                  />
+                </div>
               </Field>
             </div>
           </div>
         </div>
 
-        <Button onClick={save} disabled={updateSettings.isPending}>
+        <Button
+          onClick={save}
+          disabled={updateSettings.isPending || !hasChanges}
+        >
           {updateSettings.isPending && (
             <Loader2 className="h-4 w-4 animate-spin" />
           )}

--- a/src/components/projects/panes/AutoFixPane.tsx
+++ b/src/components/projects/panes/AutoFixPane.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Loader2 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
@@ -20,6 +21,8 @@ import {
   CURSOR_MODEL_OPTIONS,
   OPENCODE_MODEL_OPTIONS,
 } from '@/components/chat/toolbar/toolbar-options'
+
+export const MR_ROBOT_SETTINGS_BADGE = 'Beta'
 
 const DEFAULT_AUTO_FIX_SETTINGS: ProjectAutoFixSettings = {
   enabled: false,
@@ -188,7 +191,15 @@ export function AutoFixPane({ projectId }: { projectId: string }) {
     <div className="space-y-6">
       <div className="space-y-4">
         <div>
-          <h3 className="text-lg font-medium text-foreground">Mr. Robot</h3>
+          <div className="flex items-center gap-2">
+            <h3 className="text-lg font-medium text-foreground">Mr. Robot</h3>
+            <Badge
+              variant="outline"
+              className="px-1.5 py-0 text-[10px] uppercase tracking-wide text-muted-foreground"
+            >
+              {MR_ROBOT_SETTINGS_BADGE}
+            </Badge>
+          </div>
           <Separator className="mt-2" />
         </div>
 

--- a/src/components/projects/panes/AutoFixPane.tsx
+++ b/src/components/projects/panes/AutoFixPane.tsx
@@ -1,0 +1,427 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+import { Switch } from '@/components/ui/switch'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useProjects, useUpdateProjectSettings } from '@/services/projects'
+import type { ProjectAutoFixSettings } from '@/types/projects'
+import { codexDefaultModelOptions, modelOptions } from '@/types/preferences'
+import {
+  CURSOR_MODEL_OPTIONS,
+  OPENCODE_MODEL_OPTIONS,
+} from '@/components/chat/toolbar/toolbar-options'
+
+const DEFAULT_AUTO_FIX_SETTINGS: ProjectAutoFixSettings = {
+  enabled: false,
+  interval_minutes: 30,
+  issue_limit: 1,
+  max_parallel_worktrees: 1,
+  planning_backend: 'claude',
+  planning_model: null,
+  auto_yolo_enabled: false,
+  yolo_backend: 'claude',
+  yolo_model: null,
+  active_hours_enabled: false,
+  active_hours_start: 20,
+  active_hours_end: 8,
+}
+
+const HOUR_OPTIONS = Array.from({ length: 24 }, (_, hour) => hour)
+
+function formatHour(hour: number): string {
+  const period = hour < 12 ? 'AM' : 'PM'
+  const display = hour % 12 === 0 ? 12 : hour % 12
+  return `${display}:00 ${period}`
+}
+
+function Field({
+  label,
+  description,
+  children,
+}: {
+  label: string
+  description?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="space-y-2">
+      <Label className="text-sm text-foreground">{label}</Label>
+      {description && (
+        <div className="text-xs text-muted-foreground">{description}</div>
+      )}
+      {children}
+    </div>
+  )
+}
+
+function getModelOptions(backend: string) {
+  switch (backend) {
+    case 'codex':
+      return codexDefaultModelOptions
+    case 'opencode':
+      return OPENCODE_MODEL_OPTIONS
+    case 'cursor':
+      return CURSOR_MODEL_OPTIONS
+    case 'claude':
+    default:
+      return modelOptions
+  }
+}
+
+function ModelSelect({
+  backend,
+  value,
+  disabled,
+  onChange,
+}: {
+  backend: string
+  value: string | null | undefined
+  disabled?: boolean
+  onChange: (value: string | null) => void
+}) {
+  const options = getModelOptions(backend)
+
+  return (
+    <Select
+      value={value ?? 'default'}
+      disabled={disabled}
+      onValueChange={v => onChange(v === 'default' ? null : v)}
+    >
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="default">Backend default</SelectItem>
+        {options.map(option => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+export function AutoFixPane({ projectId }: { projectId: string }) {
+  const { data: projects = [] } = useProjects()
+  const project = projects.find(p => p.id === projectId)
+  const updateSettings = useUpdateProjectSettings()
+
+  const initialSettings = useMemo(
+    () => ({
+      ...DEFAULT_AUTO_FIX_SETTINGS,
+      ...(project?.auto_fix_settings ?? {}),
+    }),
+    [project?.auto_fix_settings]
+  )
+  const [settings, setSettings] =
+    useState<ProjectAutoFixSettings>(initialSettings)
+
+  useEffect(() => {
+    setSettings(initialSettings)
+  }, [initialSettings])
+
+  const setNumber = (
+    key: 'interval_minutes' | 'issue_limit' | 'max_parallel_worktrees',
+    value: string
+  ) => {
+    const parsed = Number.parseInt(value, 10)
+    setSettings(current => ({
+      ...current,
+      [key]: Number.isFinite(parsed) ? Math.max(1, parsed) : 1,
+    }))
+  }
+
+  const saveSettings = (nextSettings = settings) => {
+    updateSettings.mutate({
+      projectId,
+      autoFixSettings: {
+        ...nextSettings,
+        planning_model: nextSettings.planning_model?.trim() || null,
+        yolo_model: nextSettings.yolo_model?.trim() || null,
+      },
+    })
+  }
+
+  const save = () => saveSettings()
+
+  const handleEnabledChange = (enabled: boolean) => {
+    const nextSettings = { ...settings, enabled }
+    setSettings(nextSettings)
+    saveSettings(nextSettings)
+  }
+
+  const handleActiveHoursEnabledChange = (active_hours_enabled: boolean) => {
+    const nextSettings = { ...settings, active_hours_enabled }
+    setSettings(nextSettings)
+    saveSettings(nextSettings)
+  }
+
+  const handleAutoYoloEnabledChange = (auto_yolo_enabled: boolean) => {
+    const nextSettings = { ...settings, auto_yolo_enabled }
+    setSettings(nextSettings)
+    saveSettings(nextSettings)
+  }
+
+  const setHour = (
+    key: 'active_hours_start' | 'active_hours_end',
+    value: string
+  ) => {
+    const parsed = Number.parseInt(value, 10)
+    setSettings(current => ({
+      ...current,
+      [key]: Number.isFinite(parsed) ? parsed : 0,
+    }))
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-lg font-medium text-foreground">Mr. Robot</h3>
+          <Separator className="mt-2" />
+        </div>
+
+        <div className="flex items-start justify-between gap-4 rounded-lg border bg-muted/20 p-4">
+          <div className="max-w-2xl">
+            <Label className="text-sm text-foreground">
+              Mr. Robot issue sweeps
+            </Label>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Poll open GitHub issues, create one Jean worktree per issue, and
+              draft a focused plan. Optionally let Mr. Robot yolo the plan too.
+            </p>
+          </div>
+          <Switch
+            checked={settings.enabled}
+            onCheckedChange={handleEnabledChange}
+            disabled={updateSettings.isPending}
+          />
+        </div>
+
+        <div className="rounded-lg border p-4">
+          <h4 className="mb-4 text-sm font-medium text-foreground">
+            Schedule and limits
+          </h4>
+          <div className="grid gap-4 md:grid-cols-3">
+            <Field label="Check every">
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  min={1}
+                  value={settings.interval_minutes}
+                  onChange={event =>
+                    setNumber('interval_minutes', event.target.value)
+                  }
+                />
+                <span className="text-sm text-muted-foreground">minutes</span>
+              </div>
+            </Field>
+            <Field label="Issues per run">
+              <Input
+                type="number"
+                min={1}
+                value={settings.issue_limit}
+                onChange={event => setNumber('issue_limit', event.target.value)}
+              />
+            </Field>
+            <Field label="Max active worktrees">
+              <Input
+                type="number"
+                min={1}
+                value={settings.max_parallel_worktrees}
+                onChange={event =>
+                  setNumber('max_parallel_worktrees', event.target.value)
+                }
+              />
+            </Field>
+          </div>
+
+          <Separator className="my-4" />
+
+          <div className="flex items-start justify-between gap-4">
+            <div className="max-w-2xl">
+              <Label className="text-sm text-foreground">Active hours</Label>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Only start new fixes during these hours (local time). Wraps past
+                midnight.
+              </p>
+            </div>
+            <Switch
+              checked={settings.active_hours_enabled ?? false}
+              onCheckedChange={handleActiveHoursEnabledChange}
+              disabled={updateSettings.isPending}
+            />
+          </div>
+
+          {settings.active_hours_enabled && (
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <Field label="From">
+                <Select
+                  value={String(settings.active_hours_start ?? 20)}
+                  onValueChange={value => setHour('active_hours_start', value)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {HOUR_OPTIONS.map(hour => (
+                      <SelectItem key={hour} value={String(hour)}>
+                        {formatHour(hour)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
+              <Field label="To">
+                <Select
+                  value={String(settings.active_hours_end ?? 8)}
+                  onValueChange={value => setHour('active_hours_end', value)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {HOUR_OPTIONS.map(hour => (
+                      <SelectItem key={hour} value={String(hour)}>
+                        {formatHour(hour)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
+            </div>
+          )}
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="rounded-lg border p-4">
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <div>
+              <h4 className="text-sm font-medium text-foreground">
+                Planning
+              </h4>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Plan issues automatically based on the backend model.
+              </p>
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <Field label="Backend">
+                <Select
+                  value={settings.planning_backend}
+                  onValueChange={planning_backend =>
+                    setSettings(current => ({
+                      ...current,
+                      planning_backend,
+                      planning_model: null,
+                    }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="claude">Claude</SelectItem>
+                    <SelectItem value="codex">Codex</SelectItem>
+                    <SelectItem value="opencode">OpenCode</SelectItem>
+                    <SelectItem value="cursor">Cursor</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+              <Field label="Model">
+                <ModelSelect
+                  backend={settings.planning_backend}
+                  value={settings.planning_model}
+                  onChange={planning_model =>
+                    setSettings(current => ({ ...current, planning_model }))
+                  }
+                />
+              </Field>
+            </div>
+          </div>
+
+          <div className="rounded-lg border p-4">
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <div>
+                <h4 className="text-sm font-medium text-foreground">
+                  Yolo execution
+                </h4>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Automatically approve ready plans and start execution.
+                </p>
+              </div>
+              <Checkbox
+                aria-label="Also yolo approved plans"
+                checked={settings.auto_yolo_enabled ?? false}
+                onCheckedChange={checked =>
+                  handleAutoYoloEnabledChange(checked === true)
+                }
+                disabled={updateSettings.isPending}
+              />
+            </div>
+            <div
+              className={
+                settings.auto_yolo_enabled
+                  ? 'grid gap-4 sm:grid-cols-2'
+                  : 'grid gap-4 sm:grid-cols-2 opacity-50'
+              }
+            >
+              <Field label="Backend">
+                <Select
+                  value={settings.yolo_backend}
+                  disabled={!settings.auto_yolo_enabled}
+                  onValueChange={yolo_backend =>
+                    setSettings(current => ({
+                      ...current,
+                      yolo_backend,
+                      yolo_model: null,
+                    }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="claude">Claude</SelectItem>
+                    <SelectItem value="codex">Codex</SelectItem>
+                    <SelectItem value="opencode">OpenCode</SelectItem>
+                    <SelectItem value="cursor">Cursor</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+              <Field label="Model">
+                <ModelSelect
+                  backend={settings.yolo_backend}
+                  value={settings.yolo_model}
+                  disabled={!settings.auto_yolo_enabled}
+                  onChange={yolo_model =>
+                    setSettings(current => ({ ...current, yolo_model }))
+                  }
+                />
+              </Field>
+            </div>
+          </div>
+        </div>
+
+        <Button onClick={save} disabled={updateSettings.isPending}>
+          {updateSettings.isPending && (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          )}
+          Save settings
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/projects/panes/AutoFixPane.tsx
+++ b/src/components/projects/panes/AutoFixPane.tsx
@@ -319,12 +319,12 @@ export function AutoFixPane({ projectId }: { projectId: string }) {
           <div className="rounded-lg border p-4">
             <div className="mb-4 flex items-start justify-between gap-4">
               <div>
-              <h4 className="text-sm font-medium text-foreground">
-                Planning
-              </h4>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Plan issues automatically based on the backend model.
-              </p>
+                <h4 className="text-sm font-medium text-foreground">
+                  Planning
+                </h4>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Plan issues automatically based on the backend model.
+                </p>
               </div>
             </div>
 

--- a/src/services/projects.ts
+++ b/src/services/projects.ts
@@ -460,6 +460,7 @@ export function useCreateWorktree() {
       advisoryContext,
       linearContext,
       customName,
+      origin,
       background: _background,
     }: {
       projectId: string
@@ -522,6 +523,8 @@ export function useCreateWorktree() {
       }
       /** Custom worktree name (used when retrying after path conflict) */
       customName?: string
+      /** Origin/category for the worktree */
+      origin?: Worktree['origin']
       /** When true, skip auto-navigation (CMD+Click from new session modal) */
       background?: boolean
     }): Promise<Worktree> => {
@@ -547,6 +550,7 @@ export function useCreateWorktree() {
         advisoryContext,
         linearContext,
         customName,
+        origin,
       })
       return worktree
     },
@@ -941,6 +945,7 @@ export function useWorktreeEvents() {
           issueNumber,
           securityAlertNumber,
           advisoryGhsaId,
+          origin,
         } = event.payload
         logger.info('Worktree creating (background started)', { id, name })
 
@@ -960,6 +965,7 @@ export function useWorktreeEvents() {
               issue_number: issueNumber,
               security_alert_number: securityAlertNumber,
               advisory_ghsa_id: advisoryGhsaId,
+              origin,
               created_at: Math.floor(Date.now() / 1000),
               status: 'pending' as const,
               session_type: 'worktree' as Worktree['session_type'],
@@ -2503,6 +2509,7 @@ export function useUpdateProjectSettings() {
       worktreesDir,
       linearApiKey,
       linearTeamId,
+      autoFixSettings,
     }: {
       projectId: string
       name?: string
@@ -2515,6 +2522,7 @@ export function useUpdateProjectSettings() {
       worktreesDir?: string
       linearApiKey?: string
       linearTeamId?: string
+      autoFixSettings?: Project['auto_fix_settings']
       linkedProjectIds?: string[]
     }): Promise<Project> => {
       if (!isTauri()) {
@@ -2538,6 +2546,7 @@ export function useUpdateProjectSettings() {
         worktreesDir,
         linearApiKey,
         linearTeamId,
+        autoFixSettings,
         linkedProjectIds,
       })
       logger.info('Project settings updated', { project })

--- a/src/types/projects.ts
+++ b/src/types/projects.ts
@@ -8,6 +8,23 @@ export type SessionType = 'worktree' | 'base'
 
 export type WorktreeSortMode = 'created' | 'last_activity' | 'manual'
 
+export type WorktreeOrigin = 'manual' | 'auto_fix'
+
+export interface ProjectAutoFixSettings {
+  enabled: boolean
+  interval_minutes: number
+  issue_limit: number
+  max_parallel_worktrees: number
+  planning_backend: string
+  planning_model?: string | null
+  auto_yolo_enabled?: boolean
+  yolo_backend: string
+  yolo_model?: string | null
+  active_hours_enabled?: boolean
+  active_hours_start?: number
+  active_hours_end?: number
+}
+
 /**
  * Status of a worktree (for tracking background operations)
  */
@@ -62,6 +79,8 @@ export interface Project {
   linear_team_id?: string | null
   /** IDs of linked projects for cross-project context sharing */
   linked_project_ids?: string[]
+  /** Per-project automated issue fixing settings */
+  auto_fix_settings?: ProjectAutoFixSettings | null
 }
 
 export interface DirEntry {
@@ -165,6 +184,8 @@ export interface Worktree {
   label?: LabelData
   /** Display order within project (lower = higher in list, base sessions ignore this) */
   order: number
+  /** Origin/category for this worktree */
+  origin?: WorktreeOrigin
   /** Unix timestamp when worktree was archived (undefined = not archived) */
   archived_at?: number
   /** Unix timestamp when worktree was last opened/viewed by the user */
@@ -186,6 +207,7 @@ export interface WorktreeCreatingEvent {
   issueNumber?: number
   securityAlertNumber?: number
   advisoryGhsaId?: string
+  origin?: WorktreeOrigin
   autoOpenInJean: boolean
 }
 


### PR DESCRIPTION
## Summary
- Add per-project Mr. Robot settings for scheduled GitHub issue sweeps, active-hour limits, planning backend/model selection, and optional yolo execution.
- Start an Auto Fix background scheduler that creates issue worktrees, launches planning sessions, and can automatically approve ready plans for yolo execution.
- Track Auto Fix worktrees separately with a dedicated canvas filter tab and settings shortcut.
- Emit a user-facing stop notification and disable Auto Fix when backend quota or auth errors are detected.
- Add focused Rust and frontend tests for scheduling helpers, settings serialization, yolo guards, and canvas filtering.