### PR TITLE
feat(chat): add model picker for plan approvals

### DIFF
--- a/src/components/chat/ApprovalModelSubmenu.test.tsx
+++ b/src/components/chat/ApprovalModelSubmenu.test.tsx
@@ -9,6 +9,16 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { ApprovalModelSubmenu } from './ApprovalModelSubmenu'
 
+const preferencesMock = vi.hoisted(() => ({
+  data: {
+    default_provider: null as string | null,
+    custom_cli_profiles: [] as {
+      name: string
+      settings_json: string
+    }[],
+  },
+}))
+
 class ResizeObserverMock {
   observe() {
     return undefined
@@ -46,12 +56,17 @@ vi.mock('@/services/cursor-cli', () => ({
 
 vi.mock('@/services/preferences', () => ({
   usePreferences: () => ({
-    data: {
-      selected_provider: null,
-      custom_claude_profiles: [],
-    },
+    data: preferencesMock.data,
   }),
 }))
+
+function findModelItem(model: string) {
+  const item = screen
+    .getAllByRole('menuitem')
+    .find(menuItem => within(menuItem).queryByText(model))
+  expect(item).toBeDefined()
+  return item as HTMLElement
+}
 
 function renderMenu(onSelect = vi.fn()) {
   render(
@@ -66,6 +81,11 @@ function renderMenu(onSelect = vi.fn()) {
 }
 
 beforeEach(() => {
+  preferencesMock.data = {
+    default_provider: null,
+    custom_cli_profiles: [],
+  }
+
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: vi.fn().mockImplementation(() => ({
@@ -131,13 +151,6 @@ describe('ApprovalModelSubmenu', () => {
 
     await user.hover(screen.getByRole('menuitem', { name: /other model/i }))
     await waitFor(() => expect(screen.getByText('Codex')).toBeInTheDocument())
-    const findModelItem = (model: string) => {
-      const item = screen
-        .getAllByRole('menuitem')
-        .find(menuItem => within(menuItem).queryByText(model))
-      expect(item).toBeDefined()
-      return item as HTMLElement
-    }
 
     fireEvent.click(findModelItem('gpt-5.4'))
     fireEvent.click(findModelItem('openai/gpt-5.4'))
@@ -154,6 +167,75 @@ describe('ApprovalModelSubmenu', () => {
     expect(onSelect).toHaveBeenCalledWith({
       backend: 'cursor',
       model: 'cursor/composer-2',
+    })
+  })
+
+  it('resolves Claude labels from custom provider settings_json and selects one-shot aliases', async () => {
+    const user = userEvent.setup()
+    preferencesMock.data = {
+      default_provider: 'OpenRouter',
+      custom_cli_profiles: [
+        {
+          name: 'OpenRouter',
+          settings_json: JSON.stringify({
+            env: {
+              ANTHROPIC_DEFAULT_OPUS_MODEL: 'anthropic/claude-opus-4.8',
+              ANTHROPIC_DEFAULT_SONNET_MODEL: 'anthropic/claude-sonnet-4.6',
+              ANTHROPIC_MODEL: 'anthropic/claude-haiku-4.5',
+            },
+          }),
+        },
+      ],
+    }
+    const onSelect = renderMenu()
+
+    await user.hover(screen.getByRole('menuitem', { name: /other model/i }))
+    await waitFor(() => expect(screen.getByText('Claude')).toBeInTheDocument())
+
+    expect(
+      screen.getByText('Opus (anthropic/claude-opus-4.8)')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Sonnet (anthropic/claude-sonnet-4.6)')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Haiku (anthropic/claude-haiku-4.5)')
+    ).toBeInTheDocument()
+
+    fireEvent.click(findModelItem('Sonnet (anthropic/claude-sonnet-4.6)'))
+
+    expect(onSelect).toHaveBeenCalledWith({
+      backend: 'claude',
+      model: 'sonnet',
+    })
+  })
+
+  it('falls back to short Claude aliases when custom provider settings_json is invalid', async () => {
+    const user = userEvent.setup()
+    preferencesMock.data = {
+      default_provider: 'BrokenProvider',
+      custom_cli_profiles: [
+        {
+          name: 'BrokenProvider',
+          settings_json: '{not valid json',
+        },
+      ],
+    }
+    const onSelect = renderMenu()
+
+    await user.hover(screen.getByRole('menuitem', { name: /other model/i }))
+    await waitFor(() => expect(screen.getByText('Claude')).toBeInTheDocument())
+
+    expect(screen.getByText('Opus')).toBeInTheDocument()
+    expect(screen.getByText('Sonnet')).toBeInTheDocument()
+    expect(screen.getByText('Haiku')).toBeInTheDocument()
+    expect(screen.queryByText(/anthropic\/claude/)).toBeNull()
+
+    fireEvent.click(findModelItem('Haiku'))
+
+    expect(onSelect).toHaveBeenCalledWith({
+      backend: 'claude',
+      model: 'haiku',
     })
   })
 })

--- a/src/components/chat/ApprovalModelSubmenu.test.tsx
+++ b/src/components/chat/ApprovalModelSubmenu.test.tsx
@@ -1,0 +1,159 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { fireEvent, render, screen, waitFor, within } from '@/test/test-utils'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { ApprovalModelSubmenu } from './ApprovalModelSubmenu'
+
+class ResizeObserverMock {
+  observe() {
+    return undefined
+  }
+  unobserve() {
+    return undefined
+  }
+  disconnect() {
+    return undefined
+  }
+}
+
+globalThis.ResizeObserver =
+  ResizeObserverMock as unknown as typeof ResizeObserver
+if (typeof Element !== 'undefined') {
+  Element.prototype.scrollIntoView = vi.fn()
+}
+
+vi.mock('@/hooks/useInstalledBackends', () => ({
+  useInstalledBackends: () => ({
+    installedBackends: ['claude', 'codex', 'opencode', 'cursor'],
+    isLoading: false,
+  }),
+}))
+
+vi.mock('@/services/opencode-cli', () => ({
+  useAvailableOpencodeModels: () => ({ data: ['openai/gpt-5.4'] }),
+}))
+
+vi.mock('@/services/cursor-cli', () => ({
+  useAvailableCursorModels: () => ({
+    data: [{ id: 'composer-2', label: 'Composer 2' }],
+  }),
+}))
+
+vi.mock('@/services/preferences', () => ({
+  usePreferences: () => ({
+    data: {
+      selected_provider: null,
+      custom_claude_profiles: [],
+    },
+  }),
+}))
+
+function renderMenu(onSelect = vi.fn()) {
+  render(
+    <DropdownMenu open>
+      <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <ApprovalModelSubmenu onSelect={onSelect} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+  return onSelect
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+describe('ApprovalModelSubmenu', () => {
+  it('renders other model choices grouped by installed backend', async () => {
+    const user = userEvent.setup()
+    renderMenu()
+
+    await user.hover(screen.getByRole('menuitem', { name: /other model/i }))
+    await waitFor(() => expect(screen.getByText('Claude')).toBeInTheDocument())
+
+    expect(screen.getByText('Codex')).toBeInTheDocument()
+    expect(screen.getByText('OpenCode')).toBeInTheDocument()
+    expect(screen.getByText('Cursor')).toBeInTheDocument()
+  })
+
+  it('filters the model list from a search input at the top', async () => {
+    const user = userEvent.setup()
+    renderMenu()
+
+    await user.hover(screen.getByRole('menuitem', { name: /other model/i }))
+    const searchInput = await screen.findByPlaceholderText(/search models/i)
+
+    await user.type(searchInput, 'composer')
+
+    expect(
+      screen.getByRole('menuitem', { name: /Composer 2/ })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /GPT 5\.5/ })).toBeNull()
+    expect(screen.queryByText('Claude')).toBeNull()
+    expect(screen.queryByText('Codex')).toBeNull()
+    expect(screen.queryByText('Cursor')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when the search has no model matches', async () => {
+    const user = userEvent.setup()
+    renderMenu()
+
+    await user.hover(screen.getByRole('menuitem', { name: /other model/i }))
+    const searchInput = await screen.findByPlaceholderText(/search models/i)
+
+    await user.type(searchInput, 'no-such-model')
+
+    expect(screen.getByText('No models found.')).toBeInTheDocument()
+    expect(screen.queryByText('Claude')).toBeNull()
+  })
+
+  it('selecting Codex/OpenCode/Cursor models calls callback with one-shot override', async () => {
+    const user = userEvent.setup()
+    const onSelect = renderMenu()
+
+    await user.hover(screen.getByRole('menuitem', { name: /other model/i }))
+    await waitFor(() => expect(screen.getByText('Codex')).toBeInTheDocument())
+    const findModelItem = (model: string) => {
+      const item = screen
+        .getAllByRole('menuitem')
+        .find(menuItem => within(menuItem).queryByText(model))
+      expect(item).toBeDefined()
+      return item as HTMLElement
+    }
+
+    fireEvent.click(findModelItem('gpt-5.4'))
+    fireEvent.click(findModelItem('openai/gpt-5.4'))
+    fireEvent.click(findModelItem('cursor/composer-2'))
+
+    expect(onSelect).toHaveBeenCalledWith({
+      backend: 'codex',
+      model: 'gpt-5.4',
+    })
+    expect(onSelect).toHaveBeenCalledWith({
+      backend: 'opencode',
+      model: 'openai/gpt-5.4',
+    })
+    expect(onSelect).toHaveBeenCalledWith({
+      backend: 'cursor',
+      model: 'cursor/composer-2',
+    })
+  })
+})

--- a/src/components/chat/ApprovalModelSubmenu.tsx
+++ b/src/components/chat/ApprovalModelSubmenu.tsx
@@ -1,0 +1,242 @@
+import { useMemo, useState } from 'react'
+import type { CliBackend, CustomCliProfile } from '@/types/preferences'
+import { usePreferences } from '@/services/preferences'
+import { useInstalledBackends } from '@/hooks/useInstalledBackends'
+import { useAvailableOpencodeModels } from '@/services/opencode-cli'
+import { useAvailableCursorModels } from '@/services/cursor-cli'
+import {
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  CODEX_MODEL_OPTIONS,
+  CURSOR_MODEL_OPTIONS,
+  MODEL_OPTIONS,
+  OPENCODE_MODEL_OPTIONS,
+} from '@/components/chat/toolbar/toolbar-options'
+import { Input } from '@/components/ui/input'
+import { buildBackendModelSections } from '@/components/chat/toolbar/useToolbarDerivedState'
+import {
+  formatCursorModelLabel,
+  formatOpencodeModelLabel,
+} from '@/components/chat/toolbar/toolbar-utils'
+
+export interface ApprovalModelOverride {
+  backend: CliBackend
+  model: string
+}
+
+interface ApprovalModelSubmenuProps {
+  onSelect: (override: ApprovalModelOverride) => void
+  label?: string
+  disabled?: boolean
+}
+
+interface ApprovalActionGroupProps {
+  title: string
+  defaultModelLabel?: string | null
+  shortcut?: string
+  disabled?: boolean
+  separatorBefore?: boolean
+  onDefaultSelect: () => void
+  onModelSelect: (override: ApprovalModelOverride) => void
+}
+
+function getClaudeModelOptions(
+  selectedProvider: string | null | undefined,
+  customCliProfiles: CustomCliProfile[]
+): { value: string; label: string }[] {
+  if (!selectedProvider || selectedProvider === '__anthropic__') {
+    return MODEL_OPTIONS
+  }
+
+  const profile = customCliProfiles.find(p => p.name === selectedProvider)
+  let opusModel: string | undefined
+  let sonnetModel: string | undefined
+  let haikuModel: string | undefined
+  if (profile?.settings_json) {
+    try {
+      const settings = JSON.parse(profile.settings_json)
+      const env = settings?.env
+      if (env) {
+        opusModel = env.ANTHROPIC_DEFAULT_OPUS_MODEL || env.ANTHROPIC_MODEL
+        sonnetModel = env.ANTHROPIC_DEFAULT_SONNET_MODEL || env.ANTHROPIC_MODEL
+        haikuModel = env.ANTHROPIC_DEFAULT_HAIKU_MODEL || env.ANTHROPIC_MODEL
+      }
+    } catch {
+      // Ignore invalid profile JSON; fall back to short labels.
+    }
+  }
+
+  const suffix = (model?: string) => (model ? ` (${model})` : '')
+  return [
+    { value: 'opus', label: `Opus${suffix(opusModel)}` },
+    { value: 'sonnet', label: `Sonnet${suffix(sonnetModel)}` },
+    { value: 'haiku', label: `Haiku${suffix(haikuModel)}` },
+  ]
+}
+
+export function ApprovalModelSubmenu({
+  onSelect,
+  label = 'Other model…',
+  disabled,
+}: ApprovalModelSubmenuProps) {
+  const { data: preferences } = usePreferences()
+  const { installedBackends } = useInstalledBackends()
+  const { data: availableOpencodeModels } = useAvailableOpencodeModels({
+    enabled: installedBackends.includes('opencode'),
+  })
+  const { data: availableCursorModels } = useAvailableCursorModels({
+    enabled: installedBackends.includes('cursor'),
+  })
+
+  const selectedProvider = preferences?.default_provider ?? null
+  const customCliProfiles = preferences?.custom_cli_profiles ?? []
+  const claudeModelOptions = useMemo(
+    () => getClaudeModelOptions(selectedProvider, customCliProfiles),
+    [selectedProvider, customCliProfiles]
+  )
+  const opencodeModelOptions = useMemo(
+    () =>
+      availableOpencodeModels?.map(model => ({
+        value: model,
+        label: formatOpencodeModelLabel(model),
+      })) ?? OPENCODE_MODEL_OPTIONS,
+    [availableOpencodeModels]
+  )
+  const cursorModelOptions = useMemo(
+    () =>
+      availableCursorModels?.map(model => ({
+        value: `cursor/${model.id}`,
+        label: model.label || formatCursorModelLabel(model.id),
+      })) ?? CURSOR_MODEL_OPTIONS,
+    [availableCursorModels]
+  )
+
+  const [search, setSearch] = useState('')
+  const sections = useMemo(
+    () =>
+      buildBackendModelSections({
+        installedBackends,
+        claudeModelOptions,
+        codexModelOptions: CODEX_MODEL_OPTIONS,
+        opencodeModelOptions,
+        cursorModelOptions,
+      }).filter(section => section.options.length > 0),
+    [
+      installedBackends,
+      claudeModelOptions,
+      opencodeModelOptions,
+      cursorModelOptions,
+    ]
+  )
+
+  const filteredSections = useMemo(() => {
+    const query = search.trim().toLowerCase()
+    if (!query) return sections
+
+    return sections
+      .map(section => ({
+        ...section,
+        options: section.options.filter(option =>
+          `${section.label} ${option.label} ${option.value}`
+            .toLowerCase()
+            .includes(query)
+        ),
+      }))
+      .filter(section => section.options.length > 0)
+  }, [search, sections])
+
+  if (sections.length === 0) return null
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger disabled={disabled}>
+        {label}
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent
+        className="max-h-[28rem] min-w-[20rem] overflow-y-auto"
+        onFocusOutside={event => event.preventDefault()}
+      >
+        <div
+          className="sticky top-0 z-10 border-b bg-popover p-2"
+          onKeyDown={event => event.stopPropagation()}
+        >
+          <Input
+            value={search}
+            onChange={event => setSearch(event.target.value)}
+            placeholder="Search models..."
+            className="h-8 text-sm"
+          />
+        </div>
+        {filteredSections.length === 0 ? (
+          <div className="px-2 py-3 text-sm text-muted-foreground">
+            No models found.
+          </div>
+        ) : (
+          filteredSections.map((section, sectionIndex) => (
+            <div key={section.backend}>
+              {sectionIndex > 0 && <DropdownMenuSeparator />}
+              <DropdownMenuLabel>{section.label}</DropdownMenuLabel>
+              {section.options.map(option => (
+                <DropdownMenuItem
+                  key={`${section.backend}:${option.value}`}
+                  onClick={() =>
+                    onSelect({ backend: section.backend, model: option.value })
+                  }
+                >
+                  <span className="flex min-w-0 flex-col">
+                    <span className="truncate">{option.label}</span>
+                    <span className="truncate text-[10px] text-muted-foreground">
+                      {option.value}
+                    </span>
+                  </span>
+                </DropdownMenuItem>
+              ))}
+            </div>
+          ))
+        )}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  )
+}
+
+export function ApprovalActionGroup({
+  title,
+  defaultModelLabel,
+  shortcut,
+  disabled,
+  separatorBefore,
+  onDefaultSelect,
+  onModelSelect,
+}: ApprovalActionGroupProps) {
+  return (
+    <>
+      {separatorBefore && <DropdownMenuSeparator />}
+      <DropdownMenuLabel className="text-xs text-muted-foreground">
+        {title}
+      </DropdownMenuLabel>
+      <DropdownMenuItem onClick={onDefaultSelect} disabled={disabled}>
+        <span className="flex min-w-0 flex-col">
+          <span className="truncate">
+            {defaultModelLabel ?? 'Current default'}
+          </span>
+          <span className="text-[10px] text-muted-foreground">
+            (use default)
+          </span>
+        </span>
+        {shortcut && <DropdownMenuShortcut>{shortcut}</DropdownMenuShortcut>}
+      </DropdownMenuItem>
+      <ApprovalModelSubmenu
+        label="Other model…"
+        disabled={disabled}
+        onSelect={onModelSelect}
+      />
+    </>
+  )
+}

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -1284,6 +1284,8 @@ export function ChatWindow({
       preferences?.selected_codex_model,
       preferences?.selected_opencode_model,
       preferences?.selected_cursor_model,
+      preferences?.selected_pi_model,
+      preferences?.selected_commandcode_model,
       session?.backend,
     ]
   )
@@ -1467,6 +1469,8 @@ export function ChatWindow({
       preferences?.selected_codex_model,
       preferences?.selected_opencode_model,
       preferences?.selected_cursor_model,
+      preferences?.selected_pi_model,
+      preferences?.selected_commandcode_model,
       session?.backend,
     ]
   )
@@ -1740,6 +1744,8 @@ export function ChatWindow({
       preferences?.selected_codex_model,
       preferences?.selected_opencode_model,
       preferences?.selected_cursor_model,
+      preferences?.selected_pi_model,
+      preferences?.selected_commandcode_model,
       session?.backend,
     ]
   )

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -109,6 +109,8 @@ import { ReviewMethodModal } from './ReviewMethodModal'
 import { QueuedMessagesList } from './QueuedMessageItem'
 import { FloatingButtons } from './FloatingButtons'
 import { PlanDialog } from './PlanDialog'
+import type { ApprovalModelOverride } from './ApprovalModelSubmenu'
+import { resolveApprovalLabel } from './approval-label-utils'
 import { StreamingMessage } from './StreamingMessage'
 import { CompactStreamingTicker } from './CompactStreamingTicker'
 import { CompactMessageList } from './CompactMessageList'
@@ -621,6 +623,18 @@ export function ChatWindow({
     preferences
   )
   const selectedModel: string = session?.selected_model ?? defaultModel
+  const buildNewContextLabel = resolveApprovalLabel(
+    'build',
+    preferences,
+    selectedBackend,
+    { forceModeOverride: true }
+  )
+  const yoloNewContextLabel = resolveApprovalLabel(
+    'yolo',
+    preferences,
+    selectedBackend,
+    { forceModeOverride: true }
+  )
 
   // Per-session thinking level, falls back to preferences default
   const defaultThinkingLevel =
@@ -1093,7 +1107,7 @@ export function ChatWindow({
 
   // Clear context approval handler for PlanDialog
   const handlePlanDialogClearContextApprove = useCallback(
-    async (editedPlanContent: string) => {
+    async (editedPlanContent: string, override?: ApprovalModelOverride) => {
       if (!activeSessionId || !activeWorktreeId || !activeWorktreePath) return
 
       // Mark pending plan approved if exists
@@ -1147,8 +1161,11 @@ export function ChatWindow({
 
       // Send plan as first message in YOLO mode
       const yoloBackend =
-        (yoloBackendRef.current as Session['backend']) ?? undefined
+        override?.backend ??
+        (yoloBackendRef.current as Session['backend']) ??
+        undefined
       const yoloModel =
+        override?.model ??
         yoloModelRef.current ??
         (yoloBackend === 'codex'
           ? (preferences?.selected_codex_model ?? 'gpt-5.5')
@@ -1163,7 +1180,7 @@ export function ChatWindow({
                     'commandcode/default')
                   : selectedModelRef.current)
       const yoloOverride =
-        yoloModelRef.current || yoloBackend
+        override || yoloModelRef.current || yoloBackend
           ? [yoloBackend, yoloModel].filter(Boolean).join(' / ')
           : ''
       const message = yoloOverride
@@ -1266,13 +1283,14 @@ export function ChatWindow({
       useAdaptiveThinkingRef,
       preferences?.selected_codex_model,
       preferences?.selected_opencode_model,
+      preferences?.selected_cursor_model,
       session?.backend,
     ]
   )
 
   // Clear context approval handler for PlanDialog (build mode)
   const handlePlanDialogClearContextBuildApprove = useCallback(
-    async (editedPlanContent: string) => {
+    async (editedPlanContent: string, override?: ApprovalModelOverride) => {
       if (!activeSessionId || !activeWorktreeId || !activeWorktreePath) return
 
       // Mark pending plan approved if exists
@@ -1326,8 +1344,11 @@ export function ChatWindow({
 
       // Send plan as first message in build mode using build overrides
       const buildBackend =
-        (buildBackendRef.current as Session['backend']) ?? undefined
+        override?.backend ??
+        (buildBackendRef.current as Session['backend']) ??
+        undefined
       const buildModel =
+        override?.model ??
         buildModelRef.current ??
         (buildBackend === 'codex'
           ? (preferences?.selected_codex_model ?? 'gpt-5.5')
@@ -1342,7 +1363,7 @@ export function ChatWindow({
                     'commandcode/default')
                   : selectedModelRef.current)
       const buildOverride =
-        buildModelRef.current || buildBackend
+        override || buildModelRef.current || buildBackend
           ? [buildBackend, buildModel].filter(Boolean).join(' / ')
           : ''
       const message = buildOverride
@@ -1445,13 +1466,18 @@ export function ChatWindow({
       useAdaptiveThinkingRef,
       preferences?.selected_codex_model,
       preferences?.selected_opencode_model,
+      preferences?.selected_cursor_model,
       session?.backend,
     ]
   )
 
   // Worktree approval handler for PlanDialog (creates new worktree + session)
   const handlePlanDialogWorktreeApprove = useCallback(
-    async (editedPlanContent: string, mode: 'build' | 'yolo') => {
+    async (
+      editedPlanContent: string,
+      mode: 'build' | 'yolo',
+      override?: ApprovalModelOverride
+    ) => {
       const projectId = worktree?.project_id
       if (
         !activeSessionId ||
@@ -1584,8 +1610,11 @@ export function ChatWindow({
         : buildThinkingLevelRef
       const modeEffortRef = isYolo ? yoloEffortLevelRef : buildEffortLevelRef
       const modeBackend =
-        (modeBackendRef.current as Session['backend']) ?? undefined
+        override?.backend ??
+        (modeBackendRef.current as Session['backend']) ??
+        undefined
       const modeModel =
+        override?.model ??
         modeModelRef.current ??
         (modeBackend === 'codex'
           ? (preferences?.selected_codex_model ?? 'gpt-5.5')
@@ -1600,7 +1629,7 @@ export function ChatWindow({
                     'commandcode/default')
                   : selectedModelRef.current)
       const modeOverride =
-        modeModelRef.current || modeBackend
+        override || modeModelRef.current || modeBackend
           ? [modeBackend, modeModel].filter(Boolean).join(' / ')
           : ''
       const message = modeOverride
@@ -1710,19 +1739,20 @@ export function ChatWindow({
       useAdaptiveThinkingRef,
       preferences?.selected_codex_model,
       preferences?.selected_opencode_model,
+      preferences?.selected_cursor_model,
       session?.backend,
     ]
   )
 
   const handlePlanDialogWorktreeBuildApprove = useCallback(
-    (editedPlanContent: string) =>
-      handlePlanDialogWorktreeApprove(editedPlanContent, 'build'),
+    (editedPlanContent: string, override?: ApprovalModelOverride) =>
+      handlePlanDialogWorktreeApprove(editedPlanContent, 'build', override),
     [handlePlanDialogWorktreeApprove]
   )
 
   const handlePlanDialogWorktreeYoloApprove = useCallback(
-    (editedPlanContent: string) =>
-      handlePlanDialogWorktreeApprove(editedPlanContent, 'yolo'),
+    (editedPlanContent: string, override?: ApprovalModelOverride) =>
+      handlePlanDialogWorktreeApprove(editedPlanContent, 'yolo', override),
     [handlePlanDialogWorktreeApprove]
   )
 
@@ -2207,22 +2237,37 @@ export function ChatWindow({
     isCursorBackend,
   ])
 
-  const floatingClearContextBuildApprove = useCallback(() => {
-    if (pendingPlanMessage)
-      handleClearContextApprovalBuild(pendingPlanMessage.id)
-  }, [pendingPlanMessage, handleClearContextApprovalBuild])
+  const floatingClearContextBuildApprove = useCallback(
+    (override?: ApprovalModelOverride) => {
+      if (pendingPlanMessage)
+        handleClearContextApprovalBuild(pendingPlanMessage.id, override)
+    },
+    [pendingPlanMessage, handleClearContextApprovalBuild]
+  )
 
-  const floatingClearContextApprove = useCallback(() => {
-    if (pendingPlanMessage) handleClearContextApproval(pendingPlanMessage.id)
-  }, [pendingPlanMessage, handleClearContextApproval])
+  const floatingClearContextApprove = useCallback(
+    (override?: ApprovalModelOverride) => {
+      if (pendingPlanMessage)
+        handleClearContextApproval(pendingPlanMessage.id, override)
+    },
+    [pendingPlanMessage, handleClearContextApproval]
+  )
 
-  const floatingWorktreeBuildApprove = useCallback(() => {
-    if (pendingPlanMessage) handleWorktreeBuildApproval(pendingPlanMessage.id)
-  }, [pendingPlanMessage, handleWorktreeBuildApproval])
+  const floatingWorktreeBuildApprove = useCallback(
+    (override?: ApprovalModelOverride) => {
+      if (pendingPlanMessage)
+        handleWorktreeBuildApproval(pendingPlanMessage.id, override)
+    },
+    [pendingPlanMessage, handleWorktreeBuildApproval]
+  )
 
-  const floatingWorktreeYoloApprove = useCallback(() => {
-    if (pendingPlanMessage) handleWorktreeYoloApproval(pendingPlanMessage.id)
-  }, [pendingPlanMessage, handleWorktreeYoloApproval])
+  const floatingWorktreeYoloApprove = useCallback(
+    (override?: ApprovalModelOverride) => {
+      if (pendingPlanMessage)
+        handleWorktreeYoloApproval(pendingPlanMessage.id, override)
+    },
+    [pendingPlanMessage, handleWorktreeYoloApproval]
+  )
 
   // Pending attachment removal, slash command execution, queue management
   const {
@@ -2819,6 +2864,8 @@ export function ChatWindow({
                         isAtBottom={isAtBottom || messages.length === 0}
                         isSending={isSending}
                         approveShortcut={approveShortcut}
+                        buildDefaultModelLabel={buildNewContextLabel}
+                        yoloDefaultModelLabel={yoloNewContextLabel}
                         onApprove={floatingApprove}
                         onYoloApprove={floatingYoloApprove}
                         onClearContextBuildApprove={

--- a/src/components/chat/ExitPlanModeButton.test.tsx
+++ b/src/components/chat/ExitPlanModeButton.test.tsx
@@ -1,0 +1,115 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@/test/test-utils'
+import { ExitPlanModeButton } from './ExitPlanModeButton'
+import type { ToolCall } from '@/types/chat'
+
+class ResizeObserverMock {
+  observe() {
+    return undefined
+  }
+  unobserve() {
+    return undefined
+  }
+  disconnect() {
+    return undefined
+  }
+}
+
+globalThis.ResizeObserver =
+  ResizeObserverMock as unknown as typeof ResizeObserver
+
+vi.mock('@/hooks/useInstalledBackends', () => ({
+  useInstalledBackends: () => ({
+    installedBackends: ['claude'],
+    isLoading: false,
+  }),
+}))
+
+vi.mock('@/services/opencode-cli', () => ({
+  useAvailableOpencodeModels: () => ({ data: [] }),
+}))
+
+vi.mock('@/services/cursor-cli', () => ({
+  useAvailableCursorModels: () => ({ data: [] }),
+}))
+
+vi.mock('@/services/preferences', () => ({
+  usePreferences: () => ({
+    data: {
+      yolo_backend: 'codex',
+      yolo_model: 'gpt-5.5',
+      selected_codex_model: 'gpt-5.5',
+      default_backend: 'claude',
+    },
+  }),
+}))
+
+vi.mock('@/store/chat-store', () => ({
+  useChatStore: (
+    selector: (state: { selectedBackends: Record<string, string> }) => unknown
+  ) => selector({ selectedBackends: {} }),
+}))
+
+const planToolCalls: ToolCall[] = [
+  {
+    id: 'plan-1',
+    name: 'CodexPlan',
+    input: { plan_preview: 'Plan' },
+  },
+]
+
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+describe('ExitPlanModeButton', () => {
+  it('groups yolo new-session and new-worktree model choices under titled sections', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ExitPlanModeButton
+        toolCalls={planToolCalls}
+        isApproved={false}
+        onPlanApproval={vi.fn()}
+        onPlanApprovalYolo={vi.fn()}
+        onClearContextApproval={vi.fn()}
+        onWorktreeYoloApproval={vi.fn()}
+        sessionId="session-1"
+      />
+    )
+
+    const yoloChevron = screen.getAllByRole('button', { name: '' }).at(-1)
+    expect(yoloChevron).toBeDefined()
+    await user.click(yoloChevron as HTMLElement)
+
+    expect(screen.getByText('New Session (YOLO)')).toBeInTheDocument()
+    expect(screen.getByText('New Worktree (YOLO)')).toBeInTheDocument()
+    expect(screen.queryByText('New Session (YOLO): Other model…')).toBeNull()
+    expect(screen.queryByText('New Worktree (YOLO): Other model…')).toBeNull()
+
+    const groups = screen.getAllByText(/New (Session|Worktree) \(YOLO\)/)
+    expect(groups).toHaveLength(2)
+    expect(
+      screen.getAllByRole('menuitem', { name: /Other model/i })
+    ).toHaveLength(2)
+    expect(screen.getAllByText('Codex · GPT 5.5')).toHaveLength(2)
+    expect(screen.getAllByText('(use default)')).toHaveLength(2)
+    expect(
+      screen.getAllByRole('menuitem', { name: /\(use default\)/i })
+    ).toHaveLength(2)
+  })
+})

--- a/src/components/chat/ExitPlanModeButton.test.tsx
+++ b/src/components/chat/ExitPlanModeButton.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { render, screen } from '@/test/test-utils'
 import { ExitPlanModeButton } from './ExitPlanModeButton'
 import type { ToolCall } from '@/types/chat'
+import type * as DropdownMenuModule from '@/components/ui/dropdown-menu'
 
 class ResizeObserverMock {
   observe() {
@@ -22,7 +23,7 @@ globalThis.ResizeObserver =
 
 vi.mock('@/hooks/useInstalledBackends', () => ({
   useInstalledBackends: () => ({
-    installedBackends: ['claude'],
+    installedBackends: ['claude', 'codex'],
     isLoading: false,
   }),
 }))
@@ -52,6 +53,44 @@ vi.mock('@/store/chat-store', () => ({
   ) => selector({ selectedBackends: {} }),
 }))
 
+vi.mock('./ApprovalModelSubmenu', async () => {
+  const { DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator } =
+    await vi.importActual<typeof DropdownMenuModule>(
+      '@/components/ui/dropdown-menu'
+    )
+
+  return {
+    ApprovalActionGroup: ({
+      title,
+      defaultModelLabel,
+      separatorBefore,
+      onDefaultSelect,
+      onModelSelect,
+    }: {
+      title: string
+      defaultModelLabel?: string | null
+      separatorBefore?: boolean
+      onDefaultSelect: () => void
+      onModelSelect: (override: { backend: string; model: string }) => void
+    }) => (
+      <>
+        {separatorBefore && <DropdownMenuSeparator />}
+        <DropdownMenuLabel>{title}</DropdownMenuLabel>
+        <DropdownMenuItem onClick={onDefaultSelect}>
+          <span>{defaultModelLabel ?? 'Current default'}</span>
+          <span>(use default)</span>
+        </DropdownMenuItem>
+        <div role="menuitem">Other model…</div>
+        <DropdownMenuItem
+          onClick={() => onModelSelect({ backend: 'codex', model: 'gpt-5.5' })}
+        >
+          Codex · GPT 5.5
+        </DropdownMenuItem>
+      </>
+    ),
+  }
+})
+
 const planToolCalls: ToolCall[] = [
   {
     id: 'plan-1',
@@ -79,6 +118,8 @@ beforeEach(() => {
 describe('ExitPlanModeButton', () => {
   it('groups yolo new-session and new-worktree model choices under titled sections', async () => {
     const user = userEvent.setup()
+    const onClearContextApproval = vi.fn()
+    const onWorktreeYoloApproval = vi.fn()
 
     render(
       <ExitPlanModeButton
@@ -86,15 +127,19 @@ describe('ExitPlanModeButton', () => {
         isApproved={false}
         onPlanApproval={vi.fn()}
         onPlanApprovalYolo={vi.fn()}
-        onClearContextApproval={vi.fn()}
-        onWorktreeYoloApproval={vi.fn()}
+        onClearContextApproval={onClearContextApproval}
+        onWorktreeYoloApproval={onWorktreeYoloApproval}
         sessionId="session-1"
       />
     )
 
     const yoloChevron = screen.getAllByRole('button', { name: '' }).at(-1)
     expect(yoloChevron).toBeDefined()
-    await user.click(yoloChevron as HTMLElement)
+    const openYoloMenu = async () => {
+      await user.click(yoloChevron as HTMLElement)
+    }
+
+    await openYoloMenu()
 
     expect(screen.getByText('New Session (YOLO)')).toBeInTheDocument()
     expect(screen.getByText('New Worktree (YOLO)')).toBeInTheDocument()
@@ -106,10 +151,47 @@ describe('ExitPlanModeButton', () => {
     expect(
       screen.getAllByRole('menuitem', { name: /Other model/i })
     ).toHaveLength(2)
-    expect(screen.getAllByText('Codex · GPT 5.5')).toHaveLength(2)
+    expect(
+      screen.getAllByRole('menuitem', { name: /^Codex · GPT 5\.5$/i })
+    ).toHaveLength(2)
     expect(screen.getAllByText('(use default)')).toHaveLength(2)
     expect(
       screen.getAllByRole('menuitem', { name: /\(use default\)/i })
     ).toHaveLength(2)
+
+    await user.click(
+      screen.getAllByRole('menuitem', { name: /\(use default\)/i })[0]
+    )
+    expect(onClearContextApproval).toHaveBeenCalledWith()
+
+    await openYoloMenu()
+    await user.click(
+      screen.getAllByRole('menuitem', { name: /\(use default\)/i })[1]
+    )
+    expect(onWorktreeYoloApproval).toHaveBeenCalledWith()
+
+    await openYoloMenu()
+    await user.click(
+      screen.getAllByRole('menuitem', { name: /Other model/i })[0]
+    )
+    await user.click(
+      screen.getAllByRole('menuitem', { name: /^Codex · GPT 5\.5$/i })[0]
+    )
+    expect(onClearContextApproval).toHaveBeenCalledWith({
+      backend: 'codex',
+      model: 'gpt-5.5',
+    })
+
+    await openYoloMenu()
+    await user.click(
+      screen.getAllByRole('menuitem', { name: /Other model/i })[1]
+    )
+    await user.click(
+      screen.getAllByRole('menuitem', { name: /^Codex · GPT 5\.5$/i })[1]
+    )
+    expect(onWorktreeYoloApproval).toHaveBeenCalledWith({
+      backend: 'codex',
+      model: 'gpt-5.5',
+    })
   })
 })

--- a/src/components/chat/ExitPlanModeButton.tsx
+++ b/src/components/chat/ExitPlanModeButton.tsx
@@ -11,9 +11,9 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import {
-  DropdownMenuItem,
-  DropdownMenuShortcut,
-} from '@/components/ui/dropdown-menu'
+  ApprovalActionGroup,
+  type ApprovalModelOverride,
+} from './ApprovalModelSubmenu'
 import { formatShortcutDisplay, DEFAULT_KEYBINDINGS } from '@/types/keybindings'
 
 interface ExitPlanModeButtonProps {
@@ -23,10 +23,10 @@ interface ExitPlanModeButtonProps {
   hasFollowUpMessage?: boolean
   onPlanApproval?: () => void
   onPlanApprovalYolo?: () => void
-  onClearContextApproval?: () => void
-  onClearContextBuildApproval?: () => void
-  onWorktreeBuildApproval?: () => void
-  onWorktreeYoloApproval?: () => void
+  onClearContextApproval?: (override?: ApprovalModelOverride) => void
+  onClearContextBuildApproval?: (override?: ApprovalModelOverride) => void
+  onWorktreeBuildApproval?: (override?: ApprovalModelOverride) => void
+  onWorktreeYoloApproval?: (override?: ApprovalModelOverride) => void
   buttonRef?: React.RefObject<HTMLButtonElement | null>
   shortcut?: string
   shortcutYolo?: string
@@ -108,37 +108,28 @@ export function ExitPlanModeButton({
           tooltip={approveTooltip}
           onClick={() => onPlanApproval?.()}
         >
-          <DropdownMenuItem onClick={() => onClearContextBuildApproval?.()}>
-            <span className="flex flex-col">
-              <span>New Session</span>
-              {buildNewContextLabel && (
-                <span className="text-[10px] text-muted-foreground">
-                  {buildNewContextLabel}
-                </span>
-              )}
-            </span>
-            <DropdownMenuShortcut>
-              {formatShortcutDisplay(
+          {onClearContextBuildApproval && (
+            <ApprovalActionGroup
+              title="New Session"
+              defaultModelLabel={buildNewContextLabel}
+              shortcut={formatShortcutDisplay(
                 DEFAULT_KEYBINDINGS.approve_plan_clear_context_build
               )}
-            </DropdownMenuShortcut>
-          </DropdownMenuItem>
+              onDefaultSelect={() => onClearContextBuildApproval()}
+              onModelSelect={override => onClearContextBuildApproval(override)}
+            />
+          )}
           {onWorktreeBuildApproval && (
-            <DropdownMenuItem onClick={() => onWorktreeBuildApproval()}>
-              <span className="flex flex-col">
-                <span>New Worktree</span>
-                {buildNewContextLabel && (
-                  <span className="text-[10px] text-muted-foreground">
-                    {buildNewContextLabel}
-                  </span>
-                )}
-              </span>
-              <DropdownMenuShortcut>
-                {formatShortcutDisplay(
-                  DEFAULT_KEYBINDINGS.approve_plan_worktree_build
-                )}
-              </DropdownMenuShortcut>
-            </DropdownMenuItem>
+            <ApprovalActionGroup
+              title="New Worktree"
+              defaultModelLabel={buildNewContextLabel}
+              separatorBefore
+              shortcut={formatShortcutDisplay(
+                DEFAULT_KEYBINDINGS.approve_plan_worktree_build
+              )}
+              onDefaultSelect={() => onWorktreeBuildApproval()}
+              onModelSelect={override => onWorktreeBuildApproval(override)}
+            />
           )}
         </SplitButton>
       ) : (
@@ -164,37 +155,28 @@ export function ExitPlanModeButton({
           variant="outline"
           onClick={() => onPlanApprovalYolo?.()}
         >
-          <DropdownMenuItem onClick={() => onClearContextApproval?.()}>
-            <span className="flex flex-col">
-              <span>New Session (YOLO)</span>
-              {yoloNewContextLabel && (
-                <span className="text-[10px] text-muted-foreground">
-                  {yoloNewContextLabel}
-                </span>
-              )}
-            </span>
-            <DropdownMenuShortcut>
-              {formatShortcutDisplay(
+          {onClearContextApproval && (
+            <ApprovalActionGroup
+              title="New Session (YOLO)"
+              defaultModelLabel={yoloNewContextLabel}
+              shortcut={formatShortcutDisplay(
                 DEFAULT_KEYBINDINGS.approve_plan_clear_context
               )}
-            </DropdownMenuShortcut>
-          </DropdownMenuItem>
+              onDefaultSelect={() => onClearContextApproval()}
+              onModelSelect={override => onClearContextApproval(override)}
+            />
+          )}
           {onWorktreeYoloApproval && (
-            <DropdownMenuItem onClick={() => onWorktreeYoloApproval()}>
-              <span className="flex flex-col">
-                <span>New Worktree (YOLO)</span>
-                {yoloNewContextLabel && (
-                  <span className="text-[10px] text-muted-foreground">
-                    {yoloNewContextLabel}
-                  </span>
-                )}
-              </span>
-              <DropdownMenuShortcut>
-                {formatShortcutDisplay(
-                  DEFAULT_KEYBINDINGS.approve_plan_worktree_yolo
-                )}
-              </DropdownMenuShortcut>
-            </DropdownMenuItem>
+            <ApprovalActionGroup
+              title="New Worktree (YOLO)"
+              defaultModelLabel={yoloNewContextLabel}
+              separatorBefore
+              shortcut={formatShortcutDisplay(
+                DEFAULT_KEYBINDINGS.approve_plan_worktree_yolo
+              )}
+              onDefaultSelect={() => onWorktreeYoloApproval()}
+              onModelSelect={override => onWorktreeYoloApproval(override)}
+            />
           )}
         </SplitButton>
       ) : (

--- a/src/components/chat/FloatingButtons.tsx
+++ b/src/components/chat/FloatingButtons.tsx
@@ -14,6 +14,10 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { formatShortcutDisplay, DEFAULT_KEYBINDINGS } from '@/types/keybindings'
+import {
+  ApprovalActionGroup,
+  type ApprovalModelOverride,
+} from './ApprovalModelSubmenu'
 
 interface FloatingButtonsProps {
   /** Whether a plan needs approval (streaming or pending) */
@@ -30,14 +34,18 @@ interface FloatingButtonsProps {
   onApprove: () => void
   /** Callback for approve (yolo mode) */
   onYoloApprove: () => void
+  /** Label for the build default backend/model */
+  buildDefaultModelLabel?: string | null
+  /** Label for the yolo default backend/model */
+  yoloDefaultModelLabel?: string | null
   /** Callback for clear context build approval */
-  onClearContextBuildApprove?: () => void
+  onClearContextBuildApprove?: (override?: ApprovalModelOverride) => void
   /** Callback for clear context yolo approval */
-  onClearContextApprove?: () => void
+  onClearContextApprove?: (override?: ApprovalModelOverride) => void
   /** Callback for worktree build approval */
-  onWorktreeBuildApprove?: () => void
+  onWorktreeBuildApprove?: (override?: ApprovalModelOverride) => void
   /** Callback for worktree yolo approval */
-  onWorktreeYoloApprove?: () => void
+  onWorktreeYoloApprove?: (override?: ApprovalModelOverride) => void
   /** Callback to scroll to findings */
   onScrollToFindings: () => void
   /** Callback to scroll to bottom */
@@ -56,6 +64,8 @@ export const FloatingButtons = memo(function FloatingButtons({
   approveShortcut,
   onApprove,
   onYoloApprove,
+  buildDefaultModelLabel,
+  yoloDefaultModelLabel,
   onClearContextBuildApprove,
   onClearContextApprove,
   onWorktreeBuildApprove,
@@ -66,10 +76,14 @@ export const FloatingButtons = memo(function FloatingButtons({
   const showApproveButton = showApprove && !isAtBottom
 
   const withScroll = useCallback(
-    (fn?: () => void) => () => {
-      fn?.()
-      onScrollToBottom()
-    },
+    (
+      fn?: (override?: ApprovalModelOverride) => void,
+      override?: ApprovalModelOverride
+    ) =>
+      () => {
+        fn?.(override)
+        onScrollToBottom()
+      },
     [onScrollToBottom]
   )
 
@@ -112,48 +126,63 @@ export const FloatingButtons = memo(function FloatingButtons({
                   </DropdownMenuShortcut>
                 </DropdownMenuItem>
                 {onClearContextBuildApprove && (
-                  <DropdownMenuItem
-                    onClick={withScroll(onClearContextBuildApprove)}
-                  >
-                    New Session
-                    <DropdownMenuShortcut>
-                      {formatShortcutDisplay(
-                        DEFAULT_KEYBINDINGS.approve_plan_clear_context_build
-                      )}
-                    </DropdownMenuShortcut>
-                  </DropdownMenuItem>
+                  <ApprovalActionGroup
+                    title="New Session"
+                    defaultModelLabel={buildDefaultModelLabel}
+                    shortcut={formatShortcutDisplay(
+                      DEFAULT_KEYBINDINGS.approve_plan_clear_context_build
+                    )}
+                    onDefaultSelect={withScroll(onClearContextBuildApprove)}
+                    onModelSelect={override => {
+                      onClearContextBuildApprove(override)
+                      onScrollToBottom()
+                    }}
+                  />
                 )}
                 {onClearContextApprove && (
-                  <DropdownMenuItem onClick={withScroll(onClearContextApprove)}>
-                    New Session (YOLO)
-                    <DropdownMenuShortcut>
-                      {formatShortcutDisplay(
-                        DEFAULT_KEYBINDINGS.approve_plan_clear_context
-                      )}
-                    </DropdownMenuShortcut>
-                  </DropdownMenuItem>
+                  <ApprovalActionGroup
+                    title="New Session (YOLO)"
+                    defaultModelLabel={yoloDefaultModelLabel}
+                    separatorBefore={Boolean(onClearContextBuildApprove)}
+                    shortcut={formatShortcutDisplay(
+                      DEFAULT_KEYBINDINGS.approve_plan_clear_context
+                    )}
+                    onDefaultSelect={withScroll(onClearContextApprove)}
+                    onModelSelect={override => {
+                      onClearContextApprove(override)
+                      onScrollToBottom()
+                    }}
+                  />
                 )}
                 {onWorktreeBuildApprove && (
-                  <DropdownMenuItem
-                    onClick={withScroll(onWorktreeBuildApprove)}
-                  >
-                    New Worktree
-                    <DropdownMenuShortcut>
-                      {formatShortcutDisplay(
-                        DEFAULT_KEYBINDINGS.approve_plan_worktree_build
-                      )}
-                    </DropdownMenuShortcut>
-                  </DropdownMenuItem>
+                  <ApprovalActionGroup
+                    title="New Worktree"
+                    defaultModelLabel={buildDefaultModelLabel}
+                    separatorBefore
+                    shortcut={formatShortcutDisplay(
+                      DEFAULT_KEYBINDINGS.approve_plan_worktree_build
+                    )}
+                    onDefaultSelect={withScroll(onWorktreeBuildApprove)}
+                    onModelSelect={override => {
+                      onWorktreeBuildApprove(override)
+                      onScrollToBottom()
+                    }}
+                  />
                 )}
                 {onWorktreeYoloApprove && (
-                  <DropdownMenuItem onClick={withScroll(onWorktreeYoloApprove)}>
-                    New Worktree (YOLO)
-                    <DropdownMenuShortcut>
-                      {formatShortcutDisplay(
-                        DEFAULT_KEYBINDINGS.approve_plan_worktree_yolo
-                      )}
-                    </DropdownMenuShortcut>
-                  </DropdownMenuItem>
+                  <ApprovalActionGroup
+                    title="New Worktree (YOLO)"
+                    defaultModelLabel={yoloDefaultModelLabel}
+                    separatorBefore={Boolean(onWorktreeBuildApprove)}
+                    shortcut={formatShortcutDisplay(
+                      DEFAULT_KEYBINDINGS.approve_plan_worktree_yolo
+                    )}
+                    onDefaultSelect={withScroll(onWorktreeYoloApprove)}
+                    onModelSelect={override => {
+                      onWorktreeYoloApprove(override)
+                      onScrollToBottom()
+                    }}
+                  />
                 )}
               </DropdownMenuContent>
             </DropdownMenu>

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -53,6 +53,7 @@ import {
 } from './message-content-utils'
 import { hasQuestionAnswerOutput } from '@/types/chat'
 import { MessageSettingsBadges } from '@/components/chat/MessageSettingsBadges'
+import type { ApprovalModelOverride } from './ApprovalModelSubmenu'
 
 interface MessageItemProps {
   /** The message to render */
@@ -86,13 +87,25 @@ interface MessageItemProps {
   /** Callback when user approves a plan with yolo mode */
   onPlanApprovalYolo?: (messageId: string) => void
   /** Callback for clear context approval (new session with plan in yolo mode) */
-  onClearContextApproval?: (messageId: string) => void
+  onClearContextApproval?: (
+    messageId: string,
+    override?: ApprovalModelOverride
+  ) => void
   /** Callback for clear context approval (new session with plan in build mode) */
-  onClearContextApprovalBuild?: (messageId: string) => void
+  onClearContextApprovalBuild?: (
+    messageId: string,
+    override?: ApprovalModelOverride
+  ) => void
   /** Callback for worktree approval (new worktree with plan in build mode) */
-  onWorktreeBuildApproval?: (messageId: string) => void
+  onWorktreeBuildApproval?: (
+    messageId: string,
+    override?: ApprovalModelOverride
+  ) => void
   /** Callback for worktree approval (new worktree with plan in yolo mode) */
-  onWorktreeYoloApproval?: (messageId: string) => void
+  onWorktreeYoloApproval?: (
+    messageId: string,
+    override?: ApprovalModelOverride
+  ) => void
   /** Callback when user answers a question */
   onQuestionAnswer: (
     toolCallId: string,
@@ -204,24 +217,36 @@ export const MessageItem = memo(function MessageItem({
   }, [onPlanApprovalYolo, message.id])
 
   // Stable callback for clear context approval
-  const handleClearContextApproval = useCallback(() => {
-    onClearContextApproval?.(message.id)
-  }, [onClearContextApproval, message.id])
+  const handleClearContextApproval = useCallback(
+    (override?: ApprovalModelOverride) => {
+      onClearContextApproval?.(message.id, override)
+    },
+    [onClearContextApproval, message.id]
+  )
 
   // Stable callback for clear context build approval
-  const handleClearContextApprovalBuild = useCallback(() => {
-    onClearContextApprovalBuild?.(message.id)
-  }, [onClearContextApprovalBuild, message.id])
+  const handleClearContextApprovalBuild = useCallback(
+    (override?: ApprovalModelOverride) => {
+      onClearContextApprovalBuild?.(message.id, override)
+    },
+    [onClearContextApprovalBuild, message.id]
+  )
 
   // Stable callback for worktree build approval
-  const handleWorktreeBuildApproval = useCallback(() => {
-    onWorktreeBuildApproval?.(message.id)
-  }, [onWorktreeBuildApproval, message.id])
+  const handleWorktreeBuildApproval = useCallback(
+    (override?: ApprovalModelOverride) => {
+      onWorktreeBuildApproval?.(message.id, override)
+    },
+    [onWorktreeBuildApproval, message.id]
+  )
 
   // Stable callback for worktree yolo approval
-  const handleWorktreeYoloApproval = useCallback(() => {
-    onWorktreeYoloApproval?.(message.id)
-  }, [onWorktreeYoloApproval, message.id])
+  const handleWorktreeYoloApproval = useCallback(
+    (override?: ApprovalModelOverride) => {
+      onWorktreeYoloApproval?.(message.id, override)
+    },
+    [onWorktreeYoloApproval, message.id]
+  )
 
   // Stable callback for checking if finding is fixed
   const handleIsFindingFixed = useCallback(

--- a/src/components/chat/PlanDialog.tsx
+++ b/src/components/chat/PlanDialog.tsx
@@ -21,9 +21,9 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Markdown } from '@/components/ui/markdown'
 import { SplitButton } from '@/components/ui/split-button'
 import {
-  DropdownMenuItem,
-  DropdownMenuShortcut,
-} from '@/components/ui/dropdown-menu'
+  ApprovalActionGroup,
+  type ApprovalModelOverride,
+} from './ApprovalModelSubmenu'
 import { formatShortcutDisplay, DEFAULT_KEYBINDINGS } from '@/types/keybindings'
 
 export interface ApprovalContext {
@@ -41,10 +41,22 @@ interface PlanDialogBaseProps {
   approvalContext?: ApprovalContext
   onApprove?: (updatedPlan: string) => void
   onApproveYolo?: (updatedPlan: string) => void
-  onClearContextApprove?: (updatedPlan: string) => void
-  onClearContextBuildApprove?: (updatedPlan: string) => void
-  onWorktreeBuildApprove?: (updatedPlan: string) => void
-  onWorktreeYoloApprove?: (updatedPlan: string) => void
+  onClearContextApprove?: (
+    updatedPlan: string,
+    override?: ApprovalModelOverride
+  ) => void
+  onClearContextBuildApprove?: (
+    updatedPlan: string,
+    override?: ApprovalModelOverride
+  ) => void
+  onWorktreeBuildApprove?: (
+    updatedPlan: string,
+    override?: ApprovalModelOverride
+  ) => void
+  onWorktreeYoloApprove?: (
+    updatedPlan: string,
+    override?: ApprovalModelOverride
+  ) => void
   /** Hide approve buttons (e.g. for Codex which has no native approval flow) */
   hideApproveButtons?: boolean
 }
@@ -171,25 +183,37 @@ export function PlanDialog({
     onClose()
   }, [editedContent, onApproveYolo, onClose])
 
-  const handleClearContextApprove = useCallback(() => {
-    onClearContextApprove?.(editedContent)
-    onClose()
-  }, [editedContent, onClearContextApprove, onClose])
+  const handleClearContextApprove = useCallback(
+    (override?: ApprovalModelOverride) => {
+      onClearContextApprove?.(editedContent, override)
+      onClose()
+    },
+    [editedContent, onClearContextApprove, onClose]
+  )
 
-  const handleClearContextBuildApprove = useCallback(() => {
-    onClearContextBuildApprove?.(editedContent)
-    onClose()
-  }, [editedContent, onClearContextBuildApprove, onClose])
+  const handleClearContextBuildApprove = useCallback(
+    (override?: ApprovalModelOverride) => {
+      onClearContextBuildApprove?.(editedContent, override)
+      onClose()
+    },
+    [editedContent, onClearContextBuildApprove, onClose]
+  )
 
-  const handleWorktreeBuildApprove = useCallback(() => {
-    onWorktreeBuildApprove?.(editedContent)
-    onClose()
-  }, [editedContent, onWorktreeBuildApprove, onClose])
+  const handleWorktreeBuildApprove = useCallback(
+    (override?: ApprovalModelOverride) => {
+      onWorktreeBuildApprove?.(editedContent, override)
+      onClose()
+    },
+    [editedContent, onWorktreeBuildApprove, onClose]
+  )
 
-  const handleWorktreeYoloApprove = useCallback(() => {
-    onWorktreeYoloApprove?.(editedContent)
-    onClose()
-  }, [editedContent, onWorktreeYoloApprove, onClose])
+  const handleWorktreeYoloApprove = useCallback(
+    (override?: ApprovalModelOverride) => {
+      onWorktreeYoloApprove?.(editedContent, override)
+      onClose()
+    },
+    [editedContent, onWorktreeYoloApprove, onClose]
+  )
 
   // Keyboard shortcuts for approve actions
   useEffect(() => {
@@ -348,44 +372,29 @@ export function PlanDialog({
                 disabled={!canApprove}
               >
                 {onClearContextBuildApprove && (
-                  <DropdownMenuItem
-                    onClick={handleClearContextBuildApprove}
+                  <ApprovalActionGroup
+                    title="New Session"
+                    defaultModelLabel={buildNewContextLabel}
+                    shortcut={formatShortcutDisplay(
+                      DEFAULT_KEYBINDINGS.approve_plan_clear_context_build
+                    )}
                     disabled={!canApprove}
-                  >
-                    <span className="flex flex-col">
-                      <span>New Session</span>
-                      {buildNewContextLabel && (
-                        <span className="text-[10px] text-muted-foreground">
-                          {buildNewContextLabel}
-                        </span>
-                      )}
-                    </span>
-                    <DropdownMenuShortcut>
-                      {formatShortcutDisplay(
-                        DEFAULT_KEYBINDINGS.approve_plan_clear_context_build
-                      )}
-                    </DropdownMenuShortcut>
-                  </DropdownMenuItem>
+                    onDefaultSelect={() => handleClearContextBuildApprove()}
+                    onModelSelect={handleClearContextBuildApprove}
+                  />
                 )}
                 {onWorktreeBuildApprove && (
-                  <DropdownMenuItem
-                    onClick={handleWorktreeBuildApprove}
+                  <ApprovalActionGroup
+                    title="New Worktree"
+                    defaultModelLabel={buildNewContextLabel}
+                    separatorBefore
+                    shortcut={formatShortcutDisplay(
+                      DEFAULT_KEYBINDINGS.approve_plan_worktree_build
+                    )}
                     disabled={!canApprove}
-                  >
-                    <span className="flex flex-col">
-                      <span>New Worktree</span>
-                      {buildNewContextLabel && (
-                        <span className="text-[10px] text-muted-foreground">
-                          {buildNewContextLabel}
-                        </span>
-                      )}
-                    </span>
-                    <DropdownMenuShortcut>
-                      {formatShortcutDisplay(
-                        DEFAULT_KEYBINDINGS.approve_plan_worktree_build
-                      )}
-                    </DropdownMenuShortcut>
-                  </DropdownMenuItem>
+                    onDefaultSelect={() => handleWorktreeBuildApprove()}
+                    onModelSelect={handleWorktreeBuildApprove}
+                  />
                 )}
               </SplitButton>
               <SplitButton
@@ -396,44 +405,29 @@ export function PlanDialog({
                 disabled={!canApprove}
               >
                 {onClearContextApprove && (
-                  <DropdownMenuItem
-                    onClick={handleClearContextApprove}
+                  <ApprovalActionGroup
+                    title="New Session (YOLO)"
+                    defaultModelLabel={yoloNewContextLabel}
+                    shortcut={formatShortcutDisplay(
+                      DEFAULT_KEYBINDINGS.approve_plan_clear_context
+                    )}
                     disabled={!canApprove}
-                  >
-                    <span className="flex flex-col">
-                      <span>New Session (YOLO)</span>
-                      {yoloNewContextLabel && (
-                        <span className="text-[10px] text-muted-foreground">
-                          {yoloNewContextLabel}
-                        </span>
-                      )}
-                    </span>
-                    <DropdownMenuShortcut>
-                      {formatShortcutDisplay(
-                        DEFAULT_KEYBINDINGS.approve_plan_clear_context
-                      )}
-                    </DropdownMenuShortcut>
-                  </DropdownMenuItem>
+                    onDefaultSelect={() => handleClearContextApprove()}
+                    onModelSelect={handleClearContextApprove}
+                  />
                 )}
                 {onWorktreeYoloApprove && (
-                  <DropdownMenuItem
-                    onClick={handleWorktreeYoloApprove}
+                  <ApprovalActionGroup
+                    title="New Worktree (YOLO)"
+                    defaultModelLabel={yoloNewContextLabel}
+                    separatorBefore
+                    shortcut={formatShortcutDisplay(
+                      DEFAULT_KEYBINDINGS.approve_plan_worktree_yolo
+                    )}
                     disabled={!canApprove}
-                  >
-                    <span className="flex flex-col">
-                      <span>New Worktree (YOLO)</span>
-                      {yoloNewContextLabel && (
-                        <span className="text-[10px] text-muted-foreground">
-                          {yoloNewContextLabel}
-                        </span>
-                      )}
-                    </span>
-                    <DropdownMenuShortcut>
-                      {formatShortcutDisplay(
-                        DEFAULT_KEYBINDINGS.approve_plan_worktree_yolo
-                      )}
-                    </DropdownMenuShortcut>
-                  </DropdownMenuItem>
+                    onDefaultSelect={() => handleWorktreeYoloApprove()}
+                    onModelSelect={handleWorktreeYoloApprove}
+                  />
                 )}
               </SplitButton>
             </div>

--- a/src/components/chat/approval-label-utils.test.ts
+++ b/src/components/chat/approval-label-utils.test.ts
@@ -19,21 +19,50 @@ describe('resolveApprovalLabel', () => {
       forceModeOverride: true,
     })
 
-    expect(label).toContain('codex')
+    expect(label).toContain('Codex')
     expect(label).toContain('GPT 5.5')
   })
 
   it('keeps same-session labels on current backend when override backend differs', () => {
     const label = resolveApprovalLabel('yolo', prefs, 'claude')
 
-    expect(label).not.toContain('codex')
+    expect(label).not.toContain('Codex')
+    expect(label).toContain('Claude')
     expect(label).toContain('Opus')
   })
 
   it('uses yolo backend override for same-session labels when backend matches', () => {
     const label = resolveApprovalLabel('yolo', prefs, 'codex')
 
-    expect(label).toContain('codex')
+    expect(label).toContain('Codex')
     expect(label).toContain('GPT 5.5')
+  })
+
+  it('shows Claude as the backend name for default Claude labels', () => {
+    const label = resolveApprovalLabel('build', prefs, 'claude', {
+      forceModeOverride: true,
+    })
+
+    expect(label).toContain('Claude')
+    expect(label).toContain('Opus')
+  })
+
+  it('formats backend names in display case', () => {
+    expect(
+      resolveApprovalLabel(
+        'build',
+        { ...prefs, build_backend: 'opencode', build_model: null },
+        'claude',
+        { forceModeOverride: true }
+      )
+    ).toContain('OpenCode')
+    expect(
+      resolveApprovalLabel(
+        'build',
+        { ...prefs, build_backend: 'cursor', build_model: null },
+        'claude',
+        { forceModeOverride: true }
+      )
+    ).toContain('Cursor')
   })
 })

--- a/src/components/chat/approval-label-utils.test.ts
+++ b/src/components/chat/approval-label-utils.test.ts
@@ -64,5 +64,13 @@ describe('resolveApprovalLabel', () => {
         { forceModeOverride: true }
       )
     ).toContain('Cursor')
+    expect(
+      resolveApprovalLabel(
+        'build',
+        { ...prefs, build_backend: 'commandcode', build_model: null },
+        'claude',
+        { forceModeOverride: true }
+      )
+    ).toContain('CommandCode')
   })
 })

--- a/src/components/chat/approval-label-utils.ts
+++ b/src/components/chat/approval-label-utils.ts
@@ -4,6 +4,21 @@ interface ResolveApprovalLabelOptions {
   forceModeOverride?: boolean
 }
 
+const BACKEND_LABELS: Record<string, string> = {
+  claude: 'Claude',
+  codex: 'Codex',
+  opencode: 'OpenCode',
+  cursor: 'Cursor',
+  commandcode: 'CommandCode',
+}
+
+function formatBackendLabel(backend: string): string {
+  return (
+    BACKEND_LABELS[backend] ??
+    backend.charAt(0).toUpperCase() + backend.slice(1)
+  )
+}
+
 /**
  * Resolves a human-readable label for the backend + model that will be used
  * when approving a plan in build or yolo mode.
@@ -57,8 +72,7 @@ export function resolveApprovalLabel(
   if (!resolvedModel && !resolvedBackend) return null
   const modelLabel = resolvedModel ? getMessageModelLabel(resolvedModel) : null
   const parts: string[] = []
-  if (resolvedBackend && resolvedBackend !== 'claude')
-    parts.push(resolvedBackend)
+  if (resolvedBackend) parts.push(formatBackendLabel(resolvedBackend))
   if (modelLabel) parts.push(modelLabel)
   return parts.length > 0 ? parts.join(' · ') : null
 }

--- a/src/components/chat/hooks/useMessageHandlers.ts
+++ b/src/components/chat/hooks/useMessageHandlers.ts
@@ -1241,8 +1241,11 @@ export function useMessageHandlers({
       const prefs = queryClient.getQueryData<AppPreferences>(
         preferencesQueryKeys.preferences()
       )
+      const validatedOverrideBackend = asSessionBackend(
+        effectiveOverride?.backend
+      )
       const modeBackendOverride =
-        effectiveOverride?.backend ?? asSessionBackend(modeBackendRef.current)
+        validatedOverrideBackend ?? asSessionBackend(modeBackendRef.current)
       const resolvedBackend = modeBackendOverride
       const modelBackend = resolvedBackend ?? currentSessionBackend
       const resolvedModel =
@@ -1827,8 +1830,11 @@ export function useMessageHandlers({
       const prefs = queryClient.getQueryData<AppPreferences>(
         preferencesQueryKeys.preferences()
       )
+      const validatedOverrideBackend = asSessionBackend(
+        oneShotOverride?.backend
+      )
       const modeBackendOverride =
-        oneShotOverride?.backend ?? asSessionBackend(modeBackendRef.current)
+        validatedOverrideBackend ?? asSessionBackend(modeBackendRef.current)
       const resolvedBackend = modeBackendOverride
       const modelBackend = resolvedBackend ?? currentSessionBackend
       const resolvedModel =

--- a/src/components/chat/hooks/useMessageHandlers.ts
+++ b/src/components/chat/hooks/useMessageHandlers.ts
@@ -43,6 +43,7 @@ import type {
   WorktreeCreateErrorEvent,
 } from '@/types/projects'
 import { clearPlanApprovalTransientState } from './plan-approval-state'
+import type { ApprovalModelOverride } from '../ApprovalModelSubmenu'
 
 /** Git commands to auto-approve for magic prompts (no permission prompts needed) */
 export const GIT_ALLOWED_TOOLS = [
@@ -132,13 +133,25 @@ interface MessageHandlers {
   handlePlanApprovalYolo: (messageId: string, updatedPlan?: string) => void
   handleStreamingPlanApproval: () => void
   handleStreamingPlanApprovalYolo: () => void
-  handleClearContextApproval: (messageId: string) => void
+  handleClearContextApproval: (
+    messageId: string,
+    override?: ApprovalModelOverride
+  ) => void
   handleStreamingClearContextApproval: () => void
-  handleClearContextApprovalBuild: (messageId: string) => void
+  handleClearContextApprovalBuild: (
+    messageId: string,
+    override?: ApprovalModelOverride
+  ) => void
   handleStreamingClearContextApprovalBuild: () => void
-  handleWorktreeBuildApproval: (messageId: string) => void
+  handleWorktreeBuildApproval: (
+    messageId: string,
+    override?: ApprovalModelOverride
+  ) => void
   handleStreamingWorktreeBuildApproval: () => void
-  handleWorktreeYoloApproval: (messageId: string) => void
+  handleWorktreeYoloApproval: (
+    messageId: string,
+    override?: ApprovalModelOverride
+  ) => void
   handleStreamingWorktreeYoloApproval: () => void
   handlePendingPlanApprovalCallback: () => void
   handlePermissionApproval: (
@@ -1124,7 +1137,14 @@ export function useMessageHandlers({
   // Handle clear context approval for persisted messages
   // Resolves plan content from message tool calls, marks approved, creates new session, sends plan
   const handleClearContextApproval = useCallback(
-    async (messageId: string, mode: 'yolo' | 'build' = 'yolo') => {
+    async (
+      messageId: string,
+      modeOrOverride: 'yolo' | 'build' | ApprovalModelOverride = 'yolo',
+      oneShotOverride?: ApprovalModelOverride
+    ) => {
+      const mode = typeof modeOrOverride === 'string' ? modeOrOverride : 'yolo'
+      const effectiveOverride =
+        typeof modeOrOverride === 'string' ? oneShotOverride : modeOrOverride
       const sessionId = activeSessionIdRef.current
       const worktreeId = activeWorktreeIdRef.current
       const worktreePath = activeWorktreePathRef.current
@@ -1221,16 +1241,18 @@ export function useMessageHandlers({
       const prefs = queryClient.getQueryData<AppPreferences>(
         preferencesQueryKeys.preferences()
       )
-      const modeBackendOverride = asSessionBackend(modeBackendRef.current)
+      const modeBackendOverride =
+        effectiveOverride?.backend ?? asSessionBackend(modeBackendRef.current)
       const resolvedBackend = modeBackendOverride
       const modelBackend = resolvedBackend ?? currentSessionBackend
       const resolvedModel =
+        effectiveOverride?.model ??
         modeModelRef.current ??
         (modeBackendOverride
           ? getDefaultModelForBackend(modelBackend, prefs)
           : selectedModelRef.current)
       const modeOverride =
-        modeModelRef.current || modeBackendOverride
+        effectiveOverride || modeModelRef.current || modeBackendOverride
           ? [resolvedBackend, resolvedModel].filter(Boolean).join(' / ')
           : ''
       const planMessage = modeOverride
@@ -1612,7 +1634,8 @@ export function useMessageHandlers({
   )
 
   const handleClearContextApprovalBuild = useCallback(
-    (messageId: string) => handleClearContextApproval(messageId, 'build'),
+    (messageId: string, override?: ApprovalModelOverride) =>
+      handleClearContextApproval(messageId, 'build', override),
     [handleClearContextApproval]
   )
 
@@ -1623,7 +1646,11 @@ export function useMessageHandlers({
 
   // Handle worktree approval (create new worktree + send plan)
   const handleWorktreeApproval = useCallback(
-    async (messageId: string, mode: 'yolo' | 'build' = 'build') => {
+    async (
+      messageId: string,
+      mode: 'yolo' | 'build' = 'build',
+      oneShotOverride?: ApprovalModelOverride
+    ) => {
       const sessionId = activeSessionIdRef.current
       const worktreeId = activeWorktreeIdRef.current
       const worktreePath = activeWorktreePathRef.current
@@ -1800,16 +1827,18 @@ export function useMessageHandlers({
       const prefs = queryClient.getQueryData<AppPreferences>(
         preferencesQueryKeys.preferences()
       )
-      const modeBackendOverride = asSessionBackend(modeBackendRef.current)
+      const modeBackendOverride =
+        oneShotOverride?.backend ?? asSessionBackend(modeBackendRef.current)
       const resolvedBackend = modeBackendOverride
       const modelBackend = resolvedBackend ?? currentSessionBackend
       const resolvedModel =
+        oneShotOverride?.model ??
         modeModelRef.current ??
         (modeBackendOverride
           ? getDefaultModelForBackend(modelBackend, prefs)
           : selectedModelRef.current)
       const modeOverride =
-        modeModelRef.current || modeBackendOverride
+        oneShotOverride || modeModelRef.current || modeBackendOverride
           ? [resolvedBackend, resolvedModel].filter(Boolean).join(' / ')
           : ''
       const planMessage = modeOverride
@@ -2250,12 +2279,14 @@ export function useMessageHandlers({
   )
 
   const handleWorktreeBuildApproval = useCallback(
-    (messageId: string) => handleWorktreeApproval(messageId, 'build'),
+    (messageId: string, override?: ApprovalModelOverride) =>
+      handleWorktreeApproval(messageId, 'build', override),
     [handleWorktreeApproval]
   )
 
   const handleWorktreeYoloApproval = useCallback(
-    (messageId: string) => handleWorktreeApproval(messageId, 'yolo'),
+    (messageId: string, override?: ApprovalModelOverride) =>
+      handleWorktreeApproval(messageId, 'yolo', override),
     [handleWorktreeApproval]
   )
 

--- a/src/components/chat/toolbar/useToolbarDerivedState.ts
+++ b/src/components/chat/toolbar/useToolbarDerivedState.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import {
   getModelFastInfo,
   type ClaudeModel,
+  type CliBackend,
   type CustomCliProfile,
 } from '@/types/preferences'
 import {
@@ -15,13 +16,7 @@ import {
 import { sortModelOptionsByRawModel } from '@/components/chat/toolbar/toolbar-utils'
 
 interface UseToolbarDerivedStateArgs {
-  selectedBackend:
-    | 'claude'
-    | 'codex'
-    | 'opencode'
-    | 'cursor'
-    | 'pi'
-    | 'commandcode'
+  selectedBackend: CliBackend
   selectedProvider: string | null
   selectedModel: string
   opencodeModelOptions?: { value: string; label: string }[]
@@ -29,16 +24,65 @@ interface UseToolbarDerivedStateArgs {
   piModelOptions?: { value: string; label: string }[]
   commandcodeModelOptions?: { value: string; label: string }[]
   customCliProfiles: CustomCliProfile[]
-  installedBackends?: (
-    | 'claude'
-    | 'codex'
-    | 'opencode'
-    | 'cursor'
-    | 'pi'
-    | 'commandcode'
-  )[]
+  installedBackends?: CliBackend[]
   availableMcpServers?: { name: string; disabled?: boolean }[]
   enabledMcpServers?: string[]
+}
+
+export interface BackendModelSection {
+  backend: CliBackend
+  label: string
+  options: { value: string; label: string }[]
+}
+
+export function buildBackendModelSections({
+  installedBackends,
+  claudeModelOptions,
+  codexModelOptions,
+  opencodeModelOptions,
+  cursorModelOptions,
+  piModelOptions,
+  commandcodeModelOptions,
+}: {
+  installedBackends: CliBackend[]
+  claudeModelOptions: { value: string; label: string }[]
+  codexModelOptions: { value: string; label: string }[]
+  opencodeModelOptions: { value: string; label: string }[]
+  cursorModelOptions: { value: string; label: string }[]
+  piModelOptions?: { value: string; label: string }[]
+  commandcodeModelOptions?: { value: string; label: string }[]
+}): BackendModelSection[] {
+  const sections: BackendModelSection[] = []
+
+  for (const backend of installedBackends) {
+    if (backend === 'claude') {
+      sections.push({ backend, label: 'Claude', options: claudeModelOptions })
+    } else if (backend === 'codex') {
+      sections.push({ backend, label: 'Codex', options: codexModelOptions })
+    } else if (backend === 'opencode') {
+      sections.push({
+        backend,
+        label: 'OpenCode',
+        options: opencodeModelOptions,
+      })
+    } else if (backend === 'cursor') {
+      sections.push({ backend, label: 'Cursor', options: cursorModelOptions })
+    } else if (backend === 'pi') {
+      sections.push({
+        backend,
+        label: 'PI',
+        options: piModelOptions ?? PI_MODEL_OPTIONS,
+      })
+    } else if (backend === 'commandcode') {
+      sections.push({
+        backend,
+        label: 'Command Code',
+        options: commandcodeModelOptions ?? COMMANDCODE_MODEL_OPTIONS,
+      })
+    }
+  }
+
+  return sections
 }
 
 export function useToolbarDerivedState({
@@ -121,63 +165,27 @@ export function useToolbarDerivedState({
   const resolvedCommandCodeModelOptions =
     commandcodeModelOptions ?? COMMANDCODE_MODEL_OPTIONS
 
-  const backendModelSections = useMemo(() => {
-    const sections: {
-      backend: 'claude' | 'codex' | 'opencode' | 'cursor' | 'pi' | 'commandcode'
-      label: string
-      options: { value: string; label: string }[]
-    }[] = []
-
-    for (const backend of installedBackends) {
-      if (backend === 'claude') {
-        sections.push({
-          backend,
-          label: 'Claude',
-          options: claudeModelOptions,
-        })
-      } else if (backend === 'codex') {
-        sections.push({
-          backend,
-          label: 'Codex',
-          options: codexModelOptions,
-        })
-      } else if (backend === 'opencode') {
-        sections.push({
-          backend,
-          label: 'OpenCode',
-          options: resolvedOpencodeModelOptions,
-        })
-      } else if (backend === 'cursor') {
-        sections.push({
-          backend,
-          label: 'Cursor',
-          options: resolvedCursorModelOptions,
-        })
-      } else if (backend === 'pi') {
-        sections.push({
-          backend,
-          label: 'PI',
-          options: resolvedPiModelOptions,
-        })
-      } else if (backend === 'commandcode') {
-        sections.push({
-          backend,
-          label: 'Command Code',
-          options: resolvedCommandCodeModelOptions,
-        })
-      }
-    }
-
-    return sections
-  }, [
-    claudeModelOptions,
-    codexModelOptions,
-    installedBackends,
-    resolvedCursorModelOptions,
-    resolvedCommandCodeModelOptions,
-    resolvedOpencodeModelOptions,
-    resolvedPiModelOptions,
-  ])
+  const backendModelSections = useMemo(
+    () =>
+      buildBackendModelSections({
+        installedBackends,
+        claudeModelOptions,
+        codexModelOptions,
+        opencodeModelOptions: resolvedOpencodeModelOptions,
+        cursorModelOptions: resolvedCursorModelOptions,
+        piModelOptions: resolvedPiModelOptions,
+        commandcodeModelOptions: resolvedCommandCodeModelOptions,
+      }),
+    [
+      claudeModelOptions,
+      codexModelOptions,
+      installedBackends,
+      resolvedCursorModelOptions,
+      resolvedCommandCodeModelOptions,
+      resolvedOpencodeModelOptions,
+      resolvedPiModelOptions,
+    ]
+  )
 
   const filteredModelOptions = useMemo(() => {
     if (isCodex) return codexModelOptions


### PR DESCRIPTION
## Summary
- Adds an “Other model” submenu for plan approval actions so users can choose a one-shot backend/model override for new sessions or worktrees.
- Groups model choices by installed backend and supports searching across available Claude, Codex, OpenCode, and Cursor models.
- Updates approval labels to show display-case backend names and default model context.
- Adds focused tests for approval model selection, grouped approval menus, and label formatting.