### PR TITLE
fix(chat): disable "Mark as Idle" when review is pinned by AI results

### DIFF
--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -1212,6 +1212,13 @@ export function SessionChatModal({
                             {sessionLabel ? 'Remove Label' : 'Add Label'}
                           </ContextMenuItem>
                           <ContextMenuItem
+                            // "Mark as Idle" only clears the manual reviewing
+                            // flag. When review is driven by AI review_results,
+                            // clearing the flag leaves the session in review —
+                            // no effect — so disable it there.
+                            disabled={
+                              status === 'review' && !!session.review_results
+                            }
                             onSelect={() => {
                               const { reviewingSessions, setSessionReviewing } =
                                 useChatStore.getState()


### PR DESCRIPTION
This is just a minor thing, but it is my first contribution to an Open Source project ever. I worked with Jean/Claude Code on it (obviously). I did the best HITL I was able to. Let me know if its up to spec – or any other faux pas / transgression I am guilty on this.

---

## What

Disables the **Mark as Idle** item in the session context menu when the session is in the *review* state because it has AI `review_results` (rather than the manual reviewing flag).

## Why

The review toggle's `onSelect` only flips the manual `reviewingSessions` flag via `setSessionReviewing`. A session's status is `review` when **either** the manual flag is set **or** `session.review_results` is present:

```ts
const isReviewing = reviewingSessions[session.id] || !!session.review_results
```

So when review is driven by `review_results`, clicking **Mark as Idle** clears the manual flag but the session stays in `review` — the menu item silently does nothing.

## Fix

Guard the item with `disabled={status === 'review' && !!session.review_results}`, consistent with how the menu already avoids offering no-op actions. Manual review (no AI results) still toggles back to idle as before.

## Testing

- `bun run typecheck` / `eslint` / `prettier` clean for the changed file.
- `bun run test:run src/components/chat/SessionChatModal.removal-behavior.test.ts` passes.
- Manual: run an AI review on a session → context menu → "Mark as Idle" is disabled; a manually-reviewed session (no AI results) → "Mark as Idle" still returns it to idle.