### PR TITLE
feat(models): re-add non-1M Claude variants to model dropdowns

### DIFF
--- a/e2e/tests/model-selection.spec.ts
+++ b/e2e/tests/model-selection.spec.ts
@@ -37,8 +37,8 @@ test.describe('Model Selection', () => {
     await modelCombobox.click()
     await mockPage.waitForTimeout(200)
 
-    // Select "Opus 4.6"
-    await mockPage.getByRole('option', { name: 'Opus 4.6' }).click()
+    // Select plain "Opus 4.6" (exact — avoids matching "Opus 4.6 (1M)")
+    await mockPage.getByRole('option', { name: 'Opus 4.6', exact: true }).click()
     await mockPage.waitForTimeout(500)
 
     // Verify the selector now shows Opus 4.6

--- a/src/components/chat/toolbar/BackendModelPickerContent.test.tsx
+++ b/src/components/chat/toolbar/BackendModelPickerContent.test.tsx
@@ -76,7 +76,7 @@ beforeEach(() => {
 })
 
 describe('BackendModelPickerContent', () => {
-  it('keeps Claude 1M variants plus models without 1M support', () => {
+  it('renders Claude 1M and plain model variants', () => {
     render(
       <BackendModelPickerContent
         open
@@ -92,12 +92,15 @@ describe('BackendModelPickerContent', () => {
     )
 
     expect(screen.getByText('Opus 4.8 (1M)')).toBeInTheDocument()
+    expect(screen.getByText('Opus 4.8')).toBeInTheDocument()
     expect(screen.getByText('Opus 4.7 (1M)')).toBeInTheDocument()
+    expect(screen.getByText('Opus 4.7')).toBeInTheDocument()
     expect(screen.getByText('Opus 4.6 (1M)')).toBeInTheDocument()
+    expect(screen.getByText('Opus 4.6')).toBeInTheDocument()
     expect(screen.getByText('Sonnet 4.6 (1M)')).toBeInTheDocument()
     expect(screen.getByText('Opus 4.5')).toBeInTheDocument()
     expect(screen.getByText('Haiku')).toBeInTheDocument()
-    expect(screen.queryByText('Sonnet 4.6')).toBeNull()
+    expect(screen.getByText('Sonnet 4.6')).toBeInTheDocument()
   })
 
   it('renders backend sidebar and switches backend+model on selection', async () => {

--- a/src/components/preferences/panes/MagicPromptsPane.tsx
+++ b/src/components/preferences/panes/MagicPromptsPane.tsx
@@ -472,8 +472,11 @@ export function getMagicPromptItemId(key: keyof MagicPrompts): string {
 
 const CLAUDE_MODEL_OPTIONS: { value: MagicPromptModel; label: string }[] = [
   { value: 'claude-opus-4-8[1m]', label: 'Opus 4.8 (1M)' },
+  { value: 'claude-opus-4-8', label: 'Opus 4.8' },
   { value: 'claude-opus-4-7[1m]', label: 'Opus 4.7 (1M)' },
+  { value: 'claude-opus-4-7', label: 'Opus 4.7' },
   { value: 'claude-opus-4-6[1m]', label: 'Opus 4.6 (1M)' },
+  { value: 'claude-opus-4-6', label: 'Opus 4.6' },
   { value: 'sonnet', label: 'Sonnet 4.6' },
   { value: 'haiku', label: 'Haiku' },
 ]

--- a/src/services/preferences.test.ts
+++ b/src/services/preferences.test.ts
@@ -88,18 +88,27 @@ const createWrapper = (queryClient: QueryClient) => {
 }
 
 describe('model option helpers', () => {
-  it('uses 1M Claude variants where available and keeps no-1M-only models', () => {
+  it('offers both 1M and plain Claude variants and keeps explicit plain selections', () => {
     expect(modelOptions.map(option => option.value)).toEqual([
       'claude-opus-4-8[1m]',
+      'claude-opus-4-8',
       'claude-opus-4-7[1m]',
+      'claude-opus-4-7',
       'claude-opus-4-6[1m]',
+      'claude-opus-4-6',
       'claude-opus-4-5-20251101',
       'claude-sonnet-4-6[1m]',
+      'sonnet',
       'haiku',
     ])
-    expect(normalizeClaudeModel('sonnet')).toBe('claude-sonnet-4-6[1m]')
-    expect(normalizeClaudeModel('claude-opus-4-8')).toBe('claude-opus-4-8[1m]')
-    expect(normalizeClaudeModel('claude-opus-4-7')).toBe('claude-opus-4-7[1m]')
+    // Plain ids are selectable, so they must pass through unchanged (no 1M upgrade).
+    expect(normalizeClaudeModel('sonnet')).toBe('sonnet')
+    expect(normalizeClaudeModel('claude-opus-4-8')).toBe('claude-opus-4-8')
+    expect(normalizeClaudeModel('claude-opus-4-7')).toBe('claude-opus-4-7')
+    // Removed standalone fast entry still migrates to its 1M-fast equivalent.
+    expect(normalizeClaudeModel('claude-opus-4-6-fast')).toBe(
+      'claude-opus-4-6[1m]-fast'
+    )
   })
 
   it('offers Codex fast modes for default selectors', () => {

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1179,19 +1179,21 @@ export type ClaudeModel =
 
 export const modelOptions: { value: ClaudeModel; label: string }[] = [
   { value: 'claude-opus-4-8[1m]', label: 'Claude Opus 4.8 (1M)' },
+  { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
   { value: 'claude-opus-4-7[1m]', label: 'Claude Opus 4.7 (1M)' },
+  { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
   { value: 'claude-opus-4-6[1m]', label: 'Claude Opus 4.6 (1M)' },
+  { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
   { value: 'claude-opus-4-5-20251101', label: 'Claude Opus 4.5' },
   { value: 'claude-sonnet-4-6[1m]', label: 'Claude Sonnet 4.6 (1M)' },
+  { value: 'sonnet', label: 'Claude Sonnet 4.6' },
   { value: 'haiku', label: 'Claude Haiku' },
 ]
 
+// Plain ids are now selectable in modelOptions, so they must NOT be rewritten
+// to 1M here. Only keep migration for the removed standalone fast entry.
 const legacyClaudeDefaultModelMap = {
-  'claude-opus-4-8': 'claude-opus-4-8[1m]',
-  'claude-opus-4-7': 'claude-opus-4-7[1m]',
-  'claude-opus-4-6': 'claude-opus-4-6[1m]',
   'claude-opus-4-6-fast': 'claude-opus-4-6[1m]-fast',
-  sonnet: 'claude-sonnet-4-6[1m]',
 } as const satisfies Partial<Record<ClaudeModel, ClaudeModel>>
 
 const knownClaudeModels = new Set<string>([


### PR DESCRIPTION
## What

Re-adds the plain (non-1M) Claude model options to the model selection dropdowns. A recent release removed them, leaving only the 1M-context variants — this restores the ability to pick the lower-context models.

Restored options (in both the chat toolbar picker and the Magic Prompts model selectors):

- Claude Opus 4.8
- Claude Opus 4.7
- Claude Opus 4.6
- Claude Sonnet 4.6

…each shown alongside its existing `(1M)` sibling.

## Why / how

The plain model ids still existed in the `ClaudeModel` union — they were only dropped from the visible `modelOptions` list, and `legacyClaudeDefaultModelMap` silently upgraded a plain id to its `[1m]` variant via `normalizeClaudeModel`. So just re-adding dropdown entries wasn't enough; a plain pick would get rewritten to 1M.

- `src/types/preferences.ts` — add plain entries to `modelOptions`; shrink `legacyClaudeDefaultModelMap` to only the removed standalone `claude-opus-4-6-fast` migration so explicit plain selections persist. Plain ids land in `knownClaudeModels` automatically (built from `modelOptions`), so `sonnet` still resolves.
- `src/components/preferences/panes/MagicPromptsPane.tsx` — add plain Opus entries to `CLAUDE_MODEL_OPTIONS`.

The main chat toolbar picker derives from `modelOptions` (via `toolbar-options.ts`), so no toolbar code change was needed.

## Tests

- Updated `src/services/preferences.test.ts` and `src/components/chat/toolbar/BackendModelPickerContent.test.tsx` for the new option list and pass-through normalization.
- `e2e/tests/model-selection.spec.ts` — exact-match `"Opus 4.6"` so it no longer ambiguously matches `"Opus 4.6 (1M)"`.
- `bun run test:run` ✅ (767 passed) and `cargo test` ✅ (412 passed). e2e suite is pre-existingly red in the local mock harness (unrelated `app-loads` fails on a clean tree) — CI is the gate.

## How to test manually

- Chat toolbar model picker shows plain Opus 4.8/4.7/4.6 and Sonnet 4.6 next to the `(1M)` entries.
- Pick a plain model, send a message, reopen the picker → stays plain (not silently upgraded to 1M).
- Settings → Magic Prompts: each Claude model dropdown shows the plain entries and persists the selection.