### PR TITLE
feat(sessions): show label badges in sidebar list and tab bar

### DIFF
--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -29,6 +29,7 @@ import {
 } from 'lucide-react'
 import { ModalCloseButton } from '@/components/ui/modal-close-button'
 import { cn } from '@/lib/utils'
+import { getLabelTextColor } from '@/lib/label-colors'
 import { dismissibleToast } from '@/lib/dismissible-toast'
 import { Button } from '@/components/ui/button'
 import {
@@ -1397,8 +1398,7 @@ export function SessionChatModal({
                     const isActive = session.id === currentSessionId
                     const status = card.status
                     const config = statusConfig[status]
-                    const chatState = useChatStore.getState()
-                    const sessionLabel = chatState.sessionLabels[session.id]
+                    const sessionLabel = card.label
                     const resumeCommand = getResumeCommand(session)
                     return (
                       <ContextMenu key={session.id}>
@@ -1465,6 +1465,20 @@ export function SessionChatModal({
                                 </TooltipContent>
                               </Tooltip>
                             )}
+                            {renamingSessionId !== session.id &&
+                              sessionLabel && (
+                                <span
+                                  className="shrink-0 max-w-20 truncate rounded px-1 py-px text-[9px] font-medium uppercase tracking-wide"
+                                  style={{
+                                    backgroundColor: sessionLabel.color,
+                                    color: getLabelTextColor(
+                                      sessionLabel.color
+                                    ),
+                                  }}
+                                >
+                                  {sessionLabel.name}
+                                </span>
+                              )}
                             {renamingSessionId !== session.id && (
                               <DismissButton
                                 tooltip={'Remove session'}

--- a/src/components/chat/session-card-utils.test.ts
+++ b/src/components/chat/session-card-utils.test.ts
@@ -823,4 +823,36 @@ describe('computeSessionCardData', () => {
     expect(card.hasExitPlanMode).toBe(true)
     expect(card.status).toBe('input_required')
   })
+
+  it('exposes the session label from the store (drives sidebar/tab badges)', () => {
+    const session = createBaseSession()
+    const storeState = createBaseStoreState({
+      sessionLabels: {
+        'session-1': { name: 'Needs testing', color: '#eab308' },
+      },
+    })
+
+    const card = computeSessionCardData(session, storeState)
+
+    expect(card.label).toEqual({ name: 'Needs testing', color: '#eab308' })
+  })
+
+  it('returns a null label when the session has no label', () => {
+    const card = computeSessionCardData(
+      createBaseSession(),
+      createBaseStoreState()
+    )
+
+    expect(card.label).toBeNull()
+  })
+
+  it('only labels the matching session id', () => {
+    const storeState = createBaseStoreState({
+      sessionLabels: { 'other-session': { name: 'Bug', color: '#ef4444' } },
+    })
+
+    const card = computeSessionCardData(createBaseSession(), storeState)
+
+    expect(card.label).toBeNull()
+  })
 })

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -12,6 +12,7 @@ import {
   GitBranch,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { getLabelTextColor } from '@/lib/label-colors'
 import { dismissibleToast } from '@/lib/dismissible-toast'
 import { isBaseSession, type Worktree } from '@/types/projects'
 import { useProjectsStore } from '@/store/projects-store'
@@ -910,11 +911,22 @@ export function WorktreeItem({
                         className="h-1.5 w-1.5 shrink-0"
                       />
                       <span
-                        className="truncate text-xs"
+                        className="flex-1 truncate min-w-0 text-xs"
                         title={`${config.label}: ${card.session.name || 'Untitled'}`}
                       >
                         {card.session.name || 'Untitled'}
                       </span>
+                      {card.label && (
+                        <span
+                          className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide"
+                          style={{
+                            backgroundColor: card.label.color,
+                            color: getLabelTextColor(card.label.color),
+                          }}
+                        >
+                          {card.label.name}
+                        </span>
+                      )}
                     </button>
                   )
                 })}

--- a/src/lib/label-colors.test.ts
+++ b/src/lib/label-colors.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { getLabelTextColor, LABEL_CONTRAST_LIGHT_COLORS } from './label-colors'
+
+describe('getLabelTextColor', () => {
+  it('uses black text on light backgrounds', () => {
+    for (const color of LABEL_CONTRAST_LIGHT_COLORS) {
+      expect(getLabelTextColor(color)).toBe('black')
+    }
+  })
+
+  it('uses white text on dark/unknown backgrounds', () => {
+    expect(getLabelTextColor('#ef4444')).toBe('white') // Red
+    expect(getLabelTextColor('#8b5cf6')).toBe('white') // Purple
+    expect(getLabelTextColor('#000000')).toBe('white')
+    expect(getLabelTextColor('#123abc')).toBe('white')
+  })
+})


### PR DESCRIPTION
## Motivation

Labels are a great way to keep Jean organized as a coding workbench. As session counts grow across worktrees, labels are how you carve order out of the noise — "needs testing", "blocked", "review me", etc.

Until now, label **visibility** has been lacking: a label only showed inside the open chat window. But a label is a *session attribute* — and it should be visible **anywhere sessions are displayed**, not just after you've already opened one. Otherwise you have to open each session to remember why you tagged it, which defeats the point.

This PR closes that gap by surfacing the label as a small colored badge in the two places where you scan many sessions at once.

## What changed

- **Sidebar session list** (`WorktreeItem`): right-aligned, full-text colored badge next to each session. Long session names truncate; the badge stays whole.
- **Main tab bar** (`SessionChatModal`): compact, truncated badge next to the session name, before the close button.
- Both reuse the existing `getLabelTextColor()` contrast helper (black/white text per background).

### Notable fix

The tab bar originally read the label via a non-reactive `useChatStore.getState()` snapshot during render — so a newly assigned label never appeared until an unrelated re-render. It now reads `card.label` from `computeSessionCardData()`, which is reactive via `useCanvasStoreState()`. The badge now appears the instant a label is set/changed/removed.

## Scope

Pure presentational. No backend, type, store, or persistence changes — the label data (`sessionLabels`) and `card.label` already existed; this just renders them in two more spots.

## Tests

- `computeSessionCardData`: exposes the label, returns `null` when absent, and only labels the matching session id.
- `getLabelTextColor`: black text on light backgrounds, white on dark/unknown.

## How to test

1. `bun run tauri dev`
2. Right-click a session (or use the label button) → assign a label.
3. Tab bar: badge appears immediately next to the name.
4. Sidebar: expand the worktree → labeled session shows a right-aligned badge.
5. Change color / remove label → badge updates live. Unlabeled sessions are unchanged.
