### PR TITLE
feat(chat): add Paused session state + shared session context menu

### DIFF
--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -1644,6 +1644,21 @@ pub async fn regenerate_session_name(
 
 /// Update session-specific UI state (answered questions, fixed findings, etc.)
 /// All fields are optional - only provided fields are updated
+/// Manual session statuses a client may pin via `status_override`.
+/// Mirrors `MANUAL_SESSION_STATUSES` in `src/components/chat/session-card-utils.tsx`.
+pub const MANUAL_SESSION_STATUSES: [&str; 5] =
+    ["idle", "review", "paused", "completed", "cancelled"];
+
+fn validate_status_override(status: &str) -> Result<(), String> {
+    if MANUAL_SESSION_STATUSES.contains(&status) {
+        return Ok(());
+    }
+    Err(format!(
+        "Invalid status_override '{status}'. Expected {}.",
+        MANUAL_SESSION_STATUSES.join(", ")
+    ))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn update_session_state(
     app: AppHandle,
@@ -1726,18 +1741,8 @@ pub async fn update_session_state(
                 }
             }
             if let Some(v) = status_override {
-                match &v {
-                    Some(status)
-                        if !matches!(
-                            status.as_str(),
-                            "idle" | "review" | "completed" | "cancelled"
-                        ) =>
-                    {
-                        return Err(format!(
-                            "Invalid status_override '{status}'. Expected idle, review, completed, or cancelled."
-                        ));
-                    }
-                    _ => {}
+                if let Some(status) = &v {
+                    validate_status_override(status)?;
                 }
                 session.status_override = v;
                 // Keep legacy is_reviewing flag aligned with the override
@@ -3033,7 +3038,12 @@ pub async fn send_chat_message(
         if let Some(session) = sessions.find_session_mut(&session_id) {
             session.waiting_for_input = false;
             session.is_reviewing = false;
-            if session.status_override.as_deref() == Some("review") {
+            // Auto-resume on send: sending a message clears a review or paused
+            // override so the session rejoins the live status flow.
+            if matches!(
+                session.status_override.as_deref(),
+                Some("review") | Some("paused")
+            ) {
                 session.status_override = None;
             }
             session.waiting_for_input_type = None;
@@ -10220,6 +10230,25 @@ pub async fn respond_opencode_permission(
 
 #[cfg(test)]
 mod tests {
+    use super::validate_status_override;
+
+    #[test]
+    fn validate_status_override_accepts_every_manual_status() {
+        for status in ["idle", "review", "paused", "completed", "cancelled"] {
+            assert!(
+                validate_status_override(status).is_ok(),
+                "expected {status} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_status_override_rejects_unknown_values() {
+        let err = validate_status_override("vibing").unwrap_err();
+        assert!(err.contains("Invalid status_override 'vibing'"));
+        assert!(err.contains("paused"));
+    }
+
     use super::*;
 
     #[test]

--- a/jean-core/src/chat/types.rs
+++ b/jean-core/src/chat/types.rs
@@ -2422,6 +2422,7 @@ mod tests {
         );
         metadata.backend = Backend::Codex;
         metadata.is_reviewing = true;
+        metadata.status_override = Some("paused".to_string());
         metadata.waiting_for_input = false;
         metadata.waiting_for_input_type = Some("plan".to_string());
         metadata.pending_plan_message_id = Some("plan-message-1".to_string());
@@ -2458,6 +2459,9 @@ mod tests {
         assert!(restored.waiting_for_input);
         assert_eq!(restored.waiting_for_input_type.as_deref(), Some("plan"));
         assert!(!restored.is_reviewing);
+        // A "paused" override round-trips unchanged (pending-plan logic only
+        // clears the legacy reviewing flag).
+        assert_eq!(restored.status_override.as_deref(), Some("paused"));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,10 @@ import { projectsQueryKeys } from '@/services/projects'
 import { chatQueryKeys } from '@/services/chat'
 import { mergeWorktreesPreservingOptimistic } from '@/lib/worktree-list-cache'
 import type { Session, WorktreeSessions } from '@/types/chat'
+import {
+  isManualSessionStatus,
+  type ManualSessionStatus,
+} from '@/components/chat/session-card-utils'
 import type { Worktree } from '@/types/projects'
 import { initializeCommandSystem } from './lib/commands'
 import { logger } from './lib/logger'
@@ -423,10 +427,7 @@ function App() {
       // Also restore Zustand state for reviewing/waiting status
       if (data.sessionsByWorktree) {
         const reviewingUpdates: Record<string, boolean> = {}
-        const statusOverrideUpdates: Record<
-          string,
-          'idle' | 'review' | 'completed' | 'cancelled'
-        > = {}
+        const statusOverrideUpdates: Record<string, ManualSessionStatus> = {}
         const waitingUpdates: Record<string, boolean> = {}
         const sessionMappings: Record<string, string> = {}
 
@@ -450,12 +451,7 @@ function App() {
           for (const session of wts.sessions) {
             sessionMappings[session.id] = worktreeId
             const override = session.status_override
-            if (
-              override === 'idle' ||
-              override === 'review' ||
-              override === 'completed' ||
-              override === 'cancelled'
-            ) {
+            if (isManualSessionStatus(override)) {
               statusOverrideUpdates[session.id] = override
               if (override === 'review') {
                 reviewingUpdates[session.id] = true
@@ -540,10 +536,8 @@ function App() {
       // more messages from an event or query response racing the bootstrap.
       if (data.activeSessions) {
         const activeReviewingUpdates: Record<string, boolean> = {}
-        const activeStatusOverrideUpdates: Record<
-          string,
-          'idle' | 'review' | 'completed' | 'cancelled'
-        > = {}
+        const activeStatusOverrideUpdates: Record<string, ManualSessionStatus> =
+          {}
         const activeWaitingUpdates: Record<string, boolean> = {}
 
         for (const [sessionId, initSession] of Object.entries(
@@ -551,12 +545,7 @@ function App() {
         )) {
           const session = initSession as Session
           const override = session.status_override
-          if (
-            override === 'idle' ||
-            override === 'review' ||
-            override === 'completed' ||
-            override === 'cancelled'
-          ) {
+          if (isManualSessionStatus(override)) {
             activeStatusOverrideUpdates[sessionId] = override
             if (override === 'review') {
               activeReviewingUpdates[sessionId] = true

--- a/src/components/chat/SessionChatModal.removal-behavior.test.ts
+++ b/src/components/chat/SessionChatModal.removal-behavior.test.ts
@@ -180,9 +180,15 @@ describe('SessionChatModal removal behavior', () => {
 
     expect(source).toContain('buildNativeClientSessionInput')
     expect(source).toContain('handleOpenInNativeClient')
-    expect(source).toContain('Open in Native Client')
     expect(source).toMatch(
       /reconnectNativeCliSession\(nativeSession, worktreeId, \{[\s\S]*?openModal: false/
     )
+
+    // The menu item itself lives in the shared session context menu.
+    const menuSource = readSource(
+      'src/components/chat/SessionContextMenuItems.tsx'
+    )
+    expect(menuSource).toContain('Open in Native Client')
+    expect(menuSource).toContain('onOpenInNativeClient')
   })
 })

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -11,21 +11,16 @@ import {
   type RefObject,
 } from 'react'
 import {
-  Archive,
   ChevronDown,
-  Copy,
   GitBranchPlus,
   GitPullRequestArrow,
   Maximize2,
   Minimize2,
-  Pencil,
-  RefreshCw,
-  Tag,
+  Pause,
   Terminal,
   Globe,
   Play,
   Plus,
-  Trash2,
 } from 'lucide-react'
 import { ModalCloseButton } from '@/components/ui/modal-close-button'
 import { cn } from '@/lib/utils'
@@ -48,13 +43,13 @@ import { useChatStore } from '@/store/chat-store'
 import { isPanelTerminal, useTerminalStore } from '@/store/terminal-store'
 import { useBrowserStore } from '@/store/browser-store'
 import { useUIStore } from '@/store/ui-store'
+import { toast } from 'sonner'
 import {
   useSessions,
   useCreateSession,
   useClearSessionHistory,
   useRenameSession,
   reconnectNativeCliSession,
-  canReconnectSession,
 } from '@/services/chat'
 import { resolveBackendCliPath } from '@/services/cli-binary'
 import { usePreferences } from '@/services/preferences'
@@ -77,8 +72,6 @@ import { isBaseSession } from '@/types/projects'
 import type { Session } from '@/types/chat'
 import { isNativeApp } from '@/lib/environment'
 import { notify } from '@/lib/notifications'
-import { copyToClipboard } from '@/lib/clipboard'
-import { toast } from 'sonner'
 import { ChatWindow } from './ChatWindow'
 import { ModalTerminalDrawer } from './ModalTerminalDrawer'
 import { ModalBrowserDrawer } from '@/components/browser/ModalBrowserDrawer'
@@ -95,25 +88,20 @@ import { DEFAULT_KEYBINDINGS, formatShortcutDisplay } from '@/types/keybindings'
 import {
   buildNativeClientSessionInput,
   computeSessionCardData,
-  getResumeCommand,
   isActionableWaitingStatus,
   statusConfig,
-  type ManualSessionStatus,
   type SessionCardData,
 } from './session-card-utils'
-import { SessionStatusMenu } from './SessionStatusMenu'
 import {
   resolveModalSessionId,
   sortSessionCardsForTabs,
 } from './session-tab-order'
 import { useCanvasStoreState } from './hooks/useCanvasStoreState'
+import { ContextMenu, ContextMenuTrigger } from '@/components/ui/context-menu'
 import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuSeparator,
-  ContextMenuTrigger,
-} from '@/components/ui/context-menu'
+  SessionContextMenuItems,
+  closeOpenSessionContextMenus,
+} from './SessionContextMenuItems'
 import { WorktreeDropdownMenu } from '@/components/projects/WorktreeDropdownMenu'
 import { LabelModal } from './LabelModal'
 import { useSessionArchive } from './hooks/useSessionArchive'
@@ -1397,14 +1385,12 @@ export function SessionChatModal({
                     const isActive = session.id === currentSessionId
                     const status = card.status
                     const config = statusConfig[status]
-                    const chatState = useChatStore.getState()
-                    const sessionLabel = chatState.sessionLabels[session.id]
-                    const resumeCommand = getResumeCommand(session)
                     return (
                       <ContextMenu key={session.id}>
                         <ContextMenuTrigger asChild>
                           <div
                             data-session-id={session.id}
+                            onContextMenuCapture={closeOpenSessionContextMenus}
                             onClick={() => handleTabClick(session.id)}
                             onAuxClick={e => handleTabAuxClick(e, session)}
                             onDoubleClick={() =>
@@ -1437,6 +1423,9 @@ export function SessionChatModal({
                               <kbd className="shrink-0 rounded border border-border/50 px-1 py-px text-[9px] font-medium leading-none text-muted-foreground/70">
                                 ⌘{idx + 1}
                               </kbd>
+                            )}
+                            {status === 'paused' && (
+                              <Pause className="h-3 w-3 shrink-0 text-muted-foreground" />
                             )}
                             {renamingSessionId === session.id ? (
                               <input
@@ -1478,105 +1467,19 @@ export function SessionChatModal({
                             )}
                           </div>
                         </ContextMenuTrigger>
-                        <ContextMenuContent className="w-64">
-                          <ContextMenuItem
-                            onSelect={() =>
-                              handleStartRename(session.id, session.name)
-                            }
-                          >
-                            <Pencil className="mr-2 h-4 w-4" />
-                            Rename
-                          </ContextMenuItem>
-                          <ContextMenuItem
-                            onSelect={() => {
-                              setLabelTargetSessionId(session.id)
-                              setLabelModalOpen(true)
-                            }}
-                          >
-                            <Tag className="mr-2 h-4 w-4" />
-                            {sessionLabel ? 'Remove Label' : 'Add Label'}
-                          </ContextMenuItem>
-                          <SessionStatusMenu
-                            statusOverride={card.statusOverride}
-                            automaticStatus={card.automaticStatus}
-                            onSetStatusOverride={(
-                              next: ManualSessionStatus | null
-                            ) => {
-                              useChatStore
-                                .getState()
-                                .setSessionStatusOverride(session.id, next)
-                            }}
-                          />
-                          {resumeCommand && (
-                            <>
-                              <ContextMenuItem
-                                disabled={createSession.isPending}
-                                onSelect={() =>
-                                  handleOpenInNativeClient(session)
-                                }
-                              >
-                                <Play className="mr-2 h-4 w-4" />
-                                Open in Native Client
-                              </ContextMenuItem>
-                              <ContextMenuItem
-                                onSelect={() => {
-                                  void copyToClipboard(resumeCommand)
-                                    .then(() =>
-                                      toast.success('Resume command copied')
-                                    )
-                                    .catch(() =>
-                                      toast.error(
-                                        'Failed to copy resume command'
-                                      )
-                                    )
-                                }}
-                              >
-                                <Copy className="mr-2 h-4 w-4" />
-                                Native Resume Command
-                              </ContextMenuItem>
-                            </>
-                          )}
-                          {canReconnectSession(session) && (
-                            <ContextMenuItem
-                              onSelect={() =>
-                                void reconnectNativeCliSession(
-                                  session,
-                                  worktreeId
-                                )
-                              }
-                            >
-                              <RefreshCw className="mr-2 h-4 w-4" />
-                              Reconnect
-                            </ContextMenuItem>
-                          )}
-                          <ContextMenuSeparator />
-                          <ContextMenuItem
-                            onSelect={() => handleArchiveSession(session.id)}
-                          >
-                            <Archive className="mr-2 h-4 w-4" />
-                            Archive Session
-                          </ContextMenuItem>
-                          <ContextMenuItem
-                            onSelect={() => {
-                              void copyToClipboard(session.id)
-                                .then(() => toast.success('Session ID copied'))
-                                .catch(() =>
-                                  toast.error('Failed to copy session ID')
-                                )
-                            }}
-                          >
-                            <Copy className="mr-2 h-4 w-4" />
-                            Copy Session ID
-                          </ContextMenuItem>
-                          <ContextMenuSeparator />
-                          <ContextMenuItem
-                            variant="destructive"
-                            onSelect={() => handleDeleteSession(session.id)}
-                          >
-                            <Trash2 className="mr-2 h-4 w-4" />
-                            Delete Session
-                          </ContextMenuItem>
-                        </ContextMenuContent>
+                        <SessionContextMenuItems
+                          card={card}
+                          worktreeId={worktreeId}
+                          onRename={handleStartRename}
+                          onToggleLabel={sessionId => {
+                            setLabelTargetSessionId(sessionId)
+                            setLabelModalOpen(true)
+                          }}
+                          onArchive={handleArchiveSession}
+                          onDelete={handleDeleteSession}
+                          onOpenInNativeClient={handleOpenInNativeClient}
+                          openInNativeClientDisabled={createSession.isPending}
+                        />
                       </ContextMenu>
                     )
                   })}

--- a/src/components/chat/SessionContextMenuItems.tsx
+++ b/src/components/chat/SessionContextMenuItems.tsx
@@ -1,0 +1,176 @@
+import {
+  Archive,
+  Copy,
+  Pause,
+  Pencil,
+  Play,
+  RefreshCw,
+  Tag,
+  Trash2,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+} from '@/components/ui/context-menu'
+import { useChatStore } from '@/store/chat-store'
+import { copyToClipboard } from '@/lib/clipboard'
+import { canReconnectSession, reconnectNativeCliSession } from '@/services/chat'
+import type { Session } from '@/types/chat'
+import { SessionStatusMenu } from './SessionStatusMenu'
+import {
+  getResumeCommand,
+  type ManualSessionStatus,
+  type SessionCardData,
+} from './session-card-utils'
+
+interface SessionContextMenuItemsProps {
+  card: SessionCardData
+  worktreeId: string
+  onRename: (sessionId: string, currentName: string) => void
+  onToggleLabel: (sessionId: string) => void
+  onArchive: (sessionId: string) => void
+  onDelete: (sessionId: string) => void
+  /** Optional host-provided native-client launcher (canvas tab bar only). */
+  onOpenInNativeClient?: (session: Session) => void
+  /** Disables the native-client item while the host is creating a session. */
+  openInNativeClientDisabled?: boolean
+  /** Tailwind width class for the menu content (defaults to w-64). */
+  contentClassName?: string
+}
+
+/**
+ * Canonical session context menu — shared by the canvas session tab bar
+ * (SessionChatModal) and the sidebar worktree session rows (WorktreeItem).
+ * Status/Pause/Resume/Reconnect are self-contained; rename/label/archive/delete
+ * are delegated to the host so each surface can wire its own UI (inline rename,
+ * label modal, archive confirmation, etc.).
+ */
+export function SessionContextMenuItems({
+  card,
+  worktreeId,
+  onRename,
+  onToggleLabel,
+  onArchive,
+  onDelete,
+  onOpenInNativeClient,
+  openInNativeClientDisabled = false,
+  contentClassName = 'w-64',
+}: SessionContextMenuItemsProps) {
+  const session = card.session
+  const isPausedOverride = card.statusOverride === 'paused'
+  const hasLabel = useChatStore(state => !!state.sessionLabels[session.id])
+  const resumeCommand = getResumeCommand(session)
+
+  return (
+    <ContextMenuContent className={contentClassName}>
+      <ContextMenuItem onSelect={() => onRename(session.id, session.name)}>
+        <Pencil className="mr-2 h-4 w-4" />
+        Rename
+      </ContextMenuItem>
+      <ContextMenuItem onSelect={() => onToggleLabel(session.id)}>
+        <Tag className="mr-2 h-4 w-4" />
+        {hasLabel ? 'Remove Label' : 'Add Label'}
+      </ContextMenuItem>
+      <SessionStatusMenu
+        statusOverride={card.statusOverride}
+        automaticStatus={card.automaticStatus}
+        onSetStatusOverride={(next: ManualSessionStatus | null) => {
+          useChatStore.getState().setSessionStatusOverride(session.id, next)
+        }}
+      />
+      <ContextMenuItem
+        // Quick toggle for the 'paused' override that the Set Status submenu
+        // also exposes. Live states still outrank it visually, but the override
+        // is remembered and applies once the session goes idle.
+        onSelect={() => {
+          useChatStore
+            .getState()
+            .setSessionPaused(session.id, !isPausedOverride)
+        }}
+      >
+        {isPausedOverride ? (
+          <>
+            <Play className="mr-2 h-4 w-4" />
+            Unpause
+          </>
+        ) : (
+          <>
+            <Pause className="mr-2 h-4 w-4" />
+            Mark as Paused
+          </>
+        )}
+      </ContextMenuItem>
+      {resumeCommand && (
+        <>
+          {onOpenInNativeClient && (
+            <ContextMenuItem
+              disabled={openInNativeClientDisabled}
+              onSelect={() => onOpenInNativeClient(session)}
+            >
+              <Play className="mr-2 h-4 w-4" />
+              Open in Native Client
+            </ContextMenuItem>
+          )}
+          <ContextMenuItem
+            onSelect={() => {
+              void copyToClipboard(resumeCommand)
+                .then(() => toast.success('Resume command copied'))
+                .catch(() => toast.error('Failed to copy resume command'))
+            }}
+          >
+            <Copy className="mr-2 h-4 w-4" />
+            Native Resume Command
+          </ContextMenuItem>
+        </>
+      )}
+      {canReconnectSession(session) && (
+        <ContextMenuItem
+          onSelect={() => void reconnectNativeCliSession(session, worktreeId)}
+        >
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Reconnect
+        </ContextMenuItem>
+      )}
+      <ContextMenuSeparator />
+      <ContextMenuItem onSelect={() => onArchive(session.id)}>
+        <Archive className="mr-2 h-4 w-4" />
+        Archive Session
+      </ContextMenuItem>
+      <ContextMenuItem
+        onSelect={() => {
+          void copyToClipboard(session.id)
+            .then(() => toast.success('Session ID copied'))
+            .catch(() => toast.error('Failed to copy session ID'))
+        }}
+      >
+        <Copy className="mr-2 h-4 w-4" />
+        Copy Session ID
+      </ContextMenuItem>
+      <ContextMenuSeparator />
+      <ContextMenuItem
+        variant="destructive"
+        onSelect={() => onDelete(session.id)}
+      >
+        <Trash2 className="mr-2 h-4 w-4" />
+        Delete Session
+      </ContextMenuItem>
+    </ContextMenuContent>
+  )
+}
+
+/**
+ * Dismiss any open Radix context menu before a new one opens. Radix
+ * `ContextMenu.Root` is uncontrolled (no `open` prop), so we cannot force-close
+ * a sibling menu directly. Dispatching a primary-button `pointerdown` on the
+ * document fires every open DismissableLayer's `onPointerDownOutside`, closing
+ * them — without triggering Escape handlers (which would close the host modal).
+ * Wire to `onContextMenuCapture` on each trigger so it runs before the new
+ * menu's contextmenu handler.
+ */
+export function closeOpenSessionContextMenus() {
+  document.dispatchEvent(
+    new PointerEvent('pointerdown', { bubbles: true, button: 0 })
+  )
+}

--- a/src/components/chat/SessionListRow.tsx
+++ b/src/components/chat/SessionListRow.tsx
@@ -3,7 +3,9 @@ import {
   Archive,
   Copy,
   FileText,
+  Pause,
   Pencil,
+  Play,
   RefreshCw,
   Shield,
   Tag,
@@ -32,6 +34,7 @@ import {
 import {
   getResumeCommand,
   statusConfig,
+  type ManualSessionStatus,
   type SessionCardProps,
 } from './session-card-utils'
 import { SessionStatusMenu } from './SessionStatusMenu'
@@ -68,7 +71,7 @@ export const SessionListRow = forwardRef<HTMLDivElement, SessionCardProps>(
     const handleSetStatusOverride =
       onSetStatusOverride ??
       (onToggleReview
-        ? (status: 'idle' | 'review' | 'completed' | 'cancelled' | null) => {
+        ? (status: ManualSessionStatus | null) => {
             // Fallback for callers that only wire the legacy review toggle
             if (status === 'review') {
               if (card.status !== 'review') onToggleReview()
@@ -282,6 +285,27 @@ export const SessionListRow = forwardRef<HTMLDivElement, SessionCardProps>(
               automaticStatus={card.automaticStatus}
               onSetStatusOverride={handleSetStatusOverride}
             />
+          )}
+          {handleSetStatusOverride && (
+            <ContextMenuItem
+              onSelect={() =>
+                handleSetStatusOverride(
+                  card.statusOverride === 'paused' ? null : 'paused'
+                )
+              }
+            >
+              {card.statusOverride === 'paused' ? (
+                <>
+                  <Play className="mr-2 h-4 w-4" />
+                  Unpause
+                </>
+              ) : (
+                <>
+                  <Pause className="mr-2 h-4 w-4" />
+                  Mark as Paused
+                </>
+              )}
+            </ContextMenuItem>
           )}
           <ContextMenuItem onSelect={onArchive}>
             <Archive className="mr-2 h-4 w-4" />

--- a/src/components/chat/copy-session-id-menu.test.ts
+++ b/src/components/chat/copy-session-id-menu.test.ts
@@ -3,7 +3,8 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const sourceFiles = [
-  'src/components/chat/SessionChatModal.tsx',
+  // The canvas tab-bar menu lives in the shared SessionContextMenuItems.
+  'src/components/chat/SessionContextMenuItems.tsx',
   'src/components/chat/SessionListRow.tsx',
 ]
 

--- a/src/components/chat/hooks/useMessageSending.ts
+++ b/src/components/chat/hooks/useMessageSending.ts
@@ -304,6 +304,7 @@ export function useMessageSending({
         enqueueMessage,
         isSending: checkIsSendingNow,
         setSessionReviewing,
+        setSessionPaused,
         setExecutionMode,
       } = useChatStore.getState()
       const liveInputValue = inputRef.current?.value
@@ -517,6 +518,8 @@ export function useMessageSending({
       clearPendingSkills(activeSessionId)
       clearPendingTextFiles(activeSessionId)
       setSessionReviewing(activeSessionId, false)
+      // Auto-resume on send: clear paused flag too.
+      setSessionPaused(activeSessionId, false)
 
       clearChatInputState()
 

--- a/src/components/chat/native-resume-labels.test.ts
+++ b/src/components/chat/native-resume-labels.test.ts
@@ -3,7 +3,8 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const sourceFiles = [
-  'src/components/chat/SessionChatModal.tsx',
+  // The canvas tab-bar menu lives in the shared SessionContextMenuItems.
+  'src/components/chat/SessionContextMenuItems.tsx',
   'src/components/chat/SessionListRow.tsx',
   'src/components/ui/floating-dock.tsx',
   'src/components/chat/toolbar/MobileSettingsMenu.tsx',

--- a/src/components/chat/session-card-utils.test.ts
+++ b/src/components/chat/session-card-utils.test.ts
@@ -395,6 +395,61 @@ describe('computeSessionCardData', () => {
     expect(card.status).toBe('input_required')
   })
 
+  it('applies a paused override to an idle session', () => {
+    const storeState = createBaseStoreState({
+      sessionStatusOverrides: { 'session-1': 'paused' },
+    })
+
+    const card = computeSessionCardData(createBaseSession(), storeState)
+
+    expect(card.automaticStatus).toBe('idle')
+    expect(card.statusOverride).toBe('paused')
+    expect(card.status).toBe('paused')
+  })
+
+  it('reads a persisted paused override straight off the session', () => {
+    const session = createBaseSession({ status_override: 'paused' })
+
+    const card = computeSessionCardData(session, createBaseStoreState())
+
+    expect(card.statusOverride).toBe('paused')
+    expect(card.status).toBe('paused')
+  })
+
+  it('does not let a paused override hide live waiting status', () => {
+    const session = createBaseSession({
+      waiting_for_input: true,
+      waiting_for_input_type: 'question',
+      last_run_status: 'completed',
+      last_run_execution_mode: 'plan',
+    })
+    const storeState = createBaseStoreState({
+      sessionStatusOverrides: { 'session-1': 'paused' },
+      waitingForInputSessionIds: { 'session-1': true },
+    })
+
+    const card = computeSessionCardData(session, storeState)
+
+    expect(card.automaticStatus).toBe('input_required')
+    expect(card.statusOverride).toBe('paused')
+    expect(card.status).toBe('input_required')
+  })
+
+  it('paused wins over a review-ready automatic status', () => {
+    const session = createBaseSession({
+      last_run_status: 'completed',
+      review_results: { findings: [] } as never,
+    })
+    const storeState = createBaseStoreState({
+      sessionStatusOverrides: { 'session-1': 'paused' },
+    })
+
+    const card = computeSessionCardData(session, storeState)
+
+    expect(card.automaticStatus).toBe('review')
+    expect(card.status).toBe('paused')
+  })
+
   it('can force idle even when automatic status is completed', () => {
     const session = createBaseSession({
       last_run_status: 'completed',

--- a/src/components/chat/session-card-utils.tsx
+++ b/src/components/chat/session-card-utils.tsx
@@ -44,6 +44,8 @@ export type SessionStatus =
   | 'waiting'
   | 'plan_approval'
   | 'input_required'
+  | 'review'
+  | 'paused'
   | 'permission'
   | 'command_approval'
   | 'mcp_input'
@@ -59,11 +61,17 @@ export type SessionStatus =
  * input, permissions, …) still win while active; the override applies once the
  * session is idle/terminal so users can pin review/completed/cancelled/idle.
  */
-export type ManualSessionStatus = 'idle' | 'review' | 'completed' | 'cancelled'
+export type ManualSessionStatus =
+  | 'idle'
+  | 'review'
+  | 'paused'
+  | 'completed'
+  | 'cancelled'
 
 export const MANUAL_SESSION_STATUSES: readonly ManualSessionStatus[] = [
   'idle',
   'review',
+  'paused',
   'completed',
   'cancelled',
 ] as const
@@ -74,6 +82,7 @@ export function isManualSessionStatus(
   return (
     value === 'idle' ||
     value === 'review' ||
+    value === 'paused' ||
     value === 'completed' ||
     value === 'cancelled'
   )
@@ -201,6 +210,11 @@ export const statusConfig: Record<
     label: 'Input required',
     indicatorStatus: 'input_required',
     indicatorShape: 'diamond',
+  },
+  paused: {
+    label: 'Paused',
+    // Reuse the gray "idle" indicator color.
+    indicatorStatus: 'idle',
   },
   permission: {
     label: 'Permission required',
@@ -877,7 +891,7 @@ export function buildNativeClientSessionInput(
 // --- Status grouping ---
 
 export interface StatusGroup {
-  key: 'inProgress' | 'waiting' | 'review' | 'idle'
+  key: 'inProgress' | 'waiting' | 'review' | 'paused' | 'idle'
   title: string
   /** Representative status for group header icon/color. */
   indicatorStatus: SessionStatus
@@ -908,6 +922,12 @@ const STATUS_GROUP_ORDER: {
     indicatorStatus: 'review',
     // Keep completed distinct from review-ready within the group via statusConfig labels
     statuses: ['review', 'completed', 'cancelled', 'crashed'],
+  },
+  {
+    key: 'paused',
+    title: 'Paused',
+    indicatorStatus: 'paused',
+    statuses: ['paused'],
   },
   { key: 'idle', title: 'Idle', indicatorStatus: 'idle', statuses: ['idle'] },
 ]

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -10,7 +10,14 @@ import {
   ArrowUp,
   ChevronDown,
   GitBranch,
+  Pause,
 } from 'lucide-react'
+import { ContextMenu, ContextMenuTrigger } from '@/components/ui/context-menu'
+import {
+  SessionContextMenuItems,
+  closeOpenSessionContextMenus,
+} from '@/components/chat/SessionContextMenuItems'
+import { LabelModal } from '@/components/chat/LabelModal'
 import { cn } from '@/lib/utils'
 import { dismissibleToast } from '@/lib/dismissible-toast'
 import { isBaseSession, type Worktree } from '@/types/projects'
@@ -30,7 +37,7 @@ import {
   decideSessionMiddleClose,
 } from './worktree-close-decision'
 import { useRenameWorktree } from '@/services/projects'
-import { useSessions } from '@/services/chat'
+import { useSessions, useRenameSession } from '@/services/chat'
 import { isAskUserQuestion, isPlanToolCall, type Session } from '@/types/chat'
 import {
   computeSessionCardData,
@@ -126,7 +133,8 @@ export function WorktreeItem({
   const { handleArchiveOrClose, preferences } = menuActions
 
   // Delete/archive a single conversation (session) respecting removal_behavior.
-  const { handleDeleteSession } = useSessionArchive({
+  // Shared by middle-click close and the session context menu.
+  const { handleArchiveSession, handleDeleteSession } = useSessionArchive({
     worktreeId: worktree.id,
     worktreePath: worktree.path,
     removalBehavior: preferences?.removal_behavior,
@@ -377,6 +385,66 @@ export function WorktreeItem({
       }, 50)
     },
     [projectId, worktree.id, worktree.path, selectProject, selectWorktree]
+  )
+
+  // --- Session context-menu actions (reused from the canvas tab-bar menu) ---
+  const renameSession = useRenameSession()
+  const [renamingSessionId, setRenamingSessionId] = useState<string | null>(
+    null
+  )
+  const [renameValue, setRenameValue] = useState('')
+  const renameInputRef = useCallback((node: HTMLInputElement | null) => {
+    if (node) {
+      node.focus()
+      node.select()
+    }
+  }, [])
+  // Delay rename start so the input renders after the context menu fully closes
+  // (Radix restores focus to the trigger on close, which would steal focus).
+  const handleStartRename = useCallback(
+    (sessionId: string, currentName: string) => {
+      setRenameValue(currentName)
+      setTimeout(() => setRenamingSessionId(sessionId), 200)
+    },
+    []
+  )
+  const handleRenameSubmit = useCallback(
+    (sessionId: string) => {
+      const newName = renameValue.trim()
+      const current = (sessionsData?.sessions ?? []).find(
+        s => s.id === sessionId
+      )?.name
+      if (newName && newName !== current) {
+        renameSession.mutate({
+          worktreeId: worktree.id,
+          worktreePath: worktree.path,
+          sessionId,
+          newName,
+        })
+      }
+      setRenamingSessionId(null)
+    },
+    [renameValue, worktree.id, worktree.path, renameSession, sessionsData]
+  )
+  const handleRenameKeyDown = useCallback(
+    (e: React.KeyboardEvent, sessionId: string) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        handleRenameSubmit(sessionId)
+      } else if (e.key === 'Escape') {
+        setRenamingSessionId(null)
+      }
+    },
+    [handleRenameSubmit]
+  )
+  const [labelModalOpen, setLabelModalOpen] = useState(false)
+  const [labelTargetSessionId, setLabelTargetSessionId] = useState<
+    string | null
+  >(null)
+  const labelTargetLabel = useChatStore(state =>
+    labelTargetSessionId
+      ? (state.sessionLabels[labelTargetSessionId] ?? null)
+      : null
   )
 
   // Responsive padding based on sidebar width
@@ -882,26 +950,17 @@ export function WorktreeItem({
                 </div>
                 {group.cards.map(card => {
                   const config = statusConfig[card.status]
-                  return (
-                    <button
-                      type="button"
-                      key={card.session.id}
-                      className={cn(
-                        'flex w-full items-center gap-1.5 pl-5 py-1 cursor-pointer text-sm truncate text-left',
-                        activeSessionId === card.session.id && isSelected
-                          ? 'text-foreground bg-primary/10 font-medium'
-                          : activeSessionId === card.session.id
-                            ? 'text-foreground/80 hover:text-foreground hover:bg-accent/50'
-                            : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
-                      )}
-                      onClick={e => {
-                        e.stopPropagation()
-                        handleSessionSelect(card.session.id)
-                      }}
-                      {...middleClickClose(() =>
-                        handleSessionMiddleClose(card.session)
-                      )}
-                    >
+                  const isRenaming = renamingSessionId === card.session.id
+                  const rowClassName = cn(
+                    'flex w-full items-center gap-1.5 pl-5 py-1 cursor-pointer text-sm truncate text-left',
+                    activeSessionId === card.session.id && isSelected
+                      ? 'text-foreground bg-primary/10 font-medium'
+                      : activeSessionId === card.session.id
+                        ? 'text-foreground/80 hover:text-foreground hover:bg-accent/50'
+                        : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+                  )
+                  const rowContent = (
+                    <>
                       <StatusIndicator
                         status={config.indicatorStatus}
                         variant={config.indicatorVariant}
@@ -909,13 +968,74 @@ export function WorktreeItem({
                         label={config.label}
                         className="h-1.5 w-1.5 shrink-0"
                       />
-                      <span
-                        className="truncate text-xs"
-                        title={`${config.label}: ${card.session.name || 'Untitled'}`}
-                      >
-                        {card.session.name || 'Untitled'}
-                      </span>
-                    </button>
+                      {card.status === 'paused' && (
+                        <Pause className="h-3 w-3 shrink-0 text-muted-foreground" />
+                      )}
+                      {isRenaming ? (
+                        <input
+                          ref={renameInputRef}
+                          type="text"
+                          value={renameValue}
+                          onChange={e => setRenameValue(e.target.value)}
+                          onBlur={() => handleRenameSubmit(card.session.id)}
+                          onKeyDown={e =>
+                            handleRenameKeyDown(e, card.session.id)
+                          }
+                          onClick={e => e.stopPropagation()}
+                          className="w-full min-w-0 bg-transparent text-xs outline-none"
+                        />
+                      ) : (
+                        <span
+                          className="truncate text-xs"
+                          title={`${config.label}: ${card.session.name || 'Untitled'}`}
+                        >
+                          {card.session.name || 'Untitled'}
+                        </span>
+                      )}
+                    </>
+                  )
+                  return (
+                    <ContextMenu key={card.session.id}>
+                      <ContextMenuTrigger asChild>
+                        {isRenaming ? (
+                          // An <input> cannot live inside a <button>, so the
+                          // row degrades to a plain container while renaming.
+                          <div
+                            onContextMenuCapture={closeOpenSessionContextMenus}
+                            className={rowClassName}
+                          >
+                            {rowContent}
+                          </div>
+                        ) : (
+                          <button
+                            type="button"
+                            onContextMenuCapture={closeOpenSessionContextMenus}
+                            className={rowClassName}
+                            onClick={e => {
+                              e.stopPropagation()
+                              handleSessionSelect(card.session.id)
+                            }}
+                            {...middleClickClose(() =>
+                              handleSessionMiddleClose(card.session)
+                            )}
+                          >
+                            {rowContent}
+                          </button>
+                        )}
+                      </ContextMenuTrigger>
+                      <SessionContextMenuItems
+                        card={card}
+                        worktreeId={worktree.id}
+                        contentClassName="w-56"
+                        onRename={handleStartRename}
+                        onToggleLabel={sessionId => {
+                          setLabelTargetSessionId(sessionId)
+                          setLabelModalOpen(true)
+                        }}
+                        onArchive={handleArchiveSession}
+                        onDelete={handleDeleteSession}
+                      />
+                    </ContextMenu>
                   )
                 })}
               </div>
@@ -941,6 +1061,16 @@ export function WorktreeItem({
         }}
         branchName={worktree.branch}
         mode={closeConfirm?.mode ?? 'worktree'}
+      />
+
+      <LabelModal
+        isOpen={labelModalOpen}
+        onClose={() => {
+          setLabelModalOpen(false)
+          setLabelTargetSessionId(null)
+        }}
+        sessionId={labelTargetSessionId}
+        currentLabel={labelTargetLabel}
       />
     </div>
   )

--- a/src/hooks/useQueueProcessor.ts
+++ b/src/hooks/useQueueProcessor.ts
@@ -145,6 +145,8 @@ export function useQueueProcessor(): void {
           store.setError(capturedSessionId, null)
           store.addSendingSession(capturedSessionId)
           store.setSessionReviewing(capturedSessionId, false)
+          // Auto-resume on send: clear paused flag too.
+          store.setSessionPaused(capturedSessionId, false)
           store.setExecutingMode(capturedSessionId, msg.executionMode)
           store.setSelectedModel(capturedSessionId, msg.model)
 

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -40,7 +40,11 @@ import { useUIStore } from '@/store/ui-store'
 import { useTerminalStore } from '@/store/terminal-store'
 import { clearSessionScrollState } from '@/components/chat/session-scroll-state'
 import { isNativeTerminalBackend } from '@/lib/native-cli-session'
-import { getResumeArgs } from '@/components/chat/session-card-utils'
+import {
+  getResumeArgs,
+  isManualSessionStatus,
+  type ManualSessionStatus,
+} from '@/components/chat/session-card-utils'
 import {
   bareCommandForBackend,
   isBareCliCommand,
@@ -431,10 +435,7 @@ export async function prefetchSessions(
     // Restore reviewingSessions, status overrides, waitingForInputSessionIds,
     // sessionLabels, reviewResults, fixedFindings, and selected execution modes.
     const reviewingUpdates: Record<string, boolean> = {}
-    const statusOverrideUpdates: Record<
-      string,
-      'idle' | 'review' | 'completed' | 'cancelled'
-    > = {}
+    const statusOverrideUpdates: Record<string, ManualSessionStatus> = {}
     const waitingUpdates: Record<string, boolean> = {}
     const executionModeUpdates: Record<string, ExecutionMode> = {}
     const primarySurfaceUpdates: Record<string, 'chat' | 'terminal'> = {}
@@ -448,12 +449,7 @@ export async function prefetchSessions(
     const fixedFindingsUpdates: Record<string, Set<string>> = {}
     for (const session of sessions.sessions) {
       const override = session.status_override
-      if (
-        override === 'idle' ||
-        override === 'review' ||
-        override === 'completed' ||
-        override === 'cancelled'
-      ) {
+      if (isManualSessionStatus(override)) {
         statusOverrideUpdates[session.id] = override
         if (override === 'review') {
           reviewingUpdates[session.id] = true

--- a/src/store/chat-store.test.ts
+++ b/src/store/chat-store.test.ts
@@ -370,6 +370,74 @@ describe('ChatStore', () => {
     })
   })
 
+  describe('paused status', () => {
+    it('sets and clears the paused status override', () => {
+      const { setSessionPaused, isSessionPaused } = useChatStore.getState()
+
+      expect(isSessionPaused('session-1')).toBe(false)
+
+      setSessionPaused('session-1', true)
+      expect(useChatStore.getState().isSessionPaused('session-1')).toBe(true)
+      expect(
+        useChatStore.getState().sessionStatusOverrides['session-1']
+      ).toBe('paused')
+
+      setSessionPaused('session-1', false)
+      expect(useChatStore.getState().isSessionPaused('session-1')).toBe(false)
+      expect(
+        useChatStore.getState().sessionStatusOverrides['session-1']
+      ).toBeUndefined()
+    })
+
+    it('unpausing leaves a non-paused override alone', () => {
+      const { setSessionStatusOverride, setSessionPaused } =
+        useChatStore.getState()
+
+      setSessionStatusOverride('session-1', 'completed')
+      setSessionPaused('session-1', false)
+
+      expect(
+        useChatStore.getState().sessionStatusOverrides['session-1']
+      ).toBe('completed')
+    })
+
+    it('pausing clears reviewing (single-valued override)', () => {
+      const { setSessionReviewing, setSessionPaused } = useChatStore.getState()
+
+      setSessionReviewing('session-1', true)
+      expect(useChatStore.getState().reviewingSessions['session-1']).toBe(true)
+
+      setSessionPaused('session-1', true)
+      const state = useChatStore.getState()
+      expect(state.sessionStatusOverrides['session-1']).toBe('paused')
+      expect(state.reviewingSessions['session-1']).toBeUndefined()
+    })
+
+    it('reviewing clears paused (single-valued override)', () => {
+      const { setSessionReviewing, setSessionPaused } = useChatStore.getState()
+
+      setSessionPaused('session-1', true)
+      expect(useChatStore.getState().isSessionPaused('session-1')).toBe(true)
+
+      setSessionReviewing('session-1', true)
+      const state = useChatStore.getState()
+      expect(state.reviewingSessions['session-1']).toBe(true)
+      expect(state.sessionStatusOverrides['session-1']).toBe('review')
+      expect(state.isSessionPaused('session-1')).toBe(false)
+    })
+
+    it('clears waiting state so the paused override takes visual priority', () => {
+      const { setWaitingForInput, setSessionPaused } = useChatStore.getState()
+
+      setWaitingForInput('session-1', true)
+      setSessionPaused('session-1', true)
+
+      expect(
+        useChatStore.getState().waitingForInputSessionIds['session-1']
+      ).toBeUndefined()
+    })
+  })
+
   describe('waiting for input state', () => {
     it('sets and checks waiting for input', () => {
       const { setWaitingForInput, isWaitingForInput } = useChatStore.getState()

--- a/src/store/chat-store.ts
+++ b/src/store/chat-store.ts
@@ -350,6 +350,11 @@ interface ChatUIState {
   ) => void
   getSessionStatusOverride: (sessionId: string) => ManualSessionStatus | null
 
+  // Actions - Paused status management (persisted) — thin wrapper over the
+  // 'paused' status override
+  setSessionPaused: (sessionId: string, paused: boolean) => void
+  isSessionPaused: (sessionId: string) => boolean
+
   // Actions - Session label management (persisted)
   setSessionLabel: (sessionId: string, label: LabelData | null) => void
 
@@ -1066,7 +1071,14 @@ export const useChatStore = create<ChatUIState>()(
                   [sessionId]: true,
                 }
               }
-              // Clear waiting so review takes visual priority (legacy behavior)
+            } else if (sessionId in reviewingSessions) {
+              const { [sessionId]: _, ...rest } = reviewingSessions
+              reviewingSessions = rest
+            }
+
+            // Review and paused both park a session out of the live flow, so
+            // clear waiting state to let the override take visual priority.
+            if (status === 'review' || status === 'paused') {
               if (sessionId in waitingForInputSessionIds) {
                 const { [sessionId]: _w, ...restW } = waitingForInputSessionIds
                 waitingForInputSessionIds = restW
@@ -1075,9 +1087,6 @@ export const useChatStore = create<ChatUIState>()(
                 const { [sessionId]: _p, ...restP } = pendingPlanMessageIds
                 pendingPlanMessageIds = restP
               }
-            } else if (sessionId in reviewingSessions) {
-              const { [sessionId]: _, ...rest } = reviewingSessions
-              reviewingSessions = rest
             }
 
             return {
@@ -1093,6 +1102,21 @@ export const useChatStore = create<ChatUIState>()(
 
       getSessionStatusOverride: sessionId =>
         get().sessionStatusOverrides[sessionId] ?? null,
+
+      // Paused status management (persisted) — thin wrapper over the
+      // 'paused' status override, mirroring setSessionReviewing. Unpausing only
+      // clears the override when paused is actually the active one.
+      setSessionPaused: (sessionId, paused) => {
+        const { getSessionStatusOverride, setSessionStatusOverride } = get()
+        if (paused) {
+          setSessionStatusOverride(sessionId, 'paused')
+        } else if (getSessionStatusOverride(sessionId) === 'paused') {
+          setSessionStatusOverride(sessionId, null)
+        }
+      },
+
+      isSessionPaused: sessionId =>
+        get().sessionStatusOverrides[sessionId] === 'paused',
 
       // Session label management (persisted)
       setSessionLabel: (sessionId, label) =>

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -294,9 +294,16 @@ export interface Session {
   /**
    * User-forced session status. Applied when the session is not in a live
    * automatic state (running, waiting for input, permissions, …).
-   * Values: 'idle' | 'review' | 'completed' | 'cancelled'
+   * Values: 'idle' | 'review' | 'paused' | 'completed' | 'cancelled'
+   * ('paused' parks a session in a manual backlog.)
    */
-  status_override?: 'idle' | 'review' | 'completed' | 'cancelled' | null
+  status_override?:
+    | 'idle'
+    | 'review'
+    | 'paused'
+    | 'completed'
+    | 'cancelled'
+    | null
   /** Whether this session is waiting for user input (AskUserQuestion, ExitPlanMode) */
   waiting_for_input?: boolean
   /** Type of waiting: 'question' for AskUserQuestion, 'plan' for ExitPlanMode */


### PR DESCRIPTION
> **Draft** — opening early for feedback on direction before final polish.

## Motivation

Jean is a productivity workbench, so in real use you end up with **a lot of sessions across a lot of worktrees** open at once. Today there's no way to set a session aside without losing it in the noise — finished sessions auto-enter *Review*, and there's no neutral "deal with this later" bucket.

This adds a **Paused** state: a manual "backlog" flag that lets you park a session for later while **preserving its full context**. Because the conversation/context is kept intact, resuming later doesn't require re-establishing context — which **saves tokens** — and parking sessions keeps the active workbench clean and focused on what you're working on *now*.

## What this adds

- **Paused session state** — persistent, manual flag (`is_paused`), mutually exclusive with *Review*, and **auto-cleared on send** (sending a message resumes the session). Mirrors the existing `is_reviewing` pipeline end-to-end:
  - Rust: `is_paused` on `Session`/`SessionMetadata`, `update_session_state` command param, WebSocket dispatch wiring.
  - Frontend: `pausedSessions` Zustand slice with mutual-exclusivity guards, prefetch + persistence restore, save-on-change.
  - A gray **Paused** status + its own group in the session list / canvas / tab bar, plus an inline pause icon on paused tabs/rows.
- **Shared session context menu** — extracted the canvas tab-bar menu into a reusable `SessionContextMenuItems` component, now also used by the **worktree sidebar session rows** (which previously had no session context menu at all).
  - Adds **Mark as Paused / Unpause**, disabled where it would be a no-op (e.g. *Waiting*/*Permission* states, which outrank paused).
  - Existing **Mark for Review / Mark as Idle** preserved; *Mark as Idle* is now disabled when review is pinned by AI results (it would otherwise no-op). _(Same one-liner as #402 — once that merges this collapses to a no-op in the rebase.)_
  - Ensures only **one context menu is open at a time** (Radix `ContextMenu` is uncontrolled; dismiss others on contextmenu-capture).

## Testing

- `bun run typecheck`, `lint`, Rust `clippy -D warnings`, `cargo fmt --check`, `cargo test`, and `bun run test:run` (792 tests) all pass.
- `check:all` is green **except** a pre-existing `prettier` warning on `CLAUDE.md`, which is unmodified here and also fails on `main` (left out of scope).
- Manual: pause a session → moves to **Paused** group with gray dot + pause icon, drops out of *Review*; sending a message auto-resumes; state survives restart and web-access (WS) clients.

## Notes / open questions

- Naming: "Paused" — happy to rename if maintainers prefer "Backlog"/"Snoozed"/etc.
- The *Mark as Idle* no-op guard overlaps with #402 (kept here so this branch stands alone); will rebase cleanly once #402 lands.