### PR TITLE
feat(terminal): split panes & multiplexer views

### DIFF
--- a/src/components/chat/TerminalSplitLayout.tsx
+++ b/src/components/chat/TerminalSplitLayout.tsx
@@ -1,0 +1,326 @@
+import { Fragment, memo, useMemo, useState } from 'react'
+import { GripVertical, SquareArrowOutUpRight, X } from 'lucide-react'
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from '@/components/ui/resizable'
+import {
+  firstLeafId,
+  type SplitNode,
+  type SplitOrientation,
+} from '@/lib/terminal-split'
+import { cn } from '@/lib/utils'
+import { useTerminalStore, type TerminalInstance } from '@/store/terminal-store'
+import { InlineRename, TerminalTabContent } from './TerminalView'
+
+interface TerminalSplitLayoutProps {
+  worktreeId: string
+  worktreePath: string
+  layout: SplitNode
+  focusedTerminalId: string | undefined
+  isWorktreeActive: boolean
+  /** Show per-pane chrome (grip handle, detach, close) — when >1 pane. */
+  showPaneChrome: boolean
+  /** Stop the PTY + dispose, then prune the pane. Provided by the host view. */
+  onClosePane: (terminalId: string) => void
+  /** Pop a pane out of the split into its own view (tab). */
+  onDetachPane: (terminalId: string) => void
+  /** Rename a pane's terminal (double-click its title). */
+  onRenameTerminal: (terminalId: string, label: string) => void
+  /** A tab or pane was dropped on `targetTerminalId`. `payload` is the raw
+   * drag data (`pane:<id>` or `group:<id>`). Undefined disables drag-to-merge
+   * / drag-to-move (web/mobile). */
+  onPaneDrop?: (
+    targetTerminalId: string,
+    orientation: SplitOrientation,
+    payload: string
+  ) => void
+}
+
+/** Stable React key / panel id for a child subtree (its top-left leaf). */
+function nodeKey(node: SplitNode): string {
+  return node.type === 'leaf' ? node.terminalId : firstLeafId(node)
+}
+
+interface SharedPaneProps {
+  worktreeId: string
+  worktreePath: string
+  focusedTerminalId: string | undefined
+  isWorktreeActive: boolean
+  showPaneChrome: boolean
+  onClosePane: (terminalId: string) => void
+  onDetachPane: (terminalId: string) => void
+  onRenameTerminal: (terminalId: string, label: string) => void
+  onPaneDrop?: TerminalSplitLayoutProps['onPaneDrop']
+  terminalsById: Map<string, TerminalInstance>
+}
+
+/** One leaf pane: a title bar (label + controls) above the terminal, plus a
+ * focus ring and a drop zone. The title bar only shows in multi-pane views. */
+const SplitPane = memo(function SplitPane({
+  terminalId,
+  worktreeId,
+  worktreePath,
+  focusedTerminalId,
+  isWorktreeActive,
+  showPaneChrome,
+  onClosePane,
+  onDetachPane,
+  onRenameTerminal,
+  onPaneDrop,
+  terminalsById,
+}: SharedPaneProps & { terminalId: string }) {
+  const terminal = terminalsById.get(terminalId)
+  const dragTerminalId = useTerminalStore(state => state.dragTerminalId)
+  const isRunning = useTerminalStore(state =>
+    state.runningTerminals.has(terminalId)
+  )
+  const [dropOrientation, setDropOrientation] =
+    useState<SplitOrientation | null>(null)
+  const [editing, setEditing] = useState(false)
+  if (!terminal) return null
+
+  const isFocused = terminalId === focusedTerminalId
+  // Only accept a drop when it would actually do something: there is a drag in
+  // progress and it isn't this very pane (dropping a tab/pane on itself is a
+  // no-op, so we don't show a hint or accept it).
+  const canAcceptDrop =
+    !!onPaneDrop && dragTerminalId !== null && dragTerminalId !== terminalId
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!canAcceptDrop) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    const rect = e.currentTarget.getBoundingClientRect()
+    const ratioY = rect.height ? (e.clientY - rect.top) / rect.height : 0.5
+    // Top/bottom band ⇒ stack (vertical); middle band ⇒ side-by-side.
+    setDropOrientation(ratioY < 0.3 || ratioY > 0.7 ? 'vertical' : 'horizontal')
+  }
+
+  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return
+    setDropOrientation(null)
+  }
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!onPaneDrop) return
+    e.preventDefault()
+    const payload = e.dataTransfer.getData('text/plain')
+    setDropOrientation(null)
+    useTerminalStore.getState().setDragTerminal(null)
+    if (canAcceptDrop && payload) {
+      onPaneDrop(terminalId, dropOrientation ?? 'horizontal', payload)
+    }
+  }
+
+  return (
+    <div
+      data-terminal-pane={terminalId}
+      className={cn(
+        'group/pane relative flex h-full w-full flex-col overflow-hidden transition-colors',
+        showPaneChrome && 'ring-1 ring-inset',
+        showPaneChrome && (isFocused ? 'ring-primary/60' : 'ring-transparent')
+      )}
+      // Capture so focusing a pane wins before xterm swallows the mousedown.
+      onMouseDownCapture={() =>
+        useTerminalStore.getState().setActiveTerminal(worktreeId, terminalId)
+      }
+      onDragOver={onPaneDrop ? handleDragOver : undefined}
+      onDragLeave={onPaneDrop ? handleDragLeave : undefined}
+      onDrop={onPaneDrop ? handleDrop : undefined}
+    >
+      {showPaneChrome && (
+        <div
+          // The whole title bar is the drag handle for moving the pane.
+          draggable={!editing}
+          onDragStart={e => {
+            e.dataTransfer.effectAllowed = 'move'
+            e.dataTransfer.setData('text/plain', `pane:${terminalId}`)
+            useTerminalStore.getState().setDragTerminal(terminalId)
+          }}
+          onDragEnd={() => useTerminalStore.getState().setDragTerminal(null)}
+          className={cn(
+            'flex h-6 shrink-0 items-center gap-1 border-b border-border px-1.5 text-xs',
+            isFocused
+              ? 'bg-muted text-foreground'
+              : 'bg-muted/30 text-muted-foreground',
+            !editing && 'cursor-grab active:cursor-grabbing'
+          )}
+          title="Drag to move pane"
+        >
+          <GripVertical className="h-3 w-3 shrink-0 opacity-50" />
+          {isRunning && (
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-green-500" />
+          )}
+          {editing ? (
+            <InlineRename
+              value={terminal.label}
+              onCommit={name => {
+                onRenameTerminal(terminalId, name)
+                setEditing(false)
+              }}
+              onCancel={() => setEditing(false)}
+              className="flex-1"
+            />
+          ) : (
+            <span
+              className="flex-1 truncate"
+              title="Double-click to rename"
+              onDoubleClick={e => {
+                e.stopPropagation()
+                setEditing(true)
+              }}
+            >
+              {terminal.label}
+            </span>
+          )}
+          <button
+            type="button"
+            aria-label="Detach pane to new tab"
+            title="Detach to new tab"
+            onClick={e => {
+              e.stopPropagation()
+              onDetachPane(terminalId)
+            }}
+            className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-background hover:text-foreground"
+          >
+            <SquareArrowOutUpRight className="h-3 w-3" />
+          </button>
+          <button
+            type="button"
+            aria-label="Close pane"
+            onClick={e => {
+              e.stopPropagation()
+              onClosePane(terminalId)
+            }}
+            className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-background hover:text-red-400"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      )}
+      <div className="min-h-0 w-full flex-1">
+        <TerminalTabContent
+          terminal={terminal}
+          worktreeId={worktreeId}
+          worktreePath={worktreePath}
+          isVisible
+          isFocused={isFocused}
+          isWorktreeActive={isWorktreeActive}
+        />
+      </div>
+      {/* Drop hint: the half where the dragged terminal will land. */}
+      {dropOrientation && (
+        <div
+          className={cn(
+            'pointer-events-none absolute z-20 bg-primary/20 ring-2 ring-inset ring-primary/70',
+            dropOrientation === 'horizontal'
+              ? 'inset-y-0 right-0 w-1/2'
+              : 'inset-x-0 bottom-0 h-1/2'
+          )}
+        />
+      )}
+    </div>
+  )
+})
+
+/** Recursively renders a split node as nested resizable panel groups. */
+function SplitNodeView({
+  node,
+  path,
+  shared,
+}: {
+  node: SplitNode
+  path: number[]
+  shared: SharedPaneProps
+}) {
+  if (node.type === 'leaf') {
+    return <SplitPane terminalId={node.terminalId} {...shared} />
+  }
+
+  const childCount = node.children.length
+  return (
+    <ResizablePanelGroup
+      direction={node.orientation}
+      onLayout={sizes =>
+        useTerminalStore.getState().setPaneSizes(shared.worktreeId, path, sizes)
+      }
+    >
+      {node.children.map((child, index) => (
+        <Fragment key={nodeKey(child)}>
+          {index > 0 && (
+            <ResizableHandle
+              withHandle
+              // Explicit thickness per known orientation so the divider is
+              // clearly visible from the first render (not just after a resize).
+              className={cn(
+                'bg-border',
+                node.orientation === 'vertical'
+                  ? 'h-0.5 w-full'
+                  : 'h-full w-0.5'
+              )}
+            />
+          )}
+          <ResizablePanel
+            id={nodeKey(child)}
+            order={index}
+            defaultSize={node.sizes?.[index] ?? 100 / childCount}
+            minSize={10}
+          >
+            <SplitNodeView
+              node={child}
+              path={[...path, index]}
+              shared={shared}
+            />
+          </ResizablePanel>
+        </Fragment>
+      ))}
+    </ResizablePanelGroup>
+  )
+}
+
+/**
+ * Renders one terminal view's layout (1+ panes). Each leaf attaches its own
+ * terminal PTY; the focused pane owns the keyboard. Terminals in other views
+ * are kept mounted (hidden) by the parent TerminalView to preserve buffers.
+ */
+export function TerminalSplitLayout({
+  worktreeId,
+  worktreePath,
+  layout,
+  focusedTerminalId,
+  isWorktreeActive,
+  showPaneChrome,
+  onClosePane,
+  onDetachPane,
+  onRenameTerminal,
+  onPaneDrop,
+}: TerminalSplitLayoutProps) {
+  const terminals = useTerminalStore(state => state.terminals[worktreeId])
+
+  const terminalsById = useMemo(() => {
+    const map = new Map<string, TerminalInstance>()
+    for (const terminal of terminals ?? []) map.set(terminal.id, terminal)
+    return map
+  }, [terminals])
+
+  const shared: SharedPaneProps = {
+    worktreeId,
+    worktreePath,
+    focusedTerminalId,
+    isWorktreeActive,
+    showPaneChrome,
+    onClosePane,
+    onDetachPane,
+    onRenameTerminal,
+    onPaneDrop,
+    terminalsById,
+  }
+
+  return (
+    <div className="h-full w-full">
+      <SplitNodeView node={layout} path={[]} shared={shared} />
+    </div>
+  )
+}

--- a/src/components/chat/TerminalSplitLayout.tsx
+++ b/src/components/chat/TerminalSplitLayout.tsx
@@ -164,6 +164,7 @@ const SplitPane = memo(function SplitPane({
               }}
               onCancel={() => setEditing(false)}
               className="flex-1"
+              ariaLabel="Rename pane"
             />
           ) : (
             <span

--- a/src/components/chat/TerminalSplitLayout.tsx
+++ b/src/components/chat/TerminalSplitLayout.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo, useMemo, useState } from 'react'
+import { Fragment, memo, useState } from 'react'
 import { GripVertical, SquareArrowOutUpRight, X } from 'lucide-react'
 import {
   ResizableHandle,
@@ -36,6 +36,8 @@ interface TerminalSplitLayoutProps {
     orientation: SplitOrientation,
     payload: string
   ) => void
+  /** Lookup map shared by the host view (avoids rebuilding it per layout). */
+  terminalsById: Map<string, TerminalInstance>
 }
 
 /** Stable React key / panel id for a child subtree (its top-left leaf). */
@@ -296,15 +298,8 @@ export function TerminalSplitLayout({
   onDetachPane,
   onRenameTerminal,
   onPaneDrop,
+  terminalsById,
 }: TerminalSplitLayoutProps) {
-  const terminals = useTerminalStore(state => state.terminals[worktreeId])
-
-  const terminalsById = useMemo(() => {
-    const map = new Map<string, TerminalInstance>()
-    for (const terminal of terminals ?? []) map.set(terminal.id, terminal)
-    return map
-  }, [terminals])
-
   const shared: SharedPaneProps = {
     worktreeId,
     worktreePath,

--- a/src/components/chat/TerminalView.test.tsx
+++ b/src/components/chat/TerminalView.test.tsx
@@ -1,7 +1,9 @@
+import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent } from '@testing-library/react'
 import { render, waitFor } from '@/test/test-utils'
 import { useTerminalStore } from '@/store/terminal-store'
-import { SingleTerminalView } from './TerminalView'
+import { SingleTerminalView, TerminalView } from './TerminalView'
 
 const initTerminal = vi.fn().mockResolvedValue(undefined)
 const fit = vi.fn()
@@ -15,10 +17,86 @@ vi.mock('@/hooks/useTerminal', () => ({
   }),
 }))
 
+// Native-desktop / viewport gating is toggled per test.
+const { isNativeAppMock, isMobileMock } = vi.hoisted(() => ({
+  isNativeAppMock: vi.fn(() => true),
+  isMobileMock: vi.fn(() => false),
+}))
+
+vi.mock('@/lib/environment', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, isNativeApp: () => isNativeAppMock() }
+})
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => isMobileMock(),
+}))
+
+// Render react-resizable-panels as plain passthrough divs so split-tree
+// structure is testable without a measured layout in jsdom.
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanelGroup: ({ children }: { children: ReactNode }) => (
+    <div data-testid="rpg">{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children: ReactNode }) => (
+    <div data-testid="rp">{children}</div>
+  ),
+  ResizableHandle: () => <div data-testid="handle" />,
+}))
+
 class ResizeObserverMock {
   observe = vi.fn()
   disconnect = vi.fn()
 }
+
+const PANEL_TERMINALS = [
+  {
+    id: 't1',
+    worktreeId: 'w1',
+    command: null,
+    commandArgs: [],
+    label: 'Shell',
+    kind: 'panel' as const,
+  },
+  {
+    id: 't2',
+    worktreeId: 'w1',
+    command: null,
+    commandArgs: [],
+    label: 'Shell',
+    kind: 'panel' as const,
+  },
+]
+
+// Two single-pane views (the common case: one terminal per tab).
+const TWO_VIEWS = [
+  {
+    id: 'g1',
+    layout: { type: 'leaf' as const, terminalId: 't1' },
+    focusedTerminalId: 't1',
+  },
+  {
+    id: 'g2',
+    layout: { type: 'leaf' as const, terminalId: 't2' },
+    focusedTerminalId: 't2',
+  },
+]
+
+// One view tiling both terminals side by side.
+const SPLIT_VIEW = [
+  {
+    id: 'gs',
+    layout: {
+      type: 'split' as const,
+      orientation: 'horizontal' as const,
+      children: [
+        { type: 'leaf' as const, terminalId: 't1' },
+        { type: 'leaf' as const, terminalId: 't2' },
+      ],
+    },
+    focusedTerminalId: 't2',
+  },
+]
 
 describe('SingleTerminalView', () => {
   beforeEach(() => {
@@ -118,5 +196,200 @@ describe('SingleTerminalView', () => {
     )
 
     await waitFor(() => expect(initTerminal).toHaveBeenCalledTimes(2))
+  })
+})
+
+describe('TerminalView views (multiplexer)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isNativeAppMock.mockReturnValue(true)
+    isMobileMock.mockReturnValue(false)
+    window.ResizeObserver =
+      ResizeObserverMock as unknown as typeof ResizeObserver
+    window.requestAnimationFrame =
+      window.requestAnimationFrame ??
+      ((callback: FrameRequestCallback) => {
+        callback(0)
+        return 0
+      })
+    // Two single-pane views; view g2 (t2) active.
+    useTerminalStore.setState({
+      terminals: { w1: PANEL_TERMINALS },
+      groups: { w1: TWO_VIEWS },
+      activeGroupIds: { w1: 'g2' },
+      activeTerminalIds: { w1: 't2' },
+      dragTerminalId: null,
+      runningTerminals: new Set(),
+      failedTerminals: new Set(),
+      terminalVisible: true,
+      terminalPanelOpen: { w1: true },
+      modalTerminalOpen: {},
+    })
+  })
+
+  it('shows one tab per view and attaches only the active view', async () => {
+    const { getAllByText } = render(
+      <TerminalView worktreeId="w1" worktreePath="/tmp/w1" />
+    )
+    // Two tabs (both labelled "Shell").
+    expect(getAllByText('Shell').length).toBe(2)
+    // Only the active single-pane view attaches its terminal.
+    await waitFor(() => expect(initTerminal).toHaveBeenCalledTimes(1))
+  })
+
+  it('attaches every pane when the active view is split', async () => {
+    useTerminalStore.setState({
+      groups: { w1: SPLIT_VIEW },
+      activeGroupIds: { w1: 'gs' },
+    })
+    render(<TerminalView worktreeId="w1" worktreePath="/tmp/w1" />)
+    await waitFor(() => expect(initTerminal).toHaveBeenCalledTimes(2))
+  })
+
+  it('shows split buttons on native desktop', () => {
+    const { getByLabelText } = render(
+      <TerminalView worktreeId="w1" worktreePath="/tmp/w1" />
+    )
+    expect(getByLabelText('Split terminal right')).toBeTruthy()
+    expect(getByLabelText('Split terminal down')).toBeTruthy()
+  })
+
+  it('clicking a pane focuses it (sets the active terminal)', () => {
+    useTerminalStore.setState({
+      groups: { w1: SPLIT_VIEW },
+      activeGroupIds: { w1: 'gs' },
+    })
+    const { container } = render(
+      <TerminalView worktreeId="w1" worktreePath="/tmp/w1" />
+    )
+    const pane = container.querySelector('[data-terminal-pane="t1"]')
+    expect(pane).toBeTruthy()
+    fireEvent.mouseDown(pane as Element)
+    expect(useTerminalStore.getState().activeTerminalIds.w1).toBe('t1')
+  })
+
+  it('merges a dragged tab onto a pane (drop)', () => {
+    // Active view g2 (single t2); drag view g1 (single t1) onto pane t2.
+    useTerminalStore.getState().setDragTerminal('t1') // dragstart of view g1
+    const { container } = render(
+      <TerminalView worktreeId="w1" worktreePath="/tmp/w1" />
+    )
+    const pane = container.querySelector('[data-terminal-pane="t2"]')
+    expect(pane).toBeTruthy()
+    fireEvent.drop(pane as Element, {
+      dataTransfer: { getData: () => 'group:g1', types: ['text/plain'] },
+    })
+    const state = useTerminalStore.getState()
+    expect(state.groups.w1).toHaveLength(1) // merged into one view
+    expect(state.activeTerminalIds.w1).toBe('t1')
+  })
+
+  it('ignores dropping the active tab onto its own pane (no-op)', () => {
+    // Drag the active view g2 (terminal t2) onto its own pane t2 → nothing.
+    useTerminalStore.getState().setDragTerminal('t2')
+    const { container } = render(
+      <TerminalView worktreeId="w1" worktreePath="/tmp/w1" />
+    )
+    const pane = container.querySelector('[data-terminal-pane="t2"]')
+    expect(pane).toBeTruthy()
+    fireEvent.drop(pane as Element, {
+      dataTransfer: { getData: () => 'group:g2', types: ['text/plain'] },
+    })
+    // Still two separate views — no self-merge.
+    expect(useTerminalStore.getState().groups.w1).toHaveLength(2)
+  })
+
+  it('detaches a pane into its own view via the detach button', () => {
+    useTerminalStore.setState({
+      groups: { w1: SPLIT_VIEW },
+      activeGroupIds: { w1: 'gs' },
+    })
+    const { getAllByLabelText } = render(
+      <TerminalView worktreeId="w1" worktreePath="/tmp/w1" />
+    )
+    // Two panes ⇒ chrome present; detach the first pane.
+    const detachButtons = getAllByLabelText('Detach pane to new tab')
+    expect(detachButtons.length).toBe(2)
+    fireEvent.click(detachButtons[0] as Element)
+    const state = useTerminalStore.getState()
+    expect(state.groups.w1).toHaveLength(2) // split view + detached view
+  })
+
+  it('moves a pane onto another pane via drag (drop pane payload)', () => {
+    // Split view [t1, t2]; drag pane t1 onto pane t2 → relocate within the view.
+    useTerminalStore.setState({
+      groups: { w1: SPLIT_VIEW },
+      activeGroupIds: { w1: 'gs' },
+    })
+    useTerminalStore.getState().setDragTerminal('t1') // dragstart of pane t1
+    const { container } = render(
+      <TerminalView worktreeId="w1" worktreePath="/tmp/w1" />
+    )
+    const pane = container.querySelector('[data-terminal-pane="t2"]')
+    expect(pane).toBeTruthy()
+    fireEvent.drop(pane as Element, {
+      dataTransfer: { getData: () => 'pane:t1', types: ['text/plain'] },
+    })
+    const state = useTerminalStore.getState()
+    expect(state.groups.w1).toHaveLength(1)
+    expect(state.activeTerminalIds.w1).toBe('t1')
+  })
+
+  it('renames a view via double-click on its tab', () => {
+    const { container } = render(
+      <TerminalView worktreeId="w1" worktreePath="/tmp/w1" />
+    )
+    // Single-pane views ⇒ the only renamable spans are the two tab labels.
+    const tabLabels = container.querySelectorAll(
+      'span[title="Double-click to rename"]'
+    )
+    expect(tabLabels.length).toBe(2)
+    fireEvent.doubleClick(tabLabels[0] as Element) // view g1
+    const input = container.querySelector('input') as HTMLInputElement
+    expect(input).toBeTruthy()
+    fireEvent.change(input, { target: { value: 'Build' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    const g1 = useTerminalStore.getState().groups.w1?.find(g => g.id === 'g1')
+    expect(g1?.name).toBe('Build')
+  })
+
+  it('shows a per-pane title bar and renames a pane via double-click', () => {
+    useTerminalStore.setState({
+      groups: { w1: SPLIT_VIEW },
+      activeGroupIds: { w1: 'gs' },
+    })
+    const { container } = render(
+      <TerminalView worktreeId="w1" worktreePath="/tmp/w1" />
+    )
+    const pane = container.querySelector('[data-terminal-pane="t1"]')
+    expect(pane).toBeTruthy()
+    const label = pane?.querySelector(
+      'span[title="Double-click to rename"]'
+    ) as HTMLElement
+    expect(label).toBeTruthy()
+    fireEvent.doubleClick(label)
+    const input = pane?.querySelector('input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'logs' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    const t1 = useTerminalStore
+      .getState()
+      .terminals.w1?.find(t => t.id === 't1')
+    expect(t1?.label).toBe('logs')
+  })
+
+  it('hides split buttons on web access', () => {
+    isNativeAppMock.mockReturnValue(false)
+    const { queryByLabelText } = render(
+      <TerminalView worktreeId="w1" worktreePath="/tmp/w1" />
+    )
+    expect(queryByLabelText('Split terminal right')).toBeNull()
+  })
+
+  it('hides split buttons on mobile', () => {
+    isMobileMock.mockReturnValue(true)
+    const { queryByLabelText } = render(
+      <TerminalView worktreeId="w1" worktreePath="/tmp/w1" />
+    )
+    expect(queryByLabelText('Split terminal right')).toBeNull()
   })
 })

--- a/src/components/chat/TerminalView.tsx
+++ b/src/components/chat/TerminalView.tsx
@@ -711,6 +711,7 @@ export function TerminalView({
             onDetachPane={handleDetachPane}
             onRenameTerminal={handleRenameTerminal}
             onPaneDrop={splitEnabled ? handlePaneDrop : undefined}
+            terminalsById={terminalsById}
           />
         )}
         {/* Keep other views' terminals mounted (hidden) to preserve their buffers */}

--- a/src/components/chat/TerminalView.tsx
+++ b/src/components/chat/TerminalView.tsx
@@ -1,13 +1,30 @@
 import { useEffect, useRef, useCallback, useMemo, memo, useState } from 'react'
-import { Plus, X, Minus, Terminal, ChevronUp } from 'lucide-react'
+import {
+  Plus,
+  X,
+  Minus,
+  Terminal,
+  ChevronUp,
+  SquareSplitHorizontal,
+  SquareSplitVertical,
+} from 'lucide-react'
 import { invoke } from '@/lib/transport'
 import { useTerminal } from '@/hooks/useTerminal'
 import { useTerminalBackgroundColor } from '@/hooks/useTerminalThemeSync'
+import { useIsMobile } from '@/hooks/use-mobile'
+import { isNativeApp } from '@/lib/environment'
 import {
   isPanelTerminal,
   useTerminalStore,
+  type TerminalGroup,
   type TerminalInstance,
 } from '@/store/terminal-store'
+import {
+  collectLeafIds,
+  countLeaves,
+  firstLeafId,
+  type SplitOrientation,
+} from '@/lib/terminal-split'
 import {
   disposeTerminal,
   disposePanelWorktreeTerminals,
@@ -16,9 +33,50 @@ import { Kbd } from '@/components/ui/kbd'
 import { formatShortcutDisplay } from '@/types/keybindings'
 import { cn } from '@/lib/utils'
 import { MODAL_TERMINAL_SECONDARY_ROW_CLASS } from './modal-terminal-layout'
+import { TerminalSplitLayout } from './TerminalSplitLayout'
 import '@xterm/xterm/css/xterm.css'
 
 const EMPTY_TERMINALS: TerminalInstance[] = []
+const EMPTY_GROUPS: TerminalGroup[] = []
+const EMPTY_ID_SET: ReadonlySet<string> = new Set()
+
+/** Tiny inline text editor for renaming a view (tab) or a pane. Commits on
+ * Enter/blur, cancels on Escape. Selects all on focus for quick overwrite. */
+export function InlineRename({
+  value,
+  onCommit,
+  onCancel,
+  className,
+}: {
+  value: string
+  onCommit: (next: string) => void
+  onCancel: () => void
+  className?: string
+}) {
+  const [draft, setDraft] = useState(value)
+  return (
+    <input
+      autoFocus
+      value={draft}
+      onChange={e => setDraft(e.target.value)}
+      onFocus={e => e.currentTarget.select()}
+      // Don't let the click/drag reach the tab/pane underneath.
+      onClick={e => e.stopPropagation()}
+      onPointerDown={e => e.stopPropagation()}
+      onDoubleClick={e => e.stopPropagation()}
+      onKeyDown={e => {
+        e.stopPropagation()
+        if (e.key === 'Enter') onCommit(draft)
+        else if (e.key === 'Escape') onCancel()
+      }}
+      onBlur={() => onCommit(draft)}
+      className={cn(
+        'min-w-0 rounded border border-border bg-background px-1 text-xs text-foreground outline-none',
+        className
+      )}
+    />
+  )
+}
 
 interface TerminalViewProps {
   worktreeId: string
@@ -30,19 +88,28 @@ interface TerminalViewProps {
   hideControls?: boolean
 }
 
-/** Individual terminal tab content */
-const TerminalTabContent = memo(function TerminalTabContent({
+/**
+ * Individual terminal content surface.
+ *
+ * `isVisible` drives PTY attach/detach (a terminal is visible when it is the
+ * active tab in single mode, or a leaf in the current split layout). `isFocused`
+ * drives keyboard focus — exactly one visible pane is focused at a time so
+ * multiple split panes don't fight over `focus()`.
+ */
+export const TerminalTabContent = memo(function TerminalTabContent({
   terminal,
   worktreeId,
   worktreePath,
-  isActive,
+  isVisible,
+  isFocused = false,
   isCollapsed = false,
   isWorktreeActive = true,
 }: {
   terminal: TerminalInstance
   worktreeId: string
   worktreePath: string
-  isActive: boolean
+  isVisible: boolean
+  isFocused?: boolean
   isCollapsed?: boolean
   isWorktreeActive?: boolean
 }) {
@@ -56,7 +123,7 @@ const TerminalTabContent = memo(function TerminalTabContent({
     commandArgs: terminal.commandArgs,
   })
   const initialized = useRef(false)
-  const canAttach = isActive && !isCollapsed && isWorktreeActive
+  const canAttach = isVisible && !isCollapsed && isWorktreeActive
 
   useEffect(() => {
     if (containerRef.current && !initialized.current && canAttach) {
@@ -89,20 +156,24 @@ const TerminalTabContent = memo(function TerminalTabContent({
     }
   }, [fit, canAttach])
 
-  // Fit and focus when becoming active, expanding from collapsed, or worktree becomes visible
+  // Fit when becoming visible (active tab, expand from collapsed, worktree shown
+  // or split pane resize). Runs for every visible pane.
   useEffect(() => {
     if (canAttach && initialized.current) {
-      // Use requestAnimationFrame to ensure container has proper dimensions after expanding
-      requestAnimationFrame(() => {
-        fit()
-        focus()
-      })
+      requestAnimationFrame(() => fit())
     }
-  }, [canAttach, fit, focus])
+  }, [canAttach, fit])
+
+  // Grab the keyboard only for the focused pane.
+  useEffect(() => {
+    if (canAttach && isFocused && initialized.current) {
+      requestAnimationFrame(() => focus())
+    }
+  }, [canAttach, isFocused, focus])
 
   return (
     <div
-      className={cn('h-full w-full p-2', !isActive && 'hidden')}
+      className={cn('h-full w-full p-2', !isVisible && 'hidden')}
       style={{ backgroundColor: terminalBg }}
     >
       <div ref={containerRef} className="h-full w-full overflow-hidden" />
@@ -144,7 +215,8 @@ export const SingleTerminalView = memo(function SingleTerminalView({
         terminal={terminal}
         worktreeId={worktreeId}
         worktreePath={worktreePath}
-        isActive={isActive}
+        isVisible={isActive}
+        isFocused={isActive}
         isWorktreeActive={isWorktreeActive}
       />
     </div>
@@ -162,39 +234,75 @@ export function TerminalView({
   const allTerminals = useTerminalStore(
     state => state.terminals[worktreeId] ?? EMPTY_TERMINALS
   )
-  const terminals = useMemo(
-    () => allTerminals.filter(isPanelTerminal),
-    [allTerminals]
+  const groups = useTerminalStore(
+    state => state.groups[worktreeId] ?? EMPTY_GROUPS
+  )
+  const activeGroupId = useTerminalStore(
+    state => state.activeGroupIds[worktreeId]
   )
   const activeTerminalId = useTerminalStore(
     state => state.activeTerminalIds[worktreeId]
   )
   const runningTerminals = useTerminalStore(state => state.runningTerminals)
-  const hasRunningPanelTerminal = terminals.some(terminal =>
+
+  // Split panes are a native-desktop affordance; web/mobile stay single-pane
+  // (no split buttons, no drag-to-merge — views created there are always 1 pane).
+  const isMobile = useIsMobile()
+  const splitEnabled = isNativeApp() && !isMobile
+
+  const panelTerminals = useMemo(
+    () => allTerminals.filter(isPanelTerminal),
+    [allTerminals]
+  )
+  const terminalsById = useMemo(() => {
+    const map = new Map<string, TerminalInstance>()
+    for (const terminal of allTerminals) map.set(terminal.id, terminal)
+    return map
+  }, [allTerminals])
+  const hasRunningPanelTerminal = panelTerminals.some(terminal =>
     runningTerminals.has(terminal.id)
   )
 
+  const activeGroup = useMemo(
+    () => groups.find(group => group.id === activeGroupId) ?? groups[0],
+    [groups, activeGroupId]
+  )
+  const activeLeafIds = useMemo<ReadonlySet<string>>(
+    () =>
+      activeGroup ? new Set(collectLeafIds(activeGroup.layout)) : EMPTY_ID_SET,
+    [activeGroup]
+  )
+  const hiddenTerminals = useMemo(
+    () => panelTerminals.filter(terminal => !activeLeafIds.has(terminal.id)),
+    [panelTerminals, activeLeafIds]
+  )
+  const activePaneCount = activeGroup ? countLeaves(activeGroup.layout) : 0
+
   const {
     addTerminal,
-    removeTerminal,
-    reorderPanelTerminals,
-    setActiveTerminal,
+    reorderGroups,
     setTerminalVisible,
     setTerminalPanelOpen,
   } = useTerminalStore.getState()
-  const [draggedTerminalId, setDraggedTerminalId] = useState<string | null>(
-    null
+  const [draggedGroupId, setDraggedGroupId] = useState<string | null>(null)
+  const [editingGroupId, setEditingGroupId] = useState<string | null>(null)
+
+  const handleRenameGroup = useCallback(
+    (groupId: string, name: string) => {
+      useTerminalStore.getState().renameGroup(worktreeId, groupId, name)
+      setEditingGroupId(null)
+    },
+    [worktreeId]
   )
 
-  // Auto-create a terminal only on initial mount (not when tabs are closed)
+  // Auto-create a view only on initial mount (not when tabs are closed)
   const mountedRef = useRef(false)
   useEffect(() => {
     if (!mountedRef.current) {
       mountedRef.current = true
-      const existing = (
-        useTerminalStore.getState().terminals[worktreeId] ?? []
-      ).filter(isPanelTerminal)
-      if (existing.length === 0) {
+      const existingGroups =
+        useTerminalStore.getState().groups[worktreeId] ?? []
+      if (existingGroups.length === 0) {
         addTerminal(worktreeId)
       }
     }
@@ -204,74 +312,169 @@ export function TerminalView({
     addTerminal(worktreeId)
   }, [worktreeId, addTerminal])
 
-  const handleCloseTerminal = useCallback(
-    async (e: React.MouseEvent, terminalId: string) => {
+  const closePanelIfEmpty = useCallback(() => {
+    const remaining = (
+      useTerminalStore.getState().terminals[worktreeId] ?? []
+    ).filter(isPanelTerminal)
+    if (remaining.length === 0) {
+      setTerminalPanelOpen(worktreeId, false)
+      setTerminalVisible(false)
+      useTerminalStore.getState().setModalTerminalOpen(worktreeId, false)
+    }
+  }, [worktreeId, setTerminalPanelOpen, setTerminalVisible])
+
+  const stopAndDispose = useCallback(async (terminalId: string) => {
+    try {
+      await invoke('stop_terminal', { terminalId })
+    } catch {
+      // Terminal may already be stopped
+    }
+    disposeTerminal(terminalId)
+  }, [])
+
+  // Close a whole view (tab): every pane it contains.
+  const handleCloseGroup = useCallback(
+    async (e: React.MouseEvent, groupId: string) => {
       e.stopPropagation()
-      // Stop the PTY process
-      try {
-        await invoke('stop_terminal', { terminalId })
-      } catch {
-        // Terminal may already be stopped
+      const group = (useTerminalStore.getState().groups[worktreeId] ?? []).find(
+        g => g.id === groupId
+      )
+      if (!group) return
+      for (const terminalId of collectLeafIds(group.layout)) {
+        await stopAndDispose(terminalId)
+        useTerminalStore.getState().removeTerminal(worktreeId, terminalId)
       }
-      // Dispose xterm instance (cleanup listeners, clear buffer)
-      disposeTerminal(terminalId)
-      // Remove from store
-      removeTerminal(worktreeId, terminalId)
-      const remaining = (
-        useTerminalStore.getState().terminals[worktreeId] ?? []
-      ).filter(isPanelTerminal)
-      if (remaining.length === 0) {
-        setTerminalPanelOpen(worktreeId, false)
-        setTerminalVisible(false)
-        useTerminalStore.getState().setModalTerminalOpen(worktreeId, false)
-      }
+      closePanelIfEmpty()
     },
-    [worktreeId, removeTerminal, setTerminalPanelOpen, setTerminalVisible]
+    [worktreeId, stopAndDispose, closePanelIfEmpty]
   )
 
-  const handleSelectTerminal = useCallback(
+  // Close a single pane within the active view.
+  const handleCloseSplitPane = useCallback(
+    async (terminalId: string) => {
+      await stopAndDispose(terminalId)
+      useTerminalStore.getState().closeSplitPane(worktreeId, terminalId)
+      closePanelIfEmpty()
+    },
+    [worktreeId, stopAndDispose, closePanelIfEmpty]
+  )
+
+  const handleSelectGroup = useCallback(
+    (groupId: string) => {
+      useTerminalStore.getState().setActiveGroup(worktreeId, groupId)
+    },
+    [worktreeId]
+  )
+
+  const handleSplit = useCallback(
+    (orientation: SplitOrientation) => {
+      useTerminalStore.getState().splitTerminal(worktreeId, orientation)
+    },
+    [worktreeId]
+  )
+
+  const handleDetachPane = useCallback(
     (terminalId: string) => {
-      setActiveTerminal(worktreeId, terminalId)
+      useTerminalStore.getState().detachPane(worktreeId, terminalId)
     },
-    [worktreeId, setActiveTerminal]
+    [worktreeId]
   )
 
-  const handleTerminalDragStart = useCallback(
-    (e: React.DragEvent<HTMLButtonElement>, terminalId: string) => {
-      setDraggedTerminalId(terminalId)
+  const handleRenameTerminal = useCallback(
+    (terminalId: string, label: string) => {
+      useTerminalStore.getState().renameTerminal(worktreeId, terminalId, label)
+    },
+    [worktreeId]
+  )
+
+  // A tab or pane was dropped on a pane. `payload` is `pane:<id>` (move that
+  // pane) or `group:<id>` (merge that single-pane view's terminal).
+  const handlePaneDrop = useCallback(
+    (
+      targetTerminalId: string,
+      orientation: SplitOrientation,
+      payload: string
+    ) => {
+      const store = useTerminalStore.getState()
+      if (payload.startsWith('pane:')) {
+        store.moveTerminalToPane(
+          worktreeId,
+          payload.slice('pane:'.length),
+          targetTerminalId,
+          orientation
+        )
+        return
+      }
+      if (payload.startsWith('group:')) {
+        const sourceGroup = (store.groups[worktreeId] ?? []).find(
+          g => g.id === payload.slice('group:'.length)
+        )
+        // Only single-pane tabs merge into a pane (a whole split can't).
+        if (!sourceGroup || countLeaves(sourceGroup.layout) !== 1) return
+        store.moveTerminalToPane(
+          worktreeId,
+          firstLeafId(sourceGroup.layout),
+          targetTerminalId,
+          orientation
+        )
+      }
+    },
+    [worktreeId]
+  )
+
+  const handleGroupDragStart = useCallback(
+    (e: React.DragEvent<HTMLButtonElement>, groupId: string) => {
+      setDraggedGroupId(groupId)
       e.dataTransfer.effectAllowed = 'move'
-      e.dataTransfer.setData('text/plain', terminalId)
+      e.dataTransfer.setData('text/plain', `group:${groupId}`)
+      // Only single-pane views can drop onto a pane; expose that terminal so
+      // panes can validate the drop (multi-pane tabs only reorder).
+      const grp = (useTerminalStore.getState().groups[worktreeId] ?? []).find(
+        g => g.id === groupId
+      )
+      useTerminalStore
+        .getState()
+        .setDragTerminal(
+          grp && countLeaves(grp.layout) === 1 ? firstLeafId(grp.layout) : null
+        )
     },
-    []
+    [worktreeId]
   )
 
-  const handleTerminalDragOver = useCallback(
+  const handleGroupDragEnd = useCallback(() => {
+    setDraggedGroupId(null)
+    useTerminalStore.getState().setDragTerminal(null)
+  }, [])
+
+  const handleGroupDragOver = useCallback(
     (e: React.DragEvent<HTMLButtonElement>) => {
-      if (!draggedTerminalId) return
+      if (!draggedGroupId) return
       e.preventDefault()
       e.dataTransfer.dropEffect = 'move'
     },
-    [draggedTerminalId]
+    [draggedGroupId]
   )
 
-  const handleTerminalDrop = useCallback(
-    (e: React.DragEvent<HTMLButtonElement>, targetTerminalId: string) => {
+  const handleGroupDrop = useCallback(
+    (e: React.DragEvent<HTMLButtonElement>, targetGroupId: string) => {
       e.preventDefault()
+      const raw = e.dataTransfer.getData('text/plain')
+      // Only tab (group) drags reorder; a pane dropped on a tab is ignored.
       const sourceId =
-        draggedTerminalId || e.dataTransfer.getData('text/plain') || null
-      setDraggedTerminalId(null)
-      if (!sourceId || sourceId === targetTerminalId) return
+        draggedGroupId ?? (raw.startsWith('group:') ? raw.slice(6) : null)
+      setDraggedGroupId(null)
+      if (!sourceId || sourceId === targetGroupId) return
 
-      const panelIds = terminals.map(terminal => terminal.id)
-      const fromIndex = panelIds.indexOf(sourceId)
-      const toIndex = panelIds.indexOf(targetTerminalId)
+      const ids = groups.map(group => group.id)
+      const fromIndex = ids.indexOf(sourceId)
+      const toIndex = ids.indexOf(targetGroupId)
       if (fromIndex === -1 || toIndex === -1) return
 
-      panelIds.splice(fromIndex, 1)
-      panelIds.splice(toIndex, 0, sourceId)
-      reorderPanelTerminals(worktreeId, panelIds)
+      ids.splice(fromIndex, 1)
+      ids.splice(toIndex, 0, sourceId)
+      reorderGroups(worktreeId, ids)
     },
-    [draggedTerminalId, reorderPanelTerminals, terminals, worktreeId]
+    [draggedGroupId, reorderGroups, groups, worktreeId]
   )
 
   const handleMinimize = useCallback(() => {
@@ -303,13 +506,13 @@ export function TerminalView({
         </button>
         {/* Keep terminals mounted but hidden to preserve state */}
         <div className="hidden">
-          {terminals.map(terminal => (
+          {panelTerminals.map(terminal => (
             <TerminalTabContent
               key={terminal.id}
               terminal={terminal}
               worktreeId={worktreeId}
               worktreePath={worktreePath}
-              isActive={terminal.id === activeTerminalId}
+              isVisible={activeLeafIds.has(terminal.id)}
               isCollapsed
               isWorktreeActive={isWorktreeActive}
             />
@@ -329,35 +532,71 @@ export function TerminalView({
         )}
       >
         <div className="flex min-w-0 items-center overflow-x-auto">
-          {terminals.map((terminal, index) => {
-            const isActive = terminal.id === activeTerminalId
-            const isRunning = runningTerminals.has(terminal.id)
+          {groups.map((group, index) => {
+            const isActive = group.id === activeGroupId
+            const leafIds = collectLeafIds(group.layout)
+            const paneCount = leafIds.length
+            const isRunning = leafIds.some(id => runningTerminals.has(id))
+            const derivedLabel =
+              terminalsById.get(group.focusedTerminalId)?.label ??
+              terminalsById.get(leafIds[0] ?? '')?.label ??
+              'Shell'
+            const label = group.name ?? derivedLabel
+            const isEditing = editingGroupId === group.id
             const shortcutLabel =
               index < 9 ? formatShortcutDisplay(`mod+${index + 1}`) : null
 
             return (
               <button
-                key={terminal.id}
+                key={group.id}
                 type="button"
                 draggable
-                onDragStart={e => handleTerminalDragStart(e, terminal.id)}
-                onDragOver={handleTerminalDragOver}
-                onDrop={e => handleTerminalDrop(e, terminal.id)}
-                onDragEnd={() => setDraggedTerminalId(null)}
-                onClick={() => handleSelectTerminal(terminal.id)}
+                onDragStart={e => handleGroupDragStart(e, group.id)}
+                onDragOver={handleGroupDragOver}
+                onDrop={e => handleGroupDrop(e, group.id)}
+                onDragEnd={handleGroupDragEnd}
+                onClick={() => handleSelectGroup(group.id)}
                 className={cn(
                   'group flex shrink-0 items-center gap-1.5 border-r border-border px-3 py-1.5 text-xs transition-colors',
                   isActive
                     ? 'bg-muted text-foreground'
                     : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
-                  draggedTerminalId === terminal.id && 'opacity-60'
+                  draggedGroupId === group.id && 'opacity-60'
                 )}
               >
-                {/* Running indicator */}
+                {/* Running indicator: any pane in this view is running */}
                 {isRunning && (
                   <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
                 )}
-                <span className="max-w-[100px] truncate">{terminal.label}</span>
+                {/* Split indicator: this view tiles several panes */}
+                {paneCount > 1 && (
+                  <span
+                    className="flex items-center gap-0.5 text-primary/80"
+                    title={`${paneCount} panes`}
+                  >
+                    <SquareSplitHorizontal className="h-3 w-3" />
+                    <span className="text-[9px]">{paneCount}</span>
+                  </span>
+                )}
+                {isEditing ? (
+                  <InlineRename
+                    value={label}
+                    onCommit={name => handleRenameGroup(group.id, name)}
+                    onCancel={() => setEditingGroupId(null)}
+                    className="max-w-[100px]"
+                  />
+                ) : (
+                  <span
+                    className="max-w-[100px] truncate"
+                    title="Double-click to rename"
+                    onDoubleClick={e => {
+                      e.stopPropagation()
+                      setEditingGroupId(group.id)
+                    }}
+                  >
+                    {label}
+                  </span>
+                )}
                 {shortcutLabel && (
                   <Kbd
                     className={cn(
@@ -370,16 +609,16 @@ export function TerminalView({
                     {shortcutLabel}
                   </Kbd>
                 )}
-                {/* Close button - always visible */}
+                {/* Close button - closes the whole view */}
                 <span
                   role="button"
                   tabIndex={0}
-                  onClick={e => handleCloseTerminal(e, terminal.id)}
+                  onClick={e => handleCloseGroup(e, group.id)}
                   onKeyDown={e => {
                     if (e.key === 'Enter' || e.key === ' ') {
-                      handleCloseTerminal(
+                      handleCloseGroup(
                         e as unknown as React.MouseEvent,
-                        terminal.id
+                        group.id
                       )
                     }
                   }}
@@ -404,6 +643,30 @@ export function TerminalView({
         >
           <Plus className="h-3.5 w-3.5" />
         </button>
+
+        {/* Split buttons - native desktop only (gated by splitEnabled) */}
+        {splitEnabled && groups.length > 0 && (
+          <>
+            <button
+              type="button"
+              onClick={() => handleSplit('horizontal')}
+              className="flex shrink-0 items-center px-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+              aria-label="Split terminal right"
+              title="Split right"
+            >
+              <SquareSplitHorizontal className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              onClick={() => handleSplit('vertical')}
+              className="flex shrink-0 items-center px-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+              aria-label="Split terminal down"
+              title="Split down"
+            >
+              <SquareSplitVertical className="h-3.5 w-3.5" />
+            </button>
+          </>
+        )}
 
         {/* Spacer */}
         <div className="flex-1" />
@@ -433,18 +696,36 @@ export function TerminalView({
         )}
       </div>
 
-      {/* Terminal content area */}
+      {/* Terminal content area: the active view's layout (1+ panes). */}
       <div className="relative min-h-0 flex-1 overflow-hidden">
-        {terminals.map(terminal => (
-          <TerminalTabContent
-            key={terminal.id}
-            terminal={terminal}
+        {activeGroup && (
+          <TerminalSplitLayout
+            key={activeGroup.id}
             worktreeId={worktreeId}
             worktreePath={worktreePath}
-            isActive={terminal.id === activeTerminalId}
+            layout={activeGroup.layout}
+            focusedTerminalId={activeTerminalId}
             isWorktreeActive={isWorktreeActive}
+            showPaneChrome={activePaneCount > 1}
+            onClosePane={handleCloseSplitPane}
+            onDetachPane={handleDetachPane}
+            onRenameTerminal={handleRenameTerminal}
+            onPaneDrop={splitEnabled ? handlePaneDrop : undefined}
           />
-        ))}
+        )}
+        {/* Keep other views' terminals mounted (hidden) to preserve their buffers */}
+        <div className="hidden">
+          {hiddenTerminals.map(terminal => (
+            <TerminalTabContent
+              key={terminal.id}
+              terminal={terminal}
+              worktreeId={worktreeId}
+              worktreePath={worktreePath}
+              isVisible={false}
+              isWorktreeActive={isWorktreeActive}
+            />
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/src/components/chat/TerminalView.tsx
+++ b/src/components/chat/TerminalView.tsx
@@ -47,16 +47,20 @@ export function InlineRename({
   onCommit,
   onCancel,
   className,
+  ariaLabel,
 }: {
   value: string
   onCommit: (next: string) => void
   onCancel: () => void
   className?: string
+  /** Accessible name for the rename field (e.g. "Rename view"/"Rename pane"). */
+  ariaLabel?: string
 }) {
   const [draft, setDraft] = useState(value)
   return (
     <input
       autoFocus
+      aria-label={ariaLabel}
       value={draft}
       onChange={e => setDraft(e.target.value)}
       onFocus={e => e.currentTarget.select()}
@@ -91,10 +95,12 @@ interface TerminalViewProps {
 /**
  * Individual terminal content surface.
  *
- * `isVisible` drives PTY attach/detach (a terminal is visible when it is the
- * active tab in single mode, or a leaf in the current split layout). `isFocused`
- * drives keyboard focus — exactly one visible pane is focused at a time so
- * multiple split panes don't fight over `focus()`.
+ * `isVisible` gates PTY attach + fit (a terminal is visible when it is the
+ * active tab in single mode, or a leaf in the current split layout). Hidden
+ * terminals stay mounted to preserve their scrollback buffers — they are never
+ * detached here; teardown happens explicitly on close. `isFocused` drives
+ * keyboard focus — exactly one visible pane is focused at a time so multiple
+ * split panes don't fight over `focus()`.
  */
 export const TerminalTabContent = memo(function TerminalTabContent({
   terminal,
@@ -329,7 +335,10 @@ export function TerminalView({
     } catch {
       // Terminal may already be stopped
     }
-    disposeTerminal(terminalId)
+    // disposeTerminal is async; swallow rejection so the chain never rejects.
+    await disposeTerminal(terminalId).catch(() => {
+      /* already disposed */
+    })
   }, [])
 
   // Close a whole view (tab): every pane it contains.
@@ -340,8 +349,11 @@ export function TerminalView({
         g => g.id === groupId
       )
       if (!group) return
-      for (const terminalId of collectLeafIds(group.layout)) {
-        await stopAndDispose(terminalId)
+      const leafIds = collectLeafIds(group.layout)
+      // Stop/dispose every pane concurrently rather than serially — for a
+      // multi-pane view this avoids stacking one PTY round-trip per pane.
+      await Promise.all(leafIds.map(stopAndDispose))
+      for (const terminalId of leafIds) {
         useTerminalStore.getState().removeTerminal(worktreeId, terminalId)
       }
       closePanelIfEmpty()
@@ -463,6 +475,9 @@ export function TerminalView({
       const sourceId =
         draggedGroupId ?? (raw.startsWith('group:') ? raw.slice(6) : null)
       setDraggedGroupId(null)
+      // Clear the cross-pane drag id here too — don't rely solely on dragEnd,
+      // which may not fire when the drop is handled outside the drag source.
+      useTerminalStore.getState().setDragTerminal(null)
       if (!sourceId || sourceId === targetGroupId) return
 
       const ids = groups.map(group => group.id)
@@ -584,6 +599,7 @@ export function TerminalView({
                     onCommit={name => handleRenameGroup(group.id, name)}
                     onCancel={() => setEditingGroupId(null)}
                     className="max-w-[100px]"
+                    ariaLabel="Rename view"
                   />
                 ) : (
                   <span

--- a/src/components/preferences/panes/KeybindingsPane.tsx
+++ b/src/components/preferences/panes/KeybindingsPane.tsx
@@ -65,9 +65,10 @@ const categoryTitles: Record<string, string> = {
   chat: 'Chat',
   navigation: 'Navigation',
   git: 'Git',
+  terminal: 'Terminal',
 }
 
-const categoryOrder = ['chat', 'navigation', 'git']
+const categoryOrder = ['chat', 'navigation', 'git', 'terminal']
 
 interface KeybindingsPaneProps {
   searchTargetAction?: KeybindingAction | null

--- a/src/hooks/useMainWindowEventListeners.test.tsx
+++ b/src/hooks/useMainWindowEventListeners.test.tsx
@@ -6,22 +6,28 @@ import {
   addTerminalTabForShortcut,
   blurFocusedTerminalForShortcut,
   closeActiveTerminalTabForShortcut,
+  closeFocusedTerminalPaneForShortcut,
   findKeybindingAction,
+  focusNextTerminalPaneForShortcut,
   getTerminalShortcutWorktreeId,
   isPlainSessionTerminalFocused,
   shouldAllowKeybindingThroughOpenOverlay,
   shouldLetPlanDialogHandleAction,
+  splitTerminalForShortcut,
   switchActiveTerminalTabByIndexForShortcut,
 } from './useMainWindowEventListeners'
+import { collectLeafIds } from '@/lib/terminal-split'
 import { DEFAULT_KEYBINDINGS } from '@/types/keybindings'
 
-const { mockInvoke, mockListen, mockDisposeTerminal } = vi.hoisted(() => ({
-  mockInvoke: vi.fn().mockResolvedValue(undefined),
-  mockListen: vi.fn().mockResolvedValue(() => {
-    /* noop cleanup */
-  }),
-  mockDisposeTerminal: vi.fn(),
-}))
+const { mockInvoke, mockListen, mockDisposeTerminal, isNativeAppMock } =
+  vi.hoisted(() => ({
+    mockInvoke: vi.fn().mockResolvedValue(undefined),
+    mockListen: vi.fn().mockResolvedValue(() => {
+      /* noop cleanup */
+    }),
+    mockDisposeTerminal: vi.fn(),
+    isNativeAppMock: vi.fn(() => true),
+  }))
 
 vi.mock('@/lib/transport', () => ({
   invoke: mockInvoke,
@@ -32,6 +38,11 @@ vi.mock('@/lib/terminal-instances', () => ({
   disposeTerminal: mockDisposeTerminal,
   startHeadless: vi.fn(),
 }))
+
+vi.mock('@/lib/environment', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, isNativeApp: () => isNativeAppMock() }
+})
 
 function focusTerminal() {
   document.body.innerHTML = ''
@@ -318,11 +329,27 @@ describe('useMainWindowEventListeners terminal shortcuts', () => {
           },
         ],
       },
+      groups: {
+        'modal-worktree': [
+          {
+            id: 'gm1',
+            layout: { type: 'leaf', terminalId: 'term-1' },
+            focusedTerminalId: 'term-1',
+          },
+          {
+            id: 'gm2',
+            layout: { type: 'leaf', terminalId: 'term-2' },
+            focusedTerminalId: 'term-2',
+          },
+        ],
+      },
+      activeGroupIds: { 'modal-worktree': 'gm1' },
       activeTerminalIds: { 'modal-worktree': 'term-1' },
       modalTerminalOpen: { 'modal-worktree': true },
       terminalVisible: true,
     })
 
+    // Tabs are views (groups) now; index 1 = the second view (term-2).
     expect(switchActiveTerminalTabByIndexForShortcut(1)).toBe(true)
     expect(
       useTerminalStore.getState().activeTerminalIds['modal-worktree']
@@ -425,5 +452,106 @@ describe('dialog overlay keybinding passthrough', () => {
         useUIStore.getState()
       )
     ).toBe(false)
+  })
+})
+
+describe('terminal split-pane shortcuts', () => {
+  const activeLayoutIds = (worktreeId: string): string[] => {
+    const s = useTerminalStore.getState()
+    const group = (s.groups[worktreeId] ?? []).find(
+      g => g.id === s.activeGroupIds[worktreeId]
+    )
+    return group ? collectLeafIds(group.layout) : []
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isNativeAppMock.mockReturnValue(true)
+    document.body.innerHTML = ''
+
+    useChatStore.setState({ activeWorktreeId: 'w1' })
+    useUIStore.setState({
+      sessionChatModalOpen: false,
+      sessionChatModalWorktreeId: null,
+    })
+    useTerminalStore.setState({
+      terminals: {},
+      groups: {},
+      activeGroupIds: {},
+      activeTerminalIds: {},
+      runningTerminals: new Set(),
+      failedTerminals: new Set(),
+      terminalVisible: true,
+      terminalPanelOpen: { w1: true },
+      modalTerminalOpen: {},
+    })
+  })
+
+  it('splits the focused pane (in the active view) on native desktop', () => {
+    const a = useTerminalStore.getState().addTerminal('w1')
+
+    expect(splitTerminalForShortcut('horizontal')).toBe(true)
+
+    const ids = activeLayoutIds('w1')
+    expect(ids).toHaveLength(2)
+    expect(ids[0]).toBe(a)
+  })
+
+  it('does not split on web access (non-native)', () => {
+    isNativeAppMock.mockReturnValue(false)
+    useTerminalStore.getState().addTerminal('w1')
+
+    expect(splitTerminalForShortcut('horizontal')).toBe(false)
+    expect(activeLayoutIds('w1')).toHaveLength(1)
+  })
+
+  it('does not split when the terminal panel is closed', () => {
+    // addTerminal opens the panel, so close it afterwards.
+    useTerminalStore.getState().addTerminal('w1')
+    useTerminalStore.setState({ terminalPanelOpen: {} })
+
+    expect(splitTerminalForShortcut('horizontal')).toBe(false)
+  })
+
+  it('focus_next_pane cycles focus across panes of the active view', () => {
+    const a = useTerminalStore.getState().addTerminal('w1')
+    const b = useTerminalStore.getState().splitTerminal('w1', 'horizontal')
+
+    // After split the new pane (b) is focused; next wraps to a, then back to b.
+    expect(useTerminalStore.getState().activeTerminalIds.w1).toBe(b)
+    focusNextTerminalPaneForShortcut()
+    expect(useTerminalStore.getState().activeTerminalIds.w1).toBe(a)
+    focusNextTerminalPaneForShortcut()
+    expect(useTerminalStore.getState().activeTerminalIds.w1).toBe(b)
+  })
+
+  it('focus_next_pane is a no-op without a split', () => {
+    useTerminalStore.getState().addTerminal('w1')
+    expect(focusNextTerminalPaneForShortcut()).toBe(false)
+  })
+
+  it('close_terminal_pane stops + disposes the focused pane, view survives', () => {
+    const a = useTerminalStore.getState().addTerminal('w1')
+    const b = useTerminalStore.getState().splitTerminal('w1', 'horizontal')
+
+    expect(closeFocusedTerminalPaneForShortcut()).toBe(true)
+
+    // PTY stopped + xterm disposed for the focused pane (b).
+    expect(mockInvoke).toHaveBeenCalledWith('stop_terminal', {
+      terminalId: b,
+    })
+    expect(mockDisposeTerminal).toHaveBeenCalledWith(b)
+
+    const state = useTerminalStore.getState()
+    expect(state.terminals.w1?.map(t => t.id)).toEqual([a])
+    // The view stays as a single-pane view focused on the sibling.
+    expect(activeLayoutIds('w1')).toEqual([a])
+    expect(state.activeTerminalIds.w1).toBe(a)
+  })
+
+  it('close_terminal_pane is a no-op for a single-pane view', () => {
+    useTerminalStore.getState().addTerminal('w1')
+    expect(closeFocusedTerminalPaneForShortcut()).toBe(false)
+    expect(mockDisposeTerminal).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/useMainWindowEventListeners.test.tsx
+++ b/src/hooks/useMainWindowEventListeners.test.tsx
@@ -25,7 +25,7 @@ const { mockInvoke, mockListen, mockDisposeTerminal, isNativeAppMock } =
     mockListen: vi.fn().mockResolvedValue(() => {
       /* noop cleanup */
     }),
-    mockDisposeTerminal: vi.fn(),
+    mockDisposeTerminal: vi.fn().mockResolvedValue(undefined),
     isNativeAppMock: vi.fn(() => true),
   }))
 

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -218,7 +218,10 @@ export function closeFocusedTerminalPaneForShortcut(): boolean {
   invoke('stop_terminal', { terminalId: focusedId }).catch(() => {
     /* noop */
   })
-  disposeTerminal(focusedId)
+  // disposeTerminal is async; fire-and-forget but swallow rejections.
+  void disposeTerminal(focusedId).catch(() => {
+    /* noop */
+  })
   store.closeSplitPane(worktreeId, focusedId)
   return true
 }

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -7,6 +7,12 @@ import { useUIStore } from '@/store/ui-store'
 import { useProjectsStore } from '@/store/projects-store'
 import { useChatStore } from '@/store/chat-store'
 import { isPanelTerminal, useTerminalStore } from '@/store/terminal-store'
+import {
+  collectLeafIds,
+  countLeaves,
+  hasLeaf,
+  type SplitOrientation,
+} from '@/lib/terminal-split'
 import { useBrowserStore } from '@/store/browser-store'
 import { projectsQueryKeys } from '@/services/projects'
 import { chatQueryKeys } from '@/services/chat'
@@ -147,15 +153,91 @@ export function switchActiveTerminalTabByIndexForShortcut(
   if (!worktreeId) return false
 
   const terminalStore = useTerminalStore.getState()
-  const terminals = (terminalStore.terminals[worktreeId] ?? []).filter(
-    isPanelTerminal
-  )
-  const targetTerminal = terminals[index]
+  // Tabs are views (groups) now; switch by view index.
+  const targetGroup = (terminalStore.groups[worktreeId] ?? [])[index]
 
-  if (targetTerminal) {
-    terminalStore.setActiveTerminal(worktreeId, targetTerminal.id)
+  if (targetGroup) {
+    terminalStore.setActiveGroup(worktreeId, targetGroup.id)
   }
 
+  return true
+}
+
+/** The worktree whose terminal surface is current (modal-aware), regardless of
+ * DOM focus — split shortcuts work whether or not the terminal has focus. */
+function getActiveTerminalWorktreeId(): string | null {
+  const uiState = useUIStore.getState()
+  const chatState = useChatStore.getState()
+  const worktreeId = uiState.sessionChatModalOpen
+    ? (uiState.sessionChatModalWorktreeId ?? chatState.activeWorktreeId)
+    : chatState.activeWorktreeId
+  if (!worktreeId) return null
+
+  const terminalState = useTerminalStore.getState()
+  const open =
+    terminalState.terminalPanelOpen[worktreeId] ||
+    terminalState.modalTerminalOpen[worktreeId]
+  return open ? worktreeId : null
+}
+
+export function splitTerminalForShortcut(
+  orientation: SplitOrientation
+): boolean {
+  // Split panes are a native-desktop affordance only.
+  if (!isNativeApp()) return false
+  const worktreeId = getActiveTerminalWorktreeId()
+  if (!worktreeId) return false
+  return (
+    useTerminalStore.getState().splitTerminal(worktreeId, orientation) !==
+    undefined
+  )
+}
+
+export function closeFocusedTerminalPaneForShortcut(): boolean {
+  if (!isNativeApp()) return false
+  const worktreeId = getActiveTerminalWorktreeId()
+  if (!worktreeId) return false
+
+  const store = useTerminalStore.getState()
+  const focusedId = store.activeTerminalIds[worktreeId]
+  const activeGroup = (store.groups[worktreeId] ?? []).find(
+    g => g.id === store.activeGroupIds[worktreeId]
+  )
+  // Only acts inside a real split (>1 pane); single-pane views use Close tab.
+  if (
+    !focusedId ||
+    !activeGroup ||
+    countLeaves(activeGroup.layout) < 2 ||
+    !hasLeaf(activeGroup.layout, focusedId)
+  ) {
+    return false
+  }
+
+  invoke('stop_terminal', { terminalId: focusedId }).catch(() => {
+    /* noop */
+  })
+  disposeTerminal(focusedId)
+  store.closeSplitPane(worktreeId, focusedId)
+  return true
+}
+
+export function focusNextTerminalPaneForShortcut(): boolean {
+  if (!isNativeApp()) return false
+  const worktreeId = getActiveTerminalWorktreeId()
+  if (!worktreeId) return false
+
+  const store = useTerminalStore.getState()
+  const activeGroup = (store.groups[worktreeId] ?? []).find(
+    g => g.id === store.activeGroupIds[worktreeId]
+  )
+  if (!activeGroup) return false
+  const ids = collectLeafIds(activeGroup.layout)
+  if (ids.length < 2) return false
+
+  const current = store.activeTerminalIds[worktreeId] ?? ''
+  const index = ids.indexOf(current)
+  const next = ids[(index + 1) % ids.length]
+  if (next) store.setActiveTerminal(worktreeId, next)
   return true
 }
 
@@ -460,6 +542,22 @@ function executeKeybindingAction(
       }
       break
     }
+    case 'split_terminal_horizontal':
+      logger.debug('Keybinding: split_terminal_horizontal')
+      splitTerminalForShortcut('horizontal')
+      break
+    case 'split_terminal_vertical':
+      logger.debug('Keybinding: split_terminal_vertical')
+      splitTerminalForShortcut('vertical')
+      break
+    case 'close_terminal_pane':
+      logger.debug('Keybinding: close_terminal_pane')
+      closeFocusedTerminalPaneForShortcut()
+      break
+    case 'focus_next_pane':
+      logger.debug('Keybinding: focus_next_pane')
+      focusNextTerminalPaneForShortcut()
+      break
     case 'toggle_browser': {
       logger.debug('Keybinding: toggle_browser')
       const uiState = useUIStore.getState()
@@ -681,7 +779,11 @@ export function useMainWindowEventListeners() {
             shortcut === kb.toggle_terminal ||
             shortcut === kb.toggle_browser ||
             shortcut === kb.open_new_session_modal ||
-            shortcut === kb.cancel_prompt
+            shortcut === kb.cancel_prompt ||
+            shortcut === kb.split_terminal_horizontal ||
+            shortcut === kb.split_terminal_vertical ||
+            shortcut === kb.close_terminal_pane ||
+            shortcut === kb.focus_next_pane
           ) {
             // Let these fall through to the normal keybinding handler below
           } else {

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -6,7 +6,11 @@ import { useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { useUIStore } from '@/store/ui-store'
 import { useProjectsStore } from '@/store/projects-store'
 import { useChatStore } from '@/store/chat-store'
-import { isPanelTerminal, useTerminalStore } from '@/store/terminal-store'
+import {
+  getActiveGroup,
+  isPanelTerminal,
+  useTerminalStore,
+} from '@/store/terminal-store'
 import {
   collectLeafIds,
   countLeaves,
@@ -200,9 +204,7 @@ export function closeFocusedTerminalPaneForShortcut(): boolean {
 
   const store = useTerminalStore.getState()
   const focusedId = store.activeTerminalIds[worktreeId]
-  const activeGroup = (store.groups[worktreeId] ?? []).find(
-    g => g.id === store.activeGroupIds[worktreeId]
-  )
+  const activeGroup = getActiveGroup(store, worktreeId)
   // Only acts inside a real split (>1 pane); single-pane views use Close tab.
   if (
     !focusedId ||
@@ -227,9 +229,7 @@ export function focusNextTerminalPaneForShortcut(): boolean {
   if (!worktreeId) return false
 
   const store = useTerminalStore.getState()
-  const activeGroup = (store.groups[worktreeId] ?? []).find(
-    g => g.id === store.activeGroupIds[worktreeId]
-  )
+  const activeGroup = getActiveGroup(store, worktreeId)
   if (!activeGroup) return false
   const ids = collectLeafIds(activeGroup.layout)
   if (ids.length < 2) return false

--- a/src/lib/terminal-instances.ts
+++ b/src/lib/terminal-instances.ts
@@ -540,6 +540,12 @@ function shouldLetAppHandleShortcut(event: KeyboardEvent): boolean {
   if (!event.shiftKey && !event.altKey && /^Digit[1-9]$/.test(code)) {
     return true
   }
+  // CMD+\ / CMD+Shift+\ → split terminal pane (right / down)
+  if (!event.altKey && code === 'Backslash') return true
+  // CMD+Shift+W → close focused split pane
+  if (event.shiftKey && !event.altKey && code === 'KeyW') return true
+  // CMD+] → focus next split pane
+  if (!event.shiftKey && !event.altKey && code === 'BracketRight') return true
   // CMD+Alt+Backspace → cancel prompt
   return event.altKey && (code === 'Backspace' || code === 'Delete')
 }

--- a/src/lib/terminal-split.test.ts
+++ b/src/lib/terminal-split.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest'
+import {
+  collectLeafIds,
+  countLeaves,
+  firstLeafId,
+  hasLeaf,
+  leaf,
+  pruneLeaf,
+  setSizesAtPath,
+  splitLeaf,
+  type SplitNode,
+} from './terminal-split'
+
+describe('terminal-split helpers', () => {
+  describe('leaf / collectLeafIds / countLeaves', () => {
+    it('builds a single leaf', () => {
+      expect(leaf('a')).toEqual({ type: 'leaf', terminalId: 'a' })
+      expect(collectLeafIds(leaf('a'))).toEqual(['a'])
+      expect(countLeaves(leaf('a'))).toBe(1)
+    })
+
+    it('collects ids in document order across nested splits', () => {
+      const tree: SplitNode = {
+        type: 'split',
+        orientation: 'horizontal',
+        children: [
+          leaf('a'),
+          {
+            type: 'split',
+            orientation: 'vertical',
+            children: [leaf('b'), leaf('c')],
+          },
+        ],
+      }
+      expect(collectLeafIds(tree)).toEqual(['a', 'b', 'c'])
+      expect(countLeaves(tree)).toBe(3)
+    })
+  })
+
+  describe('hasLeaf / firstLeafId', () => {
+    it('detects presence', () => {
+      const tree = splitLeaf(leaf('a'), 'a', 'horizontal', 'b')
+      expect(hasLeaf(tree, 'a')).toBe(true)
+      expect(hasLeaf(tree, 'b')).toBe(true)
+      expect(hasLeaf(tree, 'z')).toBe(false)
+    })
+
+    it('returns the top-left leaf', () => {
+      const tree = splitLeaf(leaf('a'), 'a', 'vertical', 'b')
+      expect(firstLeafId(tree)).toBe('a')
+    })
+  })
+
+  describe('splitLeaf', () => {
+    it('wraps a single leaf into a binary split, old leaf first, 50/50', () => {
+      const tree = splitLeaf(leaf('a'), 'a', 'horizontal', 'b')
+      expect(tree).toEqual({
+        type: 'split',
+        orientation: 'horizontal',
+        children: [leaf('a'), leaf('b')],
+        sizes: [50, 50],
+      })
+    })
+
+    it('splits a nested leaf without touching siblings or parent sizes', () => {
+      const tree: SplitNode = {
+        type: 'split',
+        orientation: 'horizontal',
+        children: [leaf('a'), leaf('b')],
+        sizes: [30, 70],
+      }
+      const next = splitLeaf(tree, 'b', 'vertical', 'c')
+      expect(next).toEqual({
+        type: 'split',
+        orientation: 'horizontal',
+        children: [
+          leaf('a'),
+          {
+            type: 'split',
+            orientation: 'vertical',
+            children: [leaf('b'), leaf('c')],
+            sizes: [50, 50],
+          },
+        ],
+        sizes: [30, 70],
+      })
+    })
+
+    it('returns same reference when target is absent', () => {
+      const tree = leaf('a')
+      expect(splitLeaf(tree, 'z', 'horizontal', 'b')).toBe(tree)
+    })
+  })
+
+  describe('pruneLeaf', () => {
+    it('returns null when removing the only leaf', () => {
+      expect(pruneLeaf(leaf('a'), 'a')).toBeNull()
+    })
+
+    it('collapses a binary split to the surviving sibling', () => {
+      const tree = splitLeaf(leaf('a'), 'a', 'horizontal', 'b')
+      expect(pruneLeaf(tree, 'b')).toEqual(leaf('a'))
+    })
+
+    it('keeps remaining children and renormalizes sizes', () => {
+      const tree: SplitNode = {
+        type: 'split',
+        orientation: 'horizontal',
+        children: [leaf('a'), leaf('b'), leaf('c')],
+        sizes: [20, 30, 50],
+      }
+      const next = pruneLeaf(tree, 'b')
+      expect(next).toEqual({
+        type: 'split',
+        orientation: 'horizontal',
+        children: [leaf('a'), leaf('c')],
+        // [20, 50] renormalized to 100
+        sizes: [(20 / 70) * 100, (50 / 70) * 100],
+      })
+    })
+
+    it('returns same reference when terminal is absent', () => {
+      const tree = splitLeaf(leaf('a'), 'a', 'horizontal', 'b')
+      expect(pruneLeaf(tree, 'z')).toBe(tree)
+    })
+
+    it('prunes deeply and collapses nested splits', () => {
+      const tree: SplitNode = {
+        type: 'split',
+        orientation: 'horizontal',
+        children: [
+          leaf('a'),
+          {
+            type: 'split',
+            orientation: 'vertical',
+            children: [leaf('b'), leaf('c')],
+          },
+        ],
+      }
+      // Removing c collapses the inner split to leaf(b); outer split collapses
+      // to a horizontal [a, b].
+      expect(pruneLeaf(tree, 'c')).toEqual({
+        type: 'split',
+        orientation: 'horizontal',
+        children: [leaf('a'), leaf('b')],
+      })
+    })
+  })
+
+  describe('setSizesAtPath', () => {
+    it('sets sizes on the root split', () => {
+      const tree = splitLeaf(leaf('a'), 'a', 'horizontal', 'b')
+      const next = setSizesAtPath(tree, [], [40, 60])
+      expect(next.type === 'split' && next.sizes).toEqual([40, 60])
+    })
+
+    it('sets sizes on a nested split via path', () => {
+      const tree: SplitNode = {
+        type: 'split',
+        orientation: 'horizontal',
+        children: [
+          leaf('a'),
+          {
+            type: 'split',
+            orientation: 'vertical',
+            children: [leaf('b'), leaf('c')],
+          },
+        ],
+      }
+      const next = setSizesAtPath(tree, [1], [25, 75])
+      const inner = next.type === 'split' ? next.children[1] : null
+      expect(inner && inner.type === 'split' && inner.sizes).toEqual([25, 75])
+    })
+
+    it('returns same reference when sizes are unchanged', () => {
+      const tree: SplitNode = {
+        type: 'split',
+        orientation: 'horizontal',
+        children: [leaf('a'), leaf('b')],
+        sizes: [50, 50],
+      }
+      expect(setSizesAtPath(tree, [], [50, 50])).toBe(tree)
+    })
+  })
+})

--- a/src/lib/terminal-split.ts
+++ b/src/lib/terminal-split.ts
@@ -1,0 +1,160 @@
+/**
+ * Pure helpers for the terminal split-pane layout tree.
+ *
+ * A split layout is an immutable tree of leaves (one terminal each) and split
+ * nodes (horizontal/vertical groups of children). Layouts live in session
+ * memory only (terminal-store) and are never persisted — they describe a
+ * temporary tiling of the terminals that already exist for a worktree/session.
+ *
+ * All functions are pure: they return a new tree only when something changed,
+ * otherwise they return the same reference (so the store's no-op guards hold).
+ */
+
+export type SplitOrientation = 'horizontal' | 'vertical'
+
+export type SplitNode =
+  | { type: 'leaf'; terminalId: string }
+  | {
+      type: 'split'
+      orientation: SplitOrientation
+      children: SplitNode[]
+      /** Panel sizes in percent, one per child. Undefined = equal split. */
+      sizes?: number[]
+    }
+
+/** Build a single-leaf layout. */
+export function leaf(terminalId: string): SplitNode {
+  return { type: 'leaf', terminalId }
+}
+
+/** All terminal IDs in the tree, left-to-right / top-to-bottom order. */
+export function collectLeafIds(node: SplitNode): string[] {
+  if (node.type === 'leaf') return [node.terminalId]
+  return node.children.flatMap(collectLeafIds)
+}
+
+/** Whether the tree contains a leaf for this terminal. */
+export function hasLeaf(node: SplitNode, terminalId: string): boolean {
+  if (node.type === 'leaf') return node.terminalId === terminalId
+  return node.children.some(child => hasLeaf(child, terminalId))
+}
+
+/** The first (top-left-most) leaf's terminal ID. */
+export function firstLeafId(node: SplitNode): string {
+  let current = node
+  while (current.type === 'split') {
+    current = current.children[0] as SplitNode
+  }
+  return current.terminalId
+}
+
+/** Number of leaves (panes) in the tree. */
+export function countLeaves(node: SplitNode): number {
+  if (node.type === 'leaf') return 1
+  return node.children.reduce((sum, child) => sum + countLeaves(child), 0)
+}
+
+/**
+ * Replace the leaf for `targetTerminalId` with a split that contains the old
+ * leaf and a new leaf for `newTerminalId`. Returns the same node reference if
+ * the target leaf is not present.
+ */
+export function splitLeaf(
+  node: SplitNode,
+  targetTerminalId: string,
+  orientation: SplitOrientation,
+  newTerminalId: string
+): SplitNode {
+  if (node.type === 'leaf') {
+    if (node.terminalId !== targetTerminalId) return node
+    return {
+      type: 'split',
+      orientation,
+      children: [leaf(targetTerminalId), leaf(newTerminalId)],
+      // Explicit 50/50 so react-resizable-panels has concrete sizes on first
+      // mount (avoids a transient layout where the divider is invisible).
+      sizes: [50, 50],
+    }
+  }
+
+  let changed = false
+  const children = node.children.map(child => {
+    const next = splitLeaf(child, targetTerminalId, orientation, newTerminalId)
+    if (next !== child) changed = true
+    return next
+  })
+  if (!changed) return node
+  // Replacing a leaf child with a split child keeps the child count, so the
+  // parent's `sizes` array stays valid.
+  return { ...node, children }
+}
+
+/**
+ * Remove the leaf for `terminalId`. Split nodes left with a single child
+ * collapse into that child. Returns null when the whole tree is removed, or
+ * the same reference when the terminal was not present.
+ */
+export function pruneLeaf(
+  node: SplitNode,
+  terminalId: string
+): SplitNode | null {
+  if (node.type === 'leaf') {
+    return node.terminalId === terminalId ? null : node
+  }
+
+  let changed = false
+  const kept: { child: SplitNode; index: number }[] = []
+  node.children.forEach((child, index) => {
+    const pruned = pruneLeaf(child, terminalId)
+    if (pruned === null) {
+      changed = true
+      return
+    }
+    if (pruned !== child) changed = true
+    kept.push({ child: pruned, index })
+  })
+
+  if (!changed) return node
+  if (kept.length === 0) return null
+  if (kept.length === 1) return kept[0]?.child ?? null
+
+  const children = kept.map(entry => entry.child)
+  let sizes = node.sizes
+  if (sizes && children.length !== node.children.length) {
+    const picked = kept.map(entry => node.sizes?.[entry.index] ?? 0)
+    const total = picked.reduce((sum, value) => sum + value, 0)
+    sizes = total > 0 ? picked.map(value => (value / total) * 100) : undefined
+  }
+  return { ...node, children, sizes }
+}
+
+/**
+ * Set the `sizes` array of the split node at `path` (a list of child indices
+ * from the root). Returns the same reference when nothing changed.
+ */
+export function setSizesAtPath(
+  node: SplitNode,
+  path: number[],
+  sizes: number[]
+): SplitNode {
+  if (path.length === 0) {
+    if (node.type !== 'split') return node
+    if (sizesEqual(node.sizes, sizes)) return node
+    return { ...node, sizes }
+  }
+  if (node.type !== 'split') return node
+  const [head, ...rest] = path
+  if (head === undefined) return node
+  const child = node.children[head]
+  if (!child) return node
+  const next = setSizesAtPath(child, rest, sizes)
+  if (next === child) return node
+  const children = [...node.children]
+  children[head] = next
+  return { ...node, children }
+}
+
+function sizesEqual(a: number[] | undefined, b: number[]): boolean {
+  if (!a || a.length !== b.length) return false
+  return a.every((value, index) => value === b[index])
+}

--- a/src/store/terminal-store.test.ts
+++ b/src/store/terminal-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { useTerminalStore } from './terminal-store'
+import { useTerminalStore, type TerminalGroup } from './terminal-store'
+import { collectLeafIds, leaf } from '@/lib/terminal-split'
 
 // Mock crypto.randomUUID
 vi.stubGlobal('crypto', {
@@ -12,6 +13,8 @@ describe('TerminalStore', () => {
   beforeEach(() => {
     useTerminalStore.setState({
       terminals: {},
+      groups: {},
+      activeGroupIds: {},
       activeTerminalIds: {},
       runningTerminals: new Set(),
       failedTerminals: new Set(),
@@ -234,28 +237,24 @@ describe('TerminalStore', () => {
       )
     })
 
-    it('reorders panel terminals while preserving session terminals and active terminal', () => {
-      const { addTerminal, reorderPanelTerminals } = useTerminalStore.getState()
+    it('reorders views (tabs) by group id without changing the active view', () => {
+      const { addTerminal, reorderGroups } = useTerminalStore.getState()
 
-      const panelA = addTerminal('worktree-1', null, 'A')
-      const sessionId = addTerminal('worktree-1', null, 'Session Terminal', {
-        kind: 'session',
-        activate: false,
-        openPanel: false,
-      })
-      const panelB = addTerminal('worktree-1', null, 'B')
-      const panelC = addTerminal('worktree-1', null, 'C')
+      addTerminal('worktree-1', null, 'A')
+      addTerminal('worktree-1', null, 'B')
+      addTerminal('worktree-1', null, 'C') // last added view is active
 
-      reorderPanelTerminals('worktree-1', [panelC, panelA, panelB])
+      const groupIds = (
+        useTerminalStore.getState().groups['worktree-1'] ?? []
+      ).map(g => g.id)
+      const [gA, gB, gC] = groupIds
+
+      reorderGroups('worktree-1', [gC as string, gA as string, gB as string])
 
       const state = useTerminalStore.getState()
-      expect(state.terminals['worktree-1']?.map(t => t.id)).toEqual([
-        panelC,
-        sessionId,
-        panelA,
-        panelB,
-      ])
-      expect(state.activeTerminalIds['worktree-1']).toBe(panelC)
+      expect(state.groups['worktree-1']?.map(g => g.id)).toEqual([gC, gA, gB])
+      // Active view is preserved across reorder.
+      expect(state.activeGroupIds['worktree-1']).toBe(gC)
     })
 
     it('gets terminals for worktree', () => {
@@ -482,6 +481,293 @@ describe('TerminalStore', () => {
       expect(useTerminalStore.getState().terminalPanelOpen['worktree-1']).toBe(
         false
       )
+    })
+  })
+
+  describe('views (split panes / multiplexer)', () => {
+    const requireActiveGroup = (worktreeId: string): TerminalGroup => {
+      const s = useTerminalStore.getState()
+      const group = (s.groups[worktreeId] ?? []).find(
+        g => g.id === s.activeGroupIds[worktreeId]
+      )
+      if (!group) throw new Error('no active group')
+      return group
+    }
+
+    it('each new terminal is its own single-pane view (tab)', () => {
+      const { addTerminal } = useTerminalStore.getState()
+      addTerminal('w1')
+      addTerminal('w1')
+      const s = useTerminalStore.getState()
+      expect(s.groups['w1']).toHaveLength(2)
+      expect(
+        s.groups['w1']?.every(g => collectLeafIds(g.layout).length === 1)
+      ).toBe(true)
+    })
+
+    it('splitTerminal adds a pane to the ACTIVE view (no new tab) and focuses it', () => {
+      const { addTerminal, splitTerminal } = useTerminalStore.getState()
+      const a = addTerminal('w1')
+      const groupId = useTerminalStore.getState().activeGroupIds['w1']
+
+      const newId = splitTerminal('w1', 'horizontal')
+
+      const s = useTerminalStore.getState()
+      expect(newId).toBeDefined()
+      expect(s.groups['w1']).toHaveLength(1) // same view, no extra tab
+      expect(s.activeGroupIds['w1']).toBe(groupId)
+      const group = requireActiveGroup('w1')
+      expect(group.layout.type).toBe('split')
+      expect(group.layout.type === 'split' && group.layout.orientation).toBe(
+        'horizontal'
+      )
+      expect(collectLeafIds(group.layout)).toEqual([a, newId])
+      expect(s.activeTerminalIds['w1']).toBe(newId)
+      expect(group.focusedTerminalId).toBe(newId)
+    })
+
+    it('does not split without an active view', () => {
+      expect(
+        useTerminalStore.getState().splitTerminal('w1', 'horizontal')
+      ).toBeUndefined()
+      expect(useTerminalStore.getState().groups['w1']).toBeUndefined()
+    })
+
+    it('supports nested mixed (H + V) splits within a view', () => {
+      const { addTerminal, splitTerminal } = useTerminalStore.getState()
+      const a = addTerminal('w1')
+      const b = splitTerminal('w1', 'horizontal')
+      const c = splitTerminal('w1', 'vertical')
+
+      const group = requireActiveGroup('w1')
+      expect(collectLeafIds(group.layout)).toEqual([a, b, c])
+      expect(group.layout.type === 'split' && group.layout.orientation).toBe(
+        'horizontal'
+      )
+    })
+
+    it('closeSplitPane prunes a pane and keeps the view (now single pane)', () => {
+      const { addTerminal, splitTerminal, closeSplitPane } =
+        useTerminalStore.getState()
+      const a = addTerminal('w1')
+      const b = splitTerminal('w1', 'horizontal')
+
+      closeSplitPane('w1', b as string)
+
+      const s = useTerminalStore.getState()
+      expect(s.terminals['w1']?.map(t => t.id)).toEqual([a])
+      expect(s.groups['w1']).toHaveLength(1)
+      expect(collectLeafIds(requireActiveGroup('w1').layout)).toEqual([a])
+      expect(s.activeTerminalIds['w1']).toBe(a)
+    })
+
+    it('closeSplitPane keeps the split when 3 → 2 panes remain', () => {
+      const { addTerminal, splitTerminal, closeSplitPane } =
+        useTerminalStore.getState()
+      const a = addTerminal('w1')
+      const b = splitTerminal('w1', 'horizontal')
+      const c = splitTerminal('w1', 'horizontal')
+
+      closeSplitPane('w1', c as string)
+
+      expect(collectLeafIds(requireActiveGroup('w1').layout)).toEqual([a, b])
+    })
+
+    it('closing the last pane removes the view and selects a neighbour', () => {
+      const { addTerminal, removeTerminal } = useTerminalStore.getState()
+      const a = addTerminal('w1') // view A
+      const b = addTerminal('w1') // view B (active)
+
+      removeTerminal('w1', b)
+
+      const s = useTerminalStore.getState()
+      expect(s.groups['w1']).toHaveLength(1)
+      expect(s.activeGroupIds['w1']).toBe(s.groups['w1']?.[0]?.id)
+      expect(s.activeTerminalIds['w1']).toBe(a)
+    })
+
+    it('removeTerminal of a tiled pane prunes its view', () => {
+      const { addTerminal, splitTerminal, removeTerminal } =
+        useTerminalStore.getState()
+      const a = addTerminal('w1')
+      const b = splitTerminal('w1', 'horizontal')
+
+      removeTerminal('w1', a)
+
+      expect(useTerminalStore.getState().groups['w1']).toHaveLength(1)
+      expect(collectLeafIds(requireActiveGroup('w1').layout)).toEqual([b])
+    })
+
+    it('moveTerminalToPane merges a single-pane view into another view', () => {
+      const { addTerminal, moveTerminalToPane } = useTerminalStore.getState()
+      const a = addTerminal('w1') // view A
+      const b = addTerminal('w1') // view B (active)
+
+      moveTerminalToPane('w1', a, b, 'horizontal')
+
+      const s = useTerminalStore.getState()
+      expect(s.groups['w1']).toHaveLength(1) // source view removed
+      // splitLeaf puts the target pane first, the moved terminal second.
+      expect(collectLeafIds(requireActiveGroup('w1').layout)).toEqual([b, a])
+      expect(s.activeTerminalIds['w1']).toBe(a)
+    })
+
+    it('moveTerminalToPane moves a pane out of a multi-pane view (source survives)', () => {
+      const { addTerminal, splitTerminal, moveTerminalToPane } =
+        useTerminalStore.getState()
+      const a = addTerminal('w1') // view A (single)
+      const bTerm = addTerminal('w1') // view B (active)
+      const cTerm = splitTerminal('w1', 'horizontal') // view B = [bTerm, cTerm]
+
+      // Move cTerm out of view B into view A.
+      moveTerminalToPane('w1', cTerm as string, a, 'horizontal')
+
+      const s = useTerminalStore.getState()
+      expect(s.groups['w1']).toHaveLength(2) // both views survive
+      const groups = s.groups['w1'] ?? []
+      // View A now tiles [a, cTerm]; view B collapsed to [bTerm].
+      const viewA = groups.find(g => collectLeafIds(g.layout).includes(a))
+      const viewB = groups.find(g => collectLeafIds(g.layout).includes(bTerm))
+      expect(viewA && collectLeafIds(viewA.layout)).toEqual([a, cTerm])
+      expect(viewB && collectLeafIds(viewB.layout)).toEqual([bTerm])
+      expect(s.activeTerminalIds['w1']).toBe(cTerm)
+    })
+
+    it('moveTerminalToPane relocates a pane within the same view', () => {
+      const { addTerminal, splitTerminal, moveTerminalToPane } =
+        useTerminalStore.getState()
+      const a = addTerminal('w1')
+      const b = splitTerminal('w1', 'horizontal') // view = [a, b] horizontal
+
+      // Relocate a to split b vertically ⇒ [b, a] vertical, still one view.
+      moveTerminalToPane('w1', a, b as string, 'vertical')
+
+      const s = useTerminalStore.getState()
+      expect(s.groups['w1']).toHaveLength(1)
+      const layout = requireActiveGroup('w1').layout
+      expect(collectLeafIds(layout)).toEqual([b, a])
+      expect(layout.type === 'split' && layout.orientation).toBe('vertical')
+      expect(s.activeTerminalIds['w1']).toBe(a)
+    })
+
+    it('detachPane pops a pane out of a split into its own view', () => {
+      const { addTerminal, splitTerminal, detachPane } =
+        useTerminalStore.getState()
+      const a = addTerminal('w1')
+      const b = splitTerminal('w1', 'horizontal') // one view [a, b]
+
+      detachPane('w1', b as string)
+
+      const s = useTerminalStore.getState()
+      expect(s.groups['w1']).toHaveLength(2) // source view + new detached view
+      const groups = s.groups['w1'] ?? []
+      expect(collectLeafIds(groups[0]?.layout ?? leaf('x'))).toEqual([a])
+      expect(collectLeafIds(groups[1]?.layout ?? leaf('x'))).toEqual([b])
+      // The detached pane becomes the active view/terminal.
+      expect(s.activeTerminalIds['w1']).toBe(b)
+      expect(s.activeGroupIds['w1']).toBe(groups[1]?.id)
+    })
+
+    it('detachPane is a no-op for a single-pane view', () => {
+      const { addTerminal, detachPane } = useTerminalStore.getState()
+      addTerminal('w1')
+      const before = useTerminalStore.getState().groups['w1']
+      detachPane(
+        'w1',
+        collectLeafIds(before?.[0]?.layout ?? leaf('x'))[0] ?? ''
+      )
+      expect(useTerminalStore.getState().groups['w1']).toBe(before)
+    })
+
+    it('setDragTerminal tracks the dragged terminal and guards no-ops', () => {
+      const { setDragTerminal } = useTerminalStore.getState()
+      setDragTerminal('t1')
+      expect(useTerminalStore.getState().dragTerminalId).toBe('t1')
+      const ref = useTerminalStore.getState()
+      setDragTerminal('t1') // no-op ⇒ same state reference
+      expect(useTerminalStore.getState()).toBe(ref)
+      setDragTerminal(null)
+      expect(useTerminalStore.getState().dragTerminalId).toBeNull()
+    })
+
+    it('renameGroup sets a custom view name (trimmed); blank reverts it', () => {
+      const { addTerminal, renameGroup } = useTerminalStore.getState()
+      addTerminal('w1')
+      const groupId = useTerminalStore.getState().groups['w1']?.[0]?.id ?? ''
+
+      renameGroup('w1', groupId, '  Build  ')
+      expect(useTerminalStore.getState().groups['w1']?.[0]?.name).toBe('Build')
+
+      renameGroup('w1', groupId, '   ')
+      expect(
+        useTerminalStore.getState().groups['w1']?.[0]?.name
+      ).toBeUndefined()
+    })
+
+    it('renameTerminal sets a custom label; blank reverts to the derived one', () => {
+      const { addTerminal, renameTerminal, getTerminals } =
+        useTerminalStore.getState()
+      const id = addTerminal('w1', 'bun run dev') // derived label "bun"
+
+      renameTerminal('w1', id, 'Dev server')
+      expect(getTerminals('w1')[0]?.label).toBe('Dev server')
+
+      renameTerminal('w1', id, '   ')
+      expect(getTerminals('w1')[0]?.label).toBe('bun')
+    })
+
+    it('setActiveGroup switches the active view and its focus', () => {
+      const { addTerminal, setActiveGroup } = useTerminalStore.getState()
+      addTerminal('w1') // view A
+      addTerminal('w1') // view B (active)
+
+      const groupA = useTerminalStore.getState().groups['w1']?.[0]
+      if (!groupA) throw new Error('missing group')
+      setActiveGroup('w1', groupA.id)
+
+      const s = useTerminalStore.getState()
+      expect(s.activeGroupIds['w1']).toBe(groupA.id)
+      expect(s.activeTerminalIds['w1']).toBe(groupA.focusedTerminalId)
+    })
+
+    it('setPaneSizes stores sizes on the active view and guards no-ops', () => {
+      const { addTerminal, splitTerminal, setPaneSizes } =
+        useTerminalStore.getState()
+      addTerminal('w1')
+      splitTerminal('w1', 'horizontal')
+
+      setPaneSizes('w1', [], [30, 70])
+      const group = requireActiveGroup('w1')
+      expect(group.layout.type === 'split' && group.layout.sizes).toEqual([
+        30, 70,
+      ])
+
+      const groupsRef = useTerminalStore.getState().groups['w1']
+      setPaneSizes('w1', [], [30, 70]) // no-op ⇒ same groups reference
+      expect(useTerminalStore.getState().groups['w1']).toBe(groupsRef)
+    })
+
+    it('closeAllTerminals clears all views', () => {
+      const { addTerminal, splitTerminal, closeAllTerminals } =
+        useTerminalStore.getState()
+      addTerminal('w1')
+      splitTerminal('w1', 'horizontal')
+
+      closeAllTerminals('w1')
+
+      expect(useTerminalStore.getState().groups['w1']).toBeUndefined()
+      expect(useTerminalStore.getState().activeGroupIds['w1']).toBe('')
+    })
+
+    it('closePanelTerminals clears all views', () => {
+      const { addTerminal, splitTerminal, closePanelTerminals } =
+        useTerminalStore.getState()
+      addTerminal('w1')
+      splitTerminal('w1', 'horizontal')
+
+      closePanelTerminals('w1')
+
+      expect(useTerminalStore.getState().groups['w1']).toBeUndefined()
     })
   })
 

--- a/src/store/terminal-store.ts
+++ b/src/store/terminal-store.ts
@@ -1,6 +1,17 @@
 import { create } from 'zustand'
 import { getFilename } from '@/lib/path-utils'
 import { generateId } from '@/lib/uuid'
+import {
+  countLeaves,
+  firstLeafId,
+  hasLeaf,
+  leaf,
+  pruneLeaf,
+  setSizesAtPath,
+  splitLeaf,
+  type SplitNode,
+  type SplitOrientation,
+} from '@/lib/terminal-split'
 import type { ModalTerminalDockMode } from '@/types/ui-state'
 import { useBrowserStore } from './browser-store'
 
@@ -17,6 +28,22 @@ export interface TerminalInstance {
   kind?: TerminalKind
 }
 
+/**
+ * A terminal "view" — one tab in the strip. A view holds a split-pane layout
+ * (tree of panel terminals) plus the pane that currently owns the keyboard.
+ * A single-pane view (`layout` = one leaf) behaves exactly like a classic tab.
+ * Views are session-only state (never persisted) and only ever tile panel
+ * terminals; session terminals live outside any group.
+ */
+export interface TerminalGroup {
+  id: string
+  layout: SplitNode
+  /** The focused pane (a leaf terminal id) within this view. */
+  focusedTerminalId: string
+  /** Optional user-given view name; falls back to the focused pane's label. */
+  name?: string
+}
+
 export interface AddTerminalOptions {
   kind?: TerminalKind
   commandArgs?: string[] | null
@@ -31,10 +58,19 @@ export function isPanelTerminal(terminal: TerminalInstance): boolean {
 }
 
 interface TerminalState {
-  // Terminal instances per worktree (worktreeId -> terminals)
+  // Terminal instances per worktree (worktreeId -> terminals). This is the flat
+  // registry of every PTY-backed terminal; groups reference these by id.
   terminals: Record<string, TerminalInstance[]>
-  // Active terminal ID per worktree
+  // Views (tabs) per worktree. Each view tiles one or more panel terminals.
+  groups: Record<string, TerminalGroup[]>
+  // Active view (tab) per worktree.
+  activeGroupIds: Record<string, string>
+  // Focused pane per worktree — always a leaf of the active view's layout. Kept
+  // as the canonical "current terminal" id for run-reuse, shortcuts, etc.
   activeTerminalIds: Record<string, string>
+  // The terminal currently being dragged (tab or pane), or null. Lets panes
+  // accept a drop only when it would actually do something (source ≠ target).
+  dragTerminalId: string | null
   // Set of running terminal IDs (have active PTY process)
   runningTerminals: Set<string>
   // Set of terminal IDs that exited with non-zero exit code (crash/failure)
@@ -72,13 +108,49 @@ interface TerminalState {
     options?: AddTerminalOptions
   ) => string
   removeTerminal: (worktreeId: string, terminalId: string) => void
-  reorderPanelTerminals: (
-    worktreeId: string,
-    panelTerminalIds: string[]
-  ) => void
+  /** Reorder the views (tabs) of a worktree by group id. */
+  reorderGroups: (worktreeId: string, groupIds: string[]) => void
+  /** Focus a pane (and make its view active). Accepts any tiled panel terminal. */
   setActiveTerminal: (worktreeId: string, terminalId: string) => void
+  /** Switch the active view (tab), focusing its remembered pane. */
+  setActiveGroup: (worktreeId: string, groupId: string) => void
+  /** Track the terminal being dragged for split (tab or pane); null when idle. */
+  setDragTerminal: (terminalId: string | null) => void
+  /** Rename a view (tab). Empty/blank name reverts to the derived label. */
+  renameGroup: (worktreeId: string, groupId: string, name: string) => void
+  /** Rename a terminal (pane). Empty/blank reverts to the command-derived label. */
+  renameTerminal: (
+    worktreeId: string,
+    terminalId: string,
+    label: string
+  ) => void
   getTerminals: (worktreeId: string) => TerminalInstance[]
   getActiveTerminal: (worktreeId: string) => TerminalInstance | null
+
+  // Split-pane (multiplexer) management
+  /** Split the focused pane of the active view, creating a new terminal in that
+   * same view. Returns its id, or undefined when there is no focusable pane. */
+  splitTerminal: (
+    worktreeId: string,
+    orientation: SplitOrientation
+  ) => string | undefined
+  /** Move any pane to split `targetTerminalId` — works across views and within
+   * one view (relocate). Prunes the source view (dropping it when emptied).
+   * Powers drag-a-tab-onto-a-pane merges and drag-a-pane-onto-a-pane moves. */
+  moveTerminalToPane: (
+    worktreeId: string,
+    sourceTerminalId: string,
+    targetTerminalId: string,
+    orientation: SplitOrientation
+  ) => void
+  /** Detach a pane from its split into a brand-new view (tab) right after it.
+   * No-op for a single-pane view. The PTY/xterm is preserved. */
+  detachPane: (worktreeId: string, terminalId: string) => void
+  /** Close one pane (prune the view; remove the view when its last pane goes).
+   * Does NOT stop the PTY / dispose xterm — callers handle that side effect. */
+  closeSplitPane: (worktreeId: string, terminalId: string) => void
+  /** Persist the panel sizes of the active view's split node at `path` (root = []). */
+  setPaneSizes: (worktreeId: string, path: number[], sizes: number[]) => void
 
   // Running state (terminal has active PTY)
   setTerminalRunning: (terminalId: string, running: boolean) => void
@@ -99,6 +171,26 @@ interface TerminalState {
 
 function generateTerminalId(): string {
   return generateId()
+}
+
+function generateGroupId(): string {
+  return generateId()
+}
+
+/** Drop one key from a record, returning the same reference when absent so the
+ * store's no-op guards hold (no spurious re-render for subscribers). */
+function omitKey<T>(record: Record<string, T>, key: string): Record<string, T> {
+  if (!(key in record)) return record
+  const { [key]: _removed, ...rest } = record
+  return rest
+}
+
+/** The view containing this terminal, if any (panel terminals only). */
+function findGroupOf(
+  groups: TerminalGroup[],
+  terminalId: string
+): TerminalGroup | undefined {
+  return groups.find(group => hasLeaf(group.layout, terminalId))
 }
 
 /** Close every browser surface for this worktree — terminal modal and
@@ -134,7 +226,10 @@ function getDefaultLabel(command: string | null): string {
 
 export const useTerminalStore = create<TerminalState>((set, get) => ({
   terminals: {},
+  groups: {},
+  activeGroupIds: {},
   activeTerminalIds: {},
+  dragTerminalId: null,
   runningTerminals: new Set(),
   failedTerminals: new Set(),
   terminalVisible: false,
@@ -242,12 +337,31 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
           [worktreeId]: [...existing, terminal],
         },
       }
-      if (activate) {
-        nextState.activeTerminalIds = {
-          ...state.activeTerminalIds,
-          [worktreeId]: id,
+
+      // A new panel terminal is a new view (tab) with a single pane.
+      if (kind === 'panel') {
+        const group: TerminalGroup = {
+          id: generateGroupId(),
+          layout: leaf(id),
+          focusedTerminalId: id,
+        }
+        const existingGroups = state.groups[worktreeId] ?? []
+        nextState.groups = {
+          ...state.groups,
+          [worktreeId]: [...existingGroups, group],
+        }
+        if (activate) {
+          nextState.activeGroupIds = {
+            ...state.activeGroupIds,
+            [worktreeId]: group.id,
+          }
+          nextState.activeTerminalIds = {
+            ...state.activeTerminalIds,
+            [worktreeId]: id,
+          }
         }
       }
+
       if (openPanel) {
         nextState.terminalPanelOpen = {
           ...state.terminalPanelOpen,
@@ -267,85 +381,183 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       const hadTerminal = existing.some(t => t.id === terminalId)
       const wasRunning = state.runningTerminals.has(terminalId)
       const wasFailed = state.failedTerminals.has(terminalId)
-      const wasActive = state.activeTerminalIds[worktreeId] === terminalId
+      const groups = state.groups[worktreeId] ?? []
+      const group = findGroupOf(groups, terminalId)
 
-      if (!hadTerminal && !wasRunning && !wasFailed && !wasActive) {
+      if (!hadTerminal && !wasRunning && !wasFailed && !group) {
         return state
       }
 
       const filtered = existing.filter(t => t.id !== terminalId)
 
-      // Update running terminals
       const newRunning = new Set(state.runningTerminals)
       newRunning.delete(terminalId)
-
-      // Update failed terminals
       const newFailed = new Set(state.failedTerminals)
       newFailed.delete(terminalId)
 
-      // Update active terminal if needed
-      const currentActiveId = state.activeTerminalIds[worktreeId] ?? ''
-      const newActiveId =
-        currentActiveId === terminalId
-          ? (filtered.filter(isPanelTerminal).at(-1)?.id ?? '')
-          : currentActiveId
+      let nextGroups = groups
+      let activeGroupId = state.activeGroupIds[worktreeId] ?? ''
+      let activeTerminalId = state.activeTerminalIds[worktreeId] ?? ''
+
+      if (group) {
+        const pruned = pruneLeaf(group.layout, terminalId)
+        if (pruned === null) {
+          // Last pane of the view closed → drop the whole view (tab).
+          const index = groups.indexOf(group)
+          nextGroups = groups.filter(g => g !== group)
+          if (activeGroupId === group.id) {
+            const neighbour =
+              nextGroups[index] ??
+              nextGroups[index - 1] ??
+              nextGroups[nextGroups.length - 1]
+            activeGroupId = neighbour?.id ?? ''
+            activeTerminalId = neighbour?.focusedTerminalId ?? ''
+          }
+        } else {
+          const focused = hasLeaf(pruned, group.focusedTerminalId)
+            ? group.focusedTerminalId
+            : firstLeafId(pruned)
+          const updated: TerminalGroup = {
+            ...group,
+            layout: pruned,
+            focusedTerminalId: focused,
+          }
+          nextGroups = groups.map(g => (g === group ? updated : g))
+          if (activeGroupId === group.id) {
+            activeTerminalId = focused
+          }
+        }
+      }
 
       return {
-        terminals: {
-          ...state.terminals,
-          [worktreeId]: filtered,
+        terminals: { ...state.terminals, [worktreeId]: filtered },
+        groups: { ...state.groups, [worktreeId]: nextGroups },
+        activeGroupIds: {
+          ...state.activeGroupIds,
+          [worktreeId]: activeGroupId,
         },
         activeTerminalIds: {
           ...state.activeTerminalIds,
-          [worktreeId]: newActiveId,
+          [worktreeId]: activeTerminalId,
         },
         runningTerminals: newRunning,
         failedTerminals: newFailed,
       }
     }),
 
-  reorderPanelTerminals: (worktreeId, panelTerminalIds) =>
+  reorderGroups: (worktreeId, groupIds) =>
     set(state => {
-      const existing = state.terminals[worktreeId] ?? []
-      const panelTerminals = existing.filter(isPanelTerminal)
-      if (panelTerminals.length !== panelTerminalIds.length) return state
+      const groups = state.groups[worktreeId] ?? []
+      if (groups.length !== groupIds.length) return state
 
-      const panelById = new Map(panelTerminals.map(t => [t.id, t]))
-      const reorderedPanels = panelTerminalIds.map(id => panelById.get(id))
-      if (reorderedPanels.some(t => !t)) return state
+      const byId = new Map(groups.map(g => [g.id, g]))
+      const reordered = groupIds.map(id => byId.get(id))
+      if (reordered.some(g => !g)) return state
 
-      const nextPanels = reorderedPanels as TerminalInstance[]
-      let panelIndex = 0
-      const next = existing.map(terminal => {
-        if (!isPanelTerminal(terminal)) return terminal
-        const nextPanel = nextPanels[panelIndex]
-        panelIndex += 1
-        return nextPanel ?? terminal
-      })
+      const next = reordered as TerminalGroup[]
+      if (next.every((g, index) => g === groups[index])) return state
 
-      if (next.every((terminal, index) => terminal === existing[index])) {
-        return state
-      }
-
-      return {
-        terminals: {
-          ...state.terminals,
-          [worktreeId]: next,
-        },
-      }
+      return { groups: { ...state.groups, [worktreeId]: next } }
     }),
 
   setActiveTerminal: (worktreeId, terminalId) =>
     set(state => {
-      const terminal = (state.terminals[worktreeId] ?? []).find(
-        t => t.id === terminalId
-      )
-      if (!terminal || !isPanelTerminal(terminal)) return state
-      if (state.activeTerminalIds[worktreeId] === terminalId) return state
+      const groups = state.groups[worktreeId] ?? []
+      const group = findGroupOf(groups, terminalId)
+      if (!group) return state
+
+      const alreadyActive =
+        state.activeGroupIds[worktreeId] === group.id &&
+        state.activeTerminalIds[worktreeId] === terminalId &&
+        group.focusedTerminalId === terminalId
+      if (alreadyActive) return state
+
+      const nextGroups =
+        group.focusedTerminalId === terminalId
+          ? state.groups
+          : {
+              ...state.groups,
+              [worktreeId]: groups.map(g =>
+                g === group ? { ...g, focusedTerminalId: terminalId } : g
+              ),
+            }
+
       return {
+        groups: nextGroups,
+        activeGroupIds: { ...state.activeGroupIds, [worktreeId]: group.id },
         activeTerminalIds: {
           ...state.activeTerminalIds,
           [worktreeId]: terminalId,
+        },
+      }
+    }),
+
+  setActiveGroup: (worktreeId, groupId) =>
+    set(state => {
+      const groups = state.groups[worktreeId] ?? []
+      const group = groups.find(g => g.id === groupId)
+      if (!group) return state
+
+      const focused = hasLeaf(group.layout, group.focusedTerminalId)
+        ? group.focusedTerminalId
+        : firstLeafId(group.layout)
+
+      if (
+        state.activeGroupIds[worktreeId] === groupId &&
+        state.activeTerminalIds[worktreeId] === focused
+      ) {
+        return state
+      }
+
+      return {
+        activeGroupIds: { ...state.activeGroupIds, [worktreeId]: groupId },
+        activeTerminalIds: {
+          ...state.activeTerminalIds,
+          [worktreeId]: focused,
+        },
+      }
+    }),
+
+  setDragTerminal: terminalId =>
+    set(state =>
+      state.dragTerminalId === terminalId
+        ? state
+        : { dragTerminalId: terminalId }
+    ),
+
+  renameGroup: (worktreeId, groupId, name) =>
+    set(state => {
+      const groups = state.groups[worktreeId] ?? []
+      const group = groups.find(g => g.id === groupId)
+      if (!group) return state
+      const trimmed = name.trim()
+      const nextName = trimmed.length > 0 ? trimmed : undefined
+      if (group.name === nextName) return state
+      return {
+        groups: {
+          ...state.groups,
+          [worktreeId]: groups.map(g =>
+            g === group ? { ...g, name: nextName } : g
+          ),
+        },
+      }
+    }),
+
+  renameTerminal: (worktreeId, terminalId, label) =>
+    set(state => {
+      const terminals = state.terminals[worktreeId] ?? []
+      const terminal = terminals.find(t => t.id === terminalId)
+      if (!terminal) return state
+      const trimmed = label.trim()
+      const nextLabel =
+        trimmed.length > 0 ? trimmed : getDefaultLabel(terminal.command)
+      if (terminal.label === nextLabel) return state
+      return {
+        terminals: {
+          ...state.terminals,
+          [worktreeId]: terminals.map(t =>
+            t === terminal ? { ...t, label: nextLabel } : t
+          ),
         },
       }
     }),
@@ -357,6 +569,207 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     const activeId = get().activeTerminalIds[worktreeId]
     return terminals.find(t => isPanelTerminal(t) && t.id === activeId) ?? null
   },
+
+  splitTerminal: (worktreeId, orientation) => {
+    const state = get()
+    const groups = state.groups[worktreeId] ?? []
+    const group = groups.find(g => g.id === state.activeGroupIds[worktreeId])
+    const focusedId = state.activeTerminalIds[worktreeId]
+    if (!group || !focusedId || !hasLeaf(group.layout, focusedId)) {
+      return undefined
+    }
+
+    const newId = generateTerminalId()
+    const terminal: TerminalInstance = {
+      id: newId,
+      worktreeId,
+      command: null,
+      commandArgs: null,
+      label: getDefaultLabel(null),
+      kind: 'panel',
+    }
+
+    set(s => {
+      const sGroups = s.groups[worktreeId] ?? []
+      const sGroup = sGroups.find(g => g.id === group.id)
+      if (!sGroup) return s
+      const updated: TerminalGroup = {
+        ...sGroup,
+        layout: splitLeaf(sGroup.layout, focusedId, orientation, newId),
+        focusedTerminalId: newId,
+      }
+      return {
+        terminals: {
+          ...s.terminals,
+          [worktreeId]: [...(s.terminals[worktreeId] ?? []), terminal],
+        },
+        groups: {
+          ...s.groups,
+          [worktreeId]: sGroups.map(g => (g === sGroup ? updated : g)),
+        },
+        activeTerminalIds: { ...s.activeTerminalIds, [worktreeId]: newId },
+        terminalVisible: true,
+        terminalPanelOpen: { ...s.terminalPanelOpen, [worktreeId]: true },
+      }
+    })
+
+    return newId
+  },
+
+  moveTerminalToPane: (
+    worktreeId,
+    sourceTerminalId,
+    targetTerminalId,
+    orientation
+  ) =>
+    set(state => {
+      if (sourceTerminalId === targetTerminalId) return state
+      const groups = state.groups[worktreeId] ?? []
+      const sourceGroup = findGroupOf(groups, sourceTerminalId)
+      const targetGroup = findGroupOf(groups, targetTerminalId)
+      if (!sourceGroup || !targetGroup) return state
+
+      // Relocate within the same view: prune, then re-split at the target.
+      if (sourceGroup === targetGroup) {
+        const pruned = pruneLeaf(sourceGroup.layout, sourceTerminalId)
+        if (!pruned) return state
+        const relocated = splitLeaf(
+          pruned,
+          targetTerminalId,
+          orientation,
+          sourceTerminalId
+        )
+        if (relocated === pruned) return state // target vanished — give up
+        const updated: TerminalGroup = {
+          ...sourceGroup,
+          layout: relocated,
+          focusedTerminalId: sourceTerminalId,
+        }
+        return {
+          groups: {
+            ...state.groups,
+            [worktreeId]: groups.map(g => (g === sourceGroup ? updated : g)),
+          },
+          activeGroupIds: {
+            ...state.activeGroupIds,
+            [worktreeId]: sourceGroup.id,
+          },
+          activeTerminalIds: {
+            ...state.activeTerminalIds,
+            [worktreeId]: sourceTerminalId,
+          },
+        }
+      }
+
+      // Cross-view move: splice into the target, prune the source view.
+      const updatedTarget: TerminalGroup = {
+        ...targetGroup,
+        layout: splitLeaf(
+          targetGroup.layout,
+          targetTerminalId,
+          orientation,
+          sourceTerminalId
+        ),
+        focusedTerminalId: sourceTerminalId,
+      }
+      const prunedSource = pruneLeaf(sourceGroup.layout, sourceTerminalId)
+      let nextGroups: TerminalGroup[]
+      if (prunedSource === null) {
+        nextGroups = groups
+          .filter(g => g !== sourceGroup)
+          .map(g => (g === targetGroup ? updatedTarget : g))
+      } else {
+        const updatedSource: TerminalGroup = {
+          ...sourceGroup,
+          layout: prunedSource,
+          focusedTerminalId: hasLeaf(
+            prunedSource,
+            sourceGroup.focusedTerminalId
+          )
+            ? sourceGroup.focusedTerminalId
+            : firstLeafId(prunedSource),
+        }
+        nextGroups = groups.map(g =>
+          g === sourceGroup
+            ? updatedSource
+            : g === targetGroup
+              ? updatedTarget
+              : g
+        )
+      }
+
+      return {
+        groups: { ...state.groups, [worktreeId]: nextGroups },
+        activeGroupIds: {
+          ...state.activeGroupIds,
+          [worktreeId]: targetGroup.id,
+        },
+        activeTerminalIds: {
+          ...state.activeTerminalIds,
+          [worktreeId]: sourceTerminalId,
+        },
+      }
+    }),
+
+  detachPane: (worktreeId, terminalId) =>
+    set(state => {
+      const groups = state.groups[worktreeId] ?? []
+      const group = findGroupOf(groups, terminalId)
+      // Nothing to detach from a single-pane view.
+      if (!group || countLeaves(group.layout) < 2) return state
+
+      const pruned = pruneLeaf(group.layout, terminalId)
+      if (!pruned) return state
+      const updatedSource: TerminalGroup = {
+        ...group,
+        layout: pruned,
+        focusedTerminalId: hasLeaf(pruned, group.focusedTerminalId)
+          ? group.focusedTerminalId
+          : firstLeafId(pruned),
+      }
+      const newGroup: TerminalGroup = {
+        id: generateGroupId(),
+        layout: leaf(terminalId),
+        focusedTerminalId: terminalId,
+      }
+      // Insert the detached view right after the source view.
+      const index = groups.indexOf(group)
+      const nextGroups = [...groups]
+      nextGroups[index] = updatedSource
+      nextGroups.splice(index + 1, 0, newGroup)
+
+      return {
+        groups: { ...state.groups, [worktreeId]: nextGroups },
+        activeGroupIds: { ...state.activeGroupIds, [worktreeId]: newGroup.id },
+        activeTerminalIds: {
+          ...state.activeTerminalIds,
+          [worktreeId]: terminalId,
+        },
+      }
+    }),
+
+  // Closing a pane is exactly removing its terminal: removeTerminal prunes the
+  // view, drops it when empty, and re-focuses a surviving sibling.
+  closeSplitPane: (worktreeId, terminalId) => {
+    get().removeTerminal(worktreeId, terminalId)
+  },
+
+  setPaneSizes: (worktreeId, path, sizes) =>
+    set(state => {
+      const groups = state.groups[worktreeId] ?? []
+      const group = groups.find(g => g.id === state.activeGroupIds[worktreeId])
+      if (!group) return state
+      const next = setSizesAtPath(group.layout, path, sizes)
+      if (next === group.layout) return state
+      return {
+        groups: {
+          ...state.groups,
+          [worktreeId]: groups.map(g =>
+            g === group ? { ...g, layout: next } : g
+          ),
+        },
+      }
+    }),
 
   setTerminalRunning: (terminalId, running) =>
     set(state => {
@@ -397,8 +810,24 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     )
 
     if (existingTerminal) {
-      // Focus the existing terminal instead of creating a new one
+      // Focus the existing terminal (and its view) instead of creating one.
+      const groups = state.groups[worktreeId] ?? []
+      const group = findGroupOf(groups, existingTerminal.id)
       set({
+        groups:
+          group && group.focusedTerminalId !== existingTerminal.id
+            ? {
+                ...state.groups,
+                [worktreeId]: groups.map(g =>
+                  g === group
+                    ? { ...g, focusedTerminalId: existingTerminal.id }
+                    : g
+                ),
+              }
+            : state.groups,
+        activeGroupIds: group
+          ? { ...state.activeGroupIds, [worktreeId]: group.id }
+          : state.activeGroupIds,
         activeTerminalIds: {
           ...state.activeTerminalIds,
           [worktreeId]: existingTerminal.id,
@@ -422,7 +851,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       set({ failedTerminals: newFailed })
     }
 
-    // No existing running terminal, create a new one (addTerminal sets terminalPanelOpen)
+    // No existing running terminal — create a new view (addTerminal opens panel).
     return get().addTerminal(worktreeId, command)
   },
 
@@ -451,6 +880,11 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       terminals: {
         ...state.terminals,
         [worktreeId]: [],
+      },
+      groups: omitKey(state.groups, worktreeId),
+      activeGroupIds: {
+        ...state.activeGroupIds,
+        [worktreeId]: '',
       },
       activeTerminalIds: {
         ...state.activeTerminalIds,
@@ -493,6 +927,13 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       terminals: {
         ...state.terminals,
         [worktreeId]: sessionTerminals,
+      },
+      // Views only ever tile panel terminals, so dropping the worktree entry is
+      // safe even though session terminals are preserved.
+      groups: omitKey(state.groups, worktreeId),
+      activeGroupIds: {
+        ...state.activeGroupIds,
+        [worktreeId]: '',
       },
       activeTerminalIds: {
         ...state.activeTerminalIds,

--- a/src/store/terminal-store.ts
+++ b/src/store/terminal-store.ts
@@ -193,6 +193,15 @@ function findGroupOf(
   return groups.find(group => hasLeaf(group.layout, terminalId))
 }
 
+/** The currently-active view for a worktree, from a store snapshot. */
+export function getActiveGroup(
+  state: TerminalState,
+  worktreeId: string
+): TerminalGroup | undefined {
+  const groups = state.groups[worktreeId] ?? []
+  return groups.find(g => g.id === state.activeGroupIds[worktreeId])
+}
+
 /** Close every browser surface for this worktree — terminal modal and
  * browser surfaces are mutually exclusive. Called inside terminal-store
  * actions when opening the terminal modal. */

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -61,7 +61,7 @@ export interface KeybindingDefinition {
   label: string
   description: string
   default_shortcut: ShortcutString
-  category: 'navigation' | 'git' | 'chat'
+  category: 'navigation' | 'git' | 'chat' | 'terminal'
 }
 
 // Default keybindings configuration
@@ -298,7 +298,7 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     label: 'Toggle terminal',
     description: 'Show or hide the terminal panel',
     default_shortcut: 'mod+backquote',
-    category: 'chat',
+    category: 'terminal',
   },
   {
     action: 'toggle_browser',
@@ -425,28 +425,28 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     label: 'Split terminal right',
     description: 'Split the focused terminal pane into left/right panes',
     default_shortcut: 'mod+backslash',
-    category: 'chat',
+    category: 'terminal',
   },
   {
     action: 'split_terminal_vertical',
     label: 'Split terminal down',
     description: 'Split the focused terminal pane into top/bottom panes',
     default_shortcut: 'mod+shift+backslash',
-    category: 'chat',
+    category: 'terminal',
   },
   {
     action: 'close_terminal_pane',
     label: 'Close terminal pane',
     description: 'Close the focused split pane and collapse to its sibling',
     default_shortcut: 'mod+shift+w',
-    category: 'chat',
+    category: 'terminal',
   },
   {
     action: 'focus_next_pane',
     label: 'Focus next pane',
     description: 'Move keyboard focus to the next terminal split pane',
     default_shortcut: 'mod+bracketright',
-    category: 'chat',
+    category: 'terminal',
   },
 ]
 

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -43,6 +43,10 @@ export type KeybindingAction =
   | 'open_quick_menu'
   | 'open_usage_dropdown'
   | 'search_chat'
+  | 'split_terminal_horizontal'
+  | 'split_terminal_vertical'
+  | 'close_terminal_pane'
+  | 'focus_next_pane'
 
 // Shortcut string format: "mod+key" where mod is cmd/ctrl
 // Examples: "mod+l", "mod+shift+p", "mod+1"
@@ -105,6 +109,10 @@ export const DEFAULT_KEYBINDINGS: KeybindingsMap = {
   open_quick_menu: 'mod+period',
   open_usage_dropdown: 'mod+u',
   search_chat: 'mod+f',
+  split_terminal_horizontal: 'mod+backslash',
+  split_terminal_vertical: 'mod+shift+backslash',
+  close_terminal_pane: 'mod+shift+w',
+  focus_next_pane: 'mod+bracketright',
 }
 
 // UI definitions for the settings pane
@@ -412,6 +420,34 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     default_shortcut: 'mod+f',
     category: 'chat',
   },
+  {
+    action: 'split_terminal_horizontal',
+    label: 'Split terminal right',
+    description: 'Split the focused terminal pane into left/right panes',
+    default_shortcut: 'mod+backslash',
+    category: 'chat',
+  },
+  {
+    action: 'split_terminal_vertical',
+    label: 'Split terminal down',
+    description: 'Split the focused terminal pane into top/bottom panes',
+    default_shortcut: 'mod+shift+backslash',
+    category: 'chat',
+  },
+  {
+    action: 'close_terminal_pane',
+    label: 'Close terminal pane',
+    description: 'Close the focused split pane and collapse to its sibling',
+    default_shortcut: 'mod+shift+w',
+    category: 'chat',
+  },
+  {
+    action: 'focus_next_pane',
+    label: 'Focus next pane',
+    description: 'Move keyboard focus to the next terminal split pane',
+    default_shortcut: 'mod+bracketright',
+    category: 'chat',
+  },
 ]
 
 // Helper to convert shortcut string to display format
@@ -452,6 +488,12 @@ export function formatShortcutDisplay(
           return '→'
         case 'slash':
           return '/'
+        case 'backslash':
+          return '\\'
+        case 'bracketleft':
+          return '['
+        case 'bracketright':
+          return ']'
         case 'backspace':
           return isMac ? '⌫' : 'Backspace'
         case 'enter':


### PR DESCRIPTION
## Summary

Adds split-pane (multiplexer) support to the terminal: each terminal "view" (tab) now holds a tree of panes that can be split horizontally/vertically, resized, focused independently, detached into their own view, and rearranged via drag-and-drop.

A single-pane view behaves exactly like a classic tab, so existing behaviour is unchanged for users who never split.

## What's included

- **Split-tree model** (`src/lib/terminal-split.ts`): pure functions for a recursive `SplitNode` layout (`splitLeaf`, `pruneLeaf`, `collectLeafIds`, `countLeaves`, `setSizesAtPath`, …), fully unit-tested.
- **Store** (`src/store/terminal-store.ts`): views/groups model with `splitTerminal`, `moveTerminalToPane`, `detachPane`, `closeSplitPane`, `setPaneSizes`; no-op guards to avoid spurious re-renders.
- **UI** (`TerminalSplitLayout.tsx`, `TerminalView.tsx`): nested resizable panel groups, per-pane chrome (grip/detach/close), focus ring, drag-to-merge / drag-to-move with drop hints. Split is a native-desktop affordance (hidden on web/mobile).
- **Keyboard shortcuts** (`useMainWindowEventListeners.ts`, `types/keybindings.ts`): split right/down, close focused pane, focus next pane.
- **Cleanup commit**: share the `terminalsById` lookup map between `TerminalView` and `TerminalSplitLayout` (drops a duplicate memo + redundant store subscription); extract a reused `getActiveGroup()` store helper.

## Testing

- `bun run typecheck` — clean
- `eslint` + `prettier` on changed files — clean
- Unit tests: `terminal-split`, `terminal-store`, `TerminalView`, `useMainWindowEventListeners` — all green (110 tests)
