### PR TITLE
feat(terminal): surface Claude Code attention signals for native CLI sessions

### DIFF
--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -337,7 +337,7 @@ fn find_neighbor_non_archived_session_id(
     None
 }
 
-fn emit_sessions_cache_invalidation(app: &AppHandle) {
+pub(crate) fn emit_sessions_cache_invalidation(app: &AppHandle) {
     if let Err(e) = app.emit_all(
         "cache:invalidate",
         &serde_json::json!({ "keys": ["sessions"] }),
@@ -2030,10 +2030,29 @@ pub async fn set_session_last_opened(app: AppHandle, session_id: String) -> Resu
             .unwrap_or_default()
             .as_secs();
         metadata.last_opened_at = Some(now);
+        // Viewing a native-terminal Claude session means the user has dealt with
+        // the "needs attention" signal → clear it so the bell/badge resets.
+        let cleared = clear_terminal_waiting(&mut metadata);
         save_metadata(&app, &metadata)?;
+        if cleared {
+            emit_sessions_cache_invalidation(&app);
+        }
     }
 
     Ok(())
+}
+
+/// Clear the native-terminal "waiting for you" state. No-op for chat sessions,
+/// whose `waiting_for_input` (plan/question) must persist until answered.
+/// Returns true when it changed something.
+fn clear_terminal_waiting(metadata: &mut super::types::SessionMetadata) -> bool {
+    if metadata.primary_surface.as_deref() == Some("terminal") && metadata.waiting_for_input {
+        metadata.waiting_for_input = false;
+        metadata.waiting_for_input_type = None;
+        true
+    } else {
+        false
+    }
 }
 
 /// Bulk-update last_opened_at for multiple sessions in a single call.
@@ -2052,14 +2071,117 @@ pub async fn set_sessions_last_opened_bulk(
         .unwrap_or_default()
         .as_secs();
 
+    let mut any_cleared = false;
     for session_id in &session_ids {
         if let Ok(Some(mut metadata)) = load_metadata(&app, session_id) {
             metadata.last_opened_at = Some(now);
+            any_cleared |= clear_terminal_waiting(&mut metadata);
             save_metadata(&app, &metadata)?;
         }
     }
+    if any_cleared {
+        emit_sessions_cache_invalidation(&app);
+    }
 
     Ok(())
+}
+
+/// Auto-name a native-terminal Claude session (and its git branch) from the
+/// first submitted prompt, reusing the exact Jean Chat naming machinery.
+///
+/// Terminal sessions have no Jean-parsed messages, so "first message" is gated
+/// purely by the naming-completed flags (set once here). Background and
+/// best-effort; honors the same `auto_session_naming` / `auto_branch_naming`
+/// preferences, base-session / PR-worktree guards, model, prompt, backend and
+/// provider overrides as the chat flow. Called from the terminal hooks tailer.
+pub async fn trigger_terminal_session_naming(
+    app: AppHandle,
+    session_id: String,
+    first_prompt: String,
+) {
+    if first_prompt.trim().is_empty() {
+        return;
+    }
+    let Ok(Some(metadata)) = load_metadata(&app, &session_id) else {
+        return;
+    };
+    let worktree_id = metadata.worktree_id.clone();
+    let Ok(projects_data) = load_projects_data(&app) else {
+        return;
+    };
+    let Some(worktree_record) = projects_data.find_worktree(&worktree_id).cloned() else {
+        return;
+    };
+    let worktree_path = worktree_record.path.clone();
+
+    let sessions = match load_sessions(&app, &worktree_path, &worktree_id) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    // No parsed messages for terminal sessions → rely on the completed flags.
+    let is_first_worktree_message = !sessions.branch_naming_completed;
+    let is_first_session_message = sessions
+        .find_session(&session_id)
+        .map(|s| !s.session_naming_completed)
+        .unwrap_or(false);
+    if !is_first_worktree_message && !is_first_session_message {
+        return;
+    }
+
+    if let Ok(prefs) = crate::load_preferences(app.clone()).await {
+        let is_base_session = worktree_record.session_type == SessionType::Base;
+        let is_pr_worktree = worktree_record.pr_number.is_some();
+        let generate_branch = is_first_worktree_message
+            && prefs.auto_branch_naming
+            && !is_base_session
+            && !is_pr_worktree;
+        let generate_session = is_first_session_message && prefs.auto_session_naming;
+
+        if generate_branch || generate_session {
+            let existing_names = if generate_branch {
+                projects_data
+                    .worktrees
+                    .iter()
+                    .map(|w| w.name.clone())
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            let custom_session_prompt = if generate_session {
+                prefs.magic_prompts.session_naming.clone()
+            } else {
+                None
+            };
+            let request = NamingRequest {
+                session_id: session_id.clone(),
+                worktree_id: worktree_id.clone(),
+                worktree_path: PathBuf::from(&worktree_path),
+                first_message: first_prompt,
+                model: prefs.magic_prompt_models.session_naming_model.clone(),
+                existing_branch_names: existing_names,
+                generate_session_name: generate_session,
+                generate_branch_name: generate_branch,
+                custom_session_prompt,
+                custom_profile_name: prefs.magic_prompt_providers.session_naming_provider.clone(),
+                backend_override: prefs.magic_prompt_backends.session_naming_backend.clone(),
+                reasoning_effort: prefs.magic_prompt_efforts.session_naming_effort.clone(),
+            };
+            spawn_naming_task(app.clone(), request);
+        }
+    }
+
+    // Mark completed so re-fired hooks don't re-trigger naming.
+    let _ = with_sessions_mut(&app, &worktree_path, &worktree_id, |sessions| {
+        if is_first_worktree_message {
+            sessions.branch_naming_completed = true;
+        }
+        if is_first_session_message {
+            if let Some(session) = sessions.find_session_mut(&session_id) {
+                session.session_naming_completed = true;
+            }
+        }
+        Ok(())
+    });
 }
 
 // ============================================================================

--- a/src-tauri/src/chat/types.rs
+++ b/src-tauri/src/chat/types.rs
@@ -978,11 +978,14 @@ impl SessionMetadata {
         let waiting_for_input = self.waiting_for_input || is_pending_plan_waiting;
         let is_reviewing = self.is_reviewing && !is_pending_plan_waiting;
 
+        // Native-terminal sessions have no runs; their freshness comes from the
+        // last Claude Code hook signal so the unread bell can surface them.
         let updated_at = self
             .runs
             .last()
             .map(|r| r.ended_at.unwrap_or(r.started_at))
-            .unwrap_or(self.created_at);
+            .unwrap_or(self.created_at)
+            .max(self.terminal_activity_at.unwrap_or(0));
         let last_message_at = self.runs.last().map(|r| r.ended_at.unwrap_or(r.started_at));
         Session {
             id: self.id.clone(),
@@ -1512,6 +1515,11 @@ pub struct SessionMetadata {
     /// Display label for the terminal tab/session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub terminal_label: Option<String>,
+    /// Unix timestamp of the last native-terminal activity signal (Claude Code
+    /// hooks). Terminal sessions have no `runs`, so this drives `updated_at` /
+    /// the unread bell. None for chat sessions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_activity_at: Option<u64>,
 
     /// Run history - each entry corresponds to one Claude CLI execution
     #[serde(default)]
@@ -1632,6 +1640,7 @@ impl SessionMetadata {
             terminal_command: None,
             terminal_command_args: vec![],
             terminal_label: None,
+            terminal_activity_at: None,
             runs: vec![],
             scheduled_wakeup: None,
             version: 1,

--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -12,6 +12,7 @@ struct StartTerminalArgs {
     rows: u16,
     command: Option<String>,
     command_args: Option<Vec<String>>,
+    session_id: Option<String>,
 }
 
 fn parse_start_terminal_args(args: &Value) -> Result<StartTerminalArgs, String> {
@@ -22,6 +23,7 @@ fn parse_start_terminal_args(args: &Value) -> Result<StartTerminalArgs, String> 
         rows: from_field(args, "rows")?,
         command: from_field_opt(args, "command")?,
         command_args: field_opt(args, "commandArgs", "command_args")?,
+        session_id: field_opt(args, "sessionId", "session_id")?,
     })
 }
 
@@ -1783,6 +1785,7 @@ pub async fn dispatch_command(
                 parsed.rows,
                 parsed.command,
                 parsed.command_args,
+                parsed.session_id,
             )
             .await?;
             Ok(Value::Null)
@@ -3131,6 +3134,7 @@ mod tests {
                 rows: 40,
                 command: Some("bun".to_string()),
                 command_args: Some(vec!["run".to_string(), "dev".to_string()]),
+                session_id: None,
             }
         );
     }
@@ -3154,6 +3158,7 @@ mod tests {
                 rows: 24,
                 command: None,
                 command_args: Some(vec!["-lc".to_string(), "echo ok".to_string()]),
+                session_id: None,
             }
         );
     }

--- a/src-tauri/src/terminal/commands.rs
+++ b/src-tauri/src/terminal/commands.rs
@@ -34,6 +34,9 @@ pub async fn start_terminal(
     rows: u16,
     command: Option<String>,
     command_args: Option<Vec<String>>,
+    // Jean session id this terminal backs (when opened as a native CLI session).
+    // Used to wire Claude Code "needs attention" hooks; None for plain shells.
+    session_id: Option<String>,
 ) -> Result<(), String> {
     log::trace!("start_terminal called for terminal: {terminal_id}");
     if command.is_some() || command_args.is_some() {
@@ -49,15 +52,37 @@ pub async fn start_terminal(
         return Err("Terminal already exists".to_string());
     }
 
+    // For a native-terminal Claude session, inject Claude Code hooks so Jean can
+    // detect turn completion / attention requests (parity with Jean Chat).
+    let (command_args, signal) = match (command.as_deref(), session_id.as_deref()) {
+        (Some(cmd), Some(sid)) => {
+            let had_args = command_args.is_some();
+            let base = command_args.unwrap_or_default();
+            let (args, path) = super::hooks::inject_claude_hooks(&app, sid, cmd, base);
+            match path {
+                Some(p) => (Some(args), Some((sid.to_string(), p))),
+                // Not injected: restore original Option semantics so spawn_terminal
+                // still distinguishes "shell-wrapped" from "direct binary".
+                None => (if had_args { Some(args) } else { None }, None),
+            }
+        }
+        _ => (command_args, None),
+    };
+
     spawn_terminal(
         &app,
-        terminal_id,
+        terminal_id.clone(),
         worktree_path,
         cols,
         rows,
         command,
         command_args,
-    )
+    )?;
+
+    if let Some((sid, path)) = signal {
+        super::hooks::spawn_signal_tailer(app, sid, terminal_id, path);
+    }
+    Ok(())
 }
 
 /// Prepare context-only command args for an embedded backend terminal session.

--- a/src-tauri/src/terminal/hooks.rs
+++ b/src-tauri/src/terminal/hooks.rs
@@ -55,6 +55,14 @@ pub fn is_claude_command(command: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// POSIX single-quote-escape a string for safe embedding inside a `'...'` shell
+/// literal: every `'` becomes `'\''`. Guards against app-data paths that contain
+/// an apostrophe (e.g. a home dir like `/home/o'brien`), which would otherwise
+/// break the hook command or open a shell-injection surface.
+fn sh_single_quote_escape(s: &str) -> String {
+    s.replace('\'', "'\\''")
+}
+
 /// Build the `--settings` JSON wiring Claude Code hooks. `Stop`/`Notification`
 /// append their event name to `signal_path` (hooks run through the shell, so
 /// `echo <Event> >>` writes one newline-terminated line per event). The
@@ -62,10 +70,10 @@ pub fn is_claude_command(command: &str) -> bool {
 /// first prompt can drive iso session/branch auto-naming; it writes the prompt
 /// file BEFORE the marker so the tailer always sees a complete payload.
 fn hook_settings_json(signal_path: &Path, prompt_path: &Path) -> String {
-    let signal = signal_path.to_string_lossy();
-    let prompt = prompt_path.to_string_lossy();
-    // Single-quote paths so spaces (macOS "Application Support") are safe;
-    // session-id-derived paths never contain single quotes.
+    // Paths are wrapped in single quotes (so spaces like macOS "Application
+    // Support" are safe) and any embedded `'` is POSIX-escaped first.
+    let signal = sh_single_quote_escape(&signal_path.to_string_lossy());
+    let prompt = sh_single_quote_escape(&prompt_path.to_string_lossy());
     let echo = |event: &str| {
         serde_json::json!({
             "hooks": [ {
@@ -295,5 +303,21 @@ mod tests {
             .as_str()
             .unwrap();
         assert!(user_prompt_cmd.contains("cat > '/tmp/sess-1.prompt'"));
+    }
+
+    #[test]
+    fn settings_json_posix_escapes_apostrophes_in_paths() {
+        let json = hook_settings_json(
+            Path::new("/home/o'brien/sess.log"),
+            Path::new("/home/o'brien/sess.prompt"),
+        );
+        // Still valid JSON, and the apostrophe is POSIX-escaped as '\'' so the
+        // single-quoted shell literal stays well-formed.
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let cmd = value["hooks"]["Stop"][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap();
+        assert!(cmd.contains(r"'\''"));
+        assert!(cmd.contains(r"'/home/o'\''brien/sess.log'"));
     }
 }

--- a/src-tauri/src/terminal/hooks.rs
+++ b/src-tauri/src/terminal/hooks.rs
@@ -1,0 +1,299 @@
+//! Native-terminal Claude Code "needs attention" detection.
+//!
+//! Jean Chat runs Claude headless and parses its JSONL stream, so it knows when
+//! a turn finishes or the agent needs the user, and surfaces that through the
+//! unread bell / "Waiting" indicator. A native-terminal Claude session is just
+//! a raw PTY, so Jean is otherwise blind to that lifecycle.
+//!
+//! To restore those signals we inject Claude Code hooks (`Stop`,
+//! `Notification`, `UserPromptSubmit`) via the CLI `--settings` flag. Each hook
+//! appends its event name to a per-session signal file; a tailer thread bound
+//! to the PTY lifetime maps those events onto the session's `waiting_for_input`
+//! state and invalidates the sessions cache so the UI updates.
+//!
+//! Scope: Claude Code, Unix/macOS only (mirrors the detached-process module).
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tauri::{AppHandle, Manager};
+
+use crate::chat::storage::with_existing_metadata_mut;
+use crate::chat::tail::NdjsonTailer;
+use crate::http_server::EmitExt;
+
+/// Directory under app-data holding per-session terminal signal files.
+fn signal_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to resolve app data dir: {e}"))?
+        .join("terminal-hooks");
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("Failed to create terminal-hooks dir: {e}"))?;
+    Ok(dir)
+}
+
+/// Absolute path to a session's terminal signal file.
+fn signal_file(app: &AppHandle, session_id: &str) -> Result<PathBuf, String> {
+    // session_id is a server-generated UUID, safe as a file name.
+    Ok(signal_dir(app)?.join(format!("{session_id}.log")))
+}
+
+/// Absolute path to a session's captured-prompt file (latest UserPromptSubmit
+/// stdin JSON), used to auto-name the session from the first prompt.
+fn prompt_file(app: &AppHandle, session_id: &str) -> Result<PathBuf, String> {
+    Ok(signal_dir(app)?.join(format!("{session_id}.prompt")))
+}
+
+/// True when the terminal command is the Claude Code CLI (bare name or path).
+pub fn is_claude_command(command: &str) -> bool {
+    Path::new(command)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n == "claude" || n == "claude.exe")
+        .unwrap_or(false)
+}
+
+/// Build the `--settings` JSON wiring Claude Code hooks. `Stop`/`Notification`
+/// append their event name to `signal_path` (hooks run through the shell, so
+/// `echo <Event> >>` writes one newline-terminated line per event). The
+/// `UserPromptSubmit` hook also captures its stdin JSON to `prompt_path` so the
+/// first prompt can drive iso session/branch auto-naming; it writes the prompt
+/// file BEFORE the marker so the tailer always sees a complete payload.
+fn hook_settings_json(signal_path: &Path, prompt_path: &Path) -> String {
+    let signal = signal_path.to_string_lossy();
+    let prompt = prompt_path.to_string_lossy();
+    // Single-quote paths so spaces (macOS "Application Support") are safe;
+    // session-id-derived paths never contain single quotes.
+    let echo = |event: &str| {
+        serde_json::json!({
+            "hooks": [ {
+                "type": "command",
+                "command": format!("echo {event} >> '{signal}'"),
+            } ]
+        })
+    };
+    let user_prompt = serde_json::json!({
+        "hooks": [ {
+            "type": "command",
+            "command": format!("cat > '{prompt}'; echo UserPromptSubmit >> '{signal}'"),
+        } ]
+    });
+    serde_json::json!({
+        "hooks": {
+            "Stop": [ echo("Stop") ],
+            "Notification": [ echo("Notification") ],
+            "UserPromptSubmit": [ user_prompt ],
+        }
+    })
+    .to_string()
+}
+
+/// For a Claude terminal session, reset the signal file and append
+/// `--settings <hooks-json>` to the args. Returns the (possibly augmented) args
+/// and the signal-file path when hooks were injected. Unix/macOS only.
+pub fn inject_claude_hooks(
+    app: &AppHandle,
+    session_id: &str,
+    command: &str,
+    mut args: Vec<String>,
+) -> (Vec<String>, Option<PathBuf>) {
+    if !cfg!(unix) || !is_claude_command(command) {
+        return (args, None);
+    }
+    let signal_path = match signal_file(app, session_id) {
+        Ok(p) => p,
+        Err(e) => {
+            log::warn!("terminal hooks: cannot resolve signal file: {e}");
+            return (args, None);
+        }
+    };
+    // Truncate any stale lines from a previous run of this same session.
+    if let Err(e) = std::fs::write(&signal_path, b"") {
+        log::warn!("terminal hooks: cannot reset signal file: {e}");
+        return (args, None);
+    }
+    let prompt_path = match prompt_file(app, session_id) {
+        Ok(p) => p,
+        Err(e) => {
+            log::warn!("terminal hooks: cannot resolve prompt file: {e}");
+            return (args, None);
+        }
+    };
+    // Drop any stale captured prompt from a previous run of this session.
+    let _ = std::fs::remove_file(&prompt_path);
+    args.push("--settings".to_string());
+    args.push(hook_settings_json(&signal_path, &prompt_path));
+    log::debug!("terminal hooks: injected for session {session_id}");
+    (args, Some(signal_path))
+}
+
+/// Tail `signal_path` until the PTY is gone, mapping Claude Code hook events
+/// onto the session's waiting state. Runs on a dedicated thread.
+pub fn spawn_signal_tailer(
+    app: AppHandle,
+    session_id: String,
+    terminal_id: String,
+    signal_path: PathBuf,
+) {
+    std::thread::spawn(move || {
+        // The file was just truncated/created by inject_claude_hooks.
+        let mut tailer = match NdjsonTailer::new_from_start(&signal_path) {
+            Ok(t) => t,
+            Err(e) => {
+                log::warn!(
+                    "terminal hooks: cannot tail {}: {e}",
+                    signal_path.display()
+                );
+                return;
+            }
+        };
+        // Auto-naming is attempted once per tailer; the backend also guards via
+        // session_naming_completed so a restarted tailer never re-names.
+        let mut naming_attempted = false;
+        let mut handle = |app: &AppHandle, line: &str| {
+            apply_terminal_signal(app, &session_id, line);
+            if line == "UserPromptSubmit" && !naming_attempted {
+                naming_attempted = true;
+                maybe_trigger_naming(app, &session_id);
+            }
+        };
+        loop {
+            match tailer.poll() {
+                Ok(lines) => {
+                    for line in lines {
+                        handle(&app, line.trim());
+                    }
+                }
+                Err(e) => {
+                    log::debug!("terminal hooks: tail error: {e}");
+                    break;
+                }
+            }
+            if !super::registry::has_terminal(&terminal_id) {
+                // Final drain to catch a line written just before the PTY died.
+                if let Ok(lines) = tailer.poll() {
+                    for line in lines {
+                        handle(&app, line.trim());
+                    }
+                }
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+        let _ = std::fs::remove_file(&signal_path);
+        if let Ok(p) = prompt_file(&app, &session_id) {
+            let _ = std::fs::remove_file(p);
+        }
+        log::debug!("terminal hooks: tailer stopped for session {session_id}");
+    });
+}
+
+/// Read the captured first prompt and kick off iso session/branch auto-naming.
+/// Best-effort: silently no-ops if the prompt file is missing/unparseable.
+fn maybe_trigger_naming(app: &AppHandle, session_id: &str) {
+    let Ok(prompt_path) = prompt_file(app, session_id) else {
+        return;
+    };
+    let Ok(raw) = std::fs::read_to_string(&prompt_path) else {
+        return;
+    };
+    // UserPromptSubmit stdin JSON: { ..., "prompt": "<text>" }.
+    let prompt = serde_json::from_str::<serde_json::Value>(raw.trim())
+        .ok()
+        .and_then(|v| {
+            v.get("prompt")
+                .and_then(|p| p.as_str())
+                .map(|s| s.to_string())
+        });
+    let Some(prompt) = prompt else {
+        return;
+    };
+    if prompt.trim().is_empty() {
+        return;
+    }
+    let app = app.clone();
+    let session_id = session_id.to_string();
+    tauri::async_runtime::spawn(async move {
+        crate::chat::trigger_terminal_session_naming(app, session_id, prompt).await;
+    });
+}
+
+/// Map one hook event onto the session's waiting state and notify clients.
+fn apply_terminal_signal(app: &AppHandle, session_id: &str, event: &str) {
+    // Claude finished a turn or is asking for the user → it's their turn now.
+    let is_wait = matches!(event, "Stop" | "Notification");
+    // User submitted a prompt → Claude is working again.
+    let is_clear = event == "UserPromptSubmit";
+    if !is_wait && !is_clear {
+        return;
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let mutated = with_existing_metadata_mut(app, session_id, |m| {
+        if is_wait {
+            m.waiting_for_input = true;
+            m.waiting_for_input_type = Some("question".to_string());
+            // Bump only when entering the waiting state so the session rises in
+            // the unread bell; clearing must NOT bump (else typing re-marks it).
+            m.terminal_activity_at = Some(now);
+        } else {
+            m.waiting_for_input = false;
+            m.waiting_for_input_type = None;
+        }
+    });
+    match mutated {
+        Ok(()) => {
+            crate::chat::emit_sessions_cache_invalidation(app);
+            if is_wait {
+                // Let the UI clear it immediately if the user is actively viewing
+                // this session (so the active session never shows as waiting).
+                if let Err(e) = app.emit_all(
+                    "terminal:attention",
+                    &serde_json::json!({ "sessionId": session_id }),
+                ) {
+                    log::debug!("terminal hooks: terminal:attention emit failed: {e}");
+                }
+            }
+        }
+        Err(e) => {
+            log::debug!("terminal hooks: cannot apply '{event}' to {session_id}: {e}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_claude_command_by_name_and_path() {
+        assert!(is_claude_command("claude"));
+        assert!(is_claude_command("/home/u/.local/share/com.jean.desktop/claude-cli/claude"));
+        assert!(is_claude_command("claude.exe"));
+        assert!(!is_claude_command("codex"));
+        assert!(!is_claude_command("/usr/bin/bash"));
+        assert!(!is_claude_command(""));
+    }
+
+    #[test]
+    fn settings_json_wires_all_three_hooks_to_signal_file() {
+        let json = hook_settings_json(Path::new("/tmp/sess-1.log"), Path::new("/tmp/sess-1.prompt"));
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let hooks = &value["hooks"];
+        for event in ["Stop", "Notification", "UserPromptSubmit"] {
+            let command = hooks[event][0]["hooks"][0]["command"].as_str().unwrap();
+            assert!(command.contains(&format!("echo {event}")));
+            assert!(command.contains("'/tmp/sess-1.log'"));
+        }
+        // UserPromptSubmit additionally captures stdin (the prompt JSON) to the
+        // prompt file so the first prompt can drive auto-naming.
+        let user_prompt_cmd = hooks["UserPromptSubmit"][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap();
+        assert!(user_prompt_cmd.contains("cat > '/tmp/sess-1.prompt'"));
+    }
+}

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod hooks;
 mod pty;
 mod registry;
 mod types;

--- a/src/components/chat/FullScreenTerminalSurface.tsx
+++ b/src/components/chat/FullScreenTerminalSurface.tsx
@@ -33,9 +33,10 @@ export function FullScreenTerminalSurface({
 
   // While this terminal session is on screen, the user is viewing it: clear the
   // Claude Code "needs attention" signal as soon as it fires (window focused),
-  // and whenever the window regains focus — so the session you're looking at
-  // never lingers as "waiting" in the bell / list. Leaving the surface unmounts
-  // this effect, so a backgrounded session can still surface in the bell.
+  // and when the window regains focus if an attention arrived while it was
+  // blurred — so the session you're looking at never lingers as "waiting" in the
+  // bell / list. Leaving the surface unmounts this effect, so a backgrounded
+  // session can still surface in the bell.
   useEffect(() => {
     if (!sessionId) return
     const markViewed = () => {
@@ -49,19 +50,31 @@ export function FullScreenTerminalSurface({
         )
         .catch(() => undefined)
     }
+    // Only clear on focus when an attention signal is actually pending for this
+    // session, so an unrelated window focus never triggers a backend write.
+    let pendingAttention = false
+    let cancelled = false
     let unlisten: (() => void) | undefined
     void listen<{ sessionId: string }>('terminal:attention', event => {
-      if (event.payload?.sessionId === sessionId && document.hasFocus()) {
-        markViewed()
-      }
+      if (event.payload?.sessionId !== sessionId) return
+      if (document.hasFocus()) markViewed()
+      else pendingAttention = true
     })
       .then(fn => {
-        unlisten = fn
+        // The effect may have been cleaned up before listen() resolved; if so,
+        // dispose immediately so the listener can't leak.
+        if (cancelled) fn()
+        else unlisten = fn
       })
       .catch(() => undefined)
-    const onFocus = () => markViewed()
+    const onFocus = () => {
+      if (!pendingAttention) return
+      pendingAttention = false
+      markViewed()
+    }
     window.addEventListener('focus', onFocus)
     return () => {
+      cancelled = true
       unlisten?.()
       window.removeEventListener('focus', onFocus)
     }

--- a/src/components/chat/FullScreenTerminalSurface.tsx
+++ b/src/components/chat/FullScreenTerminalSurface.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from 'react'
 import { MessageSquare, Terminal } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { invoke, listen } from '@/lib/transport'
 import { useUIStore } from '@/store/ui-store'
 import { SingleTerminalView } from './TerminalView'
 
@@ -28,6 +30,42 @@ export function FullScreenTerminalSurface({
       useUIStore.getState().setSessionPrimarySurface(sessionId, 'chat')
     }
   }
+
+  // While this terminal session is on screen, the user is viewing it: clear the
+  // Claude Code "needs attention" signal as soon as it fires (window focused),
+  // and whenever the window regains focus — so the session you're looking at
+  // never lingers as "waiting" in the bell / list. Leaving the surface unmounts
+  // this effect, so a backgrounded session can still surface in the bell.
+  useEffect(() => {
+    if (!sessionId) return
+    const markViewed = () => {
+      void invoke('set_session_last_opened', { sessionId })
+        .then(() =>
+          window.dispatchEvent(
+            new CustomEvent('session-opened', {
+              detail: { sessionIds: [sessionId] },
+            })
+          )
+        )
+        .catch(() => undefined)
+    }
+    let unlisten: (() => void) | undefined
+    void listen<{ sessionId: string }>('terminal:attention', event => {
+      if (event.payload?.sessionId === sessionId && document.hasFocus()) {
+        markViewed()
+      }
+    })
+      .then(fn => {
+        unlisten = fn
+      })
+      .catch(() => undefined)
+    const onFocus = () => markViewed()
+    window.addEventListener('focus', onFocus)
+    return () => {
+      unlisten?.()
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [sessionId])
 
   return (
     <div

--- a/src/components/chat/NativeCliSessionsModal.tsx
+++ b/src/components/chat/NativeCliSessionsModal.tsx
@@ -326,6 +326,7 @@ export function NativeCliSessionsModal({
               commandArgs,
               activate: false,
               openPanel: false,
+              sessionId: session.id,
             }
           )
         }

--- a/src/components/chat/TerminalView.tsx
+++ b/src/components/chat/TerminalView.tsx
@@ -54,6 +54,7 @@ const TerminalTabContent = memo(function TerminalTabContent({
     worktreePath,
     command: terminal.command,
     commandArgs: terminal.commandArgs,
+    sessionId: terminal.sessionId,
   })
   const initialized = useRef(false)
   const canAttach = isActive && !isCollapsed && isWorktreeActive

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -969,6 +969,11 @@ export function useMainWindowEventListeners() {
                   queryClient.invalidateQueries({
                     queryKey: chatQueryKeys.all,
                   })
+                  // The unread bell reads a separate ['all-sessions'] query; keep
+                  // it in sync so finished/waiting sessions surface live.
+                  queryClient.invalidateQueries({
+                    queryKey: ['all-sessions'],
+                  })
                   break
                 case 'projects':
                   queryClient.invalidateQueries({

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -13,6 +13,7 @@ interface UseTerminalOptions {
   worktreePath: string
   command?: string | null
   commandArgs?: string[] | null
+  sessionId?: string | null
 }
 
 /**
@@ -28,6 +29,7 @@ export function useTerminal({
   worktreePath,
   command,
   commandArgs,
+  sessionId,
 }: UseTerminalOptions) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const attachedRef = useRef(false)
@@ -61,6 +63,7 @@ export function useTerminal({
         worktreePath,
         command,
         commandArgs,
+        sessionId,
       })
 
       // Attach terminal to this container
@@ -70,7 +73,7 @@ export function useTerminal({
       attachedRef.current = true
       attachedTerminalIdRef.current = terminalId
     },
-    [terminalId, worktreeId, worktreePath, command, commandArgs]
+    [terminalId, worktreeId, worktreePath, command, commandArgs, sessionId]
   )
 
   const fit = useCallback(() => {

--- a/src/lib/terminal-instances.ts
+++ b/src/lib/terminal-instances.ts
@@ -62,6 +62,8 @@ interface PersistentTerminal {
   worktreePath: string
   command: string | null
   commandArgs: string[] | null
+  /** Jean session id backing this terminal (session terminals only). */
+  sessionId: string | null
   initialized: boolean // PTY has been started
   opened: boolean // Terminal UI has been opened into hostElement
   readyForOutput: boolean // Ghostty Web needs one settled paint before writes
@@ -881,6 +883,7 @@ export function getOrCreateTerminal(
     worktreePath: string
     command?: string | null
     commandArgs?: string[] | null
+    sessionId?: string | null
   }
 ): PersistentTerminal {
   const existing = instances.get(terminalId)
@@ -896,6 +899,7 @@ export function getOrCreateTerminal(
     worktreePath,
     command = null,
     commandArgs = null,
+    sessionId = null,
   } = options
 
   // Ensure the visibility/focus wake handler is running.
@@ -918,6 +922,7 @@ export function getOrCreateTerminal(
     worktreePath,
     command,
     commandArgs,
+    sessionId,
     initialized: false,
     opened: false,
     readyForOutput: renderer !== 'ghostty-web',
@@ -1043,6 +1048,7 @@ export async function attachToContainer(
           rows,
           command,
           commandArgs,
+          sessionId: instance.sessionId,
         }).catch(error => {
           console.error('[terminal-instances] start_terminal failed:', error)
           terminal.writeln(`\x1b[31mFailed to start terminal: ${error}\x1b[0m`)
@@ -1075,6 +1081,7 @@ export function startHeadless(
     worktreePath: string
     command: string
     commandArgs?: string[] | null
+    sessionId?: string | null
   }
 ): void {
   const instance = getOrCreateTerminal(terminalId, options)
@@ -1092,6 +1099,7 @@ export function startHeadless(
         rows: 24,
         command: options.command,
         commandArgs: options.commandArgs ?? null,
+        sessionId: options.sessionId ?? null,
       })
     })
     .catch(error => {

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -152,6 +152,7 @@ export async function reconnectNativeCliSession(
       commandArgs: launch.args,
       activate: false,
       openPanel: false,
+      sessionId: session.id,
     }
   )
 

--- a/src/store/terminal-store.ts
+++ b/src/store/terminal-store.ts
@@ -15,6 +15,8 @@ export interface TerminalInstance {
   label: string
   /** Panel terminals belong to side/bottom/drawer tabs; session terminals are single full-screen sessions. */
   kind?: TerminalKind
+  /** Jean session id backing this terminal (session terminals only). Enables Claude Code attention hooks. */
+  sessionId?: string
 }
 
 export interface AddTerminalOptions {
@@ -24,6 +26,8 @@ export interface AddTerminalOptions {
   activate?: boolean
   /** Whether adding this terminal should open/show the side/bottom terminal panel. */
   openPanel?: boolean
+  /** Jean session id backing this terminal (session terminals only). */
+  sessionId?: string
 }
 
 export function isPanelTerminal(terminal: TerminalInstance): boolean {
@@ -232,6 +236,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       commandArgs: options?.commandArgs ?? null,
       label: label ?? getDefaultLabel(command),
       kind,
+      sessionId: options?.sessionId,
     }
 
     set(state => {


### PR DESCRIPTION
## What

Native-terminal Claude Code sessions run as a raw PTY, so Jean was blind to their
lifecycle (turn completion / waiting-for-input) — unlike headless Jean Chat, which
parses the JSONL stream and surfaces those signals in the unread bell.

## How

Inject Claude Code hooks (`Stop`, `Notification`, `UserPromptSubmit`) via the CLI
`--settings` flag when a terminal backs a Jean session:

- The hooks append event markers to a per-session signal file.
- A PTY-bound tailer thread maps those events onto the session's waiting state,
  drives a new `terminal_activity_at` freshness timestamp (terminal sessions have
  no `runs` to derive `updated_at` from), and invalidates the sessions cache so
  finished/waiting sessions surface live.
- Viewing the session clears the signal.
- The first captured prompt also feeds the existing session/branch auto-naming
  machinery.

Unix/macOS only (mirrors the detached-process module).

## Notes

- New module `src-tauri/src/terminal/hooks.rs` with unit tests (command detection +
  hook-settings JSON).
- `session_id` is threaded through `start_terminal` as an `Option`; `None` for plain
  shells means no hooks are injected.
