### PR TITLE
[codex] Add rich chat artifacts and usage limits

### DIFF
--- a/src/components/chat/ChatToolbar.tsx
+++ b/src/components/chat/ChatToolbar.tsx
@@ -55,12 +55,15 @@ import {
 } from '@/components/chat/toolbar/toolbar-utils'
 import { useAvailableOpencodeModels } from '@/services/opencode-cli'
 import { useAvailablePiModels } from '@/services/pi-cli'
+import { useCodexUsage } from '@/services/codex-cli'
+import { useClaudeUsage } from '@/services/claude-cli'
 import { useIsMobile } from '@/hooks/use-mobile'
 import {
   BackendLabel,
   getBackendPlainLabel,
 } from '@/components/ui/backend-label'
 import type { RevertCommitResponse } from '@/types/projects'
+import { hasBackend } from '@/lib/environment'
 
 // eslint-disable-next-line react-refresh/only-export-components
 export {
@@ -200,6 +203,32 @@ export const ChatToolbar = memo(function ChatToolbar({
       availableMcpServers,
       enabledMcpServers,
     })
+  const backendUsageEnabled = hasBackend()
+  const codexUsage = useCodexUsage({
+    enabled: backendUsageEnabled && selectedBackend === 'codex',
+  })
+  const claudeUsage = useClaudeUsage({
+    enabled: backendUsageEnabled && selectedBackend === 'claude',
+  })
+  const backendUsageSnapshot =
+    selectedBackend === 'codex'
+      ? codexUsage.data
+      : selectedBackend === 'claude'
+        ? claudeUsage.data
+        : null
+  const backendUsageIsFetching =
+    selectedBackend === 'codex'
+      ? codexUsage.isFetching
+      : selectedBackend === 'claude'
+        ? claudeUsage.isFetching
+        : false
+  const backendUsageError =
+    selectedBackend === 'codex'
+      ? codexUsage.error
+      : selectedBackend === 'claude'
+        ? claudeUsage.error
+        : null
+
   const availableExecutionModes = getSupportedExecutionModes(selectedBackend)
   const hasMultipleBackendModelChoices =
     backendModelSections.reduce(
@@ -487,6 +516,9 @@ export const ChatToolbar = memo(function ChatToolbar({
             providerLocked={providerLocked}
             customCliProfiles={customCliProfiles}
             isCodex={isCodex}
+            backendUsageSnapshot={backendUsageSnapshot}
+            backendUsageIsFetching={backendUsageIsFetching}
+            backendUsageError={backendUsageError}
             prUrl={prUrl}
             prNumber={prNumber}
             displayStatus={displayStatus}

--- a/src/components/chat/SmartLink.tsx
+++ b/src/components/chat/SmartLink.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from 'react'
+import { ExternalLink, FileText } from 'lucide-react'
+import { openExternal } from '@/lib/platform'
+import { invoke } from '@/lib/transport'
+import { cn } from '@/lib/utils'
+import { looksLikeFilePath, resolveFilePath } from '@/lib/link-utils'
+import type { AppPreferences } from '@/types/preferences'
+
+interface SmartLinkProps {
+  href?: string
+  children: ReactNode
+  worktreePath?: string | null
+  editor?: AppPreferences['editor']
+  onOpenFile?: ((filePath: string, line?: number, column?: number) => void) | null
+}
+
+export function SmartLink({
+  href,
+  children,
+  worktreePath,
+  editor,
+  onOpenFile,
+}: SmartLinkProps) {
+  const target = href ?? ''
+  const isFile = looksLikeFilePath(target)
+
+  const handleClick = async (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!target) return
+    event.preventDefault()
+
+    if (isFile) {
+      const resolved = resolveFilePath(target, worktreePath)
+      if (!resolved) return
+
+      if (onOpenFile) {
+        onOpenFile(resolved.filePath, resolved.line, resolved.column)
+        return
+      }
+
+      await invoke('open_file_in_default_app', {
+        path: resolved.filePath,
+        editor,
+        line: resolved.line,
+        column: resolved.column,
+      })
+      return
+    }
+
+    await openExternal(target)
+  }
+
+  return (
+    <a
+      href={target}
+      onClick={handleClick}
+      className={cn(
+        'inline-flex items-baseline gap-1 underline underline-offset-2 hover:text-foreground',
+        isFile && 'font-medium'
+      )}
+      target={isFile ? undefined : '_blank'}
+      rel="noopener noreferrer"
+      title={isFile ? 'Open file' : undefined}
+    >
+      {isFile ? (
+        <FileText className="relative top-0.5 size-3 shrink-0" />
+      ) : (
+        <ExternalLink className="relative top-0.5 size-3 shrink-0" />
+      )}
+      <span>{children}</span>
+    </a>
+  )
+}

--- a/src/components/chat/ToolArtifactPreview.test.tsx
+++ b/src/components/chat/ToolArtifactPreview.test.tsx
@@ -1,0 +1,91 @@
+import userEvent from '@testing-library/user-event'
+import { fireEvent, render, screen } from '@/test/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ToolArtifactPreview } from './ToolArtifactPreview'
+
+const mocks = vi.hoisted(() => ({
+  copyToClipboard: vi.fn(() => Promise.resolve()),
+  invoke: vi.fn(() => Promise.resolve()),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+vi.mock('@/lib/clipboard', () => ({
+  copyToClipboard: mocks.copyToClipboard,
+}))
+
+vi.mock('@/lib/transport', () => ({
+  invoke: mocks.invoke,
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: mocks.toastSuccess,
+    error: mocks.toastError,
+  },
+}))
+
+describe('ToolArtifactPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows a fallback when an image preview fails to load', () => {
+    render(
+      <ToolArtifactPreview
+        artifacts={[
+          {
+            id: 'image-1',
+            type: 'image',
+            title: 'Preview',
+            url: 'https://design.canva.ai/preview-token',
+            alt: 'Preview',
+            actions: [{ label: 'Open', url: 'https://www.canva.com/d/example' }],
+          },
+        ]}
+      />
+    )
+
+    fireEvent.error(screen.getByAltText('Preview'))
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Preview unavailable'
+    )
+    expect(screen.getByRole('link', { name: 'Open' })).toHaveAttribute(
+      'rel',
+      'noopener noreferrer'
+    )
+  })
+
+  it('copies file paths and opens the containing folder', async () => {
+    const user = userEvent.setup()
+    const onFileClick = vi.fn()
+
+    render(
+      <ToolArtifactPreview
+        artifacts={[
+          {
+            id: 'file-1',
+            type: 'file',
+            title: 'report.pdf',
+            path: '/tmp/report.pdf',
+            subtitle: '/tmp/report.pdf',
+            actions: [{ label: 'Open file', path: '/tmp/report.pdf' }],
+          },
+        ]}
+        onFileClick={onFileClick}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Open file' }))
+    await user.click(screen.getByRole('button', { name: /copy path/i }))
+    await user.click(screen.getByRole('button', { name: /open containing folder/i }))
+
+    expect(onFileClick).toHaveBeenCalledWith('/tmp/report.pdf')
+    expect(mocks.copyToClipboard).toHaveBeenCalledWith('/tmp/report.pdf')
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Path copied')
+    expect(mocks.invoke).toHaveBeenCalledWith('open_worktree_in_finder', {
+      worktreePath: '/tmp',
+    })
+  })
+})

--- a/src/components/chat/ToolArtifactPreview.tsx
+++ b/src/components/chat/ToolArtifactPreview.tsx
@@ -1,0 +1,233 @@
+import { useState } from 'react'
+import {
+  Check,
+  Copy,
+  ExternalLink,
+  FileText,
+  FolderOpen,
+  Image as ImageIcon,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import type { ToolArtifact, ToolArtifactAction } from './tool-artifacts'
+import { copyToClipboard } from '@/lib/clipboard'
+import { invoke } from '@/lib/transport'
+import { cn } from '@/lib/utils'
+
+interface ToolArtifactPreviewProps {
+  artifacts: ToolArtifact[]
+  onFileClick?: (filePath: string) => void
+}
+
+export function ToolArtifactPreview({
+  artifacts,
+  onFileClick,
+}: ToolArtifactPreviewProps) {
+  if (artifacts.length === 0) return null
+
+  return (
+    <div className="space-y-2">
+      {artifacts.map(artifact => (
+        <ArtifactCard
+          key={artifact.id}
+          artifact={artifact}
+          onFileClick={onFileClick}
+        />
+      ))}
+    </div>
+  )
+}
+
+function ArtifactCard({
+  artifact,
+  onFileClick,
+}: {
+  artifact: ToolArtifact
+  onFileClick?: (filePath: string) => void
+}) {
+  const [previewFailed, setPreviewFailed] = useState(false)
+  const hasActions = Boolean(artifact.actions?.length)
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border/50 bg-background/60">
+      {artifact.type === 'image' && artifact.url ? (
+        <div className="bg-muted/30 p-2">
+          {previewFailed ? (
+            <div
+              role="status"
+              className="rounded-md border border-dashed border-border/60 px-3 py-4 text-xs text-muted-foreground"
+            >
+              Preview unavailable — use the action buttons below.
+            </div>
+          ) : (
+            <img
+              src={artifact.url}
+              alt={artifact.alt ?? artifact.title}
+              loading="lazy"
+              fetchPriority="low"
+              onError={() => setPreviewFailed(true)}
+              className="max-h-72 w-full rounded-md object-contain"
+            />
+          )}
+        </div>
+      ) : null}
+      <div className="flex min-w-0 items-start gap-2 p-2">
+        {artifact.type === 'image' ? (
+          <ImageIcon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : artifact.type === 'file' ? (
+          <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-xs font-medium text-foreground">
+            {artifact.title}
+          </div>
+          {artifact.subtitle ? (
+            <div className="truncate text-[11px] text-muted-foreground">
+              {artifact.type === 'image' ? 'Preview' : artifact.subtitle}
+            </div>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 flex-wrap justify-end gap-1">
+          {artifact.actions?.map(action => (
+            <ArtifactActionButton
+              key={`${action.label}-${action.url ?? action.path}`}
+              action={action}
+              onFileClick={onFileClick}
+            />
+          ))}
+          {!hasActions && artifact.type === 'link' && artifact.url ? (
+            <ArtifactActionButton
+              action={{ label: 'Open', url: artifact.url }}
+              onFileClick={onFileClick}
+            />
+          ) : null}
+          {!hasActions && artifact.type === 'file' && artifact.path ? (
+            <ArtifactActionButton
+              action={{ label: 'Open file', path: artifact.path }}
+              onFileClick={onFileClick}
+            />
+          ) : null}
+          {artifact.type === 'file' && artifact.path ? (
+            <>
+              <CopyPathButton path={artifact.path} />
+              <OpenFolderButton path={artifact.path} />
+            </>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ArtifactActionButton({
+  action,
+  onFileClick,
+}: {
+  action: ToolArtifactAction
+  onFileClick?: (filePath: string) => void
+}) {
+  const className = artifactButtonClassName()
+
+  if (action.url) {
+    return (
+      <a
+        href={action.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={className}
+      >
+        {action.label}
+      </a>
+    )
+  }
+
+  if (action.path) {
+    const path = action.path
+
+    return (
+      <button
+        type="button"
+        disabled={!onFileClick}
+        onClick={() => onFileClick?.(path)}
+        className={cn(className, !onFileClick && 'opacity-50')}
+      >
+        {action.label}
+      </button>
+    )
+  }
+
+  return null
+}
+
+function CopyPathButton({ path }: { path: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    try {
+      await copyToClipboard(path)
+      setCopied(true)
+      toast.success('Path copied')
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch (error) {
+      console.error('Failed to copy artifact path:', error)
+      toast.error('Failed to copy path')
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={artifactButtonClassName()}
+      aria-label={`Copy path ${path}`}
+    >
+      {copied ? (
+        <Check className="mr-1 h-3 w-3" />
+      ) : (
+        <Copy className="mr-1 h-3 w-3" />
+      )}
+      {copied ? 'Copied' : 'Copy path'}
+    </button>
+  )
+}
+
+function OpenFolderButton({ path }: { path: string }) {
+  const handleOpenFolder = async () => {
+    try {
+      await invoke('open_worktree_in_finder', {
+        worktreePath: containingFolder(path),
+      })
+    } catch (error) {
+      console.error('Failed to open containing folder:', error)
+      toast.error('Failed to open folder')
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleOpenFolder}
+      className={artifactButtonClassName()}
+      aria-label={`Open containing folder for ${path}`}
+    >
+      <FolderOpen className="mr-1 h-3 w-3" />
+      Open folder
+    </button>
+  )
+}
+
+function artifactButtonClassName(): string {
+  return cn(
+    'inline-flex h-7 items-center rounded-md border border-border/50 px-2',
+    'text-[11px] font-medium text-foreground/80 transition-colors',
+    'hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+  )
+}
+
+function containingFolder(path: string): string {
+  const trimmed = path.replace(/\/+$/, '')
+  if (!trimmed) return '/'
+  const separatorIndex = trimmed.lastIndexOf('/')
+  return separatorIndex > 0 ? trimmed.slice(0, separatorIndex) : trimmed
+}

--- a/src/components/chat/ToolCallInline.test.tsx
+++ b/src/components/chat/ToolCallInline.test.tsx
@@ -143,4 +143,61 @@ describe('ToolCallInline', () => {
     expect(container.querySelector('diffs-container')).not.toBeNull()
     expect(screen.queryByText('Output:')).not.toBeInTheDocument()
   })
+
+  it('renders image artifacts from Canva tool output', () => {
+    render(
+      <ToolCallInline
+        toolCall={{
+          id: 'tool-canva-1',
+          name: 'mcp:canva:generate_design',
+          input: {},
+          output: JSON.stringify({
+            job: {
+              result: {
+                generated_designs: [
+                  {
+                    candidate_id: 'dg-1',
+                    url: 'https://www.canva.com/d/example',
+                    thumbnail: {
+                      url: 'https://design.canva.ai/preview-token',
+                    },
+                  },
+                ],
+              },
+            },
+          }),
+        }}
+      />
+    )
+
+    expect(screen.getByText('mcp:canva:generate_design')).toBeInTheDocument()
+    expect(screen.queryByText(/unhandled tool/i)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button'))
+
+    const image = screen.getByAltText('Preview')
+    expect(image).toHaveAttribute('src', 'https://design.canva.ai/preview-token')
+    expect(screen.getByText('Raw output:')).toBeInTheDocument()
+    expect(screen.queryByText(/design\.canva\.ai\/preview-token/)).toBeNull()
+  })
+
+  it('renders local file artifacts as clickable file cards', () => {
+    const onFileClick = vi.fn()
+    render(
+      <ToolCallInline
+        toolCall={{
+          id: 'tool-file-artifact-1',
+          name: 'Write',
+          input: {},
+          output: 'Saved report to /tmp/report.pdf',
+        }}
+        onFileClick={onFileClick}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByRole('button', { name: 'Open file' }))
+
+    expect(onFileClick).toHaveBeenCalledWith('/tmp/report.pdf')
+  })
 })

--- a/src/components/chat/ToolCallInline.tsx
+++ b/src/components/chat/ToolCallInline.tsx
@@ -40,6 +40,8 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { InlineFileDiff } from './InlineFileDiff'
+import { ToolArtifactPreview } from './ToolArtifactPreview'
+import { extractToolArtifacts, sanitizeToolOutput } from './tool-artifacts'
 
 function shouldRenderRawOutput(toolCall: ToolCall): boolean {
   return (
@@ -89,6 +91,8 @@ export function ToolCallInline({
   )
   const { icon, label, detail, filePath, expandedContent } =
     getToolDisplay(toolCall)
+  const artifacts = extractToolArtifacts(toolCall)
+  const rawOutput = sanitizeToolOutput(toolCall.output, artifacts)
 
   const handleFileClick = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -150,14 +154,23 @@ export function ToolCallInline({
             <div className="whitespace-pre-wrap text-xs text-muted-foreground">
               {expandedContent}
             </div>
+            {artifacts.length > 0 && (
+              <>
+                <div className="border-t border-border/30 my-2" />
+                <ToolArtifactPreview
+                  artifacts={artifacts}
+                  onFileClick={onFileClick}
+                />
+              </>
+            )}
             {shouldRenderRawOutput(toolCall) && (
               <>
                 <div className="border-t border-border/30 my-2" />
                 <div className="text-xs text-muted-foreground/60 mb-1">
-                  Output:
+                  {artifacts.length > 0 ? 'Raw output:' : 'Output:'}
                 </div>
                 <pre className="max-h-64 overflow-auto whitespace-pre-wrap text-xs font-mono text-foreground/80 bg-muted/50 rounded p-2">
-                  {toolCall.output}
+                  {rawOutput}
                 </pre>
               </>
             )}
@@ -1198,7 +1211,8 @@ function getToolDisplay(toolCall: ToolCall): ToolDisplay {
     }
 
     default: {
-      const isMcpTool = toolCall.name.startsWith('mcp__')
+      const isMcpTool =
+        toolCall.name.startsWith('mcp__') || toolCall.name.startsWith('mcp:')
       return {
         icon: <Terminal className="h-4 w-4 shrink-0" />,
         label: isMcpTool ? toolCall.name : `${toolCall.name} (unhandled tool)`,

--- a/src/components/chat/tool-artifacts.test.ts
+++ b/src/components/chat/tool-artifacts.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import { extractToolArtifacts, sanitizeToolOutput } from './tool-artifacts'
+
+describe('tool artifacts', () => {
+  it('extracts Canva generated design thumbnails', () => {
+    const output = JSON.stringify({
+      job: {
+        result: {
+          generated_designs: [
+            {
+              candidate_id: 'dg-1',
+              url: 'https://www.canva.com/d/example',
+              thumbnail: {
+                url: 'https://design.canva.ai/preview-token',
+              },
+            },
+          ],
+        },
+      },
+    })
+
+    const artifacts = extractToolArtifacts({
+      name: 'mcp:canva:generate_design',
+      output,
+    })
+
+    expect(artifacts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'image',
+          title: 'Preview',
+          url: 'https://design.canva.ai/preview-token',
+        }),
+      ])
+    )
+  })
+
+  it('extracts Canva design view and edit actions from nested text payloads', () => {
+    const output = JSON.stringify([
+      {
+        type: 'text',
+        text: JSON.stringify({
+          design_summary: {
+            id: 'DAHM6Wfi2oE',
+            title: 'AR-Bidder Russian Instagram Post',
+            urls: {
+              edit_url: 'https://www.canva.com/d/edit-id',
+              view_url: 'https://www.canva.com/d/view-id',
+            },
+          },
+        }),
+      },
+    ])
+
+    const artifacts = extractToolArtifacts({
+      name: 'mcp:canva:create_design_from_candidate',
+      output,
+    })
+
+    expect(artifacts).toContainEqual(
+      expect.objectContaining({
+        type: 'link',
+        title: 'AR-Bidder Russian Instagram Post',
+        url: 'https://www.canva.com/d/view-id',
+        actions: [
+          { label: 'Edit', url: 'https://www.canva.com/d/edit-id' },
+          { label: 'View', url: 'https://www.canva.com/d/view-id' },
+        ],
+      })
+    )
+  })
+
+
+  it('groups thumbnails with nested Canva actions instead of duplicating link cards', () => {
+    const output = JSON.stringify({
+      title: 'Grouped Canva card',
+      thumbnail: {
+        url: 'https://design.canva.ai/grouped-preview',
+      },
+      urls: {
+        edit_url: 'https://www.canva.com/d/edit-grouped',
+        view_url: 'https://www.canva.com/d/view-grouped',
+      },
+    })
+
+    const artifacts = extractToolArtifacts({
+      name: 'mcp:canva:get_design_pages',
+      output,
+    })
+
+    expect(artifacts).toContainEqual(
+      expect.objectContaining({
+        type: 'image',
+        title: 'Grouped Canva card',
+        url: 'https://design.canva.ai/grouped-preview',
+        actions: [
+          { label: 'Edit', url: 'https://www.canva.com/d/edit-grouped' },
+          { label: 'View', url: 'https://www.canva.com/d/view-grouped' },
+        ],
+      })
+    )
+    expect(artifacts.filter(artifact => artifact.type === 'link')).toHaveLength(0)
+  })
+
+  it('extracts local file paths from text output', () => {
+    const artifacts = extractToolArtifacts({
+      name: 'Write',
+      output: 'Saved report to /home/niko/tmp/report.pdf',
+    })
+
+    expect(artifacts).toContainEqual(
+      expect.objectContaining({
+        type: 'file',
+        title: 'report.pdf',
+        path: '/home/niko/tmp/report.pdf',
+      })
+    )
+  })
+
+  it('redacts image preview URLs from raw output when previews exist', () => {
+    const output = JSON.stringify({
+      thumbnail: {
+        url: 'https://document-export.canva.com/file.png?X-Amz-Signature=abc',
+      },
+    })
+    const artifacts = extractToolArtifacts({
+      name: 'mcp:canva:get_design_pages',
+      output,
+    })
+
+    expect(sanitizeToolOutput(output, artifacts)).not.toContain(
+      'X-Amz-Signature'
+    )
+  })
+
+  it('does not crash on broken JSON', () => {
+    expect(
+      extractToolArtifacts({
+        name: 'tool',
+        output: '{"not": "closed"',
+      })
+    ).toEqual([])
+  })
+})

--- a/src/components/chat/tool-artifacts.ts
+++ b/src/components/chat/tool-artifacts.ts
@@ -1,0 +1,483 @@
+import type { ToolCall } from '@/types/chat'
+
+export type ToolArtifactType = 'image' | 'link' | 'file'
+
+export interface ToolArtifactAction {
+  label: string
+  url?: string
+  path?: string
+}
+
+export interface ToolArtifact {
+  id: string
+  type: ToolArtifactType
+  title: string
+  subtitle?: string
+  url?: string
+  path?: string
+  alt?: string
+  actions?: ToolArtifactAction[]
+}
+
+const MAX_VISIT_DEPTH = 8
+const MAX_PARSED_TEXT_LENGTH = 200_000
+const IMAGE_URL_RE =
+  /\.(?:png|jpe?g|webp|gif|svg|avif)(?:[?#].*)?$/i
+const CANVA_THUMBNAIL_HOST_RE =
+  /^https:\/\/(?:design\.canva\.ai|document-export\.canva\.com)\//i
+const SIGNED_URL_RE = /[?&](?:X-Amz-Signature|Expires|Signature)=/i
+const URL_RE = /https?:\/\/[^\s"'<>)}\]]+/gi
+const ABSOLUTE_PATH_RE =
+  /(?:^|[\s(["'])((?:\/(?:home|tmp|var|mnt|workspace|Users)\/)[^\s"'<>)}\]]+)/g
+const FILE_FIELD_NAMES = new Set([
+  'path',
+  'file',
+  'file_path',
+  'filepath',
+  'output_path',
+  'artifact_path',
+  'design_file',
+])
+const URL_FIELD_NAMES = new Set([
+  'url',
+  'open_url',
+  'openUrl',
+  'edit_url',
+  'editUrl',
+  'view_url',
+  'viewUrl',
+  'create_url',
+  'createUrl',
+])
+
+export function extractToolArtifacts(
+  toolCall: Pick<ToolCall, 'name' | 'output'>
+): ToolArtifact[] {
+  if (toolCall.name === 'FileChange' || toolCall.name === 'Monitor') return []
+  if (!toolCall.output) return []
+
+  const collector = new ArtifactCollector(toolCall.name)
+  for (const value of expandToolOutput(toolCall.output)) {
+    visitValue(value, [], collector, 0)
+  }
+  return collector.toArray()
+}
+
+export function sanitizeToolOutput(
+  output: string | undefined,
+  artifacts: ToolArtifact[]
+): string {
+  if (!output) return ''
+
+  let sanitized = output
+  for (const artifact of artifacts) {
+    if (artifact.type !== 'image' || !artifact.url) continue
+    sanitized = sanitized
+      .split(artifact.url)
+      .join('[image preview URL redacted]')
+  }
+
+  return sanitized.replace(URL_RE, url =>
+    SIGNED_URL_RE.test(url) ? '[signed preview URL redacted]' : url
+  )
+}
+
+class ArtifactCollector {
+  private readonly seen = new Set<string>()
+  private readonly artifacts: ToolArtifact[] = []
+
+  constructor(private readonly toolName: string) {}
+
+  add(artifact: Omit<ToolArtifact, 'id'>): void {
+    const identity = [
+      artifact.type,
+      artifact.url ?? '',
+      artifact.path ?? '',
+    ].join('|')
+    if (this.seen.has(identity)) return
+    this.seen.add(identity)
+    this.artifacts.push({
+      ...artifact,
+      id: `${this.toolName || 'tool'}-${this.artifacts.length}-${hashIdentity(identity)}`,
+    })
+  }
+
+  toArray(): ToolArtifact[] {
+    return this.artifacts
+  }
+}
+
+function expandToolOutput(output: string): unknown[] {
+  const values: unknown[] = [output]
+  const parsed = parseJsonMaybe(output)
+  if (parsed !== undefined) values.push(parsed)
+  return values
+}
+
+function visitValue(
+  value: unknown,
+  path: string[],
+  collector: ArtifactCollector,
+  depth: number
+): void {
+  if (depth > MAX_VISIT_DEPTH) return
+
+  if (typeof value === 'string') {
+    const parsed = parseJsonMaybe(value)
+    if (parsed !== undefined) {
+      visitValue(parsed, path, collector, depth + 1)
+      return
+    }
+    collectFromText(value, collector)
+    return
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      visitValue(item, [...path, String(index)], collector, depth + 1)
+    )
+    return
+  }
+
+  if (!isRecord(value)) return
+
+  collectRecordArtifacts(value, path, collector)
+
+  for (const [key, child] of Object.entries(value)) {
+    if (shouldSkipNestedLinkKey(value, key)) continue
+    visitValue(child, [...path, key], collector, depth + 1)
+  }
+}
+
+function collectRecordArtifacts(
+  record: Record<string, unknown>,
+  path: string[],
+  collector: ArtifactCollector
+): void {
+  collectDesignLink(record, collector)
+  collectNestedThumbnails(record, collector)
+  collectNestedDesignLinks(record, collector)
+  collectThumbnail(record, path, collector)
+  collectFieldUrls(record, path, collector)
+  collectFieldPaths(record, collector)
+}
+
+function collectDesignLink(
+  record: Record<string, unknown>,
+  collector: ArtifactCollector,
+  titleOverride?: string
+): void {
+  const editUrl = getString(record.edit_url) ?? getString(record.editUrl)
+  const viewUrl = getString(record.view_url) ?? getString(record.viewUrl)
+  if (!editUrl && !viewUrl) return
+
+  const title = titleOverride ?? getTitle(record) ?? 'Design'
+  const actions = compactActions([
+    editUrl ? { label: 'Edit', url: editUrl } : undefined,
+    viewUrl ? { label: 'View', url: viewUrl } : undefined,
+  ])
+
+  collector.add({
+    type: 'link',
+    title,
+    subtitle: 'Canva design',
+    url: viewUrl ?? editUrl,
+    actions,
+  })
+}
+
+function collectNestedDesignLinks(
+  record: Record<string, unknown>,
+  collector: ArtifactCollector
+): void {
+  if (record.thumbnail || record.thumbnails) return
+
+  for (const key of ['urls', 'links']) {
+    const nested = record[key]
+    if (!isRecord(nested)) continue
+    collectDesignLink(nested, collector, getTitle(record))
+  }
+}
+
+function collectNestedThumbnails(
+  record: Record<string, unknown>,
+  collector: ArtifactCollector
+): void {
+  const nestedThumbnails = [
+    record.thumbnail,
+    ...(Array.isArray(record.thumbnails) ? record.thumbnails : []),
+  ]
+
+  for (const thumbnail of nestedThumbnails) {
+    if (!isRecord(thumbnail)) continue
+
+    const url = getString(thumbnail.url)
+    if (!url || !isHttpUrl(url)) continue
+    if (!isImageUrl(url) && !isThumbnailContext(['thumbnail'], thumbnail)) {
+      continue
+    }
+
+    const title = getTitle(record) ?? getTitle(thumbnail) ?? 'Preview'
+    collector.add({
+      type: 'image',
+      title,
+      subtitle: 'Image preview',
+      url,
+      alt: title,
+      actions: imageActionsFromRecords(record, thumbnail),
+    })
+  }
+}
+
+function collectThumbnail(
+  record: Record<string, unknown>,
+  path: string[],
+  collector: ArtifactCollector
+): void {
+  const url = getString(record.url)
+  if (!url || !isHttpUrl(url)) return
+  if (!isThumbnailContext(path, record) && !isImageUrl(url)) return
+
+  const title = getTitle(record) ?? 'Preview'
+  const openUrl = getString(record.open_url) ?? getString(record.openUrl)
+  const designUrl =
+    !isImageUrl(url) && !CANVA_THUMBNAIL_HOST_RE.test(url)
+      ? undefined
+      : getString(record.design_url) ??
+        getString(record.designUrl) ??
+        getString(record.view_url) ??
+        getString(record.viewUrl)
+  const fallbackUrl =
+    getString(record.create_url) ?? getString(record.createUrl)
+  const actions = compactActions([
+    openUrl ? { label: 'Open', url: openUrl } : undefined,
+    designUrl ? { label: 'View', url: designUrl } : undefined,
+    fallbackUrl ? { label: 'Open', url: fallbackUrl } : undefined,
+  ])
+
+  collector.add({
+    type: 'image',
+    title,
+    subtitle: 'Image preview',
+    url,
+    alt: title,
+    actions,
+  })
+}
+
+function imageActionsFromRecords(
+  record: Record<string, unknown>,
+  thumbnail: Record<string, unknown>
+): ToolArtifactAction[] {
+  const thumbnailOpenUrl =
+    getString(thumbnail.open_url) ?? getString(thumbnail.openUrl)
+  const editUrl = getString(record.edit_url) ?? getString(record.editUrl)
+  const viewUrl = getString(record.view_url) ?? getString(record.viewUrl)
+  const nestedUrls = getNestedUrlRecord(record)
+  const nestedEditUrl =
+    getString(nestedUrls?.edit_url) ?? getString(nestedUrls?.editUrl)
+  const nestedViewUrl =
+    getString(nestedUrls?.view_url) ?? getString(nestedUrls?.viewUrl)
+  const openUrl = getString(record.url)
+
+  return compactActions([
+    thumbnailOpenUrl ? { label: 'Open', url: thumbnailOpenUrl } : undefined,
+    editUrl ?? nestedEditUrl
+      ? { label: 'Edit', url: editUrl ?? nestedEditUrl }
+      : undefined,
+    viewUrl ?? nestedViewUrl
+      ? { label: 'View', url: viewUrl ?? nestedViewUrl }
+      : undefined,
+    openUrl ? { label: 'Open', url: openUrl } : undefined,
+  ])
+}
+
+function getNestedUrlRecord(
+  record: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  for (const key of ['urls', 'links']) {
+    const nested = record[key]
+    if (isRecord(nested)) return nested
+  }
+  return undefined
+}
+
+function collectFieldUrls(
+  record: Record<string, unknown>,
+  path: string[],
+  collector: ArtifactCollector
+): void {
+  for (const [key, value] of Object.entries(record)) {
+    if (!URL_FIELD_NAMES.has(key) || typeof value !== 'string') continue
+    if (!isHttpUrl(value)) continue
+    if (isThumbnailContext([...path, key], record) || isImageUrl(value)) {
+      collector.add({
+        type: 'image',
+        title: getTitle(record) ?? 'Preview',
+        subtitle: 'Image preview',
+        url: value,
+        alt: getTitle(record) ?? 'Preview',
+      })
+      continue
+    }
+    if (record.thumbnail || record.thumbnails) continue
+    collector.add({
+      type: 'link',
+      title: getTitle(record) ?? labelFromUrlKey(key),
+      subtitle: value,
+      url: value,
+      actions: [{ label: labelFromUrlKey(key), url: value }],
+    })
+  }
+}
+
+function collectFieldPaths(
+  record: Record<string, unknown>,
+  collector: ArtifactCollector
+): void {
+  for (const [key, value] of Object.entries(record)) {
+    if (!FILE_FIELD_NAMES.has(key) || typeof value !== 'string') continue
+    if (!isAbsoluteLocalPath(value)) continue
+    collector.add({
+      type: 'file',
+      title: getTitle(record) ?? filenameFromPath(value),
+      subtitle: value,
+      path: value,
+      actions: [{ label: 'Open file', path: value }],
+    })
+  }
+}
+
+function collectFromText(text: string, collector: ArtifactCollector): void {
+  for (const match of text.matchAll(URL_RE)) {
+    const url = match[0]
+    if (isImageUrl(url)) {
+      collector.add({
+        type: 'image',
+        title: filenameFromPath(url),
+        subtitle: 'Image preview',
+        url,
+        alt: filenameFromPath(url),
+      })
+    } else {
+      collector.add({
+        type: 'link',
+        title: 'Link',
+        subtitle: url,
+        url,
+        actions: [{ label: 'Open', url }],
+      })
+    }
+  }
+
+  for (const match of text.matchAll(ABSOLUTE_PATH_RE)) {
+    const filePath = match[1]
+    if (!filePath || !isAbsoluteLocalPath(filePath)) continue
+    collector.add({
+      type: 'file',
+      title: filenameFromPath(filePath),
+      subtitle: filePath,
+      path: filePath,
+      actions: [{ label: 'Open file', path: filePath }],
+    })
+  }
+}
+
+function parseJsonMaybe(text: string): unknown | undefined {
+  const trimmed = text.trim()
+  if (trimmed.length > MAX_PARSED_TEXT_LENGTH) return undefined
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return undefined
+  try {
+    return JSON.parse(trimmed) as unknown
+  } catch {
+    return undefined
+  }
+}
+
+function isThumbnailContext(
+  path: string[],
+  record: Record<string, unknown>
+): boolean {
+  return (
+    path.some(part => /thumbnail|preview|image/i.test(part)) ||
+    typeof record.width === 'number' ||
+    typeof record.height === 'number'
+  )
+}
+
+function shouldSkipNestedLinkKey(
+  record: Record<string, unknown>,
+  key: string
+): boolean {
+  if ((key === 'urls' || key === 'links') && (record.thumbnail || record.thumbnails)) {
+    return true
+  }
+
+  return (
+    (key === 'edit_url' ||
+      key === 'editUrl' ||
+      key === 'view_url' ||
+      key === 'viewUrl') &&
+    Boolean(record.edit_url || record.editUrl || record.view_url || record.viewUrl)
+  )
+}
+
+function compactActions(
+  actions: (ToolArtifactAction | undefined)[]
+): ToolArtifactAction[] {
+  return actions.filter((action): action is ToolArtifactAction =>
+    Boolean(action)
+  )
+}
+
+function getTitle(record: Record<string, unknown>): string | undefined {
+  for (const key of ['title', 'name', 'display_name', 'displayName', 'id']) {
+    const value = record[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return undefined
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function labelFromUrlKey(key: string): string {
+  if (/edit/i.test(key)) return 'Edit'
+  if (/view/i.test(key)) return 'View'
+  if (/create/i.test(key)) return 'Create'
+  return 'Open'
+}
+
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value)
+}
+
+function isImageUrl(value: string): boolean {
+  return IMAGE_URL_RE.test(value) || CANVA_THUMBNAIL_HOST_RE.test(value)
+}
+
+function isAbsoluteLocalPath(value: string): boolean {
+  return /^\/(?:home|tmp|var|mnt|workspace|Users)\//.test(value)
+}
+
+function filenameFromPath(value: string): string {
+  try {
+    const withoutQuery = value.split(/[?#]/, 1)[0] ?? value
+    return withoutQuery.split('/').filter(Boolean).pop() ?? value
+  } catch {
+    return value
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function hashIdentity(value: string): string {
+  let hash = 0
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash * 31 + value.charCodeAt(i)) | 0
+  }
+  return Math.abs(hash).toString(36)
+}

--- a/src/components/chat/toolbar/BackendUsageLimits.test.tsx
+++ b/src/components/chat/toolbar/BackendUsageLimits.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@/test/test-utils'
+import { BackendUsageLimits } from './BackendUsageLimits'
+
+describe('BackendUsageLimits', () => {
+  it('shows Codex five-hour and seven-day remaining limits', () => {
+    const fetchedAt = Date.parse('2026-06-18T12:00:00Z') / 1000
+
+    render(
+      <BackendUsageLimits
+        backend="codex"
+        className="flex"
+        usage={{
+          session: {
+            usedPercent: 42,
+            resetsAt: fetchedAt + 60 * 60,
+            limitWindowSeconds: 60 * 60 * 5,
+          },
+          weekly: {
+            usedPercent: 17.2,
+            resetsAt: fetchedAt + 60 * 60 * 24 * 3,
+            limitWindowSeconds: 60 * 60 * 24 * 7,
+          },
+          fetchedAt,
+        }}
+      />
+    )
+
+    expect(screen.getByText('5h')).toBeInTheDocument()
+    expect(screen.getByText('58%')).toBeInTheDocument()
+    expect(screen.getByText('7d')).toBeInTheDocument()
+    expect(screen.getByText('83%')).toBeInTheDocument()
+    expect(
+      screen.getByRole('status', {
+        name: /Codex limits: 5h 58% remaining/i,
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('uses the same compact labels for Claude limits', () => {
+    render(
+      <BackendUsageLimits
+        backend="claude"
+        className="flex"
+        usage={{
+          session: { usedPercent: 5, resetsAt: null },
+          weekly: { usedPercent: 99.6, resetsAt: null },
+          fetchedAt: Date.parse('2026-06-18T12:00:00Z') / 1000,
+        }}
+      />
+    )
+
+    expect(screen.getByText('5h')).toBeInTheDocument()
+    expect(screen.getByText('95%')).toBeInTheDocument()
+    expect(screen.getByText('7d')).toBeInTheDocument()
+    expect(screen.getByText('<1%')).toBeInTheDocument()
+    expect(
+      screen.getByRole('status', {
+        name: /Claude limits: 5h 95% remaining/i,
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('keeps an error visible instead of silently hiding the limits', () => {
+    render(
+      <BackendUsageLimits
+        backend="codex"
+        className="flex"
+        error={new Error('usage unavailable')}
+      />
+    )
+
+    expect(screen.getByText('limits failed')).toBeInTheDocument()
+    expect(
+      screen.getByRole('status', {
+        name: /Codex limits failed: usage unavailable/i,
+      })
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/chat/toolbar/BackendUsageLimits.tsx
+++ b/src/components/chat/toolbar/BackendUsageLimits.tsx
@@ -1,0 +1,240 @@
+import { Loader2 } from 'lucide-react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+export type UsageLimitBackend = 'codex' | 'claude'
+
+export interface UsageLimitWindowSnapshot {
+  usedPercent: number
+  resetsAt: number | null
+  limitWindowSeconds?: number | null
+}
+
+export interface UsageLimitSnapshot {
+  planType?: string | null
+  session?: UsageLimitWindowSnapshot | null
+  weekly?: UsageLimitWindowSnapshot | null
+  sonnetWeekly?: UsageLimitWindowSnapshot | null
+  fetchedAt?: number | null
+  rateLimitReachedType?: string | null
+}
+
+interface UsageLimitRow {
+  key: 'session' | 'weekly' | 'sonnetWeekly'
+  label: string
+  usedLabel: string
+  remainingLabel: string
+  resetShortLabel: string
+  resetFullLabel: string
+  ariaText: string
+  isEmpty: boolean
+}
+
+interface BackendUsageLimitsProps {
+  backend: UsageLimitBackend
+  usage?: UsageLimitSnapshot | null
+  isFetching?: boolean
+  error?: unknown
+  className?: string
+}
+
+const BACKEND_LABELS: Record<UsageLimitBackend, string> = {
+  codex: 'Codex',
+  claude: 'Claude',
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.min(100, Math.max(0, value))
+}
+
+function formatPercent(value: number): string {
+  const clamped = clampPercent(value)
+  if (clamped > 0 && clamped < 1) return '<1%'
+  return `${Math.round(clamped)}%`
+}
+
+function formatWindowSeconds(
+  seconds: number | null | undefined
+): string | null {
+  if (!seconds || !Number.isFinite(seconds) || seconds <= 0) return null
+
+  const days = seconds / 86_400
+  if (Number.isInteger(days) && days >= 1) return `${days}d`
+
+  const hours = seconds / 3_600
+  if (Number.isInteger(hours) && hours >= 1) return `${hours}h`
+
+  return null
+}
+
+function formatResetShort(timestamp: number | null): string {
+  if (!timestamp) return '↻ ?'
+
+  const date = new Date(timestamp * 1000)
+  if (Number.isNaN(date.getTime())) return '↻ ?'
+
+  const now = new Date()
+  const sameDay = date.toDateString() === now.toDateString()
+  const options: Intl.DateTimeFormatOptions = sameDay
+    ? { hour: '2-digit', minute: '2-digit' }
+    : { weekday: 'short', hour: '2-digit', minute: '2-digit' }
+
+  return `↻ ${date.toLocaleString(undefined, options)}`
+}
+
+function formatResetFull(timestamp: number | null): string {
+  if (!timestamp) return 'unknown'
+
+  const date = new Date(timestamp * 1000)
+  if (Number.isNaN(date.getTime())) return 'unknown'
+
+  return date.toLocaleString()
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  if (
+    error &&
+    typeof error === 'object' &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
+    return error.message
+  }
+  return 'Failed to load usage limits.'
+}
+
+function makeLimitRow(
+  key: UsageLimitRow['key'],
+  usage: UsageLimitWindowSnapshot | null | undefined
+): UsageLimitRow | null {
+  if (!usage) return null
+
+  const label =
+    key === 'session'
+      ? (formatWindowSeconds(usage.limitWindowSeconds) ?? '5h')
+      : key === 'sonnetWeekly'
+        ? 'Sonnet 7d'
+        : '7d'
+  const usedPercent = clampPercent(usage.usedPercent)
+  const remainingPercent = clampPercent(100 - usedPercent)
+  const usedLabel = formatPercent(usedPercent)
+  const remainingLabel = formatPercent(remainingPercent)
+  const resetFullLabel = formatResetFull(usage.resetsAt)
+  const resetShortLabel = formatResetShort(usage.resetsAt)
+
+  return {
+    key,
+    label,
+    usedLabel,
+    remainingLabel,
+    resetShortLabel,
+    resetFullLabel,
+    ariaText: `${label} ${remainingLabel} remaining, resets ${resetFullLabel}`,
+    isEmpty: remainingPercent <= 0,
+  }
+}
+
+export function BackendUsageLimits({
+  backend,
+  usage,
+  isFetching,
+  error,
+  className,
+}: BackendUsageLimitsProps) {
+  const primaryRows = [
+    makeLimitRow('session', usage?.session),
+    makeLimitRow('weekly', usage?.weekly),
+  ].filter((row): row is UsageLimitRow => Boolean(row))
+  const tooltipRows = [
+    ...primaryRows,
+    makeLimitRow('sonnetWeekly', usage?.sonnetWeekly),
+  ].filter((row): row is UsageLimitRow => Boolean(row))
+  const backendLabel = BACKEND_LABELS[backend]
+  const isLimited =
+    Boolean(usage?.rateLimitReachedType) || primaryRows.some(row => row.isEmpty)
+
+  if (!error && !isFetching && primaryRows.length === 0) return null
+
+  const ariaLabel = error
+    ? `${backendLabel} limits failed: ${getErrorMessage(error)}`
+    : primaryRows.length > 0
+      ? `${backendLabel} limits: ${primaryRows.map(row => row.ariaText).join('; ')}`
+      : `${backendLabel} limits loading`
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          role="status"
+          aria-label={ariaLabel}
+          className={cn(
+            'h-8 items-center gap-1.5 px-2 text-[10px] font-medium text-muted-foreground transition-colors',
+            'border-l border-border/50 bg-muted/20 hover:bg-muted/60',
+            isLimited && 'text-amber-600 dark:text-amber-400',
+            Boolean(error) && 'text-destructive',
+            className
+          )}
+        >
+          {isFetching && <Loader2 className="h-3 w-3 animate-spin" />}
+          {error ? (
+            <span>limits failed</span>
+          ) : primaryRows.length > 0 ? (
+            primaryRows.map((row, index) => (
+              <span key={row.key} className="inline-flex items-center gap-1">
+                {index > 0 && (
+                  <span className="text-muted-foreground/50">|</span>
+                )}
+                <span>{row.label}</span>
+                <span className="text-foreground">{row.remainingLabel}</span>
+                <span>{row.resetShortLabel}</span>
+              </span>
+            ))
+          ) : (
+            <span>limits…</span>
+          )}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent align="start" className="max-w-80 text-xs">
+        <div className="space-y-2">
+          <div className="font-medium text-foreground">
+            {backendLabel} usage limits
+          </div>
+          {error ? (
+            <p className="text-destructive">{getErrorMessage(error)}</p>
+          ) : tooltipRows.length > 0 ? (
+            <div className="space-y-1.5">
+              {tooltipRows.map(row => (
+                <div
+                  key={row.key}
+                  className="grid grid-cols-[auto_1fr] gap-x-2"
+                >
+                  <span className="font-medium text-foreground">
+                    {row.label}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {row.remainingLabel} left · {row.usedLabel} used · resets{' '}
+                    {row.resetFullLabel}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-muted-foreground">Loading usage limits…</p>
+          )}
+          {usage?.fetchedAt && (
+            <p className="text-[10px] text-muted-foreground/80">
+              Last updated: {new Date(usage.fetchedAt * 1000).toLocaleString()}
+            </p>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/components/chat/toolbar/DesktopToolbarControls.test.tsx
+++ b/src/components/chat/toolbar/DesktopToolbarControls.test.tsx
@@ -159,6 +159,30 @@ describe('DesktopToolbarControls', () => {
     expect(onAttach).toHaveBeenCalledTimes(1)
   })
 
+  it('shows backend usage limits beside the model picker', () => {
+    renderDesktopToolbarControls({
+      backendUsageSnapshot: {
+        session: {
+          usedPercent: 40,
+          resetsAt: null,
+          limitWindowSeconds: 18_000,
+        },
+        weekly: {
+          usedPercent: 10,
+          resetsAt: null,
+          limitWindowSeconds: 604_800,
+        },
+        fetchedAt: Date.parse('2026-06-18T12:00:00Z') / 1000,
+      },
+    })
+
+    expect(
+      screen.getByRole('status', { name: /Codex limits: 5h 60% remaining/i })
+    ).toBeInTheDocument()
+    expect(screen.getByText('7d')).toBeInTheDocument()
+    expect(screen.getByText('90%')).toBeInTheDocument()
+  })
+
   it('keeps desktop Magic and settings controls usable while questions are pending', () => {
     renderDesktopToolbarControls({ hasPendingQuestions: true })
 

--- a/src/components/chat/toolbar/DesktopToolbarControls.tsx
+++ b/src/components/chat/toolbar/DesktopToolbarControls.tsx
@@ -64,6 +64,10 @@ import {
 import { DesktopBackendModelPicker } from '@/components/chat/toolbar/DesktopBackendModelPicker'
 import { ExecutionModeDropdown } from '@/components/chat/toolbar/ExecutionModeDropdown'
 import { DockBurgerButton } from '@/components/chat/toolbar/DockBurgerButton'
+import {
+  BackendUsageLimits,
+  type UsageLimitSnapshot,
+} from '@/components/chat/toolbar/BackendUsageLimits'
 
 interface DesktopToolbarControlsProps {
   hasPendingQuestions: boolean
@@ -85,6 +89,9 @@ interface DesktopToolbarControlsProps {
   providerLocked?: boolean
   customCliProfiles: CustomCliProfile[]
   isCodex: boolean
+  backendUsageSnapshot?: UsageLimitSnapshot | null
+  backendUsageIsFetching?: boolean
+  backendUsageError?: unknown
 
   prUrl: string | undefined
   prNumber: number | undefined
@@ -160,6 +167,9 @@ export function DesktopToolbarControls({
   providerLocked,
   customCliProfiles,
   isCodex,
+  backendUsageSnapshot,
+  backendUsageIsFetching,
+  backendUsageError,
   prUrl,
   prNumber,
   displayStatus,
@@ -635,6 +645,16 @@ export function DesktopToolbarControls({
         onModelChange={handleModelChange}
         onBackendModelChange={handleBackendModelChange}
       />
+
+      {(selectedBackend === 'codex' || selectedBackend === 'claude') && (
+        <BackendUsageLimits
+          backend={selectedBackend}
+          usage={backendUsageSnapshot}
+          isFetching={backendUsageIsFetching}
+          error={backendUsageError}
+          className="hidden @xl:flex"
+        />
+      )}
 
       {!hideReasoningControl && (
         <div className="hidden @xl:block h-4 w-px bg-border/50" />

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -20,6 +20,8 @@ import remend from 'remend'
 import { Copy, Check, Table, ListChecks } from 'lucide-react'
 import { toast } from 'sonner'
 import { copyToClipboard } from '@/lib/clipboard'
+import { SmartLink } from '@/components/chat/SmartLink'
+import { enrichFilePaths } from '@/lib/path-enrichment'
 import {
   Tooltip,
   TooltipTrigger,
@@ -28,6 +30,7 @@ import {
 import { Checkbox } from '@/components/ui/checkbox'
 import { cn } from '@/lib/utils'
 import { useChatStore } from '@/store/chat-store'
+import type { AppPreferences } from '@/types/preferences'
 
 interface MarkdownProps {
   children: string
@@ -42,7 +45,25 @@ interface MarkdownProps {
   sessionId?: string
   /** Smaller mobile heading + spacing for narrow modal contexts */
   compact?: boolean
+  /** Worktree path used to resolve relative file links */
+  worktreePath?: string | null
+  /** Preferred editor used when opening file links */
+  editor?: AppPreferences['editor']
+  /** Optional override for file-link opening */
+  onOpenFile?: ((filePath: string, line?: number, column?: number) => void) | null
 }
+
+interface SmartLinkContextValue {
+  worktreePath: string | null
+  editor?: AppPreferences['editor']
+  onOpenFile: ((filePath: string, line?: number, column?: number) => void) | null
+}
+
+const SmartLinkContext = createContext<SmartLinkContextValue>({
+  worktreePath: null,
+  editor: undefined,
+  onOpenFile: null,
+})
 
 interface MarkdownTableContextValue {
   messageId: string | null
@@ -65,6 +86,26 @@ const ChecklistInjectionContext = createContext<ChecklistInjectionContextValue>(
     onToggle: () => undefined,
   }
 )
+
+function MarkdownLink({
+  href,
+  children,
+}: {
+  href?: string
+  children?: ReactNode
+}) {
+  const smartLinkContext = useContext(SmartLinkContext)
+  return (
+    <SmartLink
+      href={href}
+      worktreePath={smartLinkContext.worktreePath}
+      editor={smartLinkContext.editor}
+      onOpenFile={smartLinkContext.onOpenFile}
+    >
+      {children}
+    </SmartLink>
+  )
+}
 
 function extractText(node: ReactNode): string {
   if (typeof node === 'string') return node
@@ -393,16 +434,7 @@ const components: Components = {
   ),
 
   // Links
-  a: ({ href, children }) => (
-    <a
-      href={href}
-      className="underline underline-offset-2 hover:text-foreground"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {children}
-    </a>
-  ),
+  a: MarkdownLink,
 
   // Lists - generous spacing and indentation
   ul: ({ children, className, ...props }) => (
@@ -544,13 +576,26 @@ const Markdown = memo(function Markdown({
   messageId,
   sessionId,
   compact = false,
+  worktreePath,
+  editor,
+  onOpenFile = null,
 }: MarkdownProps) {
+  const activeWorktreePath = useChatStore(state => state.activeWorktreePath)
   // Apply remend preprocessing for streaming content to auto-close incomplete markdown
-  const content = streaming ? remend(children) : children
+  const rawContent = streaming ? remend(children) : children
+  const content = useMemo(() => enrichFilePaths(rawContent), [rawContent])
 
   const contextValue = useMemo(
     () => ({ messageId: messageId ?? null, sessionId: sessionId ?? null }),
     [messageId, sessionId]
+  )
+  const smartLinkContextValue = useMemo(
+    () => ({
+      worktreePath: worktreePath ?? activeWorktreePath ?? null,
+      editor,
+      onOpenFile,
+    }),
+    [worktreePath, activeWorktreePath, editor, onOpenFile]
   )
 
   const componentsToUse = streaming
@@ -566,13 +611,15 @@ const Markdown = memo(function Markdown({
   return (
     <div className={cn('markdown leading-relaxed break-words', className)}>
       <MarkdownTableContext.Provider value={contextValue}>
-        <ReactMarkdown
-          components={componentsToUse}
-          remarkPlugins={[remarkGfm]}
-          rehypePlugins={[rehypeRaw]}
-        >
-          {content}
-        </ReactMarkdown>
+        <SmartLinkContext.Provider value={smartLinkContextValue}>
+          <ReactMarkdown
+            components={componentsToUse}
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeRaw]}
+          >
+            {content}
+          </ReactMarkdown>
+        </SmartLinkContext.Provider>
       </MarkdownTableContext.Provider>
     </div>
   )

--- a/src/lib/link-utils.test.ts
+++ b/src/lib/link-utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { looksLikeFilePath } from './link-utils'
+
+describe('looksLikeFilePath', () => {
+  it('does not treat ordinary slash phrases as file paths', () => {
+    expect(looksLikeFilePath('Read/analyze')).toBe(false)
+  })
+
+  it('accepts common absolute and project-relative paths', () => {
+    expect(looksLikeFilePath('/home/niko/report.pdf')).toBe(true)
+    expect(looksLikeFilePath('./src/main.ts')).toBe(true)
+    expect(looksLikeFilePath('src/components/chat/ToolCallInline.tsx')).toBe(true)
+    expect(looksLikeFilePath('docs/tasks.md')).toBe(true)
+  })
+})

--- a/src/lib/link-utils.ts
+++ b/src/lib/link-utils.ts
@@ -1,0 +1,64 @@
+export interface ParsedFileLine {
+  filePath: string
+  line?: number
+  column?: number
+}
+
+const LINE_COLUMN_SUFFIX = /:(\d+)(?::(\d+))?$/
+const TRAILING_PUNCTUATION = /[),.;!?\]}]+$/
+const KNOWN_RELATIVE_PATH_PREFIX =
+  /^(?:\.github|app|assets|client|components|config|crates|docs|examples|fixtures|lib|migrations|packages|pages|public|scripts|server|services|src|styles|test|tests|tools|types|utils)\//
+const FILE_EXTENSION = /\/[^/\s]+\.[A-Za-z0-9]{1,12}$/
+
+export function parseFileLine(input: string): ParsedFileLine {
+  const trimmed = input.trim().replace(TRAILING_PUNCTUATION, '')
+  const match = LINE_COLUMN_SUFFIX.exec(trimmed)
+  if (!match) return { filePath: trimmed }
+
+  return {
+    filePath: trimmed.slice(0, match.index),
+    line: Number(match[1]),
+    column: match[2] ? Number(match[2]) : undefined,
+  }
+}
+
+export function looksLikeFilePath(input: string): boolean {
+  if (!input || /^https?:\/\//i.test(input) || /^mailto:/i.test(input)) {
+    return false
+  }
+
+  const { filePath } = parseFileLine(input)
+  if (filePath.startsWith('file://')) return true
+  if (filePath.startsWith('/') || filePath.startsWith('./')) return true
+  if (filePath.startsWith('../')) return true
+  if (!/[A-Za-z0-9_.-]+\/[^\s<>"'`]+/.test(filePath)) return false
+  return (
+    KNOWN_RELATIVE_PATH_PREFIX.test(filePath) ||
+    FILE_EXTENSION.test(filePath) ||
+    filePath.split('/').length > 2
+  )
+}
+
+export function resolveFilePath(
+  input: string,
+  worktreePath?: string | null
+): ParsedFileLine | null {
+  const parsed = parseFileLine(input)
+  let filePath = parsed.filePath
+
+  if (filePath.startsWith('file://')) {
+    try {
+      filePath = decodeURIComponent(new URL(filePath).pathname)
+    } catch {
+      return null
+    }
+  }
+
+  if (filePath.startsWith('/')) return { ...parsed, filePath }
+  if (!worktreePath) return null
+
+  const base = worktreePath.replace(/\/+$/, '')
+  const normalized = new URL(filePath, `file://${base}/`).pathname
+  if (!normalized.startsWith(`${base}/`) && normalized !== base) return null
+  return { ...parsed, filePath: normalized }
+}

--- a/src/lib/path-enrichment.ts
+++ b/src/lib/path-enrichment.ts
@@ -1,0 +1,33 @@
+import { looksLikeFilePath } from './link-utils'
+
+const PATH_TOKEN =
+  /(^|[\s([{])((?:file:\/\/[^\s<>"'`]+|(?:\/|\.{1,2}\/|[A-Za-z0-9_.-]+\/)[^\s<>"'`]+)(?::\d+(?::\d+)?)?)/g
+
+function isProbablyAlreadyLinked(prefix: string): boolean {
+  return prefix.endsWith('](') || prefix.endsWith('href="') || prefix.endsWith("href='")
+}
+
+function enrichLine(line: string): string {
+  return line.replace(PATH_TOKEN, (match, prefix: string, path: string, offset) => {
+    const before = line.slice(Math.max(0, offset - 3), offset) + prefix
+    if (isProbablyAlreadyLinked(before) || !looksLikeFilePath(path)) return match
+    return `${prefix}[${path}](${path})`
+  })
+}
+
+export function enrichFilePaths(markdown: string): string {
+  const lines = markdown.split('\n')
+  let inFence = false
+
+  return lines
+    .map(line => {
+      if (/^\s*```/.test(line)) {
+        inFence = !inFence
+        return line
+      }
+      if (inFence) return line
+      if (line.includes('`')) return line
+      return enrichLine(line)
+    })
+    .join('\n')
+}


### PR DESCRIPTION
## Summary

Adds richer chat rendering for tool outputs and backend usage state:

- extracts image, file, and link artifacts from tool output and renders compact preview cards
- redacts signed/image preview URLs from raw tool output when a card is rendered
- turns file/path references in markdown into SmartLink file links with editor-aware opening
- shows compact Codex/Claude usage limit badges next to the chat model picker, including remaining 5h/7d budget and reset time

## Validation

- `bun run typecheck`
- `bun run test:run src/components/chat/toolbar/BackendUsageLimits.test.tsx src/components/chat/toolbar/DesktopToolbarControls.test.tsx src/components/chat/ChatToolbar.test.tsx src/components/chat/ToolCallInline.test.tsx src/components/chat/ToolArtifactPreview.test.tsx src/components/chat/tool-artifacts.test.ts src/lib/link-utils.test.ts`
- `bunx eslint src/components/chat/ChatToolbar.tsx src/components/chat/ToolCallInline.tsx src/components/chat/ToolArtifactPreview.tsx src/components/chat/SmartLink.tsx src/components/chat/tool-artifacts.ts src/components/chat/toolbar/DesktopToolbarControls.tsx src/components/chat/toolbar/BackendUsageLimits.tsx src/components/ui/markdown.tsx src/lib/link-utils.ts src/lib/path-enrichment.ts --max-warnings 0`
- `git diff --check`