### PR TITLE
fix(projects): truncate long clone destinations

### DIFF
--- a/src/components/projects/CloneProjectModal.test.tsx
+++ b/src/components/projects/CloneProjectModal.test.tsx
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { render, screen, within } from '@/test/test-utils'
+import { CloneProjectModal } from './CloneProjectModal'
+import { useProjectsStore } from '@/store/projects-store'
+
+const saveMock = vi.fn()
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  save: (...args: unknown[]) => saveMock(...args),
+}))
+
+describe('CloneProjectModal', () => {
+  const longDestination =
+    '/Users/stacylia/Developer/coolify/this is a long name for a folder'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    saveMock.mockResolvedValue(longDestination)
+    ;(
+      window as unknown as { __TAURI_INTERNALS__?: { invoke: () => void } }
+    ).__TAURI_INTERNALS__ = { invoke: vi.fn() }
+    useProjectsStore.setState({
+      cloneModalOpen: true,
+      addProjectDialogOpen: true,
+      addProjectParentFolderId: null,
+    })
+  })
+
+  it('keeps long destination paths constrained and accessible', async () => {
+    render(<CloneProjectModal />)
+
+    const destinationButton = screen.getByRole('button', {
+      name: /choose destination/i,
+    })
+
+    await userEvent.click(destinationButton)
+
+    const updatedDestinationButton = await screen.findByRole('button', {
+      name: longDestination,
+    })
+    const destinationText = within(updatedDestinationButton).getByText(
+      longDestination
+    )
+    const destinationPreview = screen.getByText(longDestination, {
+      selector: 'p',
+    })
+
+    expect(updatedDestinationButton).toHaveClass(
+      'min-w-0',
+      'flex-1',
+      'overflow-hidden'
+    )
+    expect(updatedDestinationButton).toHaveAttribute('title', longDestination)
+    expect(destinationText).toHaveClass(
+      'min-w-0',
+      'flex-1',
+      'truncate',
+      'text-left'
+    )
+    expect(destinationPreview).toHaveClass('max-w-full', 'truncate')
+    expect(destinationPreview).toHaveAttribute('title', longDestination)
+  })
+})

--- a/src/components/projects/CloneProjectModal.tsx
+++ b/src/components/projects/CloneProjectModal.tsx
@@ -126,7 +126,7 @@ export function CloneProjectModal() {
   return (
     <Dialog open={cloneModalOpen} onOpenChange={handleOpenChange}>
       <>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="min-w-0 overflow-hidden sm:max-w-md">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Globe className="h-5 w-5" />
@@ -137,7 +137,7 @@ export function CloneProjectModal() {
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-4 py-4">
+          <div className="min-w-0 space-y-4 py-4">
             {/* Git URL input */}
             <div className="space-y-1.5">
               <Label htmlFor="clone-url" className="text-xs">
@@ -162,21 +162,25 @@ export function CloneProjectModal() {
             {/* Destination picker */}
             <div className="space-y-1.5">
               <Label className="text-xs">Destination</Label>
-              <div className="flex gap-2">
+              <div className="flex min-w-0 gap-2">
                 <Button
                   variant="outline"
-                  className="flex-1 justify-start"
+                  className="min-w-0 flex-1 justify-start overflow-hidden"
                   onClick={handleBrowse}
                   disabled={cloneProject.isPending}
+                  title={destination || undefined}
                 >
                   <FolderOpen className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
-                  <span className="truncate text-sm">
+                  <span className="min-w-0 flex-1 truncate text-left text-sm">
                     {destination || 'Choose destination...'}
                   </span>
                 </Button>
               </div>
               {destination && (
-                <p className="truncate text-xs text-muted-foreground">
+                <p
+                  className="max-w-full truncate text-xs text-muted-foreground"
+                  title={destination}
+                >
                   {destination}
                 </p>
               )}


### PR DESCRIPTION
## Summary
- Constrains the clone repository dialog so long destination paths no longer overflow the modal.
- Adds tooltips to preserve the full selected destination path for accessibility.
- Covers the long-path behavior with a focused component test.

fixes #424

---

Fixes #424