### PR TITLE
fix(wsl): run resolved CLIs through WSL context

### DIFF
--- a/src-tauri/src/chat/claude.rs
+++ b/src-tauri/src/chat/claude.rs
@@ -1004,7 +1004,7 @@ pub fn execute_claude_detached(
     // Get CLI path
     let cli_path = resolve_cli_binary(app);
 
-    if !cli_path.exists() {
+    if !crate::platform::resolved_cli_exists(&cli_path) {
         let error_msg = format!(
             "Claude CLI not found at {}. Please complete setup in Settings > Advanced.",
             cli_path.display()

--- a/src-tauri/src/chat/codex.rs
+++ b/src-tauri/src/chat/codex.rs
@@ -3974,7 +3974,7 @@ pub fn execute_one_shot_codex(
 ) -> Result<String, String> {
     let cli_path = crate::codex_cli::resolve_cli_binary(app)?;
 
-    if !cli_path.exists() {
+    if !crate::platform::resolved_cli_exists(&cli_path) {
         return Err("Codex CLI not installed".to_string());
     }
 
@@ -3993,19 +3993,37 @@ pub fn execute_one_shot_codex(
     std::fs::write(&schema_file, output_schema)
         .map_err(|e| format!("Failed to write schema file: {e}"))?;
 
-    let mut cmd = crate::platform::silent_command(&cli_path);
+    let wsl = crate::platform::get_wsl_config();
+    let schema_arg = if cfg!(windows) && wsl.enabled {
+        std::path::PathBuf::from(crate::platform::win_to_wsl_path(
+            &schema_file.to_string_lossy(),
+        ))
+    } else {
+        schema_file.clone()
+    };
+    let working_dir_arg = working_dir.map(|dir| {
+        if cfg!(windows) && wsl.enabled {
+            std::path::PathBuf::from(crate::platform::win_to_wsl_path(&dir.to_string_lossy()))
+        } else {
+            dir.to_path_buf()
+        }
+    });
+
+    let mut cmd = crate::platform::resolved_cli_command(&cli_path, working_dir);
     cmd.args(build_one_shot_codex_args(
         actual_model,
         is_fast,
-        &schema_file,
-        working_dir,
+        &schema_arg,
+        working_dir_arg.as_deref(),
     ));
     cmd.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
-    if let Some(dir) = working_dir {
-        cmd.current_dir(dir);
+    if !wsl.enabled {
+        if let Some(dir) = working_dir {
+            cmd.current_dir(dir);
+        }
     }
 
     let mut child = cmd

--- a/src-tauri/src/chat/codex_server.rs
+++ b/src-tauri/src/chat/codex_server.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Manager};
 
 use crate::codex_cli::resolve_cli_binary;
-use crate::platform::{is_process_alive, silent_command};
+use crate::platform::is_process_alive;
 
 // =============================================================================
 // Types
@@ -342,7 +342,7 @@ fn ensure_running_inner(app: &AppHandle) -> Result<(), String> {
     }
 
     let cli_path = resolve_cli_binary(app)?;
-    if !cli_path.exists() {
+    if !crate::platform::resolved_cli_exists(&cli_path) {
         return Err(format!(
             "Codex CLI not found at {}. Please install it in Settings > General.",
             cli_path.display()
@@ -696,7 +696,7 @@ fn ensure_running_stdio(
         cli_path.display()
     );
 
-    let mut child = silent_command(cli_path)
+    let mut child = crate::platform::resolved_cli_command(cli_path, None)
         .arg("app-server")
         .arg("--listen")
         .arg("stdio://")

--- a/src-tauri/src/gh_cli/commands.rs
+++ b/src-tauri/src/gh_cli/commands.rs
@@ -239,7 +239,7 @@ pub fn resolve_github_api_token(app: &AppHandle) -> Option<String> {
 
     let mut candidates: Vec<PathBuf> = Vec::new();
     let managed_gh = resolve_gh_binary(app);
-    if managed_gh.exists() {
+    if crate::platform::resolved_cli_exists(&managed_gh) {
         candidates.push(managed_gh);
     } else if let Ok(path) = get_gh_cli_binary_path(app) {
         if path.exists() {
@@ -249,7 +249,10 @@ pub fn resolve_github_api_token(app: &AppHandle) -> Option<String> {
     candidates.push(PathBuf::from("gh"));
 
     for program in candidates {
-        let output = match silent_command(&program).args(["auth", "token"]).output() {
+        let output = match crate::platform::resolved_cli_command(&program, None)
+            .args(["auth", "token"])
+            .output()
+        {
             Ok(output) => output,
             Err(_) => continue,
         };

--- a/src-tauri/src/platform/wsl.rs
+++ b/src-tauri/src/platform/wsl.rs
@@ -160,6 +160,34 @@ pub fn wsl_aware_command(program: &str, cwd: Option<&std::path::Path>) -> Comman
     cmd
 }
 
+/// True when `path` is a Unix-style absolute path that only exists inside WSL.
+pub fn is_wsl_unix_path(path: &std::path::Path) -> bool {
+    path.to_string_lossy().starts_with('/')
+}
+
+/// Check whether a resolved CLI path/tool is available in the current execution
+/// context. In WSL mode, Unix paths must be checked inside the distro instead
+/// of with Windows filesystem APIs.
+pub fn resolved_cli_exists(path: &std::path::Path) -> bool {
+    let config = get_wsl_config();
+    if cfg!(windows) && config.enabled {
+        let tool = path.to_string_lossy();
+        if tool.starts_with('/') {
+            return wsl_file_executable(&config.distro, &tool);
+        }
+        return check_wsl_tool(&config.distro, &tool);
+    }
+
+    path.exists()
+}
+
+/// Build a command for a resolved CLI path/tool in the current execution
+/// context. In WSL mode this routes through `wsl.exe --cd <cwd> -- <tool>`.
+pub fn resolved_cli_command(path: &std::path::Path, cwd: Option<&std::path::Path>) -> Command {
+    let program = path.to_string_lossy();
+    wsl_aware_command(&program, cwd)
+}
+
 /// Check if WSL is available on this system.
 #[cfg(windows)]
 pub fn is_wsl_available() -> bool {
@@ -555,6 +583,20 @@ mod tests {
             win_to_wsl_path(r"\\wsl.localhost\Ubuntu\home\user\project"),
             "/home/user/project"
         );
+    }
+
+    #[test]
+    fn test_is_wsl_unix_path_detects_linux_absolute_path() {
+        assert!(is_wsl_unix_path(std::path::Path::new(
+            "/home/alice/.local/share/jean/gh-cli/gh"
+        )));
+    }
+
+    #[test]
+    fn test_is_wsl_unix_path_rejects_windows_path() {
+        assert!(!is_wsl_unix_path(std::path::Path::new(
+            r"C:\Users\alice\AppData\Roaming\jean\gh-cli\gh.exe"
+        )));
     }
 
     #[test]

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -54,6 +54,10 @@ use crate::http_server::EmitExt;
 use crate::platform::silent_command;
 use crate::platform::wsl_aware_command;
 
+fn gh_command(gh: &Path, project_path: &str) -> std::process::Command {
+    crate::platform::resolved_cli_command(gh, Some(Path::new(project_path)))
+}
+
 static RELEASE_NOTES_PAREN_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\(([^)]*)\)").expect("valid release notes parenthetical regex"));
 static RELEASE_NOTES_LEADING_PR_RE: Lazy<Regex> =
@@ -5370,7 +5374,7 @@ pub async fn link_worktree_pr(
     log::trace!("Linking PR #{pr_number} to worktree {worktree_id}");
 
     let gh = resolve_gh_binary(&app);
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &worktree_path)
         .args([
             "pr",
             "view",
@@ -5378,7 +5382,6 @@ pub async fn link_worktree_pr(
             "--json",
             "number,url,title",
         ])
-        .current_dir(&worktree_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr view: {e}"))?;
 
@@ -5436,7 +5439,7 @@ pub async fn detect_open_pr_for_branch(
     let current_branch = git::get_current_branch(&worktree_path)?;
     let repo = get_repo_identifier(&worktree_path)?;
     let gh = resolve_gh_binary(&app);
-    let view_output = silent_command(&gh)
+    let view_output = gh_command(&gh, &worktree_path)
         .args([
             "api",
             "--method",
@@ -5449,7 +5452,6 @@ pub async fn detect_open_pr_for_branch(
             "-f",
             "per_page=1",
         ])
-        .current_dir(&worktree_path)
         .output()
         .map_err(|e| format!("Failed to run gh api: {e}"))?;
 
@@ -5493,9 +5495,8 @@ pub async fn detect_and_link_pr(
     log::trace!("Detecting PR for worktree {worktree_id} at {worktree_path}");
 
     let gh = resolve_gh_binary(&app);
-    let view_output = silent_command(&gh)
+    let view_output = gh_command(&gh, &worktree_path)
         .args(["pr", "view", "--json", "number,url,title"])
-        .current_dir(&worktree_path)
         .output();
 
     if let Ok(view_out) = view_output {
@@ -5584,7 +5585,7 @@ pub async fn trigger_coderabbit_pr_review(
     let gh = resolve_gh_binary(&app);
     let target_pr_number =
         pr_number.ok_or_else(|| "Open or link a PR in Jean first".to_string())?;
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &worktree_path)
         .args([
             "pr",
             "view",
@@ -5592,7 +5593,6 @@ pub async fn trigger_coderabbit_pr_review(
             "--json",
             "number,url",
         ])
-        .current_dir(&worktree_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr view: {e}"))?;
 
@@ -5606,7 +5606,7 @@ pub async fn trigger_coderabbit_pr_review(
     let pr_url = view_json["url"].as_str().unwrap_or("").to_string();
 
     let comment_body = "@coderabbitai review".to_string();
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &worktree_path)
         .args([
             "pr",
             "comment",
@@ -5614,7 +5614,6 @@ pub async fn trigger_coderabbit_pr_review(
             "--body",
             &comment_body,
         ])
-        .current_dir(&worktree_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr comment: {e}"))?;
 
@@ -6494,9 +6493,8 @@ pub async fn create_pr_with_ai_content(
 
     // Check if a PR already exists for this branch before spending time/tokens on AI generation
     let gh = resolve_gh_binary(&app);
-    let view_output = silent_command(&gh)
+    let view_output = gh_command(&gh, &worktree_path)
         .args(["pr", "view", "--json", "number,url,title"])
-        .current_dir(&worktree_path)
         .output();
 
     if let Ok(view_out) = view_output {
@@ -6629,7 +6627,7 @@ pub async fn create_pr_with_ai_content(
 
     // Create the PR using gh CLI
     log::trace!("Creating PR with gh CLI");
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &worktree_path)
         .args([
             "pr",
             "create",
@@ -6640,7 +6638,6 @@ pub async fn create_pr_with_ai_content(
             "--body",
             &pr_content.body,
         ])
-        .current_dir(&worktree_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr create: {e}"))?;
 
@@ -6648,9 +6645,8 @@ pub async fn create_pr_with_ai_content(
         let stderr = String::from_utf8_lossy(&output.stderr);
         if stderr.contains("already exists") {
             // Try to look up the existing PR and link it to the worktree
-            let view_output = silent_command(&gh)
+            let view_output = gh_command(&gh, &worktree_path)
                 .args(["pr", "view", "--json", "number,url,title"])
-                .current_dir(&worktree_path)
                 .output();
 
             if let Ok(view_out) = view_output {
@@ -6726,14 +6722,13 @@ pub async fn merge_github_pr(
     let gh = resolve_gh_binary(&app);
 
     // 1. Check PR status and mergeability
-    let view_output = silent_command(&gh)
+    let view_output = gh_command(&gh, &worktree_path)
         .args([
             "pr",
             "view",
             "--json",
             "number,state,mergeable,mergeStateStatus,url,title",
         ])
-        .current_dir(&worktree_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr view: {e}"))?;
 
@@ -6764,9 +6759,8 @@ pub async fn merge_github_pr(
     let title = pr_info["title"].as_str().unwrap_or("").to_string();
 
     // 2. Merge the PR
-    let merge_output = silent_command(&gh)
+    let merge_output = gh_command(&gh, &worktree_path)
         .args(["pr", "merge", "--merge"])
-        .current_dir(&worktree_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr merge: {e}"))?;
 
@@ -8952,7 +8946,7 @@ pub async fn list_github_releases(
     log::trace!("Listing GitHub releases for: {project_path}");
 
     let gh = resolve_gh_binary(&app);
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args([
             "release",
             "list",
@@ -8961,7 +8955,6 @@ pub async fn list_github_releases(
             "--limit",
             "30",
         ])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh CLI: {e}"))?;
 

--- a/src-tauri/src/projects/git.rs
+++ b/src-tauri/src/projects/git.rs
@@ -9,6 +9,10 @@ use serde::{Deserialize, Serialize};
 
 use super::types::{JeanConfig, MergeType};
 
+fn gh_command(gh: &Path, repo_path: &str) -> std::process::Command {
+    crate::platform::resolved_cli_command(gh, Some(Path::new(repo_path)))
+}
+
 static WORKTREE_CREATE_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 const WORKTREE_CREATE_ATTEMPTS: usize = 4;
 
@@ -895,7 +899,7 @@ pub fn git_push_to_pr(
     log::trace!("Pushing to PR #{pr_number} remote branch in {repo_path}");
 
     // 1. Query PR info from GitHub
-    let gh_output = silent_command(gh_binary)
+    let gh_output = gh_command(gh_binary, repo_path)
         .args([
             "pr",
             "view",
@@ -903,7 +907,6 @@ pub fn git_push_to_pr(
             "--json",
             "headRefName,isCrossRepository,headRepositoryOwner,headRepository",
         ])
-        .current_dir(repo_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr view: {e}"))?;
 
@@ -1357,9 +1360,8 @@ pub fn gh_pr_checkout(
         args.extend(["-b", name]);
     }
 
-    let output = silent_command(gh_binary)
+    let output = gh_command(gh_binary, worktree_path)
         .args(&args)
-        .current_dir(worktree_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr checkout: {e}"))?;
 
@@ -1767,9 +1769,8 @@ pub fn open_pull_request(
 
     log::trace!("Running gh command with args: {:?}", args);
 
-    let output = silent_command(gh_binary)
+    let output = gh_command(gh_binary, repo_path)
         .args(&args)
-        .current_dir(repo_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr create: {e}"))?;
 

--- a/src-tauri/src/projects/github_actions.rs
+++ b/src-tauri/src/projects/github_actions.rs
@@ -2,7 +2,11 @@ use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 
 use crate::gh_cli::config::resolve_gh_binary;
-use crate::platform::silent_command;
+use std::path::Path;
+
+fn gh_command(gh: &Path, project_path: &str) -> std::process::Command {
+    crate::platform::resolved_cli_command(gh, Some(Path::new(project_path)))
+}
 
 // =============================================================================
 // GitHub Actions Types
@@ -62,9 +66,8 @@ pub async fn list_workflow_runs(
         args.push(b.clone());
     }
 
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args(&args)
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh run list: {e}"))?;
 

--- a/src-tauri/src/projects/github_issues.rs
+++ b/src-tauri/src/projects/github_issues.rs
@@ -1,11 +1,15 @@
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Manager};
 
 use super::git::get_repo_identifier;
 use crate::gh_cli::config::resolve_gh_binary;
-use crate::platform::silent_command;
+
+fn gh_command(gh: &Path, project_path: &str) -> Command {
+    crate::platform::resolved_cli_command(gh, Some(Path::new(project_path)))
+}
 
 // =============================================================================
 // GitHub Types
@@ -83,9 +87,8 @@ pub async fn list_github_labels(
     log::trace!("Listing GitHub labels for {project_path}");
 
     let gh = resolve_gh_binary(&app);
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args(["label", "list", "--json", "name,color", "-L", "1000"])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh label list: {e}"))?;
 
@@ -163,7 +166,7 @@ pub async fn list_github_issues(
     let state_arg = state.unwrap_or_else(|| "open".to_string());
 
     // Run gh issue list
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args([
             "issue",
             "list",
@@ -174,7 +177,6 @@ pub async fn list_github_issues(
             "--state",
             &state_arg,
         ])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh issue list: {e}"))?;
 
@@ -212,7 +214,7 @@ pub async fn list_github_issues(
 ///
 /// Uses `gh api search/issues` to get the real total count without fetching all issues.
 /// Falls back to None on any error so callers can use issues.len() instead.
-fn get_issue_total_count(gh: &PathBuf, project_path: &str, state: &str) -> Option<u32> {
+fn get_issue_total_count(gh: &Path, project_path: &str, state: &str) -> Option<u32> {
     let repo_id = get_repo_identifier(project_path).ok()?;
     let state_qualifier = match state {
         "closed" => "+state:closed",
@@ -224,9 +226,8 @@ fn get_issue_total_count(gh: &PathBuf, project_path: &str, state: &str) -> Optio
         repo_id.owner, repo_id.repo, state_qualifier
     );
 
-    let output = silent_command(gh)
+    let output = gh_command(gh, project_path)
         .args(["api", &query])
-        .current_dir(project_path)
         .output()
         .ok()?;
 
@@ -252,7 +253,7 @@ pub async fn search_github_issues(
     log::trace!("Searching GitHub issues for {project_path} with query: {query}");
 
     let gh = resolve_gh_binary(&app);
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args([
             "issue",
             "list",
@@ -265,7 +266,6 @@ pub async fn search_github_issues(
             "--state",
             "all",
         ])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh issue list --search: {e}"))?;
 
@@ -304,7 +304,7 @@ pub async fn get_github_issue_by_number(
     log::trace!("Getting GitHub issue #{issue_number} by number for {project_path}");
 
     let gh = resolve_gh_binary(&app);
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args([
             "issue",
             "view",
@@ -312,7 +312,6 @@ pub async fn get_github_issue_by_number(
             "--json",
             "number,title,body,state,labels,createdAt,author",
         ])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh issue view: {e}"))?;
 
@@ -348,7 +347,7 @@ pub async fn get_github_issue(
 
     let gh = resolve_gh_binary(&app);
     // Run gh issue view
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args([
             "issue",
             "view",
@@ -356,7 +355,6 @@ pub async fn get_github_issue(
             "--json",
             "number,title,body,state,labels,createdAt,author,url,comments",
         ])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh issue view: {e}"))?;
 
@@ -1537,7 +1535,7 @@ pub async fn list_github_prs(
     let state_arg = state.unwrap_or_else(|| "open".to_string());
 
     // Run gh pr list
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args([
             "pr",
             "list",
@@ -1548,7 +1546,6 @@ pub async fn list_github_prs(
             "--state",
             &state_arg,
         ])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr list: {e}"))?;
 
@@ -1587,7 +1584,7 @@ pub async fn search_github_prs(
     log::trace!("Searching GitHub PRs for {project_path} with query: {query}");
 
     let gh = resolve_gh_binary(&app);
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args([
             "pr",
             "list",
@@ -1600,7 +1597,6 @@ pub async fn search_github_prs(
             "--state",
             "all",
         ])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr list --search: {e}"))?;
 
@@ -1639,7 +1635,7 @@ pub async fn get_github_pr_by_number(
     log::trace!("Getting GitHub PR #{pr_number} by number for {project_path}");
 
     let gh = resolve_gh_binary(&app);
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args([
             "pr",
             "view",
@@ -1647,7 +1643,6 @@ pub async fn get_github_pr_by_number(
             "--json",
             "number,title,body,state,headRefName,baseRefName,isDraft,createdAt,author,labels",
         ])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr view: {e}"))?;
 
@@ -1683,7 +1678,7 @@ pub async fn get_github_pr(
 
     let gh = resolve_gh_binary(&app);
     // Run gh pr view
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args([
             "pr",
             "view",
@@ -1691,7 +1686,6 @@ pub async fn get_github_pr(
             "--json",
             "number,title,body,state,headRefName,baseRefName,isDraft,createdAt,author,url,labels,comments,reviews",
         ])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr view: {e}"))?;
 
@@ -1768,9 +1762,8 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
         format!("query={query}"),
     ];
 
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args(&args)
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh api graphql: {e}"))?;
 
@@ -1898,9 +1891,8 @@ pub fn get_pr_diff(
 ) -> Result<String, String> {
     log::debug!("Fetching diff for PR #{pr_number} in {project_path}");
 
-    let output = silent_command(gh_binary)
+    let output = gh_command(gh_binary, project_path)
         .args(["pr", "diff", &pr_number.to_string(), "--color", "never"])
-        .current_dir(project_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr diff: {e}"))?;
 
@@ -2547,9 +2539,8 @@ pub async fn list_dependabot_alerts(
         repo_id.owner, repo_id.repo, state_arg
     );
 
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args(["api", &endpoint])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh api: {e}"))?;
 
@@ -2596,9 +2587,8 @@ pub async fn get_dependabot_alert(
         repo_id.owner, repo_id.repo
     );
 
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args(["api", &endpoint])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh api: {e}"))?;
 
@@ -2643,9 +2633,8 @@ pub async fn load_security_alert_context(
             "/repos/{}/{}/dependabot/alerts/{alert_number}",
             repo_id.owner, repo_id.repo
         );
-        let output = silent_command(&gh)
+        let output = gh_command(&gh, &project_path)
             .args(["api", &endpoint])
-            .current_dir(&project_path)
             .output()
             .map_err(|e| format!("Failed to run gh api: {e}"))?;
 
@@ -2870,9 +2859,8 @@ pub async fn list_repository_advisories(
         endpoint.push_str(&format!("&state={s}"));
     }
 
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args(["api", &endpoint])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh api: {e}"))?;
 
@@ -2919,9 +2907,8 @@ pub async fn get_repository_advisory(
         repo_id.owner, repo_id.repo
     );
 
-    let output = silent_command(&gh)
+    let output = gh_command(&gh, &project_path)
         .args(["api", &endpoint])
-        .current_dir(&project_path)
         .output()
         .map_err(|e| format!("Failed to run gh api: {e}"))?;
 
@@ -2966,9 +2953,8 @@ pub async fn load_advisory_context(
             "/repos/{}/{}/security-advisories/{ghsa_id}",
             repo_id.owner, repo_id.repo
         );
-        let output = silent_command(&gh)
+        let output = gh_command(&gh, &project_path)
             .args(["api", &endpoint])
-            .current_dir(&project_path)
             .output()
             .map_err(|e| format!("Failed to run gh api: {e}"))?;
 

--- a/src-tauri/src/projects/pr_status.rs
+++ b/src-tauri/src/projects/pr_status.rs
@@ -1,7 +1,10 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::platform::silent_command;
 use serde::{Deserialize, Serialize};
+
+fn gh_command(gh: &std::path::Path, project_path: &str) -> std::process::Command {
+    crate::platform::resolved_cli_command(gh, Some(std::path::Path::new(project_path)))
+}
 
 /// PR state from GitHub API
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -94,7 +97,7 @@ pub fn get_pr_status(
     log::trace!("Fetching PR status for #{pr_number} in {repo_path}");
 
     // Run gh pr view
-    let output = silent_command(gh_binary)
+    let output = gh_command(gh_binary, repo_path)
         .args([
             "pr",
             "view",
@@ -102,7 +105,6 @@ pub fn get_pr_status(
             "--json",
             "state,isDraft,reviewDecision,statusCheckRollup,mergeable",
         ])
-        .current_dir(repo_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr view: {e}"))?;
 

--- a/src-tauri/src/projects/release_notes.rs
+++ b/src-tauri/src/projects/release_notes.rs
@@ -8,6 +8,10 @@ use tauri::AppHandle;
 use crate::gh_cli::config::resolve_gh_binary;
 use crate::platform::silent_command;
 
+fn gh_command(gh: &Path, project_path: &str) -> std::process::Command {
+    crate::platform::resolved_cli_command(gh, Some(Path::new(project_path)))
+}
+
 pub type PrIssueRefsMap = BTreeMap<u32, BTreeMap<String, BTreeSet<u32>>>;
 
 static PR_NUMBER_IN_SUBJECT_RE: Lazy<Regex> =
@@ -195,7 +199,7 @@ fn load_pull_requests(
     tag_date: &str,
 ) -> Result<Vec<GitHubPullRequestCandidate>, String> {
     let search = format!("merged:>={tag_date}");
-    let output = silent_command(gh)
+    let output = gh_command(gh, project_path)
         .args([
             "pr",
             "list",
@@ -208,7 +212,6 @@ fn load_pull_requests(
             "--json",
             "number,title,body,closingIssuesReferences,mergeCommit",
         ])
-        .current_dir(project_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr list: {e}"))?;
 
@@ -230,9 +233,8 @@ fn load_pull_request_commits(
     project_path: &str,
     pr_number: u32,
 ) -> Result<Vec<GitHubPullRequestCommit>, String> {
-    let output = silent_command(gh)
+    let output = gh_command(gh, project_path)
         .args(["pr", "view", &pr_number.to_string(), "--json", "commits"])
-        .current_dir(project_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr view for #{pr_number}: {e}"))?;
 
@@ -276,7 +278,7 @@ fn load_pull_request_detail(
         commits: Vec<GitHubPullRequestCommit>,
     }
 
-    let output = silent_command(gh)
+    let output = gh_command(gh, project_path)
         .args([
             "pr",
             "view",
@@ -284,7 +286,6 @@ fn load_pull_request_detail(
             "--json",
             "number,title,body,closingIssuesReferences,commits",
         ])
-        .current_dir(project_path)
         .output()
         .map_err(|e| format!("Failed to run gh pr view for #{pr_number}: {e}"))?;
 


### PR DESCRIPTION
## Summary
- Route resolved Claude, Codex, and GitHub CLI commands through the WSL execution context when WSL mode is enabled.
- Check Unix-style managed CLI paths from inside WSL instead of relying on Windows filesystem checks.
- Convert Codex one-shot schema and working-directory paths before invoking commands in WSL.

## Fixes
- fixes #420

---

Fixes #420