### PR TITLE
fix(magic): show saved Linear context content

### DIFF
--- a/src/components/magic/LinearItemsTab.tsx
+++ b/src/components/magic/LinearItemsTab.tsx
@@ -105,6 +105,7 @@ export function LinearItemsTab({
                     <TooltipTrigger asChild>
                       <button
                         onClick={() => onViewLoaded(ctx)}
+                        aria-label={`View context for ${ctx.identifier}`}
                         className="p-1 rounded hover:bg-accent-foreground/10"
                       >
                         <Eye className="h-3.5 w-3.5 text-muted-foreground" />

--- a/src/components/magic/LoadContextModal.linear.test.tsx
+++ b/src/components/magic/LoadContextModal.linear.test.tsx
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@/test/test-utils'
+import { LoadContextModal } from './LoadContextModal'
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  invalidateQueries: vi.fn(),
+  refetch: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+vi.mock('@/lib/transport', () => ({ invoke: mocks.invoke }))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    success: vi.fn(),
+    loading: vi.fn(() => 'toast-1'),
+  },
+}))
+
+vi.mock('@tanstack/react-query', async importOriginal => ({
+  ...(await importOriginal()),
+  useQueryClient: () => ({
+    invalidateQueries: mocks.invalidateQueries,
+  }),
+}))
+
+vi.mock('@/hooks/useGhLogin', () => ({
+  useGhLogin: () => ({ triggerLogin: vi.fn(), isGhInstalled: true }),
+}))
+
+vi.mock('@/services/preferences', () => ({
+  usePreferences: () => ({ data: {} }),
+}))
+
+vi.mock('@/services/github', () => ({
+  githubQueryKeys: {
+    issues: (path: string, state: string) => ['issues', path, state],
+    prs: (path: string, state: string) => ['prs', path, state],
+    securityAlerts: (path: string, state: string) => [
+      'security-alerts',
+      path,
+      state,
+    ],
+    advisories: (path: string, state: string) => ['advisories', path, state],
+    loadedContexts: (sessionId: string) => ['loaded-contexts', sessionId],
+    loadedPrContexts: (sessionId: string) => ['loaded-pr-contexts', sessionId],
+    attachedContexts: (sessionId: string) => ['attached-contexts', sessionId],
+    loadedSecurityContexts: (sessionId: string) => [
+      'loaded-security-contexts',
+      sessionId,
+    ],
+    loadedAdvisoryContexts: (sessionId: string) => [
+      'loaded-advisory-contexts',
+      sessionId,
+    ],
+  },
+}))
+
+vi.mock('@/services/linear', () => ({
+  linearQueryKeys: {
+    issues: (projectId: string) => ['linear', 'issues', projectId],
+    loadedContexts: (sessionId: string) => [
+      'linear',
+      'loaded-contexts',
+      sessionId,
+    ],
+  },
+  isLinearAuthError: () => false,
+}))
+
+vi.mock('@/components/ui/markdown', () => ({
+  Markdown: ({ children }: { children: string }) => <div>{children}</div>,
+}))
+
+vi.mock('./hooks/useLoadContextData', () => ({
+  useLoadContextData: () => ({
+    loadedIssueContexts: [],
+    isLoadingIssueContexts: false,
+    refetchIssueContexts: mocks.refetch,
+    loadedPRContexts: [],
+    isLoadingPRContexts: false,
+    refetchPRContexts: mocks.refetch,
+    loadedSecurityContexts: [],
+    isLoadingSecurityContexts: false,
+    refetchSecurityContexts: mocks.refetch,
+    loadedAdvisoryContexts: [],
+    isLoadingAdvisoryContexts: false,
+    refetchAdvisoryContexts: mocks.refetch,
+    attachedSavedContexts: [],
+    isLoadingAttachedContexts: false,
+    refetchAttachedContexts: mocks.refetch,
+    isLoadingIssues: false,
+    isRefetchingIssues: false,
+    isSearchingIssues: false,
+    issuesError: null,
+    refetchIssues: mocks.refetch,
+    isLoadingPRs: false,
+    isRefetchingPRs: false,
+    isSearchingPRs: false,
+    prsError: null,
+    refetchPRs: mocks.refetch,
+    isLoadingSecurityAlerts: false,
+    isRefetchingSecurityAlerts: false,
+    securityError: null,
+    refetchSecurityAlerts: mocks.refetch,
+    isLoadingAdvisories: false,
+    isRefetchingAdvisories: false,
+    refetchAdvisories: mocks.refetch,
+    isLoadingContexts: false,
+    isLoadingSessions: false,
+    contextsError: null,
+    refetchContexts: mocks.refetch,
+    loadedLinearContexts: [
+      {
+        identifier: 'ENG-123',
+        title: 'Fix Linear context viewer',
+        commentCount: 1,
+        projectName: 'Jean',
+        url: 'https://linear.app/acme/issue/ENG-123',
+      },
+    ],
+    isLoadingLinearContexts: false,
+    refetchLinearContexts: mocks.refetch,
+    isLoadingLinearIssues: false,
+    isRefetchingLinearIssues: false,
+    isSearchingLinearIssues: false,
+    linearIssuesError: null,
+    refetchLinearIssues: mocks.refetch,
+    filteredIssues: [],
+    filteredPRs: [],
+    filteredSecurityAlerts: [],
+    filteredAdvisories: [],
+    filteredLinearIssues: [],
+    filteredContexts: [],
+    filteredEntries: [],
+    renameMutation: { mutate: vi.fn() },
+    hasLoadedIssueContexts: false,
+    hasLoadedPRContexts: false,
+    hasLoadedSecurityContexts: false,
+    hasLoadedAdvisoryContexts: false,
+    hasLoadedLinearContexts: true,
+    hasAttachedContexts: false,
+    hasContexts: false,
+    hasSessions: false,
+  }),
+}))
+
+describe('LoadContextModal Linear context viewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.invoke.mockResolvedValue([
+      {
+        identifier: 'ENG-123',
+        title: 'Fix Linear context viewer',
+        content:
+          '# Linear Issue ENG-123: Fix Linear context viewer\n\nExpected markdown content from Linear.',
+      },
+    ])
+  })
+
+  it('opens the saved Linear context markdown when View context is clicked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <LoadContextModal
+        open={true}
+        onOpenChange={vi.fn()}
+        worktreeId="wt-1"
+        worktreePath="/repo/worktree"
+        activeSessionId="session-1"
+        projectName="Jean"
+        projectId="project-1"
+      />
+    )
+
+    await screen.findByText('Loaded Linear Issues')
+
+    await user.click(
+      screen.getByRole('button', { name: 'View context for ENG-123' })
+    )
+
+    await waitFor(() => {
+      expect(mocks.invoke).toHaveBeenCalledWith(
+        'get_linear_issue_context_contents',
+        {
+          sessionId: 'session-1',
+          worktreeId: 'wt-1',
+          projectId: 'project-1',
+        }
+      )
+    })
+    expect(
+      await screen.findByText(/Expected markdown content from Linear/)
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/magic/LoadContextModal.tsx
+++ b/src/components/magic/LoadContextModal.tsx
@@ -536,7 +536,8 @@ export function LoadContextModal({
         {handlers.viewingContext &&
           (handlers.viewingContext.type === 'saved' ||
             handlers.viewingContext.type === 'security' ||
-            handlers.viewingContext.type === 'advisory') && (
+            handlers.viewingContext.type === 'advisory' ||
+            handlers.viewingContext.type === 'linear') && (
             <Dialog
               open={true}
               onOpenChange={() => handlers.setViewingContext(null)}
@@ -548,6 +549,8 @@ export function LoadContextModal({
                       <Shield className="h-4 w-4 text-orange-500" />
                     ) : handlers.viewingContext.type === 'advisory' ? (
                       <ShieldAlert className="h-4 w-4 text-orange-500" />
+                    ) : handlers.viewingContext.type === 'linear' ? (
+                      <LinearIcon className="h-4 w-4 text-violet-500" />
                     ) : (
                       <FolderOpen className="h-4 w-4 text-blue-500" />
                     )}

--- a/src/components/magic/hooks/useLoadContextHandlers.ts
+++ b/src/components/magic/hooks/useLoadContextHandlers.ts
@@ -33,11 +33,18 @@ import type { LinearIssue, LoadedLinearIssueContext } from '@/types/linear'
 import type { MagicPromptProviders } from '@/types/preferences'
 import type { SessionWithContext } from '../LoadContextItems'
 
+interface LinearIssueContextContent {
+  identifier: string
+  title: string
+  content: string
+}
+
 export interface ViewingContext {
   type: 'issue' | 'pr' | 'security' | 'advisory' | 'saved' | 'linear'
   number?: number
   ghsaId?: string
   slug?: string
+  identifier?: string
   title: string
   content: string
 }
@@ -571,14 +578,34 @@ export function useLoadContextHandlers({
   const handleViewLinearIssue = useCallback(
     async (ctx: LoadedLinearIssueContext) => {
       if (!activeSessionId || !projectId) return
-      // Show the identifier and title in a simple viewer
-      setViewingContext({
-        type: 'linear',
-        title: `${ctx.identifier}: ${ctx.title}`,
-        content: '',
-      })
+      try {
+        const contents = await invoke<LinearIssueContextContent[]>(
+          'get_linear_issue_context_contents',
+          {
+            sessionId: activeSessionId,
+            worktreeId: worktreeId ?? undefined,
+            projectId,
+          }
+        )
+        const match = contents.find(
+          content =>
+            content.identifier.toLowerCase() === ctx.identifier.toLowerCase()
+        )
+        if (!match) {
+          toast.error(`Failed to load context: ${ctx.identifier} not found`)
+          return
+        }
+        setViewingContext({
+          type: 'linear',
+          identifier: ctx.identifier,
+          title: `${ctx.identifier}: ${ctx.title}`,
+          content: match.content,
+        })
+      } catch (error) {
+        toast.error(`Failed to load context: ${error}`)
+      }
     },
-    [activeSessionId, projectId]
+    [activeSessionId, worktreeId, projectId]
   )
 
   const handleSelectLinearIssue = useCallback(


### PR DESCRIPTION
## Summary
- Load the saved Linear issue markdown when clicking View context in the context modal.
- Render Linear context in the full-screen context viewer with Linear-specific labeling.
- Add test coverage for opening a saved Linear context from the loaded contexts list.

## Issue
fixes #427

---

Fixes #427