### PR TITLE
fix(chat): tolerate stale terminal disposal

### DIFF
--- a/src/components/chat/ChatWindow.terminal-modal-regression.test.ts
+++ b/src/components/chat/ChatWindow.terminal-modal-regression.test.ts
@@ -32,20 +32,26 @@ describe('terminal primary surface modal regression', () => {
   it('auto-restores terminal sessions silently without marking them opened', () => {
     const source = readSource('src/components/chat/ChatWindow.tsx')
 
-    expect(source).toContain('reconnectNativeCliSession(session, activeWorktreeId')
-    expect(source).toContain('openModal: false')
-    expect(source).toContain('showToast: false')
-    expect(source).toContain('markOpened: false')
+    expect(source).toMatch(
+      /reconnectNativeCliSession\s*\(\s*session\s*,\s*activeWorktreeId/
+    )
+    expect(source).toMatch(/openModal:\s*false/)
+    expect(source).toMatch(/showToast:\s*false/)
+    expect(source).toMatch(/markOpened:\s*false/)
   })
 
   it('guards terminal auto-restore against session switches and duplicate spawns', () => {
     const source = readSource('src/components/chat/ChatWindow.tsx')
 
-    expect(source).toContain('if (isSessionSwitching) return')
-    expect(source).toContain(
-      'if (autoReconnectingRef.current.has(deferredSessionId)) return'
+    expect(source).toMatch(/if\s*\(\s*isSessionSwitching\s*\)\s*return/)
+    expect(source).toMatch(
+      /if\s*\(\s*autoReconnectingRef\.current\.has\s*\(\s*deferredSessionId\s*\)\s*\)\s*return/
     )
-    expect(source).toContain('autoReconnectingRef.current.add(sessionId)')
-    expect(source).toContain('autoReconnectingRef.current.delete(sessionId)')
+    expect(source).toMatch(
+      /autoReconnectingRef\.current\.add\s*\(\s*sessionId\s*\)/
+    )
+    expect(source).toMatch(
+      /autoReconnectingRef\.current\.delete\s*\(\s*sessionId\s*\)/
+    )
   })
 })

--- a/src/services/chat.test.ts
+++ b/src/services/chat.test.ts
@@ -22,6 +22,7 @@ import { useChatStore } from '@/store/chat-store'
 import { useUIStore } from '@/store/ui-store'
 import { useTerminalStore } from '@/store/terminal-store'
 import { toast } from 'sonner'
+import { disposeTerminal } from '@/lib/terminal-instances'
 import type { Session } from '@/types/chat'
 
 const toastMock = toast as unknown as {
@@ -108,6 +109,8 @@ describe('reconnectNativeCliSession', () => {
   beforeEach(async () => {
     toastMock.success.mockClear()
     toastMock.error.mockClear()
+    ;(disposeTerminal as ReturnType<typeof vi.fn>).mockClear()
+    ;(disposeTerminal as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
     const { invoke } = await import('@/lib/transport')
     ;(invoke as ReturnType<typeof vi.fn>).mockClear()
     ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
@@ -167,5 +170,49 @@ describe('reconnectNativeCliSession', () => {
     expect(invoke).not.toHaveBeenCalledWith('set_session_last_opened', {
       sessionId: 'session-1',
     })
+  })
+
+  it('marks the session opened by default (manual reconnect)', async () => {
+    const { invoke } = await import('@/lib/transport')
+
+    await reconnectNativeCliSession(terminalSession, 'wt-1')
+
+    expect(invoke).toHaveBeenCalledWith('set_session_last_opened', {
+      sessionId: 'session-1',
+    })
+  })
+
+  it('continues reconnecting when old terminal disposal fails', async () => {
+    useUIStore.setState({
+      sessionPrimarySurface: {},
+      sessionTerminalIds: { 'session-1': 'old-terminal' },
+    })
+    useTerminalStore.setState({
+      terminals: {
+        'wt-1': [
+          {
+            id: 'old-terminal',
+            worktreeId: 'wt-1',
+            label: 'Old Terminal',
+            command: 'claude',
+          },
+        ],
+      },
+      modalTerminalOpen: {},
+    })
+    ;(disposeTerminal as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('already disposed')
+    )
+
+    await reconnectNativeCliSession(terminalSession, 'wt-1')
+
+    const terminalId = useUIStore.getState().sessionTerminalIds['session-1']
+    expect(terminalId).toBeDefined()
+    expect(terminalId).not.toBe('old-terminal')
+    expect(
+      useTerminalStore
+        .getState()
+        .terminals['wt-1']?.some(terminal => terminal.id === 'old-terminal')
+    ).toBe(false)
   })
 })

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -150,7 +150,9 @@ export async function reconnectNativeCliSession(
     await invoke('stop_terminal', { terminalId: oldTerminalId }).catch(() => {
       // Terminal may already be stopped.
     })
-    await disposeTerminal(oldTerminalId)
+    await disposeTerminal(oldTerminalId).catch(() => {
+      // Terminal UI may already be disposed.
+    })
     terminalStore.removeTerminal(worktreeId, oldTerminalId)
   }
 


### PR DESCRIPTION
## Summary
- Continue reconnecting native CLI chat sessions when the previous terminal UI has already been disposed.
- Keep regression coverage flexible for terminal auto-restore behavior and add tests for manual reconnect last-opened updates and stale terminal cleanup.