### PR TITLE
fix: persist and resume native Claude/Codex/OpenCode terminal sessions

### DIFF
--- a/docs/developer/architecture-guide.md
+++ b/docs/developer/architecture-guide.md
@@ -96,7 +96,15 @@ Additional systems (no dedicated docs yet):
   terminals. Full-screen pure CLI sessions persist their intent on `Session`
   (`primary_surface`, `terminal_command`, `terminal_label`) and lazily recreate
   a PTY only when the user reopens that session, so hidden historical CLI
-  sessions do not start background processes. The native CLI picker also merges
+  sessions do not start background processes. Native Claude terminal sessions
+  receive a generated `--session-id` when created. Codex and OpenCode terminal
+  sessions snapshot their backend history before launch and bind the single new
+  native session/thread ID back to Jean metadata; ambiguous concurrent matches
+  are never guessed. Cold restoration uses `claude --resume <id>`,
+  `codex resume <id>`, or `opencode --session <id>` while preserving global
+  permission/yolo flags. Legacy native terminal sessions without either a typed
+  ID or persisted resume arguments show the native-history picker instead of
+  silently launching an unrelated conversation. The native CLI picker also merges
   backend-owned history from local stores where stable (`~/.codex/sessions/**`
   and `~/.claude/projects/<escaped-cwd>/**`) and imports a chosen history row as
   a Jean terminal session running the backend's native resume command.

--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -668,8 +668,12 @@ pub async fn create_session(
     terminal_command: Option<String>,
     terminal_command_args: Option<Vec<String>>,
     terminal_label: Option<String>,
+    native_session_id: Option<String>,
 ) -> Result<Session, String> {
     log::trace!("Creating new session for worktree: {worktree_id}");
+    if native_session_id.is_some() && primary_surface.as_deref() != Some("terminal") {
+        return Err("Native session IDs are only valid for terminal sessions".to_string());
+    }
 
     let preferences = crate::load_preferences(app.clone()).await.ok();
 
@@ -743,6 +747,9 @@ pub async fn create_session(
         session.terminal_command = terminal_command.clone();
         session.terminal_command_args = terminal_command_args.clone().unwrap_or_default();
         session.terminal_label = terminal_label.clone();
+        if let Some(native_session_id) = native_session_id.as_deref() {
+            persist_salvaged_resume_id(&mut session, &backend_enum, native_session_id);
+        }
         if primary_surface.as_deref() != Some("terminal") {
             session.selected_model = preferences
                 .as_ref()
@@ -9446,5 +9453,23 @@ my-disabled: /usr/bin/disabled (STDIO) - disabled";
         let remaining = vec![s2, s3];
         let selected = find_neighbor_non_archived_session_id(&remaining, 0);
         assert_eq!(selected.as_deref(), Some("s3"));
+    }
+
+    #[test]
+    fn native_terminal_resume_ids_are_saved_on_the_backend_specific_field() {
+        let mut claude = Session::new("Claude".to_string(), 0, Backend::Claude);
+        persist_salvaged_resume_id(&mut claude, &Backend::Claude, "claude-session");
+        assert_eq!(claude.claude_session_id.as_deref(), Some("claude-session"));
+
+        let mut codex = Session::new("Codex".to_string(), 0, Backend::Codex);
+        persist_salvaged_resume_id(&mut codex, &Backend::Codex, "codex-thread");
+        assert_eq!(codex.codex_thread_id.as_deref(), Some("codex-thread"));
+
+        let mut opencode = Session::new("OpenCode".to_string(), 0, Backend::Opencode);
+        persist_salvaged_resume_id(&mut opencode, &Backend::Opencode, "opencode-session");
+        assert_eq!(
+            opencode.opencode_session_id.as_deref(),
+            Some("opencode-session")
+        );
     }
 }

--- a/src-tauri/src/chat/native_history.rs
+++ b/src-tauri/src/chat/native_history.rs
@@ -8,8 +8,8 @@ use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 use tauri::AppHandle;
 
-use super::storage::with_existing_metadata_mut;
-use super::types::Backend;
+use super::storage::{load_metadata, with_existing_metadata_mut};
+use super::types::{Backend, SessionMetadata};
 use crate::http_server::EmitExt;
 
 const MAX_NATIVE_HISTORY_FILES: usize = 10_000;
@@ -148,6 +148,23 @@ fn persist_native_cli_session_id(
     Ok(())
 }
 
+fn validate_native_cli_tracking_metadata(
+    metadata: &SessionMetadata,
+    backend: &str,
+) -> Result<(), String> {
+    if metadata.primary_surface.as_deref() != Some("terminal") {
+        return Err(format!("Session {} is not a terminal session", metadata.id));
+    }
+
+    match (backend, &metadata.backend) {
+        ("codex", Backend::Codex) | ("opencode", Backend::Opencode) => Ok(()),
+        _ => Err(format!(
+            "Backend {backend} does not match session {}",
+            metadata.id
+        )),
+    }
+}
+
 #[tauri::command]
 pub async fn bind_native_cli_session(
     app: AppHandle,
@@ -173,6 +190,9 @@ pub async fn track_native_cli_session(
             "Native CLI tracking is not supported for backend {backend}"
         ));
     }
+    let metadata = load_metadata(&app, &session_id)?
+        .ok_or_else(|| format!("Session {session_id} not found"))?;
+    validate_native_cli_tracking_metadata(&metadata, &backend)?;
 
     let known_session_ids = load_native_session_ids_uncached(&worktree_path, &backend)?
         .into_iter()
@@ -1028,6 +1048,24 @@ mod tests {
             ),
             NewNativeSession::Ambiguous
         );
+    }
+
+    #[test]
+    fn native_session_tracking_validation_requires_matching_terminal_metadata() {
+        let mut metadata = crate::chat::types::SessionMetadata::new(
+            "jean-session".to_string(),
+            "worktree-1".to_string(),
+            "Codex".to_string(),
+            0,
+        );
+        metadata.backend = Backend::Codex;
+        metadata.primary_surface = Some("terminal".to_string());
+
+        assert!(validate_native_cli_tracking_metadata(&metadata, "codex").is_ok());
+        assert!(validate_native_cli_tracking_metadata(&metadata, "opencode").is_err());
+
+        metadata.primary_surface = Some("chat".to_string());
+        assert!(validate_native_cli_tracking_metadata(&metadata, "codex").is_err());
     }
 
     #[test]

--- a/src-tauri/src/chat/native_history.rs
+++ b/src-tauri/src/chat/native_history.rs
@@ -1,11 +1,16 @@
 use serde::Serialize;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant, UNIX_EPOCH};
+use tauri::AppHandle;
+
+use super::storage::with_existing_metadata_mut;
+use super::types::Backend;
+use crate::http_server::EmitExt;
 
 const MAX_NATIVE_HISTORY_FILES: usize = 10_000;
 const MAX_NATIVE_HISTORY_CACHE_ROWS: usize = 500;
@@ -16,6 +21,7 @@ const NATIVE_HISTORY_CACHE_TTL: Duration = Duration::from_secs(30);
 static NATIVE_HISTORY_CACHE: OnceLock<
     Mutex<HashMap<NativeHistoryCacheKey, NativeHistoryCacheEntry>>,
 > = OnceLock::new();
+static NATIVE_SESSION_TRACKERS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -77,6 +83,160 @@ pub async fn list_native_cli_sessions(
     ))
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum NewNativeSession {
+    Pending,
+    Found(String),
+    Ambiguous,
+}
+
+fn find_new_native_session_id(
+    known_session_ids: &HashSet<String>,
+    current_session_ids: Vec<String>,
+) -> NewNativeSession {
+    let mut new_ids = current_session_ids
+        .into_iter()
+        .filter(|id| !known_session_ids.contains(id))
+        .collect::<Vec<_>>();
+    new_ids.sort();
+    new_ids.dedup();
+    match new_ids.as_slice() {
+        [] => NewNativeSession::Pending,
+        [id] => NewNativeSession::Found(id.clone()),
+        _ => NewNativeSession::Ambiguous,
+    }
+}
+
+fn persist_native_cli_session_id(
+    app: &AppHandle,
+    jean_session_id: &str,
+    backend: &str,
+    native_session_id: &str,
+) -> Result<(), String> {
+    with_existing_metadata_mut(app, jean_session_id, |metadata| {
+        if metadata.primary_surface.as_deref() != Some("terminal") {
+            return Err(format!(
+                "Session {jean_session_id} is not a terminal session"
+            ));
+        }
+
+        match (backend, &metadata.backend) {
+            ("claude", Backend::Claude) => {
+                metadata.claude_session_id = Some(native_session_id.to_string())
+            }
+            ("codex", Backend::Codex) => {
+                metadata.codex_thread_id = Some(native_session_id.to_string())
+            }
+            ("opencode", Backend::Opencode) => {
+                metadata.opencode_session_id = Some(native_session_id.to_string())
+            }
+            _ => {
+                return Err(format!(
+                    "Backend {backend} does not match session {jean_session_id}"
+                ));
+            }
+        }
+        Ok(())
+    })??;
+
+    if let Err(error) = app.emit_all(
+        "cache:invalidate",
+        &serde_json::json!({ "keys": ["sessions"] }),
+    ) {
+        log::error!("Failed to invalidate sessions after native CLI binding: {error}");
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn bind_native_cli_session(
+    app: AppHandle,
+    session_id: String,
+    backend: String,
+    native_session_id: String,
+) -> Result<(), String> {
+    persist_native_cli_session_id(&app, &session_id, &backend, &native_session_id)
+}
+
+/// Snapshot native history before a new PTY starts, then bind the one newly
+/// created CLI conversation to its Jean terminal session. Ambiguous matches
+/// are never guessed.
+#[tauri::command]
+pub async fn track_native_cli_session(
+    app: AppHandle,
+    worktree_path: String,
+    session_id: String,
+    backend: String,
+) -> Result<(), String> {
+    if backend != "codex" && backend != "opencode" {
+        return Err(format!(
+            "Native CLI tracking is not supported for backend {backend}"
+        ));
+    }
+
+    let known_session_ids = load_native_session_ids_uncached(&worktree_path, &backend)?
+        .into_iter()
+        .collect::<HashSet<_>>();
+    let trackers = NATIVE_SESSION_TRACKERS.get_or_init(|| Mutex::new(HashSet::new()));
+    {
+        let mut active = trackers
+            .lock()
+            .map_err(|_| "Native session tracker lock poisoned".to_string())?;
+        if !active.insert(session_id.clone()) {
+            return Ok(());
+        }
+    }
+
+    tauri::async_runtime::spawn(async move {
+        const FAST_ATTEMPTS: usize = 90;
+        const MAX_ATTEMPTS: usize = 261;
+        for attempt in 0..MAX_ATTEMPTS {
+            match load_native_session_ids_uncached(&worktree_path, &backend) {
+                Ok(current_ids) => {
+                    match find_new_native_session_id(&known_session_ids, current_ids) {
+                        NewNativeSession::Pending => {}
+                        NewNativeSession::Found(native_session_id) => {
+                            match persist_native_cli_session_id(
+                                &app,
+                                &session_id,
+                                &backend,
+                                &native_session_id,
+                            ) {
+                                Ok(()) => log::info!(
+                                    "Bound Jean terminal session {session_id} to {backend} session {native_session_id}"
+                                ),
+                                Err(error) => log::warn!(
+                                    "Failed to bind Jean terminal session {session_id}: {error}"
+                                ),
+                            }
+                            break;
+                        }
+                        NewNativeSession::Ambiguous => {
+                            log::warn!(
+                                "Refusing to guess native {backend} session for Jean session {session_id}: multiple new sessions appeared"
+                            );
+                            break;
+                        }
+                    }
+                }
+                Err(error) => {
+                    log::debug!(
+                        "Native {backend} session tracking scan failed for {session_id}: {error}"
+                    );
+                }
+            }
+            let poll_delay = if attempt < FAST_ATTEMPTS { 1 } else { 10 };
+            tokio::time::sleep(Duration::from_secs(poll_delay)).await;
+        }
+
+        if let Ok(mut active) = trackers.lock() {
+            active.remove(&session_id);
+        }
+    });
+
+    Ok(())
+}
+
 fn get_cached_native_sessions(
     worktree_path: &str,
     backend: &str,
@@ -121,6 +281,47 @@ fn load_native_sessions_uncached(
         "commandcode" => Ok(Vec::new()),
         other => Err(format!("Unsupported native CLI history backend: {other}")),
     }
+}
+
+fn load_native_session_ids_uncached(
+    worktree_path: &str,
+    backend: &str,
+) -> Result<Vec<String>, String> {
+    let Some(home) = dirs::home_dir() else {
+        return Ok(Vec::new());
+    };
+
+    let mut ids: Vec<String> = match backend {
+        "codex" => {
+            let root = home.join(".codex").join("sessions");
+            if !root.exists() {
+                return Ok(Vec::new());
+            }
+            collect_jsonl_files(&root, Some("rollout-"))?
+                .into_iter()
+                .filter_map(|path| parse_codex_session_identity(&path, worktree_path))
+                .collect()
+        }
+        "opencode" => {
+            let root = home
+                .join(".local")
+                .join("share")
+                .join("opencode")
+                .join("storage")
+                .join("session");
+            if !root.exists() {
+                return Ok(Vec::new());
+            }
+            collect_files_with_extension(&root, "json")?
+                .into_iter()
+                .filter_map(|path| parse_opencode_session_identity(&path, worktree_path))
+                .collect()
+        }
+        other => return Err(format!("Unsupported native CLI tracking backend: {other}")),
+    };
+    ids.sort();
+    ids.dedup();
+    Ok(ids)
 }
 
 fn filter_cached_native_sessions(
@@ -382,6 +583,31 @@ fn parse_codex_session_file(path: &Path, worktree_path: &str) -> Option<NativeCl
     })
 }
 
+fn parse_codex_session_identity(path: &Path, worktree_path: &str) -> Option<String> {
+    let contents = fs::read_to_string(path).ok()?;
+    for line in contents.lines().take(100) {
+        let value: Value = serde_json::from_str(line).ok()?;
+        if value.get("type").and_then(Value::as_str) != Some("session_meta") {
+            continue;
+        }
+        let payload = value.get("payload")?;
+        if payload.get("source").and_then(Value::as_str) == Some("exec")
+            || payload.get("originator").and_then(Value::as_str) == Some("codex_exec")
+        {
+            return None;
+        }
+        let cwd = payload.get("cwd").and_then(Value::as_str)?;
+        if !same_path(cwd, worktree_path) {
+            return None;
+        }
+        return payload
+            .get("id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
+    None
+}
+
 fn codex_title_from_line(value: &Value) -> Option<String> {
     if value.get("type").and_then(Value::as_str) == Some("event_msg") {
         let payload = value.get("payload")?;
@@ -578,6 +804,23 @@ fn parse_opencode_session_file(
     })
 }
 
+fn parse_opencode_session_identity(path: &Path, worktree_path: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(&fs::read_to_string(path).ok()?).ok()?;
+    let cwd = value
+        .get("directory")
+        .or_else(|| value.get("path"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .or_else(|| opencode_project_worktree_from_path(path))?;
+    if !same_path(&cwd, worktree_path) {
+        return None;
+    }
+    value
+        .get("id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
 fn opencode_project_worktree_from_path(path: &Path) -> Option<String> {
     let project_id = path.parent()?.file_name()?.to_str()?;
     let project_path = dirs::home_dir()?
@@ -760,6 +1003,34 @@ mod tests {
     }
 
     #[test]
+    fn native_session_tracking_requires_one_unambiguous_new_id() {
+        let known = HashSet::from(["existing".to_string()]);
+
+        assert_eq!(
+            find_new_native_session_id(&known, vec!["existing".to_string()]),
+            NewNativeSession::Pending
+        );
+        assert_eq!(
+            find_new_native_session_id(
+                &known,
+                vec!["existing".to_string(), "new-session".to_string()]
+            ),
+            NewNativeSession::Found("new-session".to_string())
+        );
+        assert_eq!(
+            find_new_native_session_id(
+                &known,
+                vec![
+                    "existing".to_string(),
+                    "new-a".to_string(),
+                    "new-b".to_string()
+                ]
+            ),
+            NewNativeSession::Ambiguous
+        );
+    }
+
+    #[test]
     fn native_history_default_returns_latest_five_from_cache() {
         let sessions = (0..10)
             .map(|index| test_session(index, index as u64, &format!("task {index}")))
@@ -854,6 +1125,10 @@ mod tests {
         assert_eq!(parsed.id, "jean-session");
         assert_eq!(parsed.title, "name a session");
         assert_eq!(parsed.resume_args, vec!["resume", "jean-session"]);
+        assert_eq!(
+            parse_codex_session_identity(&path, "/tmp/worktree").as_deref(),
+            Some("jean-session")
+        );
         let _ = fs::remove_file(path);
         let _ = fs::remove_dir(dir);
     }
@@ -1063,6 +1338,10 @@ mod tests {
         .unwrap();
 
         assert!(parse_codex_session_file(&path, "/tmp/worktree").is_none());
+        assert_eq!(
+            parse_codex_session_identity(&path, "/tmp/worktree").as_deref(),
+            Some("context-only-session")
+        );
         let _ = fs::remove_file(path);
         let _ = fs::remove_dir(dir);
     }
@@ -1112,6 +1391,33 @@ mod tests {
         let parsed = parse_codex_session_file(&path, "/tmp/worktree").unwrap();
         assert_eq!(parsed.id, "aborted-session");
         assert_eq!(parsed.title, "ps -ef");
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_dir(dir);
+    }
+
+    #[test]
+    fn opencode_identity_is_available_before_a_title_exists() {
+        let dir = std::env::temp_dir().join(format!(
+            "jean-native-history-test-opencode-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&dir);
+        let path = dir.join("session.json");
+        fs::write(
+            &path,
+            serde_json::json!({
+                "id": "opencode-session",
+                "directory": "/tmp/worktree"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        assert!(parse_opencode_session_file(&path, "/tmp/worktree").is_none());
+        assert_eq!(
+            parse_opencode_session_identity(&path, "/tmp/worktree").as_deref(),
+            Some("opencode-session")
+        );
         let _ = fs::remove_file(path);
         let _ = fs::remove_dir(dir);
     }

--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -979,6 +979,27 @@ pub async fn dispatch_command(
             .await?;
             to_value(result)
         }
+        "bind_native_cli_session" => {
+            let session_id: String = field(&args, "sessionId", "session_id")?;
+            let backend: String = from_field(&args, "backend")?;
+            let native_session_id: String = field(&args, "nativeSessionId", "native_session_id")?;
+            crate::chat::bind_native_cli_session(
+                app.clone(),
+                session_id,
+                backend,
+                native_session_id,
+            )
+            .await?;
+            Ok(Value::Null)
+        }
+        "track_native_cli_session" => {
+            let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
+            let session_id: String = field(&args, "sessionId", "session_id")?;
+            let backend: String = from_field(&args, "backend")?;
+            crate::chat::track_native_cli_session(app.clone(), worktree_path, session_id, backend)
+                .await?;
+            Ok(Value::Null)
+        }
         "get_session" => {
             let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
             let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
@@ -1020,6 +1041,8 @@ pub async fn dispatch_command(
                 field_opt(&args, "terminalCommandArgs", "terminal_command_args")?;
             let terminal_label: Option<String> =
                 field_opt(&args, "terminalLabel", "terminal_label")?;
+            let native_session_id: Option<String> =
+                field_opt(&args, "nativeSessionId", "native_session_id")?;
             let result = crate::chat::create_session(
                 app.clone(),
                 worktree_id,
@@ -1030,6 +1053,7 @@ pub async fn dispatch_command(
                 terminal_command,
                 terminal_command_args,
                 terminal_label,
+                native_session_id,
             )
             .await?;
             to_value(result)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4436,6 +4436,8 @@ pub fn run() {
             chat::get_session,
             chat::load_older_session_messages,
             chat::list_native_cli_sessions,
+            chat::bind_native_cli_session,
+            chat::track_native_cli_session,
             chat::create_session,
             chat::rename_session,
             chat::regenerate_session_name,

--- a/src/components/chat/ChatWindow.terminal-modal-regression.test.ts
+++ b/src/components/chat/ChatWindow.terminal-modal-regression.test.ts
@@ -38,6 +38,7 @@ describe('terminal primary surface modal regression', () => {
     expect(source).toMatch(/openModal:\s*false/)
     expect(source).toMatch(/showToast:\s*false/)
     expect(source).toMatch(/markOpened:\s*false/)
+    expect(source).toContain("session.primary_surface === 'terminal'")
   })
 
   it('guards terminal auto-restore against session switches and duplicate spawns', () => {
@@ -53,5 +54,13 @@ describe('terminal primary surface modal regression', () => {
     expect(source).toMatch(
       /autoReconnectingRef\.current\.delete\s*\(\s*sessionId\s*\)/
     )
+  })
+
+  it('shows a safe recovery state instead of an empty chat for legacy sessions', () => {
+    const source = readSource('src/components/chat/ChatWindow.tsx')
+
+    expect(source).toContain('isTerminalAwaitingReconnect')
+    expect(source).toContain('Terminal session needs to be reconnected')
+    expect(source).toContain('Choose native session')
   })
 })

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -459,6 +459,12 @@ export function ChatWindow({
   // the conversation reappears in its terminal surface. The ref guards against
   // a duplicate spawn while the async relaunch is in flight.
   const autoReconnectingRef = useRef<Set<string>>(new Set())
+  const [terminalReconnectError, setTerminalReconnectError] = useState<
+    string | null
+  >(null)
+  useEffect(() => {
+    setTerminalReconnectError(null)
+  }, [deferredSessionId])
   useEffect(() => {
     if (!deferredSessionId || !session || !activeWorktreeId) return
     // `primarySurface`/`sessionTerminalId` are keyed on `activeSessionId`, while
@@ -466,12 +472,15 @@ export function ChatWindow({
     // mismatch could relaunch the previous session's terminal (and yank the user
     // back to it). Wait until the deferred value has caught up to the active one.
     if (isSessionSwitching) return
-    if (primarySurface !== 'terminal' || sessionTerminalId) return
+    const shouldRestoreTerminal =
+      session.primary_surface === 'terminal' || primarySurface === 'terminal'
+    if (!shouldRestoreTerminal || sessionTerminalId) return
     if (!canReconnectSession(session)) return
     if (autoReconnectingRef.current.has(deferredSessionId)) return
 
     const sessionId = deferredSessionId
     autoReconnectingRef.current.add(sessionId)
+    setTerminalReconnectError(null)
     void reconnectNativeCliSession(session, activeWorktreeId, {
       openModal: false,
       showToast: false,
@@ -479,6 +488,9 @@ export function ChatWindow({
     })
       .catch(error => {
         logger.error('Auto-reconnect of terminal session failed', { error })
+        setTerminalReconnectError(
+          error instanceof Error ? error.message : String(error)
+        )
       })
       .finally(() => {
         autoReconnectingRef.current.delete(sessionId)
@@ -2451,7 +2463,24 @@ export function ChatWindow({
   }
 
   const isTerminalPrimarySurface =
-    primarySurface === 'terminal' && !!activeSessionId && !!sessionTerminalId
+    (primarySurface === 'terminal' ||
+      session?.primary_surface === 'terminal') &&
+    !!activeSessionId &&
+    !!sessionTerminalId
+  const isPersistedTerminalSurface =
+    !isSessionSwitching &&
+    session?.id === activeSessionId &&
+    session?.primary_surface === 'terminal'
+  const isTerminalAwaitingReconnect =
+    isPersistedTerminalSurface && !sessionTerminalId
+  const canReconnectTerminal = session ? canReconnectSession(session) : false
+  const handleChooseNativeSession = () => {
+    useUIStore.getState().openNewSessionModeModal({
+      worktreeId: activeWorktreeId,
+      worktreePath: activeWorktreePath,
+      origin: sessionModalOpen ? 'modal' : 'chat',
+    })
+  }
 
   return (
     <ErrorBoundary
@@ -2499,6 +2528,37 @@ export function ChatWindow({
             sessionId={activeSessionId}
             terminalId={sessionTerminalId}
           />
+        ) : isTerminalAwaitingReconnect ? (
+          <div className="flex min-h-0 flex-1 items-center justify-center p-6">
+            <div className="flex max-w-md flex-col items-center gap-3 text-center">
+              {canReconnectTerminal && !terminalReconnectError ? (
+                <>
+                  <Loader2 className="size-5 animate-spin text-muted-foreground" />
+                  <div className="text-sm font-medium">
+                    Reconnecting terminal session…
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="text-sm font-medium">
+                    Terminal session needs to be reconnected
+                  </div>
+                  <div className="text-xs leading-5 text-muted-foreground">
+                    {terminalReconnectError ??
+                      'This older session has no saved native CLI resume ID. Choose the matching native session to continue it safely.'}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleChooseNativeSession}
+                  >
+                    Choose native session
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
         ) : showReviewFullWidth && activeSessionId ? (
           <div className="flex-1 min-h-0">
             <ReviewResultsPanel

--- a/src/components/chat/NativeCliSessionsModal.tsx
+++ b/src/components/chat/NativeCliSessionsModal.tsx
@@ -351,6 +351,9 @@ export function NativeCliSessionsModal({
             return
           }
 
+          const commandArgs =
+            resumeLaunch?.args ??
+            (await resolveTerminalCommandArgs(session, launchMode === 'new'))
           if (options?.trackNativeId && backend) {
             try {
               await invoke('track_native_cli_session', {
@@ -368,9 +371,6 @@ export function NativeCliSessionsModal({
             }
           }
 
-          const commandArgs =
-            resumeLaunch?.args ??
-            (await resolveTerminalCommandArgs(session, launchMode === 'new'))
           terminalId = terminalStore.addTerminal(
             worktreeId,
             resumeLaunch?.command ?? session.terminal_command ?? command,

--- a/src/components/chat/NativeCliSessionsModal.tsx
+++ b/src/components/chat/NativeCliSessionsModal.tsx
@@ -13,6 +13,9 @@ import { Kbd } from '@/components/ui/kbd'
 import { Separator } from '@/components/ui/separator'
 import { cn } from '@/lib/utils'
 import { invoke } from '@/lib/transport'
+import { generateId } from '@/lib/uuid'
+import { logger } from '@/lib/logger'
+import { toast } from 'sonner'
 import {
   useCreateSession,
   useNativeCliSessions,
@@ -28,6 +31,10 @@ import {
 } from '@/components/ui/backend-label'
 import type { Session } from '@/types/chat'
 import type { CliBackend } from '@/types/preferences'
+import {
+  getNativeTerminalResumeLaunch,
+  isNativeTerminalBackend,
+} from '@/lib/native-cli-session'
 
 interface PreparedBackendTerminalContext {
   commandArgs: string[]
@@ -287,8 +294,15 @@ export function NativeCliSessionsModal({
   )
 
   const resolveTerminalCommandArgs = useCallback(
-    async (session: Session): Promise<string[]> => {
+    async (
+      session: Session,
+      forcePreparedContext = false
+    ): Promise<string[]> => {
       const savedArgs = session.terminal_command_args ?? []
+      if (forcePreparedContext) {
+        const preparedArgs = await prepareCommandArgs(session.id)
+        return [...savedArgs, ...preparedArgs]
+      }
       if (savedArgs.length === 0) {
         return prepareCommandArgs(session.id)
       }
@@ -302,7 +316,10 @@ export function NativeCliSessionsModal({
   )
 
   const openTerminalSession = useCallback(
-    async (session: Session) => {
+    async (
+      session: Session,
+      options?: { launchMode?: 'new' | 'resume'; trackNativeId?: boolean }
+    ) => {
       setOpeningSessionId(session.id)
       try {
         const terminalStore = useTerminalStore.getState()
@@ -316,10 +333,47 @@ export function NativeCliSessionsModal({
 
         let terminalId = existingTerminal?.id
         if (!terminalId) {
-          const commandArgs = await resolveTerminalCommandArgs(session)
+          const launchMode = options?.launchMode ?? 'resume'
+          const resumeLaunch =
+            launchMode === 'resume'
+              ? getNativeTerminalResumeLaunch(session)
+              : null
+          if (
+            launchMode === 'resume' &&
+            isNativeTerminalBackend(session.backend) &&
+            !!session.terminal_command &&
+            !resumeLaunch
+          ) {
+            toast.error('This legacy terminal session has no saved resume ID', {
+              description:
+                'Choose the matching native session from this list instead.',
+            })
+            return
+          }
+
+          if (options?.trackNativeId && backend) {
+            try {
+              await invoke('track_native_cli_session', {
+                worktreePath,
+                sessionId: session.id,
+                backend,
+              })
+            } catch (error) {
+              logger.error('Failed to start native CLI session tracking', {
+                backend,
+                sessionId: session.id,
+                error,
+              })
+              toast.error('Session opened, but its resume ID may not be saved')
+            }
+          }
+
+          const commandArgs =
+            resumeLaunch?.args ??
+            (await resolveTerminalCommandArgs(session, launchMode === 'new'))
           terminalId = terminalStore.addTerminal(
             worktreeId,
-            session.terminal_command ?? command,
+            resumeLaunch?.command ?? session.terminal_command ?? command,
             session.terminal_label ?? session.name,
             {
               kind: 'session',
@@ -353,7 +407,10 @@ export function NativeCliSessionsModal({
   )
 
   const createNewSession = useCallback(() => {
-    const commandArgs = initialCommandArgs
+    const nativeSessionId = backend === 'claude' ? generateId() : undefined
+    const commandArgs = nativeSessionId
+      ? [...initialCommandArgs, '--session-id', nativeSessionId]
+      : initialCommandArgs
     createSession.mutate(
       {
         worktreeId,
@@ -364,16 +421,27 @@ export function NativeCliSessionsModal({
         terminalCommand: command,
         terminalCommandArgs: commandArgs,
         terminalLabel: label,
+        nativeSessionId,
       },
       {
         onSuccess: session => {
-          void openTerminalSession({
-            ...session,
-            primary_surface: 'terminal',
-            terminal_command: command,
-            terminal_command_args: commandArgs,
-            terminal_label: label,
-          })
+          void openTerminalSession(
+            {
+              ...session,
+              primary_surface: 'terminal',
+              terminal_command: command,
+              terminal_command_args: commandArgs,
+              terminal_label: label,
+              claude_session_id:
+                backend === 'claude'
+                  ? nativeSessionId
+                  : session.claude_session_id,
+            },
+            {
+              launchMode: 'new',
+              trackNativeId: backend === 'codex' || backend === 'opencode',
+            }
+          )
         },
       }
     )
@@ -420,16 +488,32 @@ export function NativeCliSessionsModal({
           terminalCommand: command,
           terminalCommandArgs: resumeArgs,
           terminalLabel: nativeSession.title,
+          nativeSessionId: nativeSession.id,
         },
         {
           onSuccess: session => {
-            void openTerminalSession({
-              ...session,
-              primary_surface: 'terminal',
-              terminal_command: command,
-              terminal_command_args: resumeArgs,
-              terminal_label: nativeSession.title,
-            })
+            void openTerminalSession(
+              {
+                ...session,
+                primary_surface: 'terminal',
+                terminal_command: command,
+                terminal_command_args: resumeArgs,
+                terminal_label: nativeSession.title,
+                claude_session_id:
+                  backend === 'claude'
+                    ? nativeSession.id
+                    : session.claude_session_id,
+                codex_thread_id:
+                  backend === 'codex'
+                    ? nativeSession.id
+                    : session.codex_thread_id,
+                opencode_session_id:
+                  backend === 'opencode'
+                    ? nativeSession.id
+                    : session.opencode_session_id,
+              },
+              { launchMode: 'resume' }
+            )
           },
         }
       )
@@ -545,7 +629,11 @@ export function NativeCliSessionsModal({
                     disabled={
                       openingSessionId !== null || createSession.isPending
                     }
-                    onClick={() => void openTerminalSession(session)}
+                    onClick={() =>
+                      void openTerminalSession(session, {
+                        launchMode: 'resume',
+                      })
+                    }
                     className={cn(
                       'flex w-full min-w-0 items-start gap-3 rounded-lg border border-border/70 bg-muted/25 px-3.5 py-3 text-left transition-colors',
                       'hover:border-border hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',

--- a/src/components/chat/NewSessionModeModal.test.tsx
+++ b/src/components/chat/NewSessionModeModal.test.tsx
@@ -557,6 +557,63 @@ describe('NewSessionModeModal', () => {
     )
   })
 
+  it('starts native CLI tracking only after terminal context preparation', async () => {
+    mutate.mockImplementation(
+      (
+        _args: unknown,
+        opts?: {
+          onSuccess?: (session: {
+            id: string
+            name: string
+            backend?: string
+          }) => void
+        }
+      ) => {
+        opts?.onSuccess?.({
+          id: 'session-codex-prepare-order',
+          name: 'Codex',
+          backend: 'codex',
+        })
+      }
+    )
+    useUIStore.getState().openNewSessionModeModal({
+      worktreeId: 'worktree-1',
+      worktreePath: '/tmp/worktree-1',
+      origin: 'chat',
+    })
+
+    render(<NewSessionModeModal />)
+    fireEvent.click(screen.getByText('Codex'))
+    fireEvent.click(screen.getByText('New Codex session'))
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('prepare_backend_terminal_context', {
+        sessionId: 'session-codex-prepare-order',
+        worktreeId: 'worktree-1',
+        backend: 'codex',
+      })
+    })
+    expect(invoke).toHaveBeenCalledWith('track_native_cli_session', {
+      worktreePath: '/tmp/worktree-1',
+      sessionId: 'session-codex-prepare-order',
+      backend: 'codex',
+    })
+    const prepareCallOrder =
+      invoke.mock.invocationCallOrder[
+        invoke.mock.calls.findIndex(
+          ([command]) => command === 'prepare_backend_terminal_context'
+        )
+      ]
+    const trackCallOrder =
+      invoke.mock.invocationCallOrder[
+        invoke.mock.calls.findIndex(
+          ([command]) => command === 'track_native_cli_session'
+        )
+      ]
+    expect(prepareCallOrder).toBeLessThan(trackCallOrder)
+    expect(useTerminalStore.getState().terminals['worktree-1']).toHaveLength(1)
+  })
+
   it('opens a plain terminal session with shortcut 1', async () => {
     mutate.mockImplementation(
       (

--- a/src/components/chat/NewSessionModeModal.test.tsx
+++ b/src/components/chat/NewSessionModeModal.test.tsx
@@ -10,6 +10,7 @@ const mutate = vi.fn()
 const invoke = vi.fn()
 let sessionsData: { sessions: unknown[] }
 let nativeSessionsData: unknown[]
+let opencodeInstalled: boolean
 let cursorInstalled: boolean
 let commandCodeInstalled: boolean
 let grokInstalled: boolean
@@ -64,7 +65,10 @@ vi.mock('@/services/codex-cli', () => ({
 
 vi.mock('@/services/opencode-cli', () => ({
   useOpencodeCliStatus: () => ({
-    data: { installed: false, path: null },
+    data: {
+      installed: opencodeInstalled,
+      path: opencodeInstalled ? '/usr/local/bin/opencode' : null,
+    },
     isLoading: false,
   }),
 }))
@@ -106,6 +110,7 @@ describe('NewSessionModeModal', () => {
     invoke.mockReset()
     sessionsData = { sessions: [] }
     nativeSessionsData = []
+    opencodeInstalled = false
     cursorInstalled = false
     commandCodeInstalled = false
     grokInstalled = false
@@ -323,6 +328,11 @@ describe('NewSessionModeModal', () => {
       expect.any(Object)
     )
     await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('track_native_cli_session', {
+        worktreePath: '/tmp/worktree-1',
+        sessionId: 'session-terminal-1',
+        backend: 'codex',
+      })
       expect(invoke).toHaveBeenCalledWith('prepare_backend_terminal_context', {
         sessionId: 'session-terminal-1',
         worktreeId: 'worktree-1',
@@ -394,18 +404,31 @@ describe('NewSessionModeModal', () => {
 
     fireEvent.click(screen.getByText('New Claude session'))
 
+    const claudeCreateArgs = mutate.mock.calls[0]?.[0] as {
+      nativeSessionId: string
+      terminalCommandArgs: string[]
+    }
     expect(mutate).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         worktreeId: 'worktree-1',
         worktreePath: '/tmp/worktree-1',
         name: 'Claude',
         backend: 'claude',
         primarySurface: 'terminal',
         terminalCommand: '/usr/local/bin/claude',
-        terminalCommandArgs: ['--permission-mode', 'bypassPermissions'],
         terminalLabel: 'Claude',
-      },
+        nativeSessionId: expect.any(String),
+        terminalCommandArgs: [
+          '--permission-mode',
+          'bypassPermissions',
+          '--session-id',
+          expect.any(String),
+        ],
+      }),
       expect.any(Object)
+    )
+    expect(claudeCreateArgs.terminalCommandArgs.at(-1)).toBe(
+      claudeCreateArgs.nativeSessionId
     )
     await waitFor(() => {
       expect(invoke).toHaveBeenCalledWith('prepare_backend_terminal_context', {
@@ -421,6 +444,8 @@ describe('NewSessionModeModal', () => {
       commandArgs: [
         '--permission-mode',
         'bypassPermissions',
+        '--session-id',
+        claudeCreateArgs.nativeSessionId,
         '--context-arg',
         'context-value',
       ],
@@ -484,6 +509,52 @@ describe('NewSessionModeModal', () => {
         ],
       })
     })
+  })
+
+  it('tracks a new OpenCode terminal session before launching it', async () => {
+    opencodeInstalled = true
+    mutate.mockImplementation(
+      (
+        _args: unknown,
+        opts?: {
+          onSuccess?: (session: {
+            id: string
+            name: string
+            backend?: string
+          }) => void
+        }
+      ) => {
+        opts?.onSuccess?.({
+          id: 'session-opencode',
+          name: 'OpenCode',
+          backend: 'opencode',
+        })
+      }
+    )
+    useUIStore.getState().openNewSessionModeModal({
+      worktreeId: 'worktree-1',
+      worktreePath: '/tmp/worktree-1',
+      origin: 'chat',
+    })
+
+    render(<NewSessionModeModal />)
+    fireEvent.click(screen.getByText('OpenCode'))
+    fireEvent.click(screen.getByText('New OpenCode session'))
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('track_native_cli_session', {
+        worktreePath: '/tmp/worktree-1',
+        sessionId: 'session-opencode',
+        backend: 'opencode',
+      })
+    })
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: 'opencode',
+        terminalCommand: '/usr/local/bin/opencode',
+      }),
+      expect.any(Object)
+    )
   })
 
   it('opens a plain terminal session with shortcut 1', async () => {
@@ -565,7 +636,7 @@ describe('NewSessionModeModal', () => {
     )
   })
 
-  it('continues an existing native CLI terminal session without creating a new one', async () => {
+  it('does not relaunch a legacy native CLI session without a resume ID', async () => {
     const expectedUpdatedAt = new Date(1710000000 * 1000).toLocaleString(
       undefined,
       {
@@ -607,19 +678,14 @@ describe('NewSessionModeModal', () => {
 
     expect(mutate).not.toHaveBeenCalled()
     await waitFor(() => {
-      expect(invoke).toHaveBeenCalledWith('prepare_backend_terminal_context', {
-        sessionId: 'existing-codex-session',
-        worktreeId: 'worktree-1',
-        backend: 'codex',
-      })
+      expect(
+        useTerminalStore.getState().terminals['worktree-1'] ?? []
+      ).toHaveLength(0)
     })
-    expect(useTerminalStore.getState().terminals['worktree-1']).toHaveLength(1)
-    expect(useChatStore.getState().activeSessionIds['worktree-1']).toBe(
-      'existing-codex-session'
+    expect(invoke).not.toHaveBeenCalledWith(
+      'prepare_backend_terminal_context',
+      expect.any(Object)
     )
-    expect(
-      useChatStore.getState().selectedBackends['existing-codex-session']
-    ).toBe('codex')
   })
 
   it('imports native Codex history into a Jean terminal session', async () => {
@@ -678,6 +744,7 @@ describe('NewSessionModeModal', () => {
         terminalCommand: '/usr/local/bin/codex',
         terminalCommandArgs: ['resume', 'native-codex-thread'],
         terminalLabel: 'Native Codex task',
+        nativeSessionId: 'native-codex-thread',
       },
       expect.any(Object)
     )

--- a/src/components/chat/session-card-utils.tsx
+++ b/src/components/chat/session-card-utils.tsx
@@ -12,6 +12,7 @@ import {
   type PermissionDenial,
   type LabelData,
 } from '@/types/chat'
+import { getNativeTerminalResumeLaunch } from '@/lib/native-cli-session'
 import { findPlanFilePath, resolvePlanContent } from './tool-call-utils'
 
 export type SessionStatus =
@@ -421,24 +422,8 @@ export function getResumeArgs(
   session: Session
 ): { command: string; args: string[] } | null {
   const cmd = session.terminal_command || ''
-  if (session.backend === 'claude' && session.claude_session_id) {
-    return {
-      command: cmd || 'claude',
-      args: ['--resume', session.claude_session_id],
-    }
-  }
-  if (session.backend === 'codex' && session.codex_thread_id) {
-    return {
-      command: cmd || 'codex',
-      args: ['resume', session.codex_thread_id],
-    }
-  }
-  if (session.backend === 'opencode' && session.opencode_session_id) {
-    return {
-      command: cmd || 'opencode',
-      args: ['-s', session.opencode_session_id],
-    }
-  }
+  const nativeLaunch = getNativeTerminalResumeLaunch(session)
+  if (nativeLaunch) return nativeLaunch
   if (session.backend === 'cursor' && session.cursor_chat_id) {
     return {
       command: cmd || 'cursor-agent',

--- a/src/lib/native-cli-session.test.ts
+++ b/src/lib/native-cli-session.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import type { Session } from '@/types/chat'
+import {
+  buildNativeResumeArgs,
+  getNativeTerminalResumeLaunch,
+  hasLegacyNativeResumeArgs,
+} from './native-cli-session'
+
+const session = (overrides: Partial<Session>): Session =>
+  ({
+    id: 'session-1',
+    name: 'Native CLI',
+    order: 0,
+    created_at: 1,
+    updated_at: 1,
+    messages: [],
+    version: 2,
+    primary_surface: 'terminal',
+    ...overrides,
+  }) as Session
+
+describe('buildNativeResumeArgs', () => {
+  it('preserves Claude permission flags and replaces launch session IDs', () => {
+    expect(
+      buildNativeResumeArgs('claude', 'claude-session', [
+        '--permission-mode',
+        'bypassPermissions',
+        '--session-id',
+        'initial-session',
+      ])
+    ).toEqual([
+      '--permission-mode',
+      'bypassPermissions',
+      '--resume',
+      'claude-session',
+    ])
+  })
+
+  it('preserves Codex global flags before the resume subcommand', () => {
+    expect(
+      buildNativeResumeArgs('codex', 'codex-thread', [
+        '--dangerously-bypass-approvals-and-sandbox',
+        'resume',
+        'old-thread',
+      ])
+    ).toEqual([
+      '--dangerously-bypass-approvals-and-sandbox',
+      'resume',
+      'codex-thread',
+    ])
+  })
+
+  it('replaces OpenCode session selectors', () => {
+    expect(
+      buildNativeResumeArgs('opencode', 'opencode-session', [
+        '--model',
+        'anthropic/claude-sonnet-4-6',
+        '-s',
+        'old-session',
+      ])
+    ).toEqual([
+      '--model',
+      'anthropic/claude-sonnet-4-6',
+      '--session',
+      'opencode-session',
+    ])
+  })
+})
+
+describe('getNativeTerminalResumeLaunch', () => {
+  it('builds a typed Claude resume launch', () => {
+    expect(
+      getNativeTerminalResumeLaunch(
+        session({
+          backend: 'claude',
+          terminal_command: '/usr/local/bin/claude',
+          terminal_command_args: ['--session-id', 'claude-session'],
+          claude_session_id: 'claude-session',
+        })
+      )
+    ).toEqual({
+      command: '/usr/local/bin/claude',
+      args: ['--resume', 'claude-session'],
+    })
+  })
+
+  it('keeps legacy persisted resume arguments', () => {
+    const legacy = session({
+      backend: 'codex',
+      terminal_command: '/usr/local/bin/codex',
+      terminal_command_args: ['resume', 'legacy-thread'],
+    })
+
+    expect(hasLegacyNativeResumeArgs(legacy)).toBe(true)
+    expect(getNativeTerminalResumeLaunch(legacy)).toEqual({
+      command: '/usr/local/bin/codex',
+      args: ['resume', 'legacy-thread'],
+    })
+  })
+
+  it('refuses to relaunch a native terminal without a resume ID', () => {
+    expect(
+      getNativeTerminalResumeLaunch(
+        session({
+          backend: 'opencode',
+          terminal_command: '/usr/local/bin/opencode',
+          terminal_command_args: [],
+        })
+      )
+    ).toBeNull()
+  })
+})

--- a/src/lib/native-cli-session.ts
+++ b/src/lib/native-cli-session.ts
@@ -1,0 +1,136 @@
+import type { Session } from '@/types/chat'
+
+export type NativeTerminalBackend = 'claude' | 'codex' | 'opencode'
+
+export interface NativeTerminalLaunch {
+  command: string
+  args: string[]
+}
+
+export function isNativeTerminalBackend(
+  backend: Session['backend']
+): backend is NativeTerminalBackend {
+  return backend === 'claude' || backend === 'codex' || backend === 'opencode'
+}
+
+export function getNativeSessionId(session: Session): string | null {
+  if (session.backend === 'claude') {
+    return session.claude_session_id ?? null
+  }
+  if (session.backend === 'codex') {
+    return session.codex_thread_id ?? null
+  }
+  if (session.backend === 'opencode') {
+    return session.opencode_session_id ?? null
+  }
+  return null
+}
+
+function stripClaudeSessionArgs(args: string[]): string[] {
+  const result: string[] = []
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '--resume' || arg === '-r' || arg === '--session-id') {
+      index += 1
+      continue
+    }
+    if (arg?.startsWith('--resume=') || arg?.startsWith('--session-id=')) {
+      continue
+    }
+    if (arg) result.push(arg)
+  }
+  return result
+}
+
+function stripCodexSessionArgs(args: string[]): string[] {
+  const resumeIndex = args.indexOf('resume')
+  return resumeIndex >= 0 ? args.slice(0, resumeIndex) : [...args]
+}
+
+function stripOpenCodeSessionArgs(args: string[]): string[] {
+  const result: string[] = []
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '--session' || arg === '-s') {
+      index += 1
+      continue
+    }
+    if (arg === '--continue' || arg === '-c' || arg?.startsWith('--session=')) {
+      continue
+    }
+    if (arg) result.push(arg)
+  }
+  return result
+}
+
+export function buildNativeResumeArgs(
+  backend: NativeTerminalBackend,
+  nativeSessionId: string,
+  persistedArgs: string[] = []
+): string[] {
+  if (backend === 'claude') {
+    return [
+      ...stripClaudeSessionArgs(persistedArgs),
+      '--resume',
+      nativeSessionId,
+    ]
+  }
+  if (backend === 'codex') {
+    return [...stripCodexSessionArgs(persistedArgs), 'resume', nativeSessionId]
+  }
+  return [
+    ...stripOpenCodeSessionArgs(persistedArgs),
+    '--session',
+    nativeSessionId,
+  ]
+}
+
+export function hasLegacyNativeResumeArgs(session: Session): boolean {
+  const args = session.terminal_command_args ?? []
+  if (session.backend === 'claude') {
+    return args.some(
+      arg => arg === '--resume' || arg === '-r' || arg.startsWith('--resume=')
+    )
+  }
+  if (session.backend === 'codex') {
+    return args.includes('resume')
+  }
+  if (session.backend === 'opencode') {
+    return args.some(
+      arg => arg === '--session' || arg === '-s' || arg.startsWith('--session=')
+    )
+  }
+  return false
+}
+
+export function getNativeTerminalResumeLaunch(
+  session: Session
+): NativeTerminalLaunch | null {
+  if (!isNativeTerminalBackend(session.backend)) {
+    return null
+  }
+
+  const command = session.terminal_command
+  if (!command) return null
+
+  const nativeSessionId = getNativeSessionId(session)
+  if (nativeSessionId) {
+    return {
+      command,
+      args: buildNativeResumeArgs(
+        session.backend,
+        nativeSessionId,
+        session.terminal_command_args ?? []
+      ),
+    }
+  }
+
+  if (hasLegacyNativeResumeArgs(session)) {
+    return {
+      command,
+      args: session.terminal_command_args ?? [],
+    }
+  }
+
+  return null
+}

--- a/src/services/chat.test.ts
+++ b/src/services/chat.test.ts
@@ -17,7 +17,11 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
-import { prefetchSessions, reconnectNativeCliSession } from './chat'
+import {
+  canReconnectSession,
+  prefetchSessions,
+  reconnectNativeCliSession,
+} from './chat'
 import { useChatStore } from '@/store/chat-store'
 import { useUIStore } from '@/store/ui-store'
 import { useTerminalStore } from '@/store/terminal-store'
@@ -137,6 +141,42 @@ describe('reconnectNativeCliSession', () => {
     expect(terminal?.commandArgs).toEqual(['--resume', 'abc123'])
   })
 
+  it('preserves native CLI global flags when resuming', async () => {
+    await reconnectNativeCliSession(
+      {
+        ...terminalSession,
+        terminal_command_args: [
+          '--permission-mode',
+          'bypassPermissions',
+          '--session-id',
+          'abc123',
+        ],
+      },
+      'wt-1'
+    )
+
+    const terminalId = useUIStore.getState().sessionTerminalIds['session-1']
+    const terminal = useTerminalStore
+      .getState()
+      .terminals['wt-1']?.find(t => t.id === terminalId)
+    expect(terminal?.commandArgs).toEqual([
+      '--permission-mode',
+      'bypassPermissions',
+      '--resume',
+      'abc123',
+    ])
+  })
+
+  it('refuses to reconnect native sessions without a persisted resume ID', () => {
+    expect(
+      canReconnectSession({
+        ...terminalSession,
+        claude_session_id: undefined,
+        terminal_command_args: ['--permission-mode', 'bypassPermissions'],
+      })
+    ).toBe(false)
+  })
+
   it('opens the modal drawer and toasts by default (manual reconnect)', async () => {
     await reconnectNativeCliSession(terminalSession, 'wt-1')
 
@@ -154,7 +194,9 @@ describe('reconnectNativeCliSession', () => {
     // Terminal still restored...
     expect(useUIStore.getState().sessionTerminalIds['session-1']).toBeDefined()
     // ...but no floating drawer pops and no toast fires.
-    expect(useTerminalStore.getState().modalTerminalOpen['wt-1']).toBeUndefined()
+    expect(
+      useTerminalStore.getState().modalTerminalOpen['wt-1']
+    ).toBeUndefined()
     expect(toastMock.success).not.toHaveBeenCalled()
   })
 

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -37,6 +37,7 @@ import type { AppPreferences } from '@/types/preferences'
 import { useChatStore } from '@/store/chat-store'
 import { useUIStore } from '@/store/ui-store'
 import { useTerminalStore } from '@/store/terminal-store'
+import { isNativeTerminalBackend } from '@/lib/native-cli-session'
 import { getResumeArgs } from '@/components/chat/session-card-utils'
 import type { ReviewResponse, Worktree } from '@/types/projects'
 
@@ -98,10 +99,9 @@ export function removeSessionFromAllSessionsCache(
  * terminal command). Used to gate the "Reconnect" menu item.
  */
 export function canReconnectSession(session: Session): boolean {
-  return (
-    session.primary_surface === 'terminal' &&
-    (!!getResumeArgs(session) || !!session.terminal_command)
-  )
+  if (session.primary_surface !== 'terminal') return false
+  if (getResumeArgs(session)) return true
+  return !isNativeTerminalBackend(session.backend) && !!session.terminal_command
 }
 
 /**
@@ -131,13 +131,21 @@ export async function reconnectNativeCliSession(
   worktreeId: string,
   options?: { openModal?: boolean; showToast?: boolean; markOpened?: boolean }
 ): Promise<void> {
-  const { openModal = true, showToast = true, markOpened = true } = options ?? {}
+  const {
+    openModal = true,
+    showToast = true,
+    markOpened = true,
+  } = options ?? {}
   const resume = getResumeArgs(session)
-  const launch = resume ?? {
-    command: session.terminal_command ?? '',
-    args: session.terminal_command_args ?? [],
-  }
-  if (!launch.command) {
+  const launch =
+    resume ??
+    (!isNativeTerminalBackend(session.backend)
+      ? {
+          command: session.terminal_command ?? '',
+          args: session.terminal_command_args ?? [],
+        }
+      : null)
+  if (!launch?.command) {
     if (showToast) toast.error('No command available to reconnect this session')
     return
   }
@@ -732,6 +740,7 @@ export function useCreateSession() {
       terminalCommand,
       terminalCommandArgs,
       terminalLabel,
+      nativeSessionId,
     }: {
       worktreeId: string
       worktreePath: string
@@ -741,6 +750,7 @@ export function useCreateSession() {
       terminalCommand?: string | null
       terminalCommandArgs?: string[]
       terminalLabel?: string
+      nativeSessionId?: string
     }): Promise<Session> => {
       if (!isTauri()) {
         throw new Error('Not in Tauri context')
@@ -756,6 +766,7 @@ export function useCreateSession() {
         terminalCommand,
         terminalCommandArgs,
         terminalLabel,
+        nativeSessionId,
       })
       logger.info('Session created', { sessionId: session.id })
       return session


### PR DESCRIPTION
## Problem

Terminal-backed native CLI sessions (Claude/Codex/OpenCode opened via New Session, not Jean chat) showed a blank, disconnected page after closing and reopening Jean. The PTY is killed on close and most sessions never persisted their native conversation/resume ID, so restore fell through to an empty chat or started an unrelated new session.

## Fix

- Persist each native CLI session ID at launch/discovery:
  - **Claude**: generated UUID passed via `--session-id`
  - **Codex / OpenCode**: native ID detected after startup via ambiguity-safe background history detection, then bound
- Restore terminal-backed sessions directly from persisted session metadata instead of relying on prefetched runtime UI state.
- Reopen with the native resume command: `claude --resume <ID>`, `codex resume <ID>`, `opencode --session <ID>`.
- Legacy sessions without an ID show a recovery action instead of a blank terminal — never silently start a fresh unrelated conversation.
- Centralized resume-argument construction; preserved existing global permission/yolo flags.

## Tests

- Added Rust + frontend regression tests for persistence, discovery, and cold-restart restore.
- 1,044 frontend + 594 Rust tests pass; modified files pass format/lint.

## How to test

1. `bun run tauri dev`
2. Create Claude, Codex, and OpenCode terminal sessions; send a prompt in each.
3. Quit and reopen Jean.
4. Open each session — confirm its original CLI conversation resumes (not a blank page).