### PR TITLE
fix(mcp): support Windows local IPC

### DIFF
--- a/src-tauri/src/chat/jean_mcp.rs
+++ b/src-tauri/src/chat/jean_mcp.rs
@@ -4,7 +4,7 @@
 //! for callers that explicitly opt into runtime config assembly. Normal Jean
 //! CLI sessions use the persistent config writers in `jean_mcp_config` so the
 //! server is visible to users. The stdio helper proxies over a Jean-owned local
-//! Unix socket; no HTTP listener/port is required.
+//! local IPC; no HTTP listener/port is required.
 
 use serde_json::{json, Value};
 use tauri::AppHandle;

--- a/src-tauri/src/jean_mcp_socket.rs
+++ b/src-tauri/src/jean_mcp_socket.rs
@@ -21,7 +21,37 @@ pub fn socket_path(app: &AppHandle) -> Result<PathBuf, String> {
         .path()
         .app_data_dir()
         .map_err(|e| format!("Failed to resolve app data dir: {e}"))?;
-    Ok(dir.join("jean-mcp.sock"))
+    Ok(platform_socket_path(&dir))
+}
+
+#[cfg(unix)]
+fn platform_socket_path(app_data_dir: &std::path::Path) -> PathBuf {
+    app_data_dir.join("jean-mcp.sock")
+}
+
+#[cfg(windows)]
+fn platform_socket_path(app_data_dir: &std::path::Path) -> PathBuf {
+    windows_pipe_path_for_app_data(app_data_dir)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn platform_socket_path(app_data_dir: &std::path::Path) -> PathBuf {
+    app_data_dir.join("jean-mcp.sock")
+}
+
+#[cfg(any(windows, test))]
+fn windows_pipe_path_for_app_data(app_data_dir: &std::path::Path) -> PathBuf {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(app_data_dir.to_string_lossy().as_bytes());
+    let digest = hasher.finalize();
+    let suffix = digest[..8]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+
+    PathBuf::from(format!(r"\\.\pipe\jean-mcp-{suffix}"))
 }
 
 pub async fn get_socket_status(app: AppHandle) -> (bool, Option<String>, Option<String>) {
@@ -124,13 +154,95 @@ pub async fn start_socket_server(
     })
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+pub async fn start_socket_server(
+    app: AppHandle,
+    path: PathBuf,
+    token: String,
+) -> Result<JeanMcpSocketHandle, String> {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+
+    async fn handle_pipe_connection(
+        app: AppHandle,
+        expected_token: String,
+        mut pipe: NamedPipeServer,
+    ) {
+        let mut line = String::new();
+        let response = {
+            let mut reader = BufReader::new(&mut pipe);
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                reader.read_line(&mut line),
+            )
+            .await
+            {
+                Ok(Ok(0)) => json!({"error":"empty request"}),
+                Ok(Ok(_)) => handle_socket_request(&app, &expected_token, &line).await,
+                Ok(Err(e)) => json!({"error": format!("read failed: {e}")}),
+                Err(_) => json!({"error":"read timeout"}),
+            }
+        };
+        if let Ok(encoded) = serde_json::to_string(&response) {
+            let _ = pipe.write_all(encoded.as_bytes()).await;
+            let _ = pipe.write_all(b"\n").await;
+            let _ = pipe.flush().await;
+        }
+    }
+
+    let pipe_name = path.to_string_lossy().to_string();
+    let mut server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(&pipe_name)
+        .map_err(|e| format!("Failed to create Jean MCP named pipe {pipe_name}: {e}"))?;
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
+    let path_for_task = path.clone();
+    let token_for_task = token.clone();
+
+    tokio::spawn(async move {
+        log::info!("Jean MCP proxy named pipe listening at {pipe_name}");
+        loop {
+            tokio::select! {
+                _ = &mut shutdown_rx => {
+                    log::info!("Jean MCP proxy named pipe shutting down");
+                    break;
+                }
+                connected = server.connect() => {
+                    match connected {
+                        Ok(()) => {
+                            let next_server = match ServerOptions::new().create(&pipe_name) {
+                                Ok(next) => next,
+                                Err(e) => {
+                                    log::warn!("Jean MCP named pipe recreate failed: {e}");
+                                    break;
+                                }
+                            };
+                            let connected_server = std::mem::replace(&mut server, next_server);
+                            let app = app.clone();
+                            let expected_token = token_for_task.clone();
+                            tokio::spawn(handle_pipe_connection(app, expected_token, connected_server));
+                        }
+                        Err(e) => log::warn!("Jean MCP named pipe accept failed: {e}"),
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(JeanMcpSocketHandle {
+        shutdown_tx,
+        path: path_for_task,
+        token,
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
 pub async fn start_socket_server(
     _app: AppHandle,
     _path: PathBuf,
     _token: String,
 ) -> Result<JeanMcpSocketHandle, String> {
-    Err("Jean MCP currently requires Unix domain sockets".to_string())
+    Err("Jean MCP local IPC is not supported on this platform".to_string())
 }
 
 async fn handle_socket_request(app: &AppHandle, expected_token: &str, line: &str) -> Value {
@@ -156,5 +268,26 @@ async fn handle_socket_request(app: &AppHandle, expected_token: &str, line: &str
     match call_tool(app, &tool_call.name, tool_call.arguments, source, depth).await {
         Ok(result) => jsonrpc_ok(None, result),
         Err(e) => jsonrpc_error(None, e.code, &e.message),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    #[test]
+    fn windows_pipe_path_is_stable_and_named_pipe_safe() {
+        let one =
+            super::windows_pipe_path_for_app_data(Path::new(r"C:\Users\Ada\AppData\Roaming\Jean"));
+        let two =
+            super::windows_pipe_path_for_app_data(Path::new(r"C:\Users\Ada\AppData\Roaming\Jean"));
+        let other = super::windows_pipe_path_for_app_data(Path::new(
+            r"C:\Users\Ada\AppData\Roaming\JeanDev",
+        ));
+
+        assert_eq!(one, two);
+        assert_ne!(one, other);
+        assert!(one.to_string_lossy().starts_with(r"\\.\pipe\jean-mcp-"));
+        assert!(!one.to_string_lossy().contains(':'));
     }
 }

--- a/src-tauri/src/jean_mcp_stdio.rs
+++ b/src-tauri/src/jean_mcp_stdio.rs
@@ -1,7 +1,7 @@
 //! Stdio MCP transport for Jean.
 //!
 //! This process is launched by a local CLI as an MCP server. It proxies
-//! tools/call requests over a Jean-owned local Unix socket to the already
+//! tools/call requests over Jean-owned local IPC to the already
 //! running desktop app, avoiding HTTP ports while preserving in-process app
 //! command dispatch in the parent.
 
@@ -103,9 +103,54 @@ fn proxy_to_parent(socket: &str, request: Value) -> Result<Value, String> {
     Ok(response.get("result").cloned().unwrap_or(Value::Null))
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn proxy_to_parent(socket: &str, request: Value) -> Result<Value, String> {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::windows::named_pipe::ClientOptions;
+    use tokio::runtime::Builder;
+    use tokio::time::{timeout, Duration};
+
+    let encoded = serde_json::to_string(&request)
+        .map_err(|e| format!("Failed to encode Jean MCP pipe request: {e}"))?;
+    let runtime = Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .map_err(|e| format!("Failed to create Jean MCP pipe runtime: {e}"))?;
+
+    let response = runtime.block_on(async {
+        let mut pipe = ClientOptions::new()
+            .open(socket)
+            .map_err(|e| format!("Failed to connect Jean MCP named pipe {socket}: {e}"))?;
+        timeout(Duration::from_secs(30), async {
+            pipe.write_all(encoded.as_bytes()).await?;
+            pipe.write_all(b"\n").await?;
+            pipe.flush().await
+        })
+        .await
+        .map_err(|_| "Timed out writing Jean MCP pipe request".to_string())?
+        .map_err(|e| format!("Failed to write Jean MCP pipe request: {e}"))?;
+
+        let mut reader = BufReader::new(pipe);
+        let mut line = String::new();
+        timeout(Duration::from_secs(120), reader.read_line(&mut line))
+            .await
+            .map_err(|_| "Timed out reading Jean MCP pipe response".to_string())?
+            .map_err(|e| format!("Failed to read Jean MCP pipe response: {e}"))?;
+
+        serde_json::from_str::<Value>(&line)
+            .map_err(|e| format!("Failed to parse Jean MCP pipe response: {e}"))
+    })?;
+
+    if let Some(error) = parent_error_message(&response) {
+        return Err(error);
+    }
+    Ok(response.get("result").cloned().unwrap_or(Value::Null))
+}
+
+#[cfg(not(any(unix, windows)))]
 fn proxy_to_parent(_socket: &str, _request: Value) -> Result<Value, String> {
-    Err("Jean MCP currently requires a Unix domain socket".to_string())
+    Err("Jean MCP local IPC is not supported on this platform".to_string())
 }
 
 fn parent_error_message(response: &Value) -> Option<String> {


### PR DESCRIPTION
## Summary
- Add Windows named pipe support for Jean MCP local IPC so the desktop app can host MCP without Unix sockets.
- Update the stdio MCP bridge to connect to the Windows pipe and preserve the existing request/response proxy behavior.
- Keep Unix socket behavior intact and add coverage for stable, safe Windows pipe path generation.

## Issue
- fixes #432

---

Fixes #432