### PR TITLE
fix(claude): pass profile env to helper commands

### DIFF
--- a/src-tauri/src/chat/claude.rs
+++ b/src-tauri/src/chat/claude.rs
@@ -317,6 +317,64 @@ pub fn apply_custom_profile_settings(cmd: &mut std::process::Command, profile_na
     }
 }
 
+fn custom_profile_env_vars_from_settings(settings: &str) -> Result<Vec<(String, String)>, String> {
+    let value: serde_json::Value =
+        serde_json::from_str(settings).map_err(|e| format!("Invalid CLI profile JSON: {e}"))?;
+
+    let Some(env) = value.get("env").and_then(|env| env.as_object()) else {
+        return Ok(Vec::new());
+    };
+
+    Ok(env
+        .iter()
+        .filter_map(|(key, value)| {
+            value
+                .as_str()
+                .map(|value| (key.to_string(), value.to_string()))
+        })
+        .collect())
+}
+
+fn load_custom_profile_env_vars(profile_name: Option<&str>) -> Vec<(String, String)> {
+    let Some(name) = profile_name.filter(|name| !name.is_empty()) else {
+        return Vec::new();
+    };
+
+    let Ok(path) = crate::get_cli_profile_path(name) else {
+        return Vec::new();
+    };
+
+    if !path.exists() {
+        return Vec::new();
+    }
+
+    match std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read CLI profile '{}': {e}", path.display()))
+        .and_then(|settings| custom_profile_env_vars_from_settings(&settings))
+    {
+        Ok(env_vars) => env_vars,
+        Err(error) => {
+            log::warn!("{error}");
+            Vec::new()
+        }
+    }
+}
+
+/// Apply custom CLI profile env vars to a Command.
+///
+/// Newer Claude CLI versions may check authentication before fully applying
+/// `--settings` env, so API-compatible providers need their ANTHROPIC_* vars
+/// present in the child process environment too.
+pub fn apply_custom_profile_env(cmd: &mut std::process::Command, profile_name: Option<&str>) {
+    for (key, value) in load_custom_profile_env_vars(profile_name) {
+        cmd.env(key, value);
+    }
+}
+
+fn should_mirror_custom_profile_env_for_detached() -> bool {
+    cfg!(windows) && !crate::platform::get_wsl_config().enabled
+}
+
 /// Strip a `-fast` suffix from the model string.
 /// Returns `(actual_model, is_fast)`.
 /// E.g. `"opus-fast"` → `("opus", true)`, `"opus"` → `("opus", false)`.
@@ -461,6 +519,9 @@ fn build_claude_args(
                 }
             }
         }
+    }
+    if should_mirror_custom_profile_env_for_detached() {
+        env_vars.extend(load_custom_profile_env_vars(custom_profile_name));
     }
 
     // Thinking/effort settings: passed as separate --settings JSON (no secrets here)
@@ -2368,6 +2429,26 @@ mod tests {
             split_fast_model("claude-fable-5"),
             ("claude-fable-5", false)
         );
+    }
+
+    #[test]
+    fn custom_profile_env_vars_reads_string_env_entries() {
+        let settings = r#"{
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+                "ANTHROPIC_AUTH_TOKEN": "secret",
+                "IGNORED_NON_STRING": 123
+            }
+        }"#;
+
+        let env_vars = custom_profile_env_vars_from_settings(settings).unwrap();
+
+        assert!(env_vars.contains(&(
+            "ANTHROPIC_BASE_URL".to_string(),
+            "https://api.minimax.io/anthropic".to_string()
+        )));
+        assert!(env_vars.contains(&("ANTHROPIC_AUTH_TOKEN".to_string(), "secret".to_string())));
+        assert!(!env_vars.iter().any(|(key, _)| key == "IGNORED_NON_STRING"));
     }
 
     #[test]

--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -6765,6 +6765,7 @@ fn execute_summarization_claude(
 
     let mut cmd = crate::platform::cli_command(&cli_path.to_string_lossy(), None);
     crate::chat::claude::apply_custom_profile_settings(&mut cmd, custom_profile_name);
+    crate::chat::claude::apply_custom_profile_env(&mut cmd, custom_profile_name);
     cmd.args([
         "--print",
         "--input-format",

--- a/src-tauri/src/chat/naming.rs
+++ b/src-tauri/src/chat/naming.rs
@@ -380,6 +380,7 @@ fn generate_names(app: &AppHandle, request: &NamingRequest) -> Result<NamingOutp
         &mut cmd,
         request.custom_profile_name.as_deref(),
     );
+    crate::chat::claude::apply_custom_profile_env(&mut cmd, request.custom_profile_name.as_deref());
     cmd.args([
         "--print",
         "--input-format",

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -6934,6 +6934,7 @@ fn generate_pr_content_from_inputs(
 
     let mut cmd = crate::platform::cli_command(&cli_path.to_string_lossy(), None);
     crate::chat::claude::apply_custom_profile_settings(&mut cmd, custom_profile_name);
+    crate::chat::claude::apply_custom_profile_env(&mut cmd, custom_profile_name);
     cmd.args(build_claude_structured_output_args(
         model_str,
         "",
@@ -7575,6 +7576,7 @@ fn generate_commit_message_once(
 
     let mut cmd = crate::platform::cli_command(&cli_path.to_string_lossy(), None);
     crate::chat::claude::apply_custom_profile_settings(&mut cmd, custom_profile_name);
+    crate::chat::claude::apply_custom_profile_env(&mut cmd, custom_profile_name);
     cmd.args(build_claude_structured_output_args(
         model_str,
         "",
@@ -8105,6 +8107,7 @@ fn generate_review(
 
     let mut cmd = crate::platform::cli_command(&cli_path.to_string_lossy(), None);
     crate::chat::claude::apply_custom_profile_settings(&mut cmd, custom_profile_name);
+    crate::chat::claude::apply_custom_profile_env(&mut cmd, custom_profile_name);
     cmd.args(build_claude_structured_output_args(
         model_str,
         "none",
@@ -9215,6 +9218,7 @@ fn generate_release_notes_content(
 
     let mut cmd = crate::platform::cli_command(&cli_path.to_string_lossy(), None);
     crate::chat::claude::apply_custom_profile_settings(&mut cmd, custom_profile_name);
+    crate::chat::claude::apply_custom_profile_env(&mut cmd, custom_profile_name);
     cmd.args(build_claude_structured_output_args(
         model_str,
         "",


### PR DESCRIPTION
## Summary
- Mirror custom Claude profile environment variables into helper command processes so newer Claude CLI auth checks can see API-compatible provider credentials.
- Apply the same custom profile env handling to one-shot Claude helpers for naming, summaries, PR content, commit messages, reviews, and release notes.
- Add coverage for parsing string env entries from CLI profile settings while ignoring non-string values.

fixes #410

---

Fixes #410