### PR TITLE
fix(rtk): install CLI from verified release asset

### DIFF
--- a/src-tauri/src/opinionated/commands.rs
+++ b/src-tauri/src/opinionated/commands.rs
@@ -1,7 +1,10 @@
 use crate::platform::silent_command;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::ffi::{OsStr, OsString};
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 #[derive(Debug, Serialize)]
 pub struct PluginStatus {
@@ -13,6 +16,9 @@ const SUPERPOWERS_GIT_WORKTREE_SKILL: &str = "using-git-worktrees";
 const SUPERPOWERS_REPO_URL: &str = "https://github.com/obra/superpowers";
 const SUPERPOWERS_ARCHIVE_URL: &str =
     "https://github.com/obra/superpowers/archive/refs/heads/main.zip";
+const RTK_RELEASE_LATEST_API: &str = "https://api.github.com/repos/rtk-ai/rtk/releases/latest";
+const RTK_CLI_DIR_NAME: &str = "rtk-cli";
+const RTK_BINARY_NAME: &str = if cfg!(windows) { "rtk.exe" } else { "rtk" };
 
 fn superpowers_claude_plugin_target() -> &'static str {
     "superpowers@claude-plugins-official"
@@ -29,7 +35,7 @@ pub async fn check_opinionated_plugin_status(
     plugin_name: String,
 ) -> Result<PluginStatus, String> {
     match plugin_name.as_str() {
-        "rtk" => check_rtk_status().await,
+        "rtk" => check_rtk_status(&app).await,
         "caveman" => check_caveman_status(&app).await,
         "superpowers" => check_superpowers_status(&app).await,
         _ => Err(format!("Unknown plugin: {plugin_name}")),
@@ -42,7 +48,7 @@ pub async fn install_opinionated_plugin(
     plugin_name: String,
 ) -> Result<String, String> {
     match plugin_name.as_str() {
-        "rtk" => install_rtk().await,
+        "rtk" => install_rtk(&app).await,
         "caveman" => install_caveman(&app).await,
         "superpowers" => install_superpowers(&app).await,
         _ => Err(format!("Unknown plugin: {plugin_name}")),
@@ -64,10 +70,24 @@ pub async fn uninstall_opinionated_plugin(
     }
 }
 
-async fn check_rtk_status() -> Result<PluginStatus, String> {
-    let result = tokio::task::spawn_blocking(|| silent_command("rtk").arg("--version").output())
-        .await
-        .map_err(|e| e.to_string())?;
+async fn check_rtk_status(app: &AppHandle) -> Result<PluginStatus, String> {
+    let managed_binary = rtk_binary_path(app).ok();
+    let result = tokio::task::spawn_blocking(move || {
+        let path_result = silent_command("rtk").arg("--version").output();
+        if matches!(&path_result, Ok(output) if output.status.success()) {
+            return path_result;
+        }
+
+        if let Some(binary) = managed_binary {
+            if binary.exists() {
+                return silent_command(binary).arg("--version").output();
+            }
+        }
+
+        path_result
+    })
+    .await
+    .map_err(|e| e.to_string())?;
 
     match result {
         Ok(output) if output.status.success() => {
@@ -110,62 +130,354 @@ async fn check_caveman_status(app: &AppHandle) -> Result<PluginStatus, String> {
     Ok(PluginStatus { installed, version })
 }
 
-async fn install_rtk() -> Result<String, String> {
-    // Try brew first on macOS
-    let brew_result = tokio::task::spawn_blocking(|| {
-        silent_command("brew")
-            .args(["install", "rtk-ai/tap/rtk"])
-            .output()
-    })
-    .await
-    .map_err(|e| e.to_string())?;
+async fn install_rtk(app: &AppHandle) -> Result<String, String> {
+    let asset = current_rtk_asset()?;
+    let binary_path = rtk_binary_path(app)?;
 
-    let install_ok = match brew_result {
-        Ok(output) if output.status.success() => true,
-        _ => {
-            // Fallback to curl installer
-            let curl_result = tokio::task::spawn_blocking(|| {
-                silent_command("sh")
-                    .args([
-                        "-c",
-                        "curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh",
-                    ])
-                    .output()
-            })
-            .await
-            .map_err(|e| e.to_string())?;
+    let (archive, checksums) = download_rtk_release(&asset).await?;
+    verify_rtk_checksum(&archive, &checksums, asset.name)?;
 
-            match curl_result {
-                Ok(output) if output.status.success() => true,
-                Ok(output) => {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    return Err(format!("RTK installation failed: {stderr}"));
-                }
-                Err(e) => return Err(format!("Failed to run installer: {e}")),
-            }
-        }
+    let binary = match asset.format {
+        RtkArchiveFormat::Zip => extract_rtk_zip_binary(&archive, asset.binary_name)?,
+        RtkArchiveFormat::TarGz => extract_rtk_tar_gz_binary(&archive, asset.binary_name)?,
     };
 
-    if install_ok {
-        // Run post-install setup
-        let init_result =
-            tokio::task::spawn_blocking(|| silent_command("rtk").args(["init", "-g"]).output())
-                .await
-                .map_err(|e| e.to_string())?;
-
-        match init_result {
-            Ok(output) if output.status.success() => {
-                Ok("RTK installed and initialized successfully".to_string())
-            }
-            Ok(output) => {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                Ok(format!("RTK installed but init had warnings: {stderr}"))
-            }
-            Err(e) => Ok(format!("RTK installed but init failed: {e}")),
-        }
-    } else {
-        Err("RTK installation failed".to_string())
+    if let Some(parent) = binary_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create RTK install directory: {e}"))?;
     }
+    crate::platform::write_binary_file(&binary_path, &binary)
+        .map_err(|e| format!("Failed to install RTK binary: {e}"))?;
+    if let Some(parent) = binary_path.parent() {
+        add_dir_to_process_path(parent)?;
+        persist_rtk_dir_to_user_path(parent);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&binary_path)
+            .map_err(|e| format!("Failed to get RTK binary metadata: {e}"))?
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&binary_path, perms)
+            .map_err(|e| format!("Failed to set RTK binary permissions: {e}"))?;
+    }
+
+    let verify_output = silent_command(&binary_path)
+        .arg("--version")
+        .output()
+        .map_err(|e| format!("Failed to verify RTK installation: {e}"))?;
+    if !verify_output.status.success() {
+        return Err(command_failure_message(
+            "RTK verification failed",
+            &verify_output,
+        ));
+    }
+
+    let init_result = silent_command(&binary_path).args(["init", "-g"]).output();
+    match init_result {
+        Ok(output) if output.status.success() => Ok(format!(
+            "RTK installed and initialized successfully at {}",
+            binary_path.display()
+        )),
+        Ok(output) => Ok(format!(
+            "RTK installed to {} but init had warnings: {}",
+            binary_path.display(),
+            command_output_detail(&output)
+        )),
+        Err(e) => Ok(format!(
+            "RTK installed to {} but init failed: {e}",
+            binary_path.display()
+        )),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RtkArchiveFormat {
+    Zip,
+    TarGz,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RtkAsset {
+    name: &'static str,
+    binary_name: &'static str,
+    format: RtkArchiveFormat,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RtkGitHubRelease {
+    assets: Vec<RtkGitHubAsset>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RtkGitHubAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+fn rtk_binary_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {e}"))?;
+    Ok(app_data_dir.join(RTK_CLI_DIR_NAME).join(RTK_BINARY_NAME))
+}
+
+fn add_dir_to_process_path(dir: &Path) -> Result<(), String> {
+    let current = std::env::var_os("PATH");
+    let updated = path_with_prepended_dir(current.as_deref(), dir)?;
+    std::env::set_var("PATH", updated);
+    Ok(())
+}
+
+fn path_with_prepended_dir(current: Option<&OsStr>, dir: &Path) -> Result<OsString, String> {
+    let existing: Vec<PathBuf> = current
+        .map(std::env::split_paths)
+        .into_iter()
+        .flatten()
+        .collect();
+
+    if existing.iter().any(|path| path == dir) {
+        return current
+            .map(OsStr::to_os_string)
+            .ok_or_else(|| "PATH is empty".to_string());
+    }
+
+    let mut updated = Vec::with_capacity(existing.len() + 1);
+    updated.push(dir.to_path_buf());
+    updated.extend(existing);
+    std::env::join_paths(updated).map_err(|e| format!("Failed to update PATH for RTK: {e}"))
+}
+
+#[cfg(windows)]
+fn persist_rtk_dir_to_user_path(dir: &Path) {
+    let dir = dir.to_string_lossy().to_string();
+    let script = r#"
+$dir = $args[0]
+$old = [Environment]::GetEnvironmentVariable('Path', 'User')
+if ([string]::IsNullOrWhiteSpace($old)) {
+  [Environment]::SetEnvironmentVariable('Path', $dir, 'User')
+  exit 0
+}
+$parts = $old -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+if ($parts -notcontains $dir) {
+  [Environment]::SetEnvironmentVariable('Path', ($old.TrimEnd(';') + ';' + $dir), 'User')
+}
+"#;
+    match silent_command("powershell")
+        .args([
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            script,
+            &dir,
+        ])
+        .output()
+    {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => log::warn!(
+            "Failed to persist RTK install dir to user PATH: {}",
+            command_output_detail(&output)
+        ),
+        Err(e) => log::warn!("Failed to run PowerShell while persisting RTK PATH: {e}"),
+    }
+}
+
+#[cfg(not(windows))]
+fn persist_rtk_dir_to_user_path(_dir: &Path) {}
+
+fn current_rtk_asset() -> Result<RtkAsset, String> {
+    rtk_asset_for_platform(std::env::consts::OS, std::env::consts::ARCH)
+}
+
+fn rtk_asset_for_platform(os: &str, arch: &str) -> Result<RtkAsset, String> {
+    let asset = match (os, arch) {
+        ("windows", "x86_64") => RtkAsset {
+            name: "rtk-x86_64-pc-windows-msvc.zip",
+            binary_name: "rtk.exe",
+            format: RtkArchiveFormat::Zip,
+        },
+        ("macos", "aarch64") => RtkAsset {
+            name: "rtk-aarch64-apple-darwin.tar.gz",
+            binary_name: "rtk",
+            format: RtkArchiveFormat::TarGz,
+        },
+        ("macos", "x86_64") => RtkAsset {
+            name: "rtk-x86_64-apple-darwin.tar.gz",
+            binary_name: "rtk",
+            format: RtkArchiveFormat::TarGz,
+        },
+        ("linux", "x86_64") => RtkAsset {
+            name: "rtk-x86_64-unknown-linux-musl.tar.gz",
+            binary_name: "rtk",
+            format: RtkArchiveFormat::TarGz,
+        },
+        ("linux", "aarch64") => RtkAsset {
+            name: "rtk-aarch64-unknown-linux-gnu.tar.gz",
+            binary_name: "rtk",
+            format: RtkArchiveFormat::TarGz,
+        },
+        _ => {
+            return Err(format!(
+                "Unsupported RTK platform: {os}/{arch}. Install manually from https://github.com/rtk-ai/rtk/releases"
+            ))
+        }
+    };
+    Ok(asset)
+}
+
+async fn download_rtk_release(asset: &RtkAsset) -> Result<(Vec<u8>, String), String> {
+    let client = reqwest::Client::builder()
+        .user_agent("Jean-App/1.0")
+        .redirect(reqwest::redirect::Policy::limited(10))
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+
+    let release: RtkGitHubRelease = client
+        .get(RTK_RELEASE_LATEST_API)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch RTK release info: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("Failed to fetch RTK release info: {e}"))?
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse RTK release info: {e}"))?;
+
+    let archive_url = release_asset_url(&release, asset.name)?;
+    let checksums_url = release_asset_url(&release, "checksums.txt")?;
+
+    let archive = client
+        .get(archive_url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to download RTK archive: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("Failed to download RTK archive: {e}"))?
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read RTK archive: {e}"))?
+        .to_vec();
+
+    let checksums = client
+        .get(checksums_url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to download RTK checksums: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("Failed to download RTK checksums: {e}"))?
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read RTK checksums: {e}"))?;
+
+    Ok((archive, checksums))
+}
+
+fn release_asset_url(release: &RtkGitHubRelease, name: &str) -> Result<String, String> {
+    release
+        .assets
+        .iter()
+        .find(|asset| asset.name == name)
+        .map(|asset| asset.browser_download_url.clone())
+        .ok_or_else(|| format!("RTK release asset not found: {name}"))
+}
+
+fn rtk_expected_checksum<'a>(checksums: &'a str, asset_name: &str) -> Option<&'a str> {
+    checksums.lines().find_map(|line| {
+        let mut parts = line.split_whitespace();
+        let checksum = parts.next()?;
+        let name = parts.next()?;
+        (name == asset_name).then_some(checksum)
+    })
+}
+
+fn verify_rtk_checksum(archive: &[u8], checksums: &str, asset_name: &str) -> Result<(), String> {
+    let expected = rtk_expected_checksum(checksums, asset_name)
+        .ok_or_else(|| format!("Checksum for {asset_name} not found"))?;
+    let actual = format!("{:x}", Sha256::digest(archive));
+    if expected != actual {
+        return Err(format!(
+            "RTK checksum mismatch for {asset_name}: expected {expected}, got {actual}"
+        ));
+    }
+    Ok(())
+}
+
+fn extract_rtk_zip_binary(archive: &[u8], binary_name: &str) -> Result<Vec<u8>, String> {
+    let cursor = std::io::Cursor::new(archive);
+    let mut zip =
+        zip::ZipArchive::new(cursor).map_err(|e| format!("Failed to open RTK zip: {e}"))?;
+
+    for i in 0..zip.len() {
+        let mut file = zip
+            .by_index(i)
+            .map_err(|e| format!("Failed to read RTK zip entry: {e}"))?;
+        let Some(name) = file.enclosed_name().and_then(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.to_string())
+        }) else {
+            continue;
+        };
+
+        if name == binary_name {
+            let mut binary = Vec::new();
+            file.read_to_end(&mut binary)
+                .map_err(|e| format!("Failed to read RTK binary from zip: {e}"))?;
+            return Ok(binary);
+        }
+    }
+
+    Err(format!("RTK binary {binary_name} not found in zip"))
+}
+
+fn extract_rtk_tar_gz_binary(archive: &[u8], binary_name: &str) -> Result<Vec<u8>, String> {
+    let cursor = std::io::Cursor::new(archive);
+    let decoder = flate2::read::GzDecoder::new(cursor);
+    let mut tar = tar::Archive::new(decoder);
+
+    for entry in tar
+        .entries()
+        .map_err(|e| format!("Failed to read RTK tar entries: {e}"))?
+    {
+        let mut entry = entry.map_err(|e| format!("Failed to read RTK tar entry: {e}"))?;
+        let path = entry
+            .path()
+            .map_err(|e| format!("Failed to read RTK tar path: {e}"))?;
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+
+        if name == binary_name {
+            let mut binary = Vec::new();
+            entry
+                .read_to_end(&mut binary)
+                .map_err(|e| format!("Failed to read RTK binary from tar: {e}"))?;
+            return Ok(binary);
+        }
+    }
+
+    Err(format!("RTK binary {binary_name} not found in tar.gz"))
+}
+
+fn command_failure_message(prefix: &str, output: &std::process::Output) -> String {
+    format!("{prefix}: {}", command_output_detail(output))
+}
+
+fn command_output_detail(output: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !stderr.is_empty() {
+        return stderr;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !stdout.is_empty() {
+        return stdout;
+    }
+    format!("exit code {}", output.status)
 }
 
 async fn install_caveman(app: &AppHandle) -> Result<String, String> {
@@ -1248,6 +1560,66 @@ mod tests {
         assert_eq!(
             superpowers_claude_plugin_target(),
             "superpowers@claude-plugins-official"
+        );
+    }
+
+    #[test]
+    fn selects_windows_rtk_release_asset() {
+        let asset = rtk_asset_for_platform("windows", "x86_64").expect("asset");
+
+        assert_eq!(asset.name, "rtk-x86_64-pc-windows-msvc.zip");
+        assert_eq!(asset.binary_name, "rtk.exe");
+        assert_eq!(asset.format, RtkArchiveFormat::Zip);
+    }
+
+    #[test]
+    fn parses_rtk_checksum_for_asset() {
+        let checksums = "\
+abc123  rtk-aarch64-apple-darwin.tar.gz\n\
+def456  rtk-x86_64-pc-windows-msvc.zip\n";
+
+        assert_eq!(
+            rtk_expected_checksum(checksums, "rtk-x86_64-pc-windows-msvc.zip"),
+            Some("def456")
+        );
+    }
+
+    #[test]
+    fn extracts_rtk_exe_from_zip_archive() {
+        use std::io::{Cursor, Write};
+
+        let mut archive_bytes = Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut archive_bytes);
+            let options = zip::write::SimpleFileOptions::default();
+            writer
+                .start_file("rtk.exe", options)
+                .expect("start rtk.exe");
+            writer.write_all(b"binary").expect("write rtk.exe");
+            writer.finish().expect("finish zip");
+        }
+
+        let binary = extract_rtk_zip_binary(archive_bytes.get_ref(), "rtk.exe").expect("extract");
+
+        assert_eq!(binary, b"binary");
+    }
+
+    #[test]
+    fn prepends_rtk_install_dir_to_path_once() {
+        let existing = std::env::join_paths([PathBuf::from("/usr/bin")]).expect("join");
+        let install_dir = PathBuf::from("/tmp/rtk-cli");
+
+        let updated = path_with_prepended_dir(Some(&existing), &install_dir).expect("path");
+        let updated_again = path_with_prepended_dir(Some(&updated), &install_dir).expect("path");
+        let parts: Vec<_> = std::env::split_paths(&updated_again).collect();
+
+        assert_eq!(parts[0], install_dir);
+        assert_eq!(
+            parts
+                .iter()
+                .filter(|part| **part == PathBuf::from("/tmp/rtk-cli"))
+                .count(),
+            1
         );
     }
 


### PR DESCRIPTION
## Summary
- Replaces the RTK install flow with direct downloads from the latest GitHub release asset for the current platform.
- Verifies downloaded archives against published checksums before installing the managed RTK binary.
- Adds Windows-friendly PATH handling and install verification so Settings > Opinionated works without requiring `sh.exe` or Git Bash Unix tools.

## Tests
- Added coverage for platform asset selection, checksum parsing, zip extraction, and PATH update behavior.

fixes #429

---

Fixes #429