### PR TITLE
fix(claude-cli): keep more version history, default auto-update off (#460)

### DIFF
--- a/src-tauri/src/claude_cli/commands.rs
+++ b/src-tauri/src/claude_cli/commands.rs
@@ -293,8 +293,10 @@ pub async fn get_available_cli_versions() -> Result<Vec<ReleaseInfo>, String> {
         b_parts.cmp(&a_parts)
     });
 
-    // Take only the 5 most recent versions
-    versions.truncate(5);
+    // Take only the 12 most recent versions. Keeps enough history that users
+    // can pin a slightly older release (e.g. one that still exposes the
+    // AskUserQuestion tool) instead of being forced onto the very latest.
+    versions.truncate(12);
 
     log::trace!("Found {} Claude CLI versions", versions.len());
     Ok(versions)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -562,7 +562,8 @@ fn default_chrome_enabled() -> bool {
 }
 
 fn default_auto_update_ai_backends() -> bool {
-    true // Enabled by default — auto-install CLI updates in background
+    false // Disabled by default — surface updates via toast instead of silently
+          // rolling the managed CLI past a working/pinned version
 }
 
 fn default_canvas_layout() -> String {

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1992,7 +1992,7 @@ export const defaultPreferences: AppPreferences = {
   window_vibrancy: false, // Default: disabled (high GPU cost)
   terminal_background: 'auto',
   terminal_background_custom: null,
-  auto_update_ai_backends: true, // Default: auto-update AI backends in the background
+  auto_update_ai_backends: false, // Default: surface CLI updates via toast instead of silent background install
   jean_mcp_enabled: true, // Default: enabled
   jean_mcp_max_depth: 3,
   jean_mcp_rate_limit_per_minute: 20,


### PR DESCRIPTION
## What

Partial mitigation for #460 (`AskUserQuestion` silently degrades to plain-text on Jean-managed Claude CLI ≥ 2.1.187).

Two small changes:

- **Raise managed Claude CLI version cap 5 → 12** (`src-tauri/src/claude_cli/commands.rs`). The 5-version cap dropped 2.1.186 — the last release that exposes `AskUserQuestion` — off the selectable list, so users couldn't pin it. 12 keeps enough history to pin a slightly older release.
- **Default `auto_update_ai_backends` to `false`** (`src-tauri/src/lib.rs`, `src/types/preferences.ts`). Auto-update silently background-installs the latest stable on startup, rolling the managed CLI past a working/pinned version unprompted. Defaulting off surfaces updates via toast instead; users opt in via Settings.

## What this does NOT fix

The real fix — wiring the stream-json control-channel dialog broker (`supportedDialogKinds` + `onUserDialog`) so `AskUserQuestion` works on ≥ 2.1.187 — is still open in #460. This PR only stops the silent roll-forward and restores the pin-an-older-version stopgap.

## Notes

- `auto_update_ai_backends` is a single global preference covering all backends (Claude, Codex, gh, opencode, pi, coderabbit), so this flips the default for all of them. Existing users with the pref already persisted are unaffected; only new/default installs change.

Refs #460
