### PR TITLE
feat(chat): allow editing queued prompts

### DIFF
--- a/src-tauri/src/chat/commands.rs
+++ b/src-tauri/src/chat/commands.rs
@@ -8010,6 +8010,51 @@ pub async fn remove_queued_message(
     Ok(())
 }
 
+/// Update a specific queued message's text by its `id` field.
+/// Returns `false` when the message is no longer queued.
+/// Holds the metadata lock across the entire read-modify-write to prevent TOCTOU races.
+#[tauri::command]
+pub async fn update_queued_message(
+    app: AppHandle,
+    _worktree_id: String,
+    _worktree_path: String,
+    session_id: String,
+    message_id: String,
+    message: String,
+) -> Result<bool, String> {
+    let (updated, queue) = with_existing_metadata_mut(&app, &session_id, |metadata| {
+        let Some(idx) = metadata
+            .queued_messages
+            .iter()
+            .position(|m| m.get("id").and_then(|v| v.as_str()) == Some(message_id.as_str()))
+        else {
+            return (false, metadata.queued_messages.clone());
+        };
+
+        if queued_message_supports_any_steering(&metadata.queued_messages[idx]) {
+            return (false, metadata.queued_messages.clone());
+        }
+
+        let queued = &mut metadata.queued_messages[idx];
+        if let Some(obj) = queued.as_object_mut() {
+            obj.insert("message".to_string(), serde_json::Value::String(message));
+            return (true, metadata.queued_messages.clone());
+        }
+
+        (false, metadata.queued_messages.clone())
+    })?;
+
+    if updated {
+        app.emit_all(
+            "queue:updated",
+            &serde_json::json!({ "sessionId": session_id, "queue": queue }),
+        )
+        .ok();
+    }
+
+    Ok(updated)
+}
+
 /// Clear all queued messages for a session.
 /// Holds the metadata lock across the entire read-modify-write to prevent TOCTOU races.
 #[tauri::command]
@@ -8345,6 +8390,12 @@ fn queued_message_is_steerable_for_backend(msg: &serde_json::Value, backend: &st
             .map(|a| a.is_empty())
             .unwrap_or(true)
     })
+}
+
+fn queued_message_supports_any_steering(msg: &serde_json::Value) -> bool {
+    queued_message_is_steerable_for_backend(msg, "codex")
+        || queued_message_is_steerable_for_backend(msg, "opencode")
+        || queued_message_is_steerable_for_backend(msg, "pi")
 }
 
 /// Inject a user message into a running Pi RPC turn via the detached PI host.

--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -2623,6 +2623,23 @@ pub async fn dispatch_command(
             .await?;
             Ok(Value::Null)
         }
+        "update_queued_message" => {
+            let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
+            let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
+            let session_id: String = field(&args, "sessionId", "session_id")?;
+            let message_id: String = field(&args, "messageId", "message_id")?;
+            let message: String = from_field(&args, "message")?;
+            let result = crate::chat::update_queued_message(
+                app.clone(),
+                worktree_id,
+                worktree_path,
+                session_id,
+                message_id,
+                message,
+            )
+            .await?;
+            to_value(result)
+        }
         "clear_message_queue" => {
             let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
             let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4697,6 +4697,7 @@ pub fn run() {
             chat::enqueue_message,
             chat::dequeue_message,
             chat::remove_queued_message,
+            chat::update_queued_message,
             chat::clear_message_queue,
             chat::move_queued_message_front,
             chat::steer_codex_turn,

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -2353,7 +2353,11 @@ export function ChatWindow({
   )
 
   // Queued prompts panel actions (remove / send-now)
-  const { handleRemoveQueuedMessage, handleSendQueuedNow } =
+  const {
+    handleRemoveQueuedMessage,
+    handleEditQueuedMessage,
+    handleSendQueuedNow,
+  } =
     useQueuedPromptActions()
 
   // Pending attachment removal, slash command execution
@@ -3035,6 +3039,7 @@ export function ChatWindow({
                                 isSessionBusy={isSending || isWaitingForInput}
                                 onRemove={handleRemoveQueuedMessage}
                                 onSendNow={handleSendQueuedNow}
+                                onEdit={handleEditQueuedMessage}
                               />
                             )}
                           {/* Input area - unified container with textarea and toolbar */}

--- a/src/components/chat/QueuedPromptsPanel.test.tsx
+++ b/src/components/chat/QueuedPromptsPanel.test.tsx
@@ -3,7 +3,11 @@ import { render, screen, fireEvent } from '@/test/test-utils'
 import { QueuedPromptsPanel } from './QueuedPromptsPanel'
 import type { QueuedMessage } from '@/types/chat'
 
-const createMessage = (id: string, message: string): QueuedMessage => ({
+const createMessage = (
+  id: string,
+  message: string,
+  overrides?: Partial<QueuedMessage>
+): QueuedMessage => ({
   id,
   message,
   pendingImages: [],
@@ -15,6 +19,7 @@ const createMessage = (id: string, message: string): QueuedMessage => ({
   executionMode: 'plan',
   thinkingLevel: 'off',
   queuedAt: 0,
+  ...overrides,
 })
 
 describe('QueuedPromptsPanel', () => {
@@ -32,9 +37,11 @@ describe('QueuedPromptsPanel', () => {
     messages?: QueuedMessage[]
     onRemove?: (sessionId: string, messageId: string) => void
     onSendNow?: (sessionId: string, messageId: string) => void
+    onEdit?: (sessionId: string, messageId: string, message: string) => void
   }) => {
     const onRemove = overrides?.onRemove ?? vi.fn()
     const onSendNow = overrides?.onSendNow ?? vi.fn()
+    const onEdit = overrides?.onEdit ?? vi.fn()
     const result = render(
       <QueuedPromptsPanel
         sessionId="session-1"
@@ -42,9 +49,10 @@ describe('QueuedPromptsPanel', () => {
         isSessionBusy={false}
         onRemove={onRemove}
         onSendNow={onSendNow}
+        onEdit={onEdit}
       />
     )
-    return { ...result, onRemove, onSendNow }
+    return { ...result, onRemove, onSendNow, onEdit }
   }
 
   it('renders count badge and all queued prompts', () => {
@@ -135,6 +143,7 @@ describe('QueuedPromptsPanel', () => {
         isSessionBusy={false}
         onRemove={vi.fn()}
         onSendNow={onSendNow}
+        onEdit={vi.fn()}
       />
     )
 
@@ -168,5 +177,46 @@ describe('QueuedPromptsPanel', () => {
 
     fireEvent.click(thirdSend as HTMLElement)
     expect(onSendNow).toHaveBeenCalledWith('session-1', 'msg-3')
+  })
+
+  it('edits queued prompts when steering is not supported', () => {
+    const { onEdit } = renderPanel()
+
+    const editButton = screen.getAllByLabelText('Edit queued prompt')[0]
+    expect(editButton).toBeDefined()
+    fireEvent.click(editButton as HTMLElement)
+    const editor = screen.getByLabelText('Queued prompt text')
+    fireEvent.change(editor, { target: { value: 'Updated prompt' } })
+    fireEvent.click(screen.getByLabelText('Save queued prompt'))
+
+    expect(onEdit).toHaveBeenCalledWith('session-1', 'msg-1', 'Updated prompt')
+  })
+
+  it('does not show edit for steerable queued prompts', () => {
+    renderPanel({
+      messages: [
+        createMessage('msg-1', 'Codex prompt', {
+          backend: 'codex',
+        } as Partial<QueuedMessage>),
+        createMessage('msg-2', 'OpenCode prompt', {
+          backend: 'opencode',
+        } as Partial<QueuedMessage>),
+      ],
+    })
+
+    expect(screen.queryByLabelText('Edit queued prompt')).not.toBeInTheDocument()
+  })
+
+  it('shows edit for text-only steering backends when attachments prevent steering', () => {
+    renderPanel({
+      messages: [
+        createMessage('msg-1', 'Pi prompt', {
+          backend: 'pi',
+          pendingFiles: [{ id: 'file-1', path: '/tmp/file.txt' }] as never,
+        } as Partial<QueuedMessage>),
+      ],
+    })
+
+    expect(screen.getByLabelText('Edit queued prompt')).toBeInTheDocument()
   })
 })

--- a/src/components/chat/QueuedPromptsPanel.tsx
+++ b/src/components/chat/QueuedPromptsPanel.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
-import { ChevronRight, Clock, Paperclip, Play, X } from 'lucide-react'
+import { Check, ChevronRight, Clock, Paperclip, Pencil, Play, X } from 'lucide-react'
 import {
   Collapsible,
   CollapsibleContent,
@@ -20,6 +20,7 @@ interface QueuedPromptsPanelProps {
   isSessionBusy: boolean
   onRemove: (sessionId: string, messageId: string) => void
   onSendNow: (sessionId: string, messageId: string) => void
+  onEdit: (sessionId: string, messageId: string, message: string) => void
 }
 
 function attachmentCount(msg: QueuedMessage): number {
@@ -29,6 +30,15 @@ function attachmentCount(msg: QueuedMessage): number {
     msg.pendingSkills.length +
     msg.pendingTextFiles.length
   )
+}
+
+function canEditQueuedMessage(msg: QueuedMessage): boolean {
+  const backend = msg.backend ?? 'claude'
+  if (backend === 'codex') return false
+  if ((backend === 'opencode' || backend === 'pi') && attachmentCount(msg) === 0) {
+    return false
+  }
+  return true
 }
 
 /**
@@ -46,9 +56,12 @@ export const QueuedPromptsPanel = memo(function QueuedPromptsPanel({
   isSessionBusy,
   onRemove,
   onSendNow,
+  onEdit,
 }: QueuedPromptsPanelProps) {
   const [isOpen, setIsOpen] = useState(true)
   const [selectedIndex, setSelectedIndex] = useState(0)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editingText, setEditingText] = useState('')
   const listRef = useRef<HTMLDivElement>(null)
   const rowRefs = useRef<(HTMLDivElement | null)[]>([])
 
@@ -109,6 +122,24 @@ export const QueuedPromptsPanel = memo(function QueuedPromptsPanel({
     [messages, selectedIndex, sessionId, onRemove, onSendNow, scrollRowIntoView]
   )
 
+  const startEditing = useCallback((msg: QueuedMessage) => {
+    setEditingId(msg.id)
+    setEditingText(msg.message)
+  }, [])
+
+  const cancelEditing = useCallback(() => {
+    setEditingId(null)
+    setEditingText('')
+  }, [])
+
+  const saveEditing = useCallback(() => {
+    if (!editingId) return
+    const next = editingText.trim()
+    if (!next) return
+    onEdit(sessionId, editingId, next)
+    cancelEditing()
+  }, [cancelEditing, editingId, editingText, onEdit, sessionId])
+
   if (messages.length === 0) return null
 
   return (
@@ -143,6 +174,7 @@ export const QueuedPromptsPanel = memo(function QueuedPromptsPanel({
             {messages.map((msg, index) => {
               const isSelected = index === selectedIndex
               const attachments = attachmentCount(msg)
+              const isEditing = editingId === msg.id
               return (
                 <div
                   key={msg.id}
@@ -161,9 +193,30 @@ export const QueuedPromptsPanel = memo(function QueuedPromptsPanel({
                   <span className="shrink-0 text-muted-foreground/60 tabular-nums">
                     #{index + 1}
                   </span>
-                  <span className="min-w-0 flex-1 truncate text-foreground">
-                    {msg.message}
-                  </span>
+                  {isEditing ? (
+                    <textarea
+                      aria-label="Queued prompt text"
+                      value={editingText}
+                      onChange={e => setEditingText(e.target.value)}
+                      onClick={e => e.stopPropagation()}
+                      onKeyDown={e => {
+                        e.stopPropagation()
+                        if (e.key === 'Escape') {
+                          e.preventDefault()
+                          cancelEditing()
+                        } else if (e.key === 'Enter' && !e.shiftKey) {
+                          e.preventDefault()
+                          saveEditing()
+                        }
+                      }}
+                      className="min-h-8 flex-1 resize-none rounded border border-input bg-background px-2 py-1 text-xs text-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      autoFocus
+                    />
+                  ) : (
+                    <span className="min-w-0 flex-1 truncate text-foreground">
+                      {msg.message}
+                    </span>
+                  )}
                   {attachments > 0 && (
                     <span className="flex shrink-0 items-center gap-0.5 rounded bg-muted/50 px-1 py-0.5 text-[10px] text-muted-foreground">
                       <Paperclip className="h-2.5 w-2.5" />
@@ -178,42 +231,90 @@ export const QueuedPromptsPanel = memo(function QueuedPromptsPanel({
                         : 'opacity-0 group-hover:opacity-100'
                     )}
                   >
-                    <Tooltip>
-                      <TooltipTrigger asChild>
+                    {isEditing ? (
+                      <>
                         <button
                           type="button"
-                          aria-label="Remove from queue"
+                          aria-label="Save queued prompt"
+                          disabled={!editingText.trim()}
                           onClick={e => {
                             e.stopPropagation()
-                            onRemove(sessionId, msg.id)
+                            saveEditing()
                           }}
-                          className="rounded p-0.5 text-muted-foreground hover:bg-destructive hover:text-white transition-colors"
+                          className="rounded p-0.5 text-muted-foreground hover:bg-green-600 hover:text-white disabled:opacity-40 transition-colors"
+                        >
+                          <Check className="h-3.5 w-3.5" />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label="Cancel queued prompt edit"
+                          onClick={e => {
+                            e.stopPropagation()
+                            cancelEditing()
+                          }}
+                          className="rounded p-0.5 text-muted-foreground hover:bg-muted transition-colors"
                         >
                           <X className="h-3.5 w-3.5" />
                         </button>
-                      </TooltipTrigger>
-                      <TooltipContent>Remove from queue</TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          aria-label="Send now"
-                          onClick={e => {
-                            e.stopPropagation()
-                            onSendNow(sessionId, msg.id)
-                          }}
-                          className="rounded p-0.5 text-muted-foreground hover:bg-green-600 hover:text-white transition-colors"
-                        >
-                          <Play className="h-3.5 w-3.5" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        {isSessionBusy
-                          ? 'Send now (interrupts current run)'
-                          : 'Send now'}
-                      </TooltipContent>
-                    </Tooltip>
+                      </>
+                    ) : (
+                      <>
+                        {canEditQueuedMessage(msg) && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                type="button"
+                                aria-label="Edit queued prompt"
+                                onClick={e => {
+                                  e.stopPropagation()
+                                  startEditing(msg)
+                                }}
+                                className="rounded p-0.5 text-muted-foreground hover:bg-muted transition-colors"
+                              >
+                                <Pencil className="h-3.5 w-3.5" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent>Edit queued prompt</TooltipContent>
+                          </Tooltip>
+                        )}
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              aria-label="Remove from queue"
+                              onClick={e => {
+                                e.stopPropagation()
+                                onRemove(sessionId, msg.id)
+                              }}
+                              className="rounded p-0.5 text-muted-foreground hover:bg-destructive hover:text-white transition-colors"
+                            >
+                              <X className="h-3.5 w-3.5" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>Remove from queue</TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              aria-label="Send now"
+                              onClick={e => {
+                                e.stopPropagation()
+                                onSendNow(sessionId, msg.id)
+                              }}
+                              className="rounded p-0.5 text-muted-foreground hover:bg-green-600 hover:text-white transition-colors"
+                            >
+                              <Play className="h-3.5 w-3.5" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            {isSessionBusy
+                              ? 'Send now (interrupts current run)'
+                              : 'Send now'}
+                          </TooltipContent>
+                        </Tooltip>
+                      </>
+                    )}
                   </div>
                 </div>
               )

--- a/src/components/chat/hooks/useQueuedPromptActions.test.ts
+++ b/src/components/chat/hooks/useQueuedPromptActions.test.ts
@@ -6,6 +6,7 @@ import {
   cancelChatMessage,
   persistMoveQueuedFront,
   persistRemoveQueued,
+  persistUpdateQueued,
   steerCodexTurn,
   steerOpencodeTurn,
   steerPiTurn,
@@ -16,6 +17,7 @@ vi.mock('@/services/chat', () => ({
   cancelChatMessage: vi.fn().mockResolvedValue(true),
   persistMoveQueuedFront: vi.fn().mockResolvedValue(true),
   persistRemoveQueued: vi.fn(),
+  persistUpdateQueued: vi.fn().mockResolvedValue(true),
   steerCodexTurn: vi.fn().mockResolvedValue(undefined),
   steerOpencodeTurn: vi.fn().mockResolvedValue(undefined),
   steerPiTurn: vi.fn().mockResolvedValue(undefined),
@@ -47,6 +49,7 @@ describe('useQueuedPromptActions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(persistMoveQueuedFront).mockResolvedValue(true)
+    vi.mocked(persistUpdateQueued).mockResolvedValue(true)
     vi.mocked(steerCodexTurn).mockResolvedValue(undefined)
     vi.mocked(steerOpencodeTurn).mockResolvedValue(undefined)
     vi.mocked(steerPiTurn).mockResolvedValue(undefined)
@@ -81,6 +84,68 @@ describe('useQueuedPromptActions', () => {
       '/tmp/worktree-1',
       'session-1',
       'msg-2'
+    )
+  })
+
+  it('edits a queued message locally and persists update', async () => {
+    const { result } = renderHook(() => useQueuedPromptActions())
+
+    await act(async () => {
+      await result.current.handleEditQueuedMessage(
+        'session-1',
+        'msg-2',
+        'updated prompt'
+      )
+    })
+
+    expect(
+      useChatStore.getState().messageQueues['session-1']?.map(m => m.message)
+    ).toEqual(['prompt msg-1', 'updated prompt', 'prompt msg-3'])
+    expect(persistUpdateQueued).toHaveBeenCalledWith(
+      'worktree-1',
+      '/tmp/worktree-1',
+      'session-1',
+      'msg-2',
+      'updated prompt'
+    )
+  })
+
+  it('does not edit when the queued message was already dequeued', async () => {
+    vi.mocked(persistUpdateQueued).mockResolvedValue(false)
+    const { result } = renderHook(() => useQueuedPromptActions())
+
+    await act(async () => {
+      await result.current.handleEditQueuedMessage(
+        'session-1',
+        'msg-2',
+        'updated prompt'
+      )
+    })
+
+    expect(
+      useChatStore.getState().messageQueues['session-1']?.map(m => m.message)
+    ).toEqual(['prompt msg-1', 'prompt msg-2', 'prompt msg-3'])
+  })
+
+  it('does not edit queued messages that can be steered', async () => {
+    useChatStore.setState({
+      messageQueues: {
+        'session-1': [createMessage('msg-1', { backend: 'codex' })],
+      },
+    })
+    const { result } = renderHook(() => useQueuedPromptActions())
+
+    await act(async () => {
+      await result.current.handleEditQueuedMessage(
+        'session-1',
+        'msg-1',
+        'updated prompt'
+      )
+    })
+
+    expect(persistUpdateQueued).not.toHaveBeenCalled()
+    expect(useChatStore.getState().messageQueues['session-1']?.[0]?.message).toBe(
+      'prompt msg-1'
     )
   })
 

--- a/src/components/chat/hooks/useQueuedPromptActions.ts
+++ b/src/components/chat/hooks/useQueuedPromptActions.ts
@@ -65,8 +65,8 @@ export function useQueuedPromptActions() {
       const trimmed = message.trim()
       if (!trimmed) return
 
-      const msg = useChatStore
-        .getState()
+      const store = useChatStore.getState()
+      const msg = store
         .getQueuedMessages(sessionId)
         .find(m => m.id === messageId)
       if (!msg || supportsSteering(msg)) return
@@ -74,18 +74,27 @@ export function useQueuedPromptActions() {
       const { worktreeId, worktreePath } = resolveWorktree(sessionId)
       if (!worktreeId || !worktreePath) return
 
-      const updated = await persistUpdateQueued(
-        worktreeId,
-        worktreePath,
-        sessionId,
-        messageId,
-        trimmed
-      )
-      if (!updated) return
-
-      useChatStore
-        .getState()
-        .updateQueuedMessage(sessionId, messageId, trimmed)
+      try {
+        const updated = await persistUpdateQueued(
+          worktreeId,
+          worktreePath,
+          sessionId,
+          messageId,
+          trimmed
+        )
+        if (!updated) {
+          // Another client already dequeued it — drop the stale local copy.
+          store.removeQueuedMessage(sessionId, messageId)
+          return
+        }
+        store.updateQueuedMessage(sessionId, messageId, trimmed)
+      } catch (error) {
+        logger.error('Failed to persist queued edit', {
+          error,
+          sessionId,
+          messageId,
+        })
+      }
     },
     []
   )

--- a/src/components/chat/hooks/useQueuedPromptActions.ts
+++ b/src/components/chat/hooks/useQueuedPromptActions.ts
@@ -3,6 +3,7 @@ import {
   cancelChatMessage,
   persistMoveQueuedFront,
   persistRemoveQueued,
+  persistUpdateQueued,
   steerCodexTurn,
   steerOpencodeTurn,
   steerPiTurn,
@@ -27,6 +28,12 @@ function hasAttachments(msg: QueuedMessage): boolean {
   )
 }
 
+function supportsSteering(msg: QueuedMessage): boolean {
+  const backend = msg.backend ?? 'claude'
+  if (backend === 'codex') return true
+  return (backend === 'opencode' || backend === 'pi') && !hasAttachments(msg)
+}
+
 /**
  * Actions for the queued prompts panel: remove a queued prompt, or send a
  * specific queued prompt immediately.
@@ -49,6 +56,36 @@ export function useQueuedPromptActions() {
       if (worktreeId && worktreePath) {
         persistRemoveQueued(worktreeId, worktreePath, sessionId, messageId)
       }
+    },
+    []
+  )
+
+  const handleEditQueuedMessage = useCallback(
+    async (sessionId: string, messageId: string, message: string) => {
+      const trimmed = message.trim()
+      if (!trimmed) return
+
+      const msg = useChatStore
+        .getState()
+        .getQueuedMessages(sessionId)
+        .find(m => m.id === messageId)
+      if (!msg || supportsSteering(msg)) return
+
+      const { worktreeId, worktreePath } = resolveWorktree(sessionId)
+      if (!worktreeId || !worktreePath) return
+
+      const updated = await persistUpdateQueued(
+        worktreeId,
+        worktreePath,
+        sessionId,
+        messageId,
+        trimmed
+      )
+      if (!updated) return
+
+      useChatStore
+        .getState()
+        .updateQueuedMessage(sessionId, messageId, trimmed)
     },
     []
   )
@@ -138,5 +175,9 @@ export function useQueuedPromptActions() {
     [handleRemoveQueuedMessage]
   )
 
-  return { handleRemoveQueuedMessage, handleSendQueuedNow }
+  return {
+    handleRemoveQueuedMessage,
+    handleEditQueuedMessage,
+    handleSendQueuedNow,
+  }
 }

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -934,10 +934,7 @@ export function useMainWindowEventListeners() {
             const currentQueue =
               useChatStore.getState().messageQueues[sessionId] ?? []
             // Skip if the queue already matches (this client caused the event)
-            if (
-              currentQueue.length === queue.length &&
-              currentQueue[0]?.id === queue[0]?.id
-            )
+            if (JSON.stringify(currentQueue) === JSON.stringify(queue))
               return
             useChatStore.setState(state => ({
               messageQueues: {

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -2665,6 +2665,26 @@ export function persistRemoveQueued(
 }
 
 /**
+ * Persist a queued message text edit.
+ * Returns false when the message is no longer queued.
+ */
+export async function persistUpdateQueued(
+  worktreeId: string,
+  worktreePath: string,
+  sessionId: string,
+  messageId: string,
+  message: string
+): Promise<boolean> {
+  return invoke<boolean>('update_queued_message', {
+    worktreeId,
+    worktreePath,
+    sessionId,
+    messageId,
+    message,
+  })
+}
+
+/**
  * Atomically move a specific queued message to the front of the persisted queue.
  * Returns false when the message is no longer queued (another client dequeued
  * or removed it) — callers must abort their send-now flow in that case.

--- a/src/store/chat-store.test.ts
+++ b/src/store/chat-store.test.ts
@@ -790,6 +790,34 @@ describe('ChatStore', () => {
       moveQueuedMessageFront('session-1', 'msg-1')
       expect(useChatStore.getState().messageQueues['session-1']).toBe(before)
     })
+
+    it('updates a queued message text by id', () => {
+      const { enqueueMessage, updateQueuedMessage, getQueuedMessages } =
+        useChatStore.getState()
+
+      enqueueMessage('session-1', createMockMessage('msg-1', 'First'))
+      enqueueMessage('session-1', createMockMessage('msg-2', 'Second'))
+
+      updateQueuedMessage('session-1', 'msg-2', 'Updated second')
+
+      expect(getQueuedMessages('session-1').map(m => m.message)).toEqual([
+        'First',
+        'Updated second',
+      ])
+    })
+
+    it('queued message update is a no-op for unknown id or unchanged text', () => {
+      const { enqueueMessage, updateQueuedMessage } = useChatStore.getState()
+
+      enqueueMessage('session-1', createMockMessage('msg-1', 'First'))
+
+      const before = useChatStore.getState().messageQueues['session-1']
+      updateQueuedMessage('session-1', 'unknown-id', 'Updated')
+      expect(useChatStore.getState().messageQueues['session-1']).toBe(before)
+
+      updateQueuedMessage('session-1', 'msg-1', 'First')
+      expect(useChatStore.getState().messageQueues['session-1']).toBe(before)
+    })
   })
 
   describe('permission approvals', () => {

--- a/src/store/chat-store.ts
+++ b/src/store/chat-store.ts
@@ -561,6 +561,11 @@ interface ChatUIState {
   enqueueMessage: (sessionId: string, message: QueuedMessage) => void
   dequeueMessage: (sessionId: string) => QueuedMessage | undefined
   removeQueuedMessage: (sessionId: string, messageId: string) => void
+  updateQueuedMessage: (
+    sessionId: string,
+    messageId: string,
+    message: string
+  ) => void
   moveQueuedMessageFront: (sessionId: string, messageId: string) => void
   clearQueue: (sessionId: string) => void
   getQueueLength: (sessionId: string) => number
@@ -2541,6 +2546,25 @@ export const useChatStore = create<ChatUIState>()(
           }),
           undefined,
           'removeQueuedMessage'
+        ),
+
+      updateQueuedMessage: (sessionId, messageId, message) =>
+        set(
+          state => {
+            const queue = state.messageQueues[sessionId] ?? []
+            const idx = queue.findIndex(m => m.id === messageId)
+            if (idx === -1 || queue[idx]?.message === message) return state
+            return {
+              messageQueues: {
+                ...state.messageQueues,
+                [sessionId]: queue.map(m =>
+                  m.id === messageId ? { ...m, message } : m
+                ),
+              },
+            }
+          },
+          undefined,
+          'updateQueuedMessage'
         ),
 
       moveQueuedMessageFront: (sessionId, messageId) =>


### PR DESCRIPTION
## Summary
- Add inline editing for queued prompts that are still waiting in the chat queue.
- Keep queued prompt edits synced across native and web clients.
- Preserve steering behavior by hiding edits for prompts that can be injected into active Codex, OpenCode, or Pi turns.
- Add tests for queued prompt editing, store updates, and edit eligibility.

## Issues
closes #433

---

Fixes #433