### PR TITLE
feat(commands): add active session rename command

### DIFF
--- a/src/components/chat/SessionChatModal.removal-behavior.test.ts
+++ b/src/components/chat/SessionChatModal.removal-behavior.test.ts
@@ -6,6 +6,25 @@ const readSource = (path: string) =>
   readFileSync(join(process.cwd(), path), 'utf8')
 
 describe('SessionChatModal removal behavior', () => {
+  it('listens for command-palette session rename requests', () => {
+    const source = readSource('src/components/chat/SessionChatModal.tsx')
+
+    expect(source).toMatch(
+      /window\.addEventListener\(\s*'command:rename-session'/
+    )
+    expect(source).toMatch(
+      /window\.removeEventListener\(\s*'command:rename-session'/
+    )
+  })
+
+  it('keeps rename input out of the clickable tab button to avoid accidental close/cancel', () => {
+    const source = readSource('src/components/chat/SessionChatModal.tsx')
+
+    expect(source).not.toContain('<button\n                            data-session-id=')
+    expect(source).toContain('<div\n                            data-session-id=')
+    expect(source).toContain('onPointerDown={e => e.stopPropagation()}')
+  })
+
   it('uses the delete-aware handler when removing non-last tabs', () => {
     const source = readSource('src/components/chat/SessionChatModal.tsx')
     const start = source.indexOf('const removeSessionTab = useCallback(')

--- a/src/components/chat/SessionChatModal.removal-behavior.test.ts
+++ b/src/components/chat/SessionChatModal.removal-behavior.test.ts
@@ -20,8 +20,8 @@ describe('SessionChatModal removal behavior', () => {
   it('keeps rename input out of the clickable tab button to avoid accidental close/cancel', () => {
     const source = readSource('src/components/chat/SessionChatModal.tsx')
 
-    expect(source).not.toContain('<button\n                            data-session-id=')
-    expect(source).toContain('<div\n                            data-session-id=')
+    expect(source).not.toMatch(/<button\s+data-session-id=/)
+    expect(source).toMatch(/<div\s+data-session-id=/)
     expect(source).toContain('onPointerDown={e => e.stopPropagation()}')
   })
 

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -396,6 +396,32 @@ export function SessionChatModal({
     [handleRenameSubmit]
   )
 
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleRenameSessionCommand = (
+      e: CustomEvent<{ sessionId?: string }>
+    ) => {
+      const sessionId = e.detail?.sessionId
+      if (!sessionId) return
+      const session = sessions.find(s => s.id === sessionId)
+      if (!session || session.archived_at) return
+
+      setRenameValue(session.name)
+      setRenamingSessionId(session.id)
+    }
+
+    window.addEventListener(
+      'command:rename-session',
+      handleRenameSessionCommand as EventListener
+    )
+    return () =>
+      window.removeEventListener(
+        'command:rename-session',
+        handleRenameSessionCommand as EventListener
+      )
+  }, [isOpen, sessions])
+
   const renameInputRef = useCallback((node: HTMLInputElement | null) => {
     if (node) {
       node.focus()
@@ -474,7 +500,7 @@ export function SessionChatModal({
   )
 
   const handleTabAuxClick = useCallback(
-    (e: MouseEvent<HTMLButtonElement>, session: Session) => {
+    (e: MouseEvent<HTMLDivElement>, session: Session) => {
       if (e.button !== 1) return
       e.preventDefault()
       e.stopPropagation()
@@ -542,10 +568,11 @@ export function SessionChatModal({
 
   const handleTabClick = useCallback(
     (sessionId: string) => {
+      if (renamingSessionId === sessionId) return
       const { setActiveSession } = useChatStore.getState()
       setActiveSession(worktreeId, sessionId)
     },
-    [worktreeId]
+    [renamingSessionId, worktreeId]
   )
 
   const reorderSessions = useReorderSessions()
@@ -588,7 +615,7 @@ export function SessionChatModal({
   }, [cards])
 
   const handleSessionDragStart = useCallback(
-    (e: React.DragEvent<HTMLButtonElement>, sessionId: string) => {
+    (e: React.DragEvent<HTMLDivElement>, sessionId: string) => {
       setDraggedSessionId(sessionId)
       e.dataTransfer.effectAllowed = 'move'
       e.dataTransfer.setData('text/plain', sessionId)
@@ -597,7 +624,7 @@ export function SessionChatModal({
   )
 
   const handleSessionDragOver = useCallback(
-    (e: React.DragEvent<HTMLButtonElement>, targetSessionId: string) => {
+    (e: React.DragEvent<HTMLDivElement>, targetSessionId: string) => {
       if (
         draggedSessionId &&
         buildReorderedSessionIdsWithinStatus(
@@ -614,7 +641,7 @@ export function SessionChatModal({
   )
 
   const handleSessionDrop = useCallback(
-    (e: React.DragEvent<HTMLButtonElement>, targetSessionId: string) => {
+    (e: React.DragEvent<HTMLDivElement>, targetSessionId: string) => {
       e.preventDefault()
       const sourceId =
         draggedSessionId || e.dataTransfer.getData('text/plain') || null
@@ -1129,8 +1156,10 @@ export function SessionChatModal({
                     return (
                       <ContextMenu key={session.id}>
                         <ContextMenuTrigger asChild>
-                          <button
+                          <div
                             data-session-id={session.id}
+                            role="button"
+                            tabIndex={0}
                             draggable={renamingSessionId !== session.id}
                             onDragStart={e =>
                               handleSessionDragStart(e, session.id)
@@ -1142,6 +1171,13 @@ export function SessionChatModal({
                             onDragEnd={() => setDraggedSessionId(null)}
                             onClick={() => handleTabClick(session.id)}
                             onAuxClick={e => handleTabAuxClick(e, session)}
+                            onKeyDown={e => {
+                              if (renamingSessionId === session.id) return
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault()
+                                handleTabClick(session.id)
+                              }
+                            }}
                             onDoubleClick={() =>
                               handleStartRenameImmediate(
                                 session.id,
@@ -1178,6 +1214,7 @@ export function SessionChatModal({
                                 onKeyDown={e =>
                                   handleRenameKeyDown(e, session.id)
                                 }
+                                onPointerDown={e => e.stopPropagation()}
                                 onClick={e => e.stopPropagation()}
                                 className="w-full min-w-0 bg-transparent text-base outline-none md:text-xs"
                               />
@@ -1209,7 +1246,7 @@ export function SessionChatModal({
                                 size="xs"
                               />
                             )}
-                          </button>
+                          </div>
                         </ContextMenuTrigger>
                         <ContextMenuContent className="w-64">
                           <ContextMenuItem

--- a/src/hooks/use-command-context.source.test.ts
+++ b/src/hooks/use-command-context.source.test.ts
@@ -9,8 +9,13 @@ describe('useCommandContext session rename wiring', () => {
   it('falls back to the selected worktree when dispatching rename-session', () => {
     const source = readSource('src/hooks/use-command-context.ts')
     const start = source.indexOf('const renameSession = useCallback(')
-    const end = source.indexOf('\n\n  // Worktrees - Create new worktree', start)
-    const renameSession = start === -1 || end === -1 ? '' : source.slice(start, end)
+    // Anchor on the callback's closing `}, [...])` rather than a comment or
+    // blank-line spacing, so harmless refactors above/below don't silently
+    // truncate the extracted body to '' and mask a real regression.
+    const close = source.indexOf('\n  }, [', start)
+    const end = close === -1 ? -1 : source.indexOf(')', close)
+    const renameSession =
+      start === -1 || end === -1 ? '' : source.slice(start, end)
 
     expect(renameSession).toContain('useProjectsStore.getState().selectedWorktreeId')
     expect(renameSession).toContain("new CustomEvent('command:rename-session'")

--- a/src/hooks/use-command-context.source.test.ts
+++ b/src/hooks/use-command-context.source.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readSource = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('useCommandContext session rename wiring', () => {
+  it('falls back to the selected worktree when dispatching rename-session', () => {
+    const source = readSource('src/hooks/use-command-context.ts')
+    const start = source.indexOf('const renameSession = useCallback(')
+    const end = source.indexOf('\n\n  // Worktrees - Create new worktree', start)
+    const renameSession = start === -1 || end === -1 ? '' : source.slice(start, end)
+
+    expect(renameSession).toContain('useProjectsStore.getState().selectedWorktreeId')
+    expect(renameSession).toContain("new CustomEvent('command:rename-session'")
+  })
+})

--- a/src/hooks/use-command-context.ts
+++ b/src/hooks/use-command-context.ts
@@ -192,13 +192,16 @@ export function useCommandContext(
 
   // Sessions - Rename session
   const renameSession = useCallback(() => {
-    const { activeWorktreeId, getActiveSession } = useChatStore.getState()
-    if (!activeWorktreeId) {
+    const chatState = useChatStore.getState()
+    const worktreeId =
+      chatState.activeWorktreeId ??
+      useProjectsStore.getState().selectedWorktreeId
+    if (!worktreeId) {
       notify('No worktree selected', undefined, { type: 'error' })
       return
     }
 
-    const sessionId = getActiveSession(activeWorktreeId)
+    const sessionId = chatState.getActiveSession(worktreeId)
     if (!sessionId) {
       notify('No session selected', undefined, { type: 'error' })
       return
@@ -451,9 +454,12 @@ export function useCommandContext(
 
   // State getters
   const hasActiveSession = useCallback(() => {
-    const { activeWorktreeId, getActiveSession } = useChatStore.getState()
-    if (!activeWorktreeId) return false
-    return !!getActiveSession(activeWorktreeId)
+    const chatState = useChatStore.getState()
+    const worktreeId =
+      chatState.activeWorktreeId ??
+      useProjectsStore.getState().selectedWorktreeId
+    if (!worktreeId) return false
+    return !!chatState.getActiveSession(worktreeId)
   }, [])
 
   const hasActiveWorktree = useCallback(() => {

--- a/src/lib/commands/commands.test.ts
+++ b/src/lib/commands/commands.test.ts
@@ -231,6 +231,13 @@ describe('Project Commands', () => {
     expect(useUIStore.getState().onboardingDismissed).toBe(false)
     expect(useUIStore.getState().featureTourOpen).toBe(false)
   })
+
+  it('rename session command delegates to session rename wiring', async () => {
+    const result = await executeCommand('rename-session', mockContext)
+
+    expect(result.success).toBe(true)
+    expect(mockContext.renameSession).toHaveBeenCalled()
+  })
 })
 
 describe('Notification Commands', () => {

--- a/src/lib/commands/project-commands.ts
+++ b/src/lib/commands/project-commands.ts
@@ -8,6 +8,7 @@ import {
   RefreshCw,
   BellDot,
   Download,
+  Pencil,
 } from 'lucide-react'
 import type { AppCommand } from './types'
 import { useUIStore } from '@/store/ui-store'
@@ -172,6 +173,21 @@ export const projectCommands: AppCommand[] = [
 
     execute: context => {
       context.openUnreadSessions()
+    },
+  },
+
+  {
+    id: 'rename-session',
+    label: 'Rename Session',
+    description: 'Rename the current session tab',
+    icon: Pencil,
+    group: 'sessions',
+    keywords: ['session', 'title', 'name', 'rename', 'tab'],
+
+    isAvailable: context => context.hasActiveSession(),
+
+    execute: context => {
+      context.renameSession()
     },
   },
 


### PR DESCRIPTION
## Summary
- Add a command palette action for renaming the current session tab.
- Allow rename requests to target the selected worktree/session even when the chat pane is not the active pane.
- Keep the rename input interactive without triggering tab selection, close, drag, or cancel behavior.

closes #359

---

Fixes #359