### PR TITLE
feat(chat): fork sessions into new worktrees

### DIFF
--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -208,6 +208,19 @@ pub async fn dispatch_command(
             // preventing WorktreeSetupCard from appearing on the canvas.
             to_value(result)
         }
+        "fork_session_to_worktree" => {
+            let source_worktree_id: String =
+                field(&args, "sourceWorktreeId", "source_worktree_id")?;
+            let source_session_id: String = field(&args, "sourceSessionId", "source_session_id")?;
+            let result = crate::projects::fork_session_to_worktree(
+                app.clone(),
+                source_worktree_id,
+                source_session_id,
+            )
+            .await?;
+            emit_cache_invalidation(app, &["projects", "sessions", "session"]);
+            to_value(result)
+        }
         "delete_worktree" => {
             let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
             crate::projects::delete_worktree(app.clone(), worktree_id).await?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4480,6 +4480,7 @@ pub fn run() {
             projects::get_worktree_diff,
             projects::create_worktree,
             projects::create_worktree_from_existing_branch,
+            projects::fork_session_to_worktree,
             projects::checkout_pr,
             projects::delete_worktree,
             projects::create_base_session,

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -3,6 +3,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -45,7 +46,7 @@ use super::types::{
     WorktreeDeletingEvent, WorktreeOrigin, WorktreePathExistsEvent,
     WorktreePermanentlyDeletedEvent, WorktreeSetupCompleteEvent, WorktreeUnarchivedEvent,
 };
-use crate::chat::types::LabelData;
+use crate::chat::types::{LabelData, Session, SessionMetadata, WorktreeSessions};
 use crate::claude_cli::resolve_cli_binary;
 use crate::coderabbit_cli::resolve_coderabbit_binary;
 use crate::codex_cli::resolve_cli_binary as resolve_codex_cli_binary;
@@ -101,6 +102,12 @@ const FAVICON_CANDIDATES: &[&str] = &[
     "assets/logo.png",
     ".idea/icon.svg",
 ];
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForkSessionToWorktreeResponse {
+    pub worktree: Worktree,
+    pub session: Session,
+}
 
 const ICON_SOURCE_FILES: &[&str] = &[
     "index.html",
@@ -1005,6 +1012,217 @@ fn truncate_utf8(input: &str, max_bytes: usize) -> (String, bool) {
         ),
         true,
     )
+}
+
+fn run_git_with_input(repo_path: &Path, args: &[&str], input: &[u8]) -> Result<(), String> {
+    let mut child = silent_command("git")
+        .args(args)
+        .current_dir(repo_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to run git {}: {e}", args.join(" ")))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(input)
+            .map_err(|e| format!("Failed to write to git {} stdin: {e}", args.join(" ")))?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("Failed to wait for git {}: {e}", args.join(" ")))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!("git {} failed: {stderr}", args.join(" ")))
+    }
+}
+
+fn git_output_bytes(repo_path: &Path, args: &[&str]) -> Result<Vec<u8>, String> {
+    let output = silent_command("git")
+        .args(args)
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| format!("Failed to run git {}: {e}", args.join(" ")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git {} failed: {stderr}", args.join(" ")));
+    }
+    Ok(output.stdout)
+}
+
+fn copy_untracked_files(source_path: &Path, target_path: &Path) -> Result<(), String> {
+    let output = git_output_bytes(
+        source_path,
+        &["ls-files", "--others", "--exclude-standard", "-z"],
+    )?;
+    for raw_path in output
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+    {
+        let relative = std::str::from_utf8(raw_path)
+            .map_err(|e| format!("Git returned a non-UTF8 untracked path: {e}"))?;
+        let source_file = source_path.join(relative);
+        if !source_file.is_file() {
+            continue;
+        }
+        let target_file = target_path.join(relative);
+        if let Some(parent) = target_file.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
+        }
+        fs::copy(&source_file, &target_file).map_err(|e| {
+            format!(
+                "Failed to copy untracked file {} to {}: {e}",
+                source_file.display(),
+                target_file.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn copy_dirty_worktree_state(source_path: &Path, target_path: &Path) -> Result<(), String> {
+    let patch = git_output_bytes(source_path, &["diff", "--binary", "HEAD"])?;
+    if !patch.is_empty() {
+        run_git_with_input(
+            target_path,
+            &["apply", "--binary", "--whitespace=nowarn"],
+            &patch,
+        )?;
+    }
+    copy_untracked_files(source_path, target_path)
+}
+
+fn forked_session_name(source_name: &str) -> String {
+    let trimmed = source_name.trim();
+    if trimmed.is_empty() {
+        "Forked Session".to_string()
+    } else if trimmed.starts_with("Fork of ") {
+        trimmed.to_string()
+    } else {
+        format!("Fork of {trimmed}")
+    }
+}
+
+fn clear_session_runtime_state(session: &mut Session) {
+    session.claude_session_id = None;
+    session.codex_thread_id = None;
+    session.codex_goal = None;
+    session.opencode_session_id = None;
+    session.cursor_chat_id = None;
+    session.pi_session_id = None;
+    session.commandcode_session_id = None;
+    session.grok_session_id = None;
+    session.is_reviewing = false;
+    session.waiting_for_input = false;
+    session.waiting_for_input_type = None;
+    session.pending_permission_denials.clear();
+    session.pending_codex_permission_requests.clear();
+    session.pending_codex_command_approval_requests.clear();
+    session.pending_codex_user_input_requests.clear();
+    session.pending_codex_mcp_elicitation_requests.clear();
+    session.pending_codex_dynamic_tool_call_requests.clear();
+    session.denied_message_context = None;
+    session.queued_messages.clear();
+    session.scheduled_wakeup = None;
+    session.last_run_status = None;
+    session.last_run_execution_mode = None;
+    session.last_run_started_at = None;
+}
+
+fn prepare_forked_session(
+    source: &Session,
+    _new_worktree_id: &str,
+    order: u32,
+    created_at: u64,
+) -> Session {
+    let mut forked = source.clone();
+    forked.id = Uuid::new_v4().to_string();
+    forked.name = forked_session_name(&source.name);
+    forked.order = order;
+    forked.created_at = created_at;
+    forked.updated_at = created_at;
+    forked.last_opened_at = Some(created_at);
+    forked.archived_at = None;
+    forked.archived_by_base_close = None;
+    forked.session_naming_completed = false;
+    clear_session_runtime_state(&mut forked);
+    forked
+}
+
+fn prepare_forked_metadata(
+    source: Option<SessionMetadata>,
+    forked_session: &Session,
+    new_worktree_id: &str,
+) -> SessionMetadata {
+    let mut metadata = source.unwrap_or_else(|| {
+        SessionMetadata::new(
+            forked_session.id.clone(),
+            new_worktree_id.to_string(),
+            forked_session.name.clone(),
+            forked_session.order,
+        )
+    });
+    metadata.id = forked_session.id.clone();
+    metadata.worktree_id = new_worktree_id.to_string();
+    metadata.name = forked_session.name.clone();
+    metadata.order = forked_session.order;
+    metadata.created_at = forked_session.created_at;
+    metadata.claude_session_id = None;
+    metadata.codex_thread_id = None;
+    metadata.codex_goal = None;
+    metadata.opencode_session_id = None;
+    metadata.cursor_chat_id = None;
+    metadata.pi_session_id = None;
+    metadata.commandcode_session_id = None;
+    metadata.grok_session_id = None;
+    metadata.session_naming_completed = false;
+    metadata.archived_at = None;
+    metadata.archived_by_base_close = None;
+    metadata.pending_permission_denials.clear();
+    metadata.pending_codex_permission_requests.clear();
+    metadata.pending_codex_command_approval_requests.clear();
+    metadata.pending_codex_user_input_requests.clear();
+    metadata.pending_codex_mcp_elicitation_requests.clear();
+    metadata.pending_codex_dynamic_tool_call_requests.clear();
+    metadata.denied_message_context = None;
+    metadata.is_reviewing = false;
+    metadata.waiting_for_input = false;
+    metadata.waiting_for_input_type = None;
+    metadata.queued_messages.clear();
+    metadata.scheduled_wakeup = None;
+    metadata
+}
+
+fn copy_session_run_files(
+    app: &AppHandle,
+    source_session_id: &str,
+    target_session_id: &str,
+) -> Result<(), String> {
+    let source_dir = crate::chat::storage::get_session_dir(app, source_session_id)?;
+    if !source_dir.exists() {
+        return Ok(());
+    }
+    let target_dir = crate::chat::storage::get_session_dir(app, target_session_id)?;
+    fs::create_dir_all(&target_dir)
+        .map_err(|e| format!("Failed to create forked session log directory: {e}"))?;
+    for entry in fs::read_dir(&source_dir)
+        .map_err(|e| format!("Failed to read source session log directory: {e}"))?
+    {
+        let entry = entry.map_err(|e| format!("Failed to read source session log entry: {e}"))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|e| format!("Failed to read session log entry type: {e}"))?;
+        if file_type.is_file() {
+            fs::copy(entry.path(), target_dir.join(entry.file_name()))
+                .map_err(|e| format!("Failed to copy session log file: {e}"))?;
+        }
+    }
+    Ok(())
 }
 
 /// Create a new worktree for a project (runs in background)
@@ -1933,6 +2151,196 @@ pub async fn create_worktree(
 
     log::trace!("Returning pending worktree: {}", pending_worktree.name);
     Ok(pending_worktree)
+}
+
+/// Fork an existing Jean session into a new worktree and continue from there.
+///
+/// The new worktree is created at the source worktree's current HEAD. Dirty tracked changes
+/// are copied with a binary git patch, and untracked non-ignored files are copied directly.
+/// The Jean session metadata and run log files are copied, but backend-native resume IDs and
+/// pending runtime prompts are cleared so the next turn starts a fresh backend conversation in
+/// the forked working directory.
+#[tauri::command]
+pub async fn fork_session_to_worktree(
+    app: AppHandle,
+    source_worktree_id: String,
+    source_session_id: String,
+) -> Result<ForkSessionToWorktreeResponse, String> {
+    log::trace!(
+        "Forking session {source_session_id} from worktree {source_worktree_id} into a new worktree"
+    );
+
+    let mut data = load_projects_data(&app)?;
+    let source_worktree = data
+        .find_worktree(&source_worktree_id)
+        .cloned()
+        .ok_or_else(|| format!("Worktree not found: {source_worktree_id}"))?;
+    let project = data
+        .find_project(&source_worktree.project_id)
+        .cloned()
+        .ok_or_else(|| format!("Project not found: {}", source_worktree.project_id))?;
+
+    let source_sessions =
+        crate::chat::storage::load_sessions(&app, &source_worktree.path, &source_worktree_id)?;
+    let source_session = source_sessions
+        .find_session(&source_session_id)
+        .cloned()
+        .ok_or_else(|| format!("Session not found: {source_session_id}"))?;
+
+    let source_path = Path::new(&source_worktree.path);
+    if !source_path.exists() {
+        return Err(format!(
+            "Source worktree path does not exist: {}",
+            source_worktree.path
+        ));
+    }
+
+    let source_head = git_output(&source_worktree.path, &["rev-parse", "--verify", "HEAD"])?
+        .trim()
+        .to_string();
+    if source_head.is_empty() {
+        return Err("Cannot fork session: source worktree has no HEAD commit".to_string());
+    }
+
+    let base_name = {
+        let sanitized = sanitize_folder_name(&format!("fork-{}", source_worktree.name));
+        if sanitized == "fork-" {
+            "fork-session".to_string()
+        } else {
+            sanitized
+        }
+    };
+    let name = generate_unique_suffix_name(&base_name, &project.path, &project.id, Some(&data));
+
+    let project_worktrees_dir =
+        get_project_worktrees_dir(&project.name, project.worktrees_dir.as_deref())?;
+    allow_project_in_asset_scope(&app, &project.path);
+    if let Some(worktrees_dir) = project_worktrees_dir.to_str() {
+        allow_project_in_asset_scope(&app, worktrees_dir);
+    }
+    let worktree_path = project_worktrees_dir.join(sanitize_folder_name(&name));
+    if worktree_path.exists() {
+        return Err(format!(
+            "Cannot fork session: target worktree path already exists: {}",
+            worktree_path.display()
+        ));
+    }
+    let worktree_path_str = worktree_path
+        .to_str()
+        .ok_or_else(|| "Invalid fork worktree path".to_string())?
+        .to_string();
+
+    git::create_worktree(&project.path, &worktree_path_str, &name, &source_head)?;
+
+    let created_at = now();
+    let max_order = data
+        .worktrees
+        .iter()
+        .filter(|w| w.project_id == project.id)
+        .map(|w| w.order)
+        .max()
+        .unwrap_or(0);
+    let worktree_id = Uuid::new_v4().to_string();
+    let worktree = Worktree {
+        id: worktree_id.clone(),
+        project_id: project.id.clone(),
+        name: name.clone(),
+        path: worktree_path_str.clone(),
+        branch: name.clone(),
+        base_branch: source_worktree
+            .base_branch
+            .clone()
+            .or(Some(project.default_branch.clone())),
+        created_at,
+        setup_output: None,
+        setup_script: None,
+        setup_success: None,
+        session_type: SessionType::Worktree,
+        pr_number: source_worktree.pr_number,
+        pr_url: source_worktree.pr_url.clone(),
+        issue_number: source_worktree.issue_number,
+        linear_issue_identifier: source_worktree.linear_issue_identifier.clone(),
+        security_alert_number: source_worktree.security_alert_number,
+        security_alert_url: source_worktree.security_alert_url.clone(),
+        advisory_ghsa_id: source_worktree.advisory_ghsa_id.clone(),
+        advisory_url: source_worktree.advisory_url.clone(),
+        cached_pr_status: None,
+        cached_check_status: None,
+        cached_behind_count: None,
+        cached_ahead_count: None,
+        cached_status_at: None,
+        cached_uncommitted_added: None,
+        cached_uncommitted_removed: None,
+        cached_branch_diff_added: None,
+        cached_branch_diff_removed: None,
+        cached_base_branch_ahead_count: None,
+        cached_base_branch_behind_count: None,
+        cached_worktree_ahead_count: None,
+        cached_unpushed_count: None,
+        pr_push_remote: source_worktree.pr_push_remote.clone(),
+        pr_push_branch: source_worktree.pr_push_branch.clone(),
+        order: max_order + 1,
+        origin: Some(WorktreeOrigin::Manual),
+        archived_at: None,
+        labels: source_worktree.labels.clone(),
+        label: source_worktree.label.clone(),
+        last_opened_at: Some(created_at),
+    };
+
+    let result = (|| -> Result<ForkSessionToWorktreeResponse, String> {
+        copy_dirty_worktree_state(source_path, &worktree_path)?;
+
+        let mut forked_session =
+            prepare_forked_session(&source_session, &worktree_id, 0, created_at);
+        let source_metadata = crate::chat::storage::load_metadata(&app, &source_session_id)?;
+        copy_session_run_files(&app, &source_session_id, &forked_session.id)?;
+        let forked_metadata =
+            prepare_forked_metadata(source_metadata, &forked_session, &worktree_id);
+
+        let saved_session = crate::chat::storage::with_sessions_mut(
+            &app,
+            &worktree.path,
+            &worktree_id,
+            |sessions: &mut WorktreeSessions| {
+                sessions.sessions.clear();
+                sessions.sessions.push(forked_session.clone());
+                sessions.active_session_id = Some(forked_session.id.clone());
+                Ok(forked_session.clone())
+            },
+        )?;
+        crate::chat::storage::save_metadata(&app, &forked_metadata)?;
+        forked_session = saved_session;
+
+        data.add_worktree(worktree.clone());
+        save_projects_data(&app, &data)?;
+
+        let created_event = WorktreeCreatedEvent {
+            worktree: worktree.clone(),
+            auto_open_in_jean: false,
+        };
+        let _ = app.emit_all("worktree:created", &created_event);
+        let _ = app.emit_all(
+            "worktrees:changed",
+            &serde_json::json!({ "project_id": project.id }),
+        );
+        let _ = app.emit_all(
+            "cache:invalidate",
+            &serde_json::json!({ "keys": ["sessions", "projects"] }),
+        );
+
+        Ok(ForkSessionToWorktreeResponse {
+            worktree,
+            session: forked_session,
+        })
+    })();
+
+    if let Err(error) = result.as_ref() {
+        log::warn!("Fork session failed after git worktree creation; cleaning up {worktree_path_str}: {error}");
+        let _ = git::remove_worktree(&project.path, &worktree_path_str);
+        let _ = git::delete_branch(&project.path, &name);
+    }
+
+    result
 }
 
 fn parse_worktree_origin(origin: Option<&str>) -> Result<Option<WorktreeOrigin>, String> {
@@ -11542,6 +11950,22 @@ pub async fn revert_last_local_commit(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chat::types::Backend;
+    use std::path::Path;
+
+    fn run_test_git(repo: &Path, args: &[&str]) {
+        let output = silent_command("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 
     #[test]
     fn parse_worktree_origin_preserves_manual_origin() {
@@ -12046,6 +12470,82 @@ Body
         assert!(args
             .windows(2)
             .any(|w| w == ["--json-schema", REVIEW_SCHEMA]));
+    }
+
+    #[test]
+    fn prepare_forked_session_clears_backend_resume_ids_and_runtime_state() {
+        let mut source = Session::new("Build auth".to_string(), 3, Backend::Codex);
+        source.claude_session_id = Some("claude-1".to_string());
+        source.codex_thread_id = Some("codex-1".to_string());
+        source.codex_goal = Some("ship the feature".to_string());
+        source.opencode_session_id = Some("opencode-1".to_string());
+        source.cursor_chat_id = Some("cursor-1".to_string());
+        source.pi_session_id = Some("pi-1".to_string());
+        source.commandcode_session_id = Some("command-1".to_string());
+        source.grok_session_id = Some("grok-1".to_string());
+        source.waiting_for_input = true;
+        source.is_reviewing = true;
+
+        let forked = prepare_forked_session(&source, "new-worktree", 0, 1234);
+
+        assert_ne!(forked.id, source.id);
+        assert_eq!(forked.name, "Fork of Build auth");
+        assert_eq!(forked.order, 0);
+        assert_eq!(forked.created_at, 1234);
+        assert_eq!(forked.updated_at, 1234);
+        assert_eq!(forked.backend, Backend::Codex);
+        assert_eq!(forked.claude_session_id, None);
+        assert_eq!(forked.codex_thread_id, None);
+        assert_eq!(forked.codex_goal, None);
+        assert_eq!(forked.opencode_session_id, None);
+        assert_eq!(forked.cursor_chat_id, None);
+        assert_eq!(forked.pi_session_id, None);
+        assert_eq!(forked.commandcode_session_id, None);
+        assert_eq!(forked.grok_session_id, None);
+        assert!(!forked.waiting_for_input);
+        assert!(!forked.is_reviewing);
+        assert!(forked.pending_codex_permission_requests.is_empty());
+        assert!(forked.queued_messages.is_empty());
+    }
+
+    #[test]
+    fn copy_dirty_worktree_state_copies_tracked_changes_and_untracked_files() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let fork = temp.path().join("fork");
+        std::fs::create_dir(&repo).expect("repo dir");
+        run_test_git(&repo, &["init", "-b", "main"]);
+        run_test_git(&repo, &["config", "user.email", "test@example.com"]);
+        run_test_git(&repo, &["config", "user.name", "Test User"]);
+        std::fs::write(repo.join("tracked.txt"), "before\n").expect("write tracked");
+        run_test_git(&repo, &["add", "."]);
+        run_test_git(&repo, &["commit", "-m", "initial"]);
+        run_test_git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "fork",
+                fork.to_str().unwrap(),
+                "HEAD",
+            ],
+        );
+
+        std::fs::write(repo.join("tracked.txt"), "after\n").expect("modify tracked");
+        std::fs::create_dir_all(repo.join("notes")).expect("notes dir");
+        std::fs::write(repo.join("notes/untracked.md"), "scratch\n").expect("write untracked");
+
+        copy_dirty_worktree_state(&repo, &fork).expect("copy dirty state");
+
+        assert_eq!(
+            std::fs::read_to_string(fork.join("tracked.txt")).unwrap(),
+            "after\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(fork.join("notes/untracked.md")).unwrap(),
+            "scratch\n"
+        );
     }
 
     #[test]

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -43,7 +43,12 @@ import {
   reconnectNativeCliSession,
   canReconnectSession,
 } from '@/services/chat'
-import { useWorktree, useProjects, useRunScripts } from '@/services/projects'
+import {
+  useWorktree,
+  useProjects,
+  useRunScripts,
+  projectsQueryKeys,
+} from '@/services/projects'
 import { useProjectsStore } from '@/store/projects-store'
 import type {
   Worktree,
@@ -155,6 +160,11 @@ import type { QueuedMessage, Session, WorktreeSessions } from '@/types/chat'
 import type { DiffRequest } from '@/types/git-diff'
 import { getEffectiveSessionWaiting } from './session-card-utils'
 
+interface ForkSessionToWorktreeResponse {
+  worktree: Worktree
+  session: Session
+}
+
 // Lazy-loaded heavy modals (code splitting)
 const GitDiffModal = lazy(() =>
   import('./GitDiffModal').then(mod => ({ default: mod.GitDiffModal }))
@@ -199,6 +209,7 @@ import { useActiveTodosAndAgents } from './hooks/useActiveTodosAndAgents'
 import { usePendingAttachments } from './hooks/usePendingAttachments'
 import { dedupeInFlightAssistantMessage } from './in-flight-message-dedupe'
 import { shouldShowPermissionApproval } from './permission-approval-utils'
+import { navigateToForkedSession } from './fork-session-navigation'
 
 // PERFORMANCE: Stable empty array references to prevent infinite render loops
 // When Zustand selectors return [], a new reference is created each time
@@ -2090,11 +2101,84 @@ export function ChatWindow({
     useUIStore.getState().setLinkedProjectsModalOpen(open)
   }, [])
 
+  const handleForkSession = useCallback(async () => {
+    if (!activeWorktreeId || !activeSessionId) {
+      toast.error('No active session to fork')
+      return
+    }
+
+    const toastId = toast.loading('Forking session to a new worktree...')
+    try {
+      const result = await invoke<ForkSessionToWorktreeResponse>(
+        'fork_session_to_worktree',
+        {
+          sourceWorktreeId: activeWorktreeId,
+          sourceSessionId: activeSessionId,
+        }
+      )
+
+      const { worktree: forkedWorktree, session: forkedSession } = result
+      queryClient.setQueryData<Worktree>(
+        [...projectsQueryKeys.all, 'worktree', forkedWorktree.id],
+        forkedWorktree
+      )
+      queryClient.setQueryData<Session>(
+        chatQueryKeys.session(forkedSession.id),
+        forkedSession
+      )
+      queryClient.invalidateQueries({ queryKey: projectsQueryKeys.list() })
+      queryClient.invalidateQueries({
+        queryKey: projectsQueryKeys.worktrees(forkedWorktree.project_id),
+      })
+      queryClient.invalidateQueries({
+        queryKey: chatQueryKeys.sessions(forkedWorktree.id),
+      })
+
+      const projectsStore = useProjectsStore.getState()
+      const chatStore = useChatStore.getState()
+      navigateToForkedSession(
+        forkedWorktree,
+        forkedSession,
+        {
+          activeWorktreePath,
+          sessionChatModalOpen: isModal || sessionModalOpen,
+        },
+        {
+          expandProject: projectsStore.expandProject,
+          selectWorktree: projectsStore.selectWorktree,
+          registerWorktreePath: chatStore.registerWorktreePath,
+          setActiveWorktree: chatStore.setActiveWorktree,
+          setActiveSession: chatStore.setActiveSession,
+          addUserInitiatedSession: chatStore.addUserInitiatedSession,
+          openWorktreeModal: (worktreeId, worktreePath) => {
+            window.dispatchEvent(
+              new CustomEvent('open-worktree-modal', {
+                detail: { worktreeId, worktreePath },
+              })
+            )
+          },
+        }
+      )
+
+      toast.success(`Forked session to ${forkedWorktree.name}`, { id: toastId })
+    } catch (err) {
+      toast.error(`Failed to fork session: ${err}`, { id: toastId })
+    }
+  }, [
+    activeSessionId,
+    activeWorktreeId,
+    activeWorktreePath,
+    isModal,
+    queryClient,
+    sessionModalOpen,
+  ])
+
   // Listen for magic-command events from MagicModal
   useMagicCommands({
     handleSaveContext,
     handleLoadContext,
     handleLinkedProjects,
+    handleForkSession,
     handleCommit,
     handleCommitAndPush: handleCommitAndPushWithPicker,
     handlePull: handlePullWithPicker,
@@ -2357,8 +2441,7 @@ export function ChatWindow({
     handleRemoveQueuedMessage,
     handleEditQueuedMessage,
     handleSendQueuedNow,
-  } =
-    useQueuedPromptActions()
+  } = useQueuedPromptActions()
 
   // Pending attachment removal, slash command execution
   const {

--- a/src/components/chat/CompactMessageList.test.tsx
+++ b/src/components/chat/CompactMessageList.test.tsx
@@ -333,8 +333,10 @@ describe('CompactMessageList', () => {
     const editedFiles = screen.getByText('Edited 1 file:')
 
     expect(editedFiles).toBeVisible()
+    expect(latestText).toBeDefined()
+    if (!latestText) throw new Error('Expected changed chat UI text to render')
     expect(
-      latestText!.compareDocumentPosition(editedFiles) &
+      latestText.compareDocumentPosition(editedFiles) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
   })

--- a/src/components/chat/fork-session-navigation.test.ts
+++ b/src/components/chat/fork-session-navigation.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+import { navigateToForkedSession } from './fork-session-navigation'
+
+const worktree = {
+  id: 'fork-wt-1',
+  path: '/tmp/fork-wt-1',
+  project_id: 'proj-1',
+}
+
+const session = {
+  id: 'fork-session-1',
+}
+
+function createActions() {
+  return {
+    expandProject: vi.fn(),
+    selectWorktree: vi.fn(),
+    registerWorktreePath: vi.fn(),
+    setActiveWorktree: vi.fn(),
+    setActiveSession: vi.fn(),
+    addUserInitiatedSession: vi.fn(),
+    openWorktreeModal: vi.fn(),
+  }
+}
+
+describe('navigateToForkedSession', () => {
+  it('keeps forked sessions in the modal when forking from a modal chat', () => {
+    const actions = createActions()
+
+    const destination = navigateToForkedSession(
+      worktree,
+      session,
+      {
+        activeWorktreePath: '/repo/current',
+        sessionChatModalOpen: true,
+      },
+      actions
+    )
+
+    expect(destination).toBe('modal')
+    expect(actions.expandProject).toHaveBeenCalledWith('proj-1')
+    expect(actions.selectWorktree).toHaveBeenCalledWith('fork-wt-1')
+    expect(actions.registerWorktreePath).toHaveBeenCalledWith(
+      'fork-wt-1',
+      '/tmp/fork-wt-1'
+    )
+    expect(actions.setActiveSession).toHaveBeenCalledWith(
+      'fork-wt-1',
+      'fork-session-1'
+    )
+    expect(actions.addUserInitiatedSession).toHaveBeenCalledWith(
+      'fork-session-1'
+    )
+    expect(actions.openWorktreeModal).toHaveBeenCalledWith(
+      'fork-wt-1',
+      '/tmp/fork-wt-1'
+    )
+    expect(actions.setActiveWorktree).not.toHaveBeenCalled()
+  })
+
+  it('switches the inline chat when forking from an inline chat', () => {
+    const actions = createActions()
+
+    const destination = navigateToForkedSession(
+      worktree,
+      session,
+      {
+        activeWorktreePath: '/repo/current',
+        sessionChatModalOpen: false,
+      },
+      actions
+    )
+
+    expect(destination).toBe('chat')
+    expect(actions.setActiveWorktree).toHaveBeenCalledWith(
+      'fork-wt-1',
+      '/tmp/fork-wt-1'
+    )
+    expect(actions.openWorktreeModal).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/chat/fork-session-navigation.ts
+++ b/src/components/chat/fork-session-navigation.ts
@@ -1,0 +1,45 @@
+import type { Worktree } from '@/types/projects'
+
+type ForkedWorktree = Pick<Worktree, 'id' | 'path' | 'project_id'>
+type ForkedSession = { id: string }
+
+interface ForkSessionNavigationContext {
+  activeWorktreePath: string | null
+  sessionChatModalOpen: boolean
+}
+
+interface ForkSessionNavigationActions {
+  expandProject: (projectId: string) => void
+  selectWorktree: (worktreeId: string) => void
+  registerWorktreePath: (worktreeId: string, worktreePath: string) => void
+  setActiveWorktree: (worktreeId: string, worktreePath: string) => void
+  setActiveSession: (worktreeId: string, sessionId: string) => void
+  addUserInitiatedSession: (sessionId: string) => void
+  openWorktreeModal: (worktreeId: string, worktreePath: string) => void
+}
+
+/**
+ * Navigate to a forked session while preserving the current presentation.
+ * Canvas/modal flows must stay in SessionChatModal so the worktree header and
+ * session tabs remain visible; inline chat flows should continue inline.
+ */
+export function navigateToForkedSession(
+  worktree: ForkedWorktree,
+  session: ForkedSession,
+  context: ForkSessionNavigationContext,
+  actions: ForkSessionNavigationActions
+): 'modal' | 'chat' {
+  actions.expandProject(worktree.project_id)
+  actions.selectWorktree(worktree.id)
+  actions.registerWorktreePath(worktree.id, worktree.path)
+  actions.setActiveSession(worktree.id, session.id)
+  actions.addUserInitiatedSession(session.id)
+
+  if (context.sessionChatModalOpen || !context.activeWorktreePath) {
+    actions.openWorktreeModal(worktree.id, worktree.path)
+    return 'modal'
+  }
+
+  actions.setActiveWorktree(worktree.id, worktree.path)
+  return 'chat'
+}

--- a/src/components/chat/hooks/useMagicCommands.test.ts
+++ b/src/components/chat/hooks/useMagicCommands.test.ts
@@ -10,6 +10,7 @@ function renderUseMagicCommands(
     handleSaveContext: vi.fn(),
     handleLoadContext: vi.fn(),
     handleLinkedProjects: vi.fn(),
+    handleForkSession: vi.fn(),
     handleCommit: vi.fn(),
     handleCommitAndPush: vi.fn(),
     handlePull: vi.fn(),
@@ -33,6 +34,18 @@ describe('useMagicCommands review comments batch', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     useChatStore.getState().setPendingMagicCommand(null)
+  })
+
+  it('dispatches the fork session magic command', () => {
+    const handlers = renderUseMagicCommands()
+
+    window.dispatchEvent(
+      new CustomEvent('magic-command', {
+        detail: { command: 'fork-session' },
+      })
+    )
+
+    expect(handlers.handleForkSession).toHaveBeenCalledTimes(1)
   })
 
   it('passes separate review comment prompts and plan mode from event detail', () => {

--- a/src/components/chat/hooks/useMagicCommands.ts
+++ b/src/components/chat/hooks/useMagicCommands.ts
@@ -21,6 +21,7 @@ interface MagicCommandHandlers {
   handleSaveContext: () => void
   handleLoadContext: () => void
   handleLinkedProjects: () => void
+  handleForkSession: () => void
   handleCommit: () => void
   handleCommitAndPush: () => void
   handlePull: () => void
@@ -62,6 +63,7 @@ export function useMagicCommands({
   handleSaveContext,
   handleLoadContext,
   handleLinkedProjects,
+  handleForkSession,
   handleCommit,
   handleCommitAndPush,
   handlePull,
@@ -83,6 +85,7 @@ export function useMagicCommands({
     handleSaveContext,
     handleLoadContext,
     handleLinkedProjects,
+    handleForkSession,
     handleCommit,
     handleCommitAndPush,
     handlePull,
@@ -105,6 +108,7 @@ export function useMagicCommands({
       handleSaveContext,
       handleLoadContext,
       handleLinkedProjects,
+      handleForkSession,
       handleCommit,
       handleCommitAndPush,
       handlePull,
@@ -150,6 +154,9 @@ export function useMagicCommands({
           break
         case 'linked-projects':
           handlers.handleLinkedProjects()
+          break
+        case 'fork-session':
+          handlers.handleForkSession()
           break
         case 'commit':
           handlers.handleCommit()

--- a/src/components/chat/hooks/useQueuedPromptActions.test.ts
+++ b/src/components/chat/hooks/useQueuedPromptActions.test.ts
@@ -110,7 +110,7 @@ describe('useQueuedPromptActions', () => {
     )
   })
 
-  it('does not edit when the queued message was already dequeued', async () => {
+  it('drops the stale local copy when the queued message was already dequeued', async () => {
     vi.mocked(persistUpdateQueued).mockResolvedValue(false)
     const { result } = renderHook(() => useQueuedPromptActions())
 
@@ -124,7 +124,7 @@ describe('useQueuedPromptActions', () => {
 
     expect(
       useChatStore.getState().messageQueues['session-1']?.map(m => m.message)
-    ).toEqual(['prompt msg-1', 'prompt msg-2', 'prompt msg-3'])
+    ).toEqual(['prompt msg-1', 'prompt msg-3'])
   })
 
   it('does not edit queued messages that can be steered', async () => {

--- a/src/components/chat/toolbar/MobileToolbarMenu.test.tsx
+++ b/src/components/chat/toolbar/MobileToolbarMenu.test.tsx
@@ -147,6 +147,43 @@ describe('MobileToolbarMenu', () => {
     dispatchSpy.mockRestore()
   })
 
+  it('shows fork session in the context section and dispatches the magic command', async () => {
+    const user = userEvent.setup()
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+
+    render(
+      <MobileToolbarMenu
+        isDisabled={false}
+        hasOpenPr={false}
+        hasIssueContexts={false}
+        hasPrContexts={false}
+        onSaveContext={vi.fn()}
+        onLoadContext={vi.fn()}
+        onCommit={vi.fn()}
+        onCommitAndPush={vi.fn()}
+        onRevertLastCommit={vi.fn()}
+        onOpenPr={vi.fn()}
+        onReview={vi.fn()}
+        onMerge={vi.fn()}
+        onMergePr={vi.fn()}
+        handlePullClick={vi.fn()}
+        handlePushClick={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /more actions/i }))
+    await user.click(screen.getByText('Fork Session'))
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'magic-command',
+        detail: { command: 'fork-session' },
+      })
+    )
+
+    dispatchSpy.mockRestore()
+  })
+
   it('shows revert commit in the commit section and invokes its handler', async () => {
     const user = userEvent.setup()
     const onRevertLastCommit = vi.fn()

--- a/src/components/chat/toolbar/MobileToolbarMenu.tsx
+++ b/src/components/chat/toolbar/MobileToolbarMenu.tsx
@@ -7,6 +7,7 @@ import {
   Eye,
   FileText,
   FolderOpen,
+  GitBranchPlus,
   GitCommitHorizontal,
   GitMerge,
   GitPullRequest,
@@ -122,6 +123,28 @@ export function MobileToolbarMenu({
             )}
           >
             K
+          </span>
+        </DropdownMenuItem>
+
+        <DropdownMenuItem
+          onClick={() => {
+            setMenuOpen(false)
+            window.dispatchEvent(
+              new CustomEvent('magic-command', {
+                detail: { command: 'fork-session' },
+              })
+            )
+          }}
+        >
+          <GitBranchPlus className="h-4 w-4" />
+          Fork Session
+          <span
+            className={cn(
+              'ml-auto text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded',
+              isMobile && 'hidden'
+            )}
+          >
+            W
           </span>
         </DropdownMenuItem>
 

--- a/src/components/magic/MagicModal.test.tsx
+++ b/src/components/magic/MagicModal.test.tsx
@@ -532,6 +532,14 @@ describe('MagicModal manual PR link', () => {
     expect(screen.queryByRole('button', { name: /release post/i })).toBeNull()
   })
 
+  it('shows the fork session magic command', () => {
+    render(<MagicModal />)
+
+    expect(
+      screen.getByRole('button', { name: /fork session/i })
+    ).toBeInTheDocument()
+  })
+
   it('reverts the last commit only after confirmation', async () => {
     const user = userEvent.setup()
     mocks.invokeMock.mockImplementation((command: string) => {

--- a/src/components/magic/MagicModal.tsx
+++ b/src/components/magic/MagicModal.tsx
@@ -3,6 +3,7 @@ import {
   ArrowDownToLine,
   ArrowUpToLine,
   GitCommitHorizontal,
+  GitBranchPlus,
   GitMerge,
   GitPullRequest,
   GitPullRequestArrow,
@@ -111,6 +112,7 @@ type MagicOption =
   | 'save-context'
   | 'load-context'
   | 'linked-projects'
+  | 'fork-session'
   | 'commit'
   | 'commit-and-push'
   | 'pull'
@@ -231,6 +233,12 @@ function buildMagicColumns(hasOpenPr: boolean): MagicColumns {
           icon: Link2,
           key: 'K',
         },
+        {
+          id: 'fork-session',
+          label: 'Fork Session',
+          icon: GitBranchPlus,
+          key: 'W',
+        },
       ],
     },
     {
@@ -343,6 +351,7 @@ const KEY_TO_OPTION: Record<string, MagicOption> = {
   s: 'save-context',
   l: 'load-context',
   k: 'linked-projects',
+  w: 'fork-session',
   c: 'commit',
   p: 'commit-and-push',
   d: 'pull',


### PR DESCRIPTION
## Summary
- Add a Fork Session magic command that creates a new worktree from the active session and navigates to the forked chat.
- Preserve source worktree context, dirty tracked changes, untracked files, session history, and related PR/issue metadata in the fork.
- Register the new backend command for both native Tauri IPC and web access dispatch, with tests for navigation, magic command dispatch, and fork state copying.