### PR TITLE
feat(github-dashboard): add global workflows view

### DIFF
--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -2908,6 +2908,22 @@ pub async fn dispatch_command(
                 crate::projects::list_workflow_runs(app.clone(), project_path, branch).await?;
             to_value(result)
         }
+        "get_workflow_run" => {
+            let project_path: String = field(&args, "projectPath", "project_path")?;
+            let run_id: u64 = field(&args, "runId", "run_id")?;
+            let result =
+                crate::projects::get_workflow_run(app.clone(), project_path, run_id).await?;
+            to_value(result)
+        }
+        "get_workflow_job_logs" => {
+            let project_path: String = field(&args, "projectPath", "project_path")?;
+            let run_id: u64 = field(&args, "runId", "run_id")?;
+            let job_id: u64 = field(&args, "jobId", "job_id")?;
+            let result =
+                crate::projects::get_workflow_job_logs(app.clone(), project_path, run_id, job_id)
+                    .await?;
+            to_value(result)
+        }
 
         // =====================================================================
         // Linear Issues

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -856,9 +856,12 @@ mod tests {
 
         let bind_host = resolve_headless_bind_host(&prefs, &overrides.host);
         let token_required = resolve_headless_token_required(&prefs, &overrides);
-        let err =
-            validate_headless_security(&bind_host, !token_required, overrides.allow_unsafe_no_token)
-                .unwrap_err();
+        let err = validate_headless_security(
+            &bind_host,
+            !token_required,
+            overrides.allow_unsafe_no_token,
+        )
+        .unwrap_err();
 
         assert!(err.contains("Refusing to disable token authentication"));
     }
@@ -2266,6 +2269,10 @@ pub struct UIState {
     #[serde(default)]
     pub dashboard_worktree_collapse_overrides: std::collections::HashMap<String, bool>,
 
+    /// GitHub dashboard project collapse overrides: projectId → collapsed (true/false)
+    #[serde(default)]
+    pub github_dashboard_project_collapse_overrides: std::collections::HashMap<String, bool>,
+
     /// Project canvas settings per project
     #[serde(default)]
     pub project_canvas_settings: std::collections::HashMap<String, ProjectCanvasSettings>,
@@ -2354,6 +2361,7 @@ impl Default for UIState {
             browser_bottom_panel_height: None,
             project_access_timestamps: std::collections::HashMap::new(),
             dashboard_worktree_collapse_overrides: std::collections::HashMap::new(),
+            github_dashboard_project_collapse_overrides: std::collections::HashMap::new(),
             project_canvas_settings: std::collections::HashMap::new(),
             last_opened_per_project: std::collections::HashMap::new(),
             version: default_ui_state_version(),
@@ -3082,11 +3090,7 @@ async fn start_http_server_headless(
 
     let token_required = resolve_headless_token_required(&prefs, overrides);
 
-    validate_headless_security(
-        &bind_host,
-        !token_required,
-        overrides.allow_unsafe_no_token,
-    )?;
+    validate_headless_security(&bind_host, !token_required, overrides.allow_unsafe_no_token)?;
 
     // Token: CLI --token used directly (not persisted), otherwise load/generate
     let token = if let Some(ref t) = overrides.token {
@@ -4599,6 +4603,8 @@ pub fn run() {
             projects::get_advisory_context_content,
             // GitHub Actions commands
             projects::list_workflow_runs,
+            projects::get_workflow_run,
+            projects::get_workflow_job_logs,
             // Saved context commands
             projects::attach_saved_context,
             projects::remove_saved_context,

--- a/src-tauri/src/projects/github_actions.rs
+++ b/src-tauri/src/projects/github_actions.rs
@@ -28,6 +28,69 @@ pub struct WorkflowRun {
     pub workflow_name: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunStep {
+    pub name: String,
+    pub number: u32,
+    pub status: String,
+    #[serde(default)]
+    pub conclusion: Option<String>,
+    #[serde(default)]
+    pub started_at: Option<String>,
+    #[serde(default)]
+    pub completed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunJob {
+    pub database_id: u64,
+    pub name: String,
+    pub status: String,
+    #[serde(default)]
+    pub conclusion: Option<String>,
+    #[serde(default)]
+    pub started_at: Option<String>,
+    #[serde(default)]
+    pub completed_at: Option<String>,
+    #[serde(default)]
+    pub steps: Vec<WorkflowRunStep>,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowJobDefinition {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub needs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunDetailsResult {
+    pub jobs: Vec<WorkflowRunJob>,
+    #[serde(default)]
+    pub job_definitions: Vec<WorkflowJobDefinition>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowJobLogLine {
+    pub step_name: String,
+    pub timestamp: Option<String>,
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowRunView {
+    jobs: Vec<WorkflowRunJob>,
+    workflow_database_id: Option<u64>,
+}
+
 /// Result of listing workflow runs, includes failed count for badge display
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -108,6 +171,178 @@ pub async fn list_workflow_runs(
     log::trace!("Found {} workflow runs ({failed_count} failed)", runs.len());
 
     Ok(WorkflowRunsResult { runs, failed_count })
+}
+
+#[tauri::command]
+pub async fn get_workflow_run(
+    app: AppHandle,
+    project_path: String,
+    run_id: u64,
+) -> Result<WorkflowRunDetailsResult, String> {
+    log::trace!("Loading workflow run details for {project_path} run {run_id}");
+
+    let gh = resolve_gh_binary(&app);
+    let args = vec![
+        "run".to_string(),
+        "view".to_string(),
+        run_id.to_string(),
+        "--json".to_string(),
+        "jobs,workflowDatabaseId".to_string(),
+    ];
+
+    let output = gh_command(&gh, &project_path)
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to run gh run view: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("gh auth login") || stderr.contains("authentication") {
+            return Err("GitHub CLI not authenticated. Run 'gh auth login' first.".to_string());
+        }
+        if stderr.contains("not a git repository") {
+            return Err("Not a git repository".to_string());
+        }
+        if stderr.contains("Could not resolve") {
+            return Err("Could not resolve repository. Is this a GitHub repository?".to_string());
+        }
+        return Err(format!("gh run view failed: {stderr}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let run_view: WorkflowRunView =
+        serde_json::from_str(&stdout).map_err(|e| format!("Failed to parse gh response: {e}"))?;
+
+    let job_definitions = match run_view.workflow_database_id {
+        Some(workflow_id) => load_workflow_job_definitions(&gh, &project_path, workflow_id),
+        None => Vec::new(),
+    };
+    let result = WorkflowRunDetailsResult {
+        jobs: run_view.jobs,
+        job_definitions,
+    };
+
+    log::trace!(
+        "Loaded workflow run details for {run_id} with {} jobs",
+        result.jobs.len()
+    );
+
+    Ok(result)
+}
+
+#[tauri::command]
+pub async fn get_workflow_job_logs(
+    app: AppHandle,
+    project_path: String,
+    run_id: u64,
+    job_id: u64,
+) -> Result<Vec<WorkflowJobLogLine>, String> {
+    log::trace!("Loading logs for workflow run {run_id} job {job_id}");
+
+    let gh = resolve_gh_binary(&app);
+    let output = gh_command(&gh, &project_path)
+        .args([
+            "run",
+            "view",
+            &run_id.to_string(),
+            "--job",
+            &job_id.to_string(),
+            "--log",
+        ])
+        .output()
+        .map_err(|e| format!("Failed to load workflow job logs: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Failed to load workflow job logs: {stderr}"));
+    }
+
+    Ok(parse_workflow_job_logs(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
+}
+
+fn parse_workflow_job_logs(output: &str) -> Vec<WorkflowJobLogLine> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.splitn(3, '\t');
+            let _job_name = parts.next()?;
+            let step_name = parts.next()?.to_string();
+            let content = parts.next()?.trim_start_matches('\u{feff}');
+            let (timestamp, message) = match content.split_once(' ') {
+                Some((timestamp, message))
+                    if timestamp.contains('T') && timestamp.ends_with('Z') =>
+                {
+                    (Some(timestamp.to_string()), message.to_string())
+                }
+                _ => (None, content.to_string()),
+            };
+
+            Some(WorkflowJobLogLine {
+                step_name,
+                timestamp,
+                message,
+            })
+        })
+        .collect()
+}
+
+fn load_workflow_job_definitions(
+    gh: &Path,
+    project_path: &str,
+    workflow_id: u64,
+) -> Vec<WorkflowJobDefinition> {
+    let output = match gh_command(gh, project_path)
+        .args(["workflow", "view", &workflow_id.to_string(), "--yaml"])
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        Ok(output) => {
+            log::warn!(
+                "Failed to load workflow graph for {workflow_id}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return Vec::new();
+        }
+        Err(error) => {
+            log::warn!("Failed to load workflow graph for {workflow_id}: {error}");
+            return Vec::new();
+        }
+    };
+
+    parse_workflow_job_definitions(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_workflow_job_definitions(yaml: &str) -> Vec<WorkflowJobDefinition> {
+    let Ok(document) = serde_yaml::from_str::<serde_yaml::Value>(yaml) else {
+        return Vec::new();
+    };
+    let Some(jobs) = document.get("jobs").and_then(serde_yaml::Value::as_mapping) else {
+        return Vec::new();
+    };
+
+    jobs.iter()
+        .filter_map(|(id, value)| {
+            let id = id.as_str()?.to_string();
+            let name = value
+                .get("name")
+                .and_then(serde_yaml::Value::as_str)
+                .unwrap_or(&id)
+                .to_string();
+            let needs = match value.get("needs") {
+                Some(serde_yaml::Value::String(need)) => vec![need.clone()],
+                Some(serde_yaml::Value::Sequence(needs)) => needs
+                    .iter()
+                    .filter_map(serde_yaml::Value::as_str)
+                    .map(String::from)
+                    .collect(),
+                _ => Vec::new(),
+            };
+
+            Some(WorkflowJobDefinition { id, name, needs })
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -217,5 +452,79 @@ mod tests {
         let json = serde_json::to_string(&result).unwrap();
         assert!(json.contains("\"failedCount\":3"));
         assert!(json.contains("\"runs\":[]"));
+    }
+
+    #[test]
+    fn test_workflow_run_details_deserialization() {
+        let json = r#"{
+            "jobs": [{
+                "databaseId": 42,
+                "name": "build",
+                "status": "completed",
+                "conclusion": "success",
+                "startedAt": "2026-07-03T07:16:52Z",
+                "completedAt": "2026-07-03T07:17:00Z",
+                "steps": [{
+                    "name": "Set up job",
+                    "number": 1,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "startedAt": "2026-07-03T07:16:53Z",
+                    "completedAt": "2026-07-03T07:16:54Z"
+                }],
+                "url": "https://github.com/cli/cli/actions/runs/1/job/42"
+            }],
+            "jobDefinitions": [{
+                "id": "build",
+                "name": "Build",
+                "needs": []
+            }]
+        }"#;
+
+        let result: WorkflowRunDetailsResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.jobs.len(), 1);
+        assert_eq!(result.jobs[0].database_id, 42);
+        assert_eq!(result.jobs[0].steps.len(), 1);
+        assert_eq!(result.jobs[0].steps[0].name, "Set up job");
+        assert_eq!(result.job_definitions[0].id, "build");
+    }
+
+    #[test]
+    fn test_parse_workflow_job_definitions() {
+        let yaml = r#"
+name: Build and deploy
+on: push
+jobs:
+  build:
+    name: Build app
+    runs-on: ubuntu-latest
+  deploy:
+    name: Deploy
+    needs: [build]
+    runs-on: ubuntu-latest
+"#;
+
+        let definitions = parse_workflow_job_definitions(yaml);
+        assert_eq!(definitions.len(), 2);
+        assert_eq!(definitions[0].id, "build");
+        assert_eq!(definitions[0].name, "Build app");
+        assert_eq!(definitions[1].needs, vec!["build"]);
+    }
+
+    #[test]
+    fn test_parse_workflow_job_logs() {
+        let output = "\
+build\tCheckout\t2026-07-03T09:00:00.123Z Fetching repository\n\
+build\tTests\t2026-07-03T09:01:00Z Running tests\n";
+
+        let logs = parse_workflow_job_logs(output);
+        assert_eq!(logs.len(), 2);
+        assert_eq!(logs[0].step_name, "Checkout");
+        assert_eq!(
+            logs[0].timestamp.as_deref(),
+            Some("2026-07-03T09:00:00.123Z")
+        );
+        assert_eq!(logs[0].message, "Fetching repository");
+        assert_eq!(logs[1].step_name, "Tests");
     }
 }

--- a/src/components/github-dashboard/GitHubDashboardModal.test.tsx
+++ b/src/components/github-dashboard/GitHubDashboardModal.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import userEvent from '@testing-library/user-event'
 import { screen, waitFor, render } from '@/test/test-utils'
 import { useUIStore } from '@/store/ui-store'
+import { useProjectsStore } from '@/store/projects-store'
 import { GitHubDashboardModal } from './GitHubDashboardModal'
 
 const mockInvoke = vi.hoisted(() => vi.fn())
@@ -87,6 +88,9 @@ describe('GitHubDashboardModal auth error handling', () => {
       data: undefined,
       isLoading: false,
       isFetching: false,
+    })
+    useProjectsStore.setState({
+      githubDashboardProjectCollapseOverrides: {},
     })
   })
 
@@ -223,5 +227,50 @@ describe('GitHubDashboardModal auth error handling', () => {
     expect(screen.getByText('1 failed')).toBeInTheDocument()
     expect(screen.getByText('1 success')).toBeInTheDocument()
     expect(screen.getByText('Open runs')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Deploy/ }))
+    expect(useUIStore.getState().workflowRunsModalWorkflowName).toBe('Deploy')
+    expect(useUIStore.getState().workflowRunsModalProjectPath).toBe(
+      '/tmp/project-1'
+    )
+  })
+
+  it('collapses and expands a project in the workflows tab', async () => {
+    mockInvoke.mockImplementation((command: string) => {
+      if (command === 'list_workflow_runs') {
+        return Promise.resolve({
+          runs: [
+            {
+              databaseId: 1,
+              name: 'build',
+              displayTitle: 'Build app',
+              status: 'completed',
+              conclusion: 'success',
+              event: 'push',
+              headBranch: 'main',
+              createdAt: '2026-07-03T08:30:00Z',
+              url: 'https://github.com/acme/project/actions/runs/1',
+              workflowName: 'Build',
+            },
+          ],
+          failedCount: 0,
+        })
+      }
+      return resolveEmptyDashboardCommand(command)
+    })
+
+    const user = userEvent.setup()
+    renderDashboard()
+
+    await user.click(screen.getByRole('button', { name: /Workflows/i }))
+    expect(await screen.findByText('Build')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Project 1/i }))
+    await waitFor(() => {
+      expect(screen.queryByText('Build')).not.toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /Project 1/i }))
+    expect(await screen.findByText('Build')).toBeInTheDocument()
   })
 })

--- a/src/components/github-dashboard/GitHubDashboardModal.test.tsx
+++ b/src/components/github-dashboard/GitHubDashboardModal.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
 import { screen, waitFor, render } from '@/test/test-utils'
 import { useUIStore } from '@/store/ui-store'
 import { GitHubDashboardModal } from './GitHubDashboardModal'
@@ -64,6 +65,8 @@ function resolveEmptyDashboardCommand(command: string) {
   if (command === 'list_github_prs') return Promise.resolve([])
   if (command === 'list_dependabot_alerts') return Promise.resolve([])
   if (command === 'list_repository_advisories') return Promise.resolve([])
+  if (command === 'list_workflow_runs')
+    return Promise.resolve({ runs: [], failedCount: 0 })
   return Promise.resolve(null)
 }
 
@@ -158,5 +161,67 @@ describe('GitHubDashboardModal auth error handling', () => {
     expect(
       await screen.findByTestId('gh-auth-error', {}, { timeout: 3000 })
     ).toBeInTheDocument()
+  })
+
+  it('shows the workflows dashboard with per-project summaries', async () => {
+    mockInvoke.mockImplementation((command: string) => {
+      if (command === 'list_workflow_runs') {
+        return Promise.resolve({
+          runs: [
+            {
+              databaseId: 3,
+              name: 'deploy',
+              displayTitle: 'Deploy production',
+              status: 'in_progress',
+              conclusion: null,
+              event: 'push',
+              headBranch: 'main',
+              createdAt: '2026-07-03T09:30:00Z',
+              url: 'https://github.com/acme/project/actions/runs/3',
+              workflowName: 'Deploy',
+            },
+            {
+              databaseId: 2,
+              name: 'test',
+              displayTitle: 'Test suite',
+              status: 'completed',
+              conclusion: 'failure',
+              event: 'push',
+              headBranch: 'main',
+              createdAt: '2026-07-03T09:00:00Z',
+              url: 'https://github.com/acme/project/actions/runs/2',
+              workflowName: 'CI',
+            },
+            {
+              databaseId: 1,
+              name: 'build',
+              displayTitle: 'Build app',
+              status: 'completed',
+              conclusion: 'success',
+              event: 'push',
+              headBranch: 'main',
+              createdAt: '2026-07-03T08:30:00Z',
+              url: 'https://github.com/acme/project/actions/runs/1',
+              workflowName: 'Build',
+            },
+          ],
+          failedCount: 1,
+        })
+      }
+      return resolveEmptyDashboardCommand(command)
+    })
+
+    const user = userEvent.setup()
+    renderDashboard()
+
+    await user.click(screen.getByRole('button', { name: /Workflows/i }))
+
+    expect(
+      await screen.findByText('Deploy', {}, { timeout: 3000 })
+    ).toBeInTheDocument()
+    expect(screen.getByText('1 running')).toBeInTheDocument()
+    expect(screen.getByText('1 failed')).toBeInTheDocument()
+    expect(screen.getByText('1 success')).toBeInTheDocument()
+    expect(screen.getByText('Open runs')).toBeInTheDocument()
   })
 })

--- a/src/components/github-dashboard/GitHubDashboardModal.tsx
+++ b/src/components/github-dashboard/GitHubDashboardModal.tsx
@@ -9,6 +9,8 @@ import { useQueries } from '@tanstack/react-query'
 import {
   Activity,
   CheckCircle2,
+  ChevronDown,
+  ChevronRight,
   CircleDot,
   Clock,
   GitPullRequest,
@@ -22,13 +24,18 @@ import {
   Wand2,
 } from 'lucide-react'
 import { toast } from 'sonner'
-import { getModifierSymbol, openExternal } from '@/lib/platform'
+import { getModifierSymbol } from '@/lib/platform'
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Input } from '@/components/ui/input'
@@ -46,6 +53,7 @@ import {
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { useUIStore } from '@/store/ui-store'
+import { useProjectsStore } from '@/store/projects-store'
 import { useProjects, isTauri, useCreateWorktree } from '@/services/projects'
 import { isFolder } from '@/types/projects'
 import {
@@ -682,28 +690,59 @@ function ProjectSection({
   project,
   count,
   actions,
+  isCollapsible = false,
+  isCollapsed,
+  onCollapsedChange,
   children,
 }: {
   project: Project
   count: number
   actions?: React.ReactNode
+  isCollapsible?: boolean
+  isCollapsed?: boolean
+  onCollapsedChange?: (collapsed: boolean) => void
   children: React.ReactNode
 }) {
-  return (
-    <div>
-      <div className="sticky top-0 z-10 flex flex-wrap items-center gap-2 px-3 py-1.5 bg-muted/80 border-b border-border">
+  const header = (
+    <div className="sticky top-0 z-10 flex flex-wrap items-center gap-2 px-3 py-1.5 bg-muted/80 border-b border-border">
+      {isCollapsible ? (
+        <CollapsibleTrigger className="inline-flex min-w-0 items-center gap-1 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wide hover:text-foreground">
+          {isCollapsed ? (
+            <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+          ) : (
+            <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+          )}
+          <span className="truncate">{project.name}</span>
+        </CollapsibleTrigger>
+      ) : (
         <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
           {project.name}
         </span>
-        <span className="text-xs text-muted-foreground bg-background border border-border rounded-full px-1.5 py-0.5 leading-none">
-          {count}
-        </span>
-        {actions && (
-          <div className="ml-auto flex items-center gap-2">{actions}</div>
-        )}
-      </div>
-      {children}
+      )}
+      <span className="text-xs text-muted-foreground bg-background border border-border rounded-full px-1.5 py-0.5 leading-none">
+        {count}
+      </span>
+      {actions && <div className="ml-auto flex items-center gap-2">{actions}</div>}
     </div>
+  )
+
+  if (!isCollapsible) {
+    return (
+      <div>
+        {header}
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <Collapsible
+      open={!isCollapsed}
+      onOpenChange={open => onCollapsedChange?.(!open)}
+    >
+      {header}
+      <CollapsibleContent>{children}</CollapsibleContent>
+    </Collapsible>
   )
 }
 
@@ -736,6 +775,13 @@ export function GitHubDashboardModal() {
     },
     [setGitHubDashboardOpen, setWorkflowRunsModalOpen]
   )
+  const handleOpenWorkflowRunsForWorkflow = useCallback(
+    (projectPath: string, workflowName: string) => {
+      setGitHubDashboardOpen(false)
+      setWorkflowRunsModalOpen(true, projectPath, null, workflowName)
+    },
+    [setGitHubDashboardOpen, setWorkflowRunsModalOpen]
+  )
   const [preview, setPreview] = useState<PreviewState | null>(null)
   // Track which item is being created (number for issues/prs/alerts, ghsaId for advisories)
   const [creatingId, setCreatingId] = useState<string | null>(null)
@@ -753,6 +799,12 @@ export function GitHubDashboardModal() {
   const { data: allProjects = [] } = useProjects()
   const { triggerLogin, isGhInstalled } = useGhLogin()
   const createWorktree = useCreateWorktree()
+  const githubDashboardProjectCollapseOverrides = useProjectsStore(
+    state => state.githubDashboardProjectCollapseOverrides
+  )
+  const setGitHubDashboardProjectCollapsed = useProjectsStore(
+    state => state.setGitHubDashboardProjectCollapsed
+  )
 
   // Only query projects with a valid path (exclude folders)
   const projects = useMemo(
@@ -1337,6 +1389,22 @@ export function GitHubDashboardModal() {
                     key={project.id}
                     project={project}
                     count={items.length}
+                    isCollapsible={activeTab === 'workflows'}
+                    isCollapsed={
+                      activeTab === 'workflows'
+                        ? githubDashboardProjectCollapseOverrides[project.id] ??
+                          false
+                        : false
+                    }
+                    onCollapsedChange={
+                      activeTab === 'workflows'
+                        ? collapsed =>
+                            setGitHubDashboardProjectCollapsed(
+                              project.id,
+                              collapsed
+                            )
+                        : undefined
+                    }
                     actions={
                       activeTab === 'workflows'
                         ? (() => {
@@ -1473,7 +1541,10 @@ export function GitHubDashboardModal() {
                           key={workflow.workflowName}
                           workflow={workflow}
                           onClick={() =>
-                            void openExternal(workflow.latestRun.url)
+                            handleOpenWorkflowRunsForWorkflow(
+                              project.path,
+                              workflow.workflowName
+                            )
                           }
                         />
                       ))}

--- a/src/components/github-dashboard/GitHubDashboardModal.tsx
+++ b/src/components/github-dashboard/GitHubDashboardModal.tsx
@@ -7,23 +7,29 @@ import {
 } from 'react'
 import { useQueries } from '@tanstack/react-query'
 import {
+  Activity,
+  CheckCircle2,
   CircleDot,
+  Clock,
   GitPullRequest,
+  Loader2,
+  MinusCircle,
   Shield,
   ShieldAlert,
   Search,
-  Loader2,
   AlertCircle,
+  XCircle,
   Wand2,
 } from 'lucide-react'
 import { toast } from 'sonner'
-import { getModifierSymbol } from '@/lib/platform'
+import { getModifierSymbol, openExternal } from '@/lib/platform'
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Input } from '@/components/ui/input'
 import {
@@ -62,6 +68,8 @@ import type {
   PullRequestContext,
   SecurityAlertContext,
   AdvisoryContext,
+  WorkflowRun,
+  WorkflowRunsResult,
 } from '@/types/github'
 import type { Project } from '@/types/projects'
 
@@ -69,7 +77,9 @@ import type { Project } from '@/types/projects'
 // Types
 // =============================================================================
 
-type DashboardTab = 'issues' | 'prs' | 'security' | 'advisories'
+type DashboardTab = 'issues' | 'prs' | 'security' | 'advisories' | 'workflows'
+
+type WorkflowStatus = 'running' | 'success' | 'failure' | 'pending'
 
 interface PreviewState {
   projectPath: string
@@ -78,9 +88,30 @@ interface PreviewState {
   ghsaId?: string
 }
 
+interface WorkflowGroup {
+  workflowName: string
+  latestRun: WorkflowRun
+  latestStatus: WorkflowStatus
+  totalCount: number
+  failedCount: number
+}
+
 function getDashboardErrorMessage(error: unknown): string {
   if (!error) return 'Failed to load GitHub dashboard data'
   return error instanceof Error ? error.message : String(error)
+}
+
+function timeAgo(dateString: string): string {
+  const seconds = Math.floor(
+    (Date.now() - new Date(dateString).getTime()) / 1000
+  )
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
 }
 
 // =============================================================================
@@ -92,6 +123,7 @@ const TABS: { id: DashboardTab; label: string; icon: ElementType }[] = [
   { id: 'prs', label: 'Pull Requests', icon: GitPullRequest },
   { id: 'security', label: 'Security', icon: Shield },
   { id: 'advisories', label: 'Advisories', icon: ShieldAlert },
+  { id: 'workflows', label: 'Workflows', icon: Activity },
 ]
 
 function DashboardTabBar({
@@ -172,6 +204,157 @@ const SEVERITY_COLORS: Record<string, string> = {
   high: 'bg-orange-500/10 text-orange-600 border-orange-500/20',
   medium: 'bg-yellow-500/10 text-yellow-600 border-yellow-500/20',
   low: 'bg-blue-500/10 text-blue-600 border-blue-500/20',
+}
+
+function getWorkflowStatus(run: WorkflowRun): WorkflowStatus {
+  if (run.status === 'in_progress' || run.status === 'queued') {
+    return 'running'
+  }
+
+  if (run.conclusion === 'failure' || run.conclusion === 'startup_failure') {
+    return 'failure'
+  }
+
+  if (run.conclusion === 'success') {
+    return 'success'
+  }
+
+  return 'pending'
+}
+
+function getWorkflowStatusIcon(status: WorkflowStatus) {
+  switch (status) {
+    case 'running':
+      return <Clock className="h-4 w-4 shrink-0 text-yellow-500" />
+    case 'success':
+      return <CheckCircle2 className="h-4 w-4 shrink-0 text-green-500" />
+    case 'failure':
+      return <XCircle className="h-4 w-4 shrink-0 text-red-500" />
+    default:
+      return <MinusCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
+  }
+}
+
+function getWorkflowStatusLabel(status: WorkflowStatus) {
+  switch (status) {
+    case 'running':
+      return 'Running'
+    case 'success':
+      return 'Success'
+    case 'failure':
+      return 'Failed'
+    default:
+      return 'Queued'
+  }
+}
+
+function getWorkflowStatusClass(status: WorkflowStatus) {
+  switch (status) {
+    case 'running':
+      return 'bg-yellow-500/10 text-yellow-600 border-yellow-500/20'
+    case 'success':
+      return 'bg-green-500/10 text-green-600 border-green-500/20'
+    case 'failure':
+      return 'bg-red-500/10 text-red-600 border-red-500/20'
+    default:
+      return 'bg-muted text-muted-foreground border-border'
+  }
+}
+
+function groupWorkflowRuns(runs: WorkflowRun[]): WorkflowGroup[] {
+  const groupMap = new Map<string, WorkflowGroup>()
+
+  for (const run of runs) {
+    const existing = groupMap.get(run.workflowName)
+    if (existing) {
+      existing.totalCount++
+      continue
+    }
+
+    groupMap.set(run.workflowName, {
+      workflowName: run.workflowName,
+      latestRun: run,
+      latestStatus: getWorkflowStatus(run),
+      totalCount: 1,
+      failedCount:
+        getWorkflowStatus(run) === 'failure' && run.conclusion !== null ? 1 : 0,
+    })
+  }
+
+  return Array.from(groupMap.values()).sort((a, b) => {
+    const statusRank: Record<WorkflowStatus, number> = {
+      running: 0,
+      failure: 1,
+      success: 2,
+      pending: 3,
+    }
+
+    const statusDiff = statusRank[a.latestStatus] - statusRank[b.latestStatus]
+    if (statusDiff !== 0) return statusDiff
+
+    return a.workflowName.localeCompare(b.workflowName)
+  })
+}
+
+function summarizeWorkflowGroups(groups: WorkflowGroup[]) {
+  return groups.reduce(
+    (summary, workflow) => {
+      summary[workflow.latestStatus]++
+      return summary
+    },
+    {
+      running: 0,
+      success: 0,
+      failure: 0,
+      pending: 0,
+    } as Record<WorkflowStatus, number>
+  )
+}
+
+function WorkflowRow({
+  workflow,
+  onClick,
+}: {
+  workflow: WorkflowGroup
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="group w-full border-b border-border px-3 py-2 text-left transition-colors hover:bg-accent last:border-b-0"
+    >
+      <div className="flex items-start gap-3">
+        {getWorkflowStatusIcon(workflow.latestStatus)}
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="truncate text-sm font-medium">
+              {workflow.workflowName}
+            </span>
+            <span
+              className={cn(
+                'inline-flex rounded-full border px-1.5 py-0.5 text-[10px] font-medium',
+                getWorkflowStatusClass(workflow.latestStatus)
+              )}
+            >
+              {getWorkflowStatusLabel(workflow.latestStatus)}
+            </span>
+            {workflow.totalCount > 1 && (
+              <span className="text-[11px] text-muted-foreground">
+                {workflow.totalCount} runs
+              </span>
+            )}
+          </div>
+          <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+            <span className="truncate">{workflow.latestRun.displayTitle}</span>
+            <span>•</span>
+            <span className="truncate">{workflow.latestRun.headBranch}</span>
+            <span>•</span>
+            <span>{timeAgo(workflow.latestRun.createdAt)}</span>
+          </div>
+        </div>
+      </div>
+    </button>
+  )
 }
 
 function IssueRow({
@@ -498,21 +681,26 @@ function AdvisoryRow({
 function ProjectSection({
   project,
   count,
+  actions,
   children,
 }: {
   project: Project
   count: number
+  actions?: React.ReactNode
   children: React.ReactNode
 }) {
   return (
     <div>
-      <div className="sticky top-0 z-10 flex items-center gap-2 px-3 py-1.5 bg-muted/80 border-b border-border">
+      <div className="sticky top-0 z-10 flex flex-wrap items-center gap-2 px-3 py-1.5 bg-muted/80 border-b border-border">
         <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
           {project.name}
         </span>
         <span className="text-xs text-muted-foreground bg-background border border-border rounded-full px-1.5 py-0.5 leading-none">
           {count}
         </span>
+        {actions && (
+          <div className="ml-auto flex items-center gap-2">{actions}</div>
+        )}
       </div>
       {children}
     </div>
@@ -528,6 +716,9 @@ export function GitHubDashboardModal() {
   const setGitHubDashboardOpen = useUIStore(
     state => state.setGitHubDashboardOpen
   )
+  const setWorkflowRunsModalOpen = useUIStore(
+    state => state.setWorkflowRunsModalOpen
+  )
   const [activeTab, setActiveTab] = useState<DashboardTab>('issues')
   const [searchQuery, setSearchQuery] = useState('')
   const [projectFilter, setProjectFilter] = useState<string>('all')
@@ -538,6 +729,13 @@ export function GitHubDashboardModal() {
       prev.includes(token) ? prev : prev ? `${prev} ${token}` : token
     )
   }, [])
+  const handleOpenWorkflowRuns = useCallback(
+    (projectPath: string) => {
+      setGitHubDashboardOpen(false)
+      setWorkflowRunsModalOpen(true, projectPath)
+    },
+    [setGitHubDashboardOpen, setWorkflowRunsModalOpen]
+  )
   const [preview, setPreview] = useState<PreviewState | null>(null)
   // Track which item is being created (number for issues/prs/alerts, ghsaId for advisories)
   const [creatingId, setCreatingId] = useState<string | null>(null)
@@ -581,6 +779,9 @@ export function GitHubDashboardModal() {
       enabled: projects.length > 0,
       staleTime: 5 * 60 * 1000,
       gcTime: 10 * 60 * 1000,
+      refetchInterval:
+        githubDashboardOpen && activeTab === 'workflows' ? 30 * 1000 : false,
+      refetchIntervalInBackground: true,
       retry: 1,
     })),
   })
@@ -648,6 +849,29 @@ export function GitHubDashboardModal() {
         } catch (error) {
           if (isGhAuthError(error)) throw error
           return []
+        }
+      },
+      enabled: projects.length > 0,
+      staleTime: 5 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
+      retry: 1,
+    })),
+  })
+
+  // Fetch workflow runs for all projects in parallel
+  const workflowResults = useQueries({
+    queries: projects.map(p => ({
+      queryKey: githubQueryKeys.workflowRuns(p.path, undefined),
+      queryFn: async (): Promise<WorkflowRunsResult> => {
+        if (!isTauri()) return { runs: [], failedCount: 0 }
+        try {
+          return await invoke<WorkflowRunsResult>('list_workflow_runs', {
+            projectPath: p.path,
+            branch: null,
+          })
+        } catch (error) {
+          if (isGhAuthError(error)) throw error
+          return { runs: [], failedCount: 0 }
         }
       },
       enabled: projects.length > 0,
@@ -878,7 +1102,9 @@ export function GitHubDashboardModal() {
         ? prResults
         : activeTab === 'security'
           ? securityResults
-          : advisoryResults
+          : activeTab === 'advisories'
+            ? advisoryResults
+            : workflowResults
 
   const commandAuthError = activeResults.find(r => isGhAuthError(r.error))
   const {
@@ -977,6 +1203,25 @@ export function GitHubDashboardModal() {
         return { project, items: filtered }
       }
 
+      if (activeTab === 'workflows') {
+        const workflowData = (workflowResults[projectIdx]?.data ?? {
+          runs: [],
+          failedCount: 0,
+        }) as WorkflowRunsResult
+        const workflows = groupWorkflowRuns(workflowData.runs)
+        const filtered = workflows.filter(workflow => {
+          if (!q) return true
+          return (
+            workflow.workflowName.toLowerCase().includes(q) ||
+            workflow.latestRun.displayTitle.toLowerCase().includes(q) ||
+            workflow.latestRun.headBranch.toLowerCase().includes(q) ||
+            workflow.latestRun.status.toLowerCase().includes(q) ||
+            (workflow.latestRun.conclusion?.toLowerCase().includes(q) ?? false)
+          )
+        })
+        return { project, items: filtered }
+      }
+
       const advisories = (advisoryResults[projectIdx]?.data ??
         []) as RepositoryAdvisory[]
       const filtered = q
@@ -996,6 +1241,7 @@ export function GitHubDashboardModal() {
     prResults,
     securityResults,
     advisoryResults,
+    workflowResults,
     q,
     labelFilters,
   ])
@@ -1004,6 +1250,19 @@ export function GitHubDashboardModal() {
     (sum, { items }) => sum + items.length,
     0
   )
+
+  const emptyStateLabel =
+    activeTab === 'issues'
+      ? 'open issues'
+      : activeTab === 'prs'
+        ? 'open pull requests'
+        : activeTab === 'security'
+          ? 'security alerts'
+          : activeTab === 'advisories'
+            ? 'advisories'
+            : 'workflow groups'
+  const searchPlaceholder =
+    activeTab === 'workflows' ? 'Search workflows...' : 'Search...'
 
   return (
     <Dialog open={githubDashboardOpen} onOpenChange={setGitHubDashboardOpen}>
@@ -1032,7 +1291,7 @@ export function GitHubDashboardModal() {
               <Input
                 value={searchQuery}
                 onChange={e => setSearchQuery(e.target.value)}
-                placeholder="Search..."
+                placeholder={searchPlaceholder}
                 className="pl-8 !h-7 py-0 text-base md:text-xs"
               />
             </div>
@@ -1066,7 +1325,7 @@ export function GitHubDashboardModal() {
               <p className="text-sm">
                 {q || labelFilters.length > 0
                   ? 'No results match your search'
-                  : `No ${activeTab === 'issues' ? 'open issues' : activeTab === 'prs' ? 'open pull requests' : activeTab === 'security' ? 'security alerts' : 'advisories'} found`}
+                  : `No ${emptyStateLabel} found`}
               </p>
             </div>
           ) : (
@@ -1078,6 +1337,38 @@ export function GitHubDashboardModal() {
                     key={project.id}
                     project={project}
                     count={items.length}
+                    actions={
+                      activeTab === 'workflows'
+                        ? (() => {
+                            const workflowItems = items as WorkflowGroup[]
+                            const summary =
+                              summarizeWorkflowGroups(workflowItems)
+                            return (
+                              <>
+                                <span className="rounded-full border border-yellow-500/20 bg-yellow-500/10 px-1.5 py-0.5 text-[10px] font-medium text-yellow-600">
+                                  {summary.running} running
+                                </span>
+                                <span className="rounded-full border border-red-500/20 bg-red-500/10 px-1.5 py-0.5 text-[10px] font-medium text-red-600">
+                                  {summary.failure} failed
+                                </span>
+                                <span className="rounded-full border border-green-500/20 bg-green-500/10 px-1.5 py-0.5 text-[10px] font-medium text-green-600">
+                                  {summary.success} success
+                                </span>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  className="h-6 px-2 text-xs"
+                                  onClick={() =>
+                                    handleOpenWorkflowRuns(project.path)
+                                  }
+                                >
+                                  Open runs
+                                </Button>
+                              </>
+                            )
+                          })()
+                        : undefined
+                    }
                   >
                     {activeTab === 'issues' &&
                       (items as GitHubIssue[]).map(issue => (
@@ -1173,6 +1464,16 @@ export function GitHubDashboardModal() {
                               project.path,
                               bg
                             )
+                          }
+                        />
+                      ))}
+                    {activeTab === 'workflows' &&
+                      (items as WorkflowGroup[]).map(workflow => (
+                        <WorkflowRow
+                          key={workflow.workflowName}
+                          workflow={workflow}
+                          onClick={() =>
+                            void openExternal(workflow.latestRun.url)
                           }
                         />
                       ))}

--- a/src/components/shared/WorkflowRunDetailsModal.tsx
+++ b/src/components/shared/WorkflowRunDetailsModal.tsx
@@ -1,0 +1,724 @@
+import { useMemo, useState } from 'react'
+import {
+  ArrowLeft,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  ExternalLink,
+  Loader2,
+  MinusCircle,
+  XCircle,
+} from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { ModalCloseButton } from '@/components/ui/modal-close-button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { useWorkflowJobLogs, useWorkflowRun } from '@/services/github'
+import { openExternal } from '@/lib/platform'
+import type {
+  WorkflowJobDefinition,
+  WorkflowJobLogLine,
+  WorkflowRun,
+  WorkflowRunJob,
+  WorkflowRunStep,
+} from '@/types/github'
+
+type WorkflowStateKind =
+  | 'running'
+  | 'success'
+  | 'failure'
+  | 'skipped'
+  | 'pending'
+
+const NODE_WIDTH = 280
+const NODE_HEIGHT = 72
+const COLUMN_GAP = 112
+const ROW_GAP = 28
+const GRAPH_PADDING = 32
+
+function getStateKind(
+  status: string,
+  conclusion?: string | null
+): WorkflowStateKind {
+  if (status === 'in_progress' || status === 'queued') return 'running'
+  if (conclusion === 'success') return 'success'
+  if (conclusion === 'failure' || conclusion === 'startup_failure')
+    return 'failure'
+  if (conclusion === 'cancelled' || conclusion === 'skipped') return 'skipped'
+  return 'pending'
+}
+
+function StateIcon({
+  status,
+  conclusion,
+  className = 'h-4 w-4',
+}: {
+  status: string
+  conclusion?: string | null
+  className?: string
+}) {
+  const kind = getStateKind(status, conclusion)
+  if (kind === 'success') {
+    return <CheckCircle2 className={`${className} shrink-0 text-green-500`} />
+  }
+  if (kind === 'failure') {
+    return <XCircle className={`${className} shrink-0 text-red-500`} />
+  }
+  if (kind === 'running') {
+    return (
+      <Loader2
+        className={`${className} shrink-0 animate-spin text-yellow-500`}
+      />
+    )
+  }
+  if (kind === 'skipped') {
+    return (
+      <MinusCircle className={`${className} shrink-0 text-muted-foreground`} />
+    )
+  }
+  return <Clock className={`${className} shrink-0 text-muted-foreground`} />
+}
+
+function stateLabel(status: string, conclusion?: string | null) {
+  const kind = getStateKind(status, conclusion)
+  if (kind === 'success') return 'Success'
+  if (kind === 'failure') return 'Failed'
+  if (kind === 'running') return 'Running'
+  if (kind === 'skipped') return 'Skipped'
+  return 'Queued'
+}
+
+function formatDuration(
+  startedAt?: string | null,
+  completedAt?: string | null
+) {
+  if (!startedAt) return null
+  const start = new Date(startedAt).getTime()
+  const end = completedAt ? new Date(completedAt).getTime() : Date.now()
+  const seconds = Math.max(0, Math.round((end - start) / 1000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = seconds % 60
+  return `${minutes}m ${remainingSeconds}s`
+}
+
+function timeAgo(dateString: string) {
+  const seconds = Math.floor(
+    (Date.now() - new Date(dateString).getTime()) / 1000
+  )
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+
+function logsForStep(
+  logs: WorkflowJobLogLine[],
+  step: WorkflowRunStep
+): WorkflowJobLogLine[] {
+  const exactMatches = logs.filter(log => log.stepName === step.name)
+  if (exactMatches.length > 0) return exactMatches
+  if (!step.startedAt) return []
+
+  const start = new Date(step.startedAt).getTime()
+  const end = step.completedAt
+    ? new Date(step.completedAt).getTime() + 1000
+    : Number.POSITIVE_INFINITY
+  return logs.filter(log => {
+    if (!log.timestamp) return false
+    const timestamp = new Date(log.timestamp).getTime()
+    return timestamp >= start && timestamp <= end
+  })
+}
+
+function logTimestamp(timestamp: string | null) {
+  if (!timestamp) return ''
+  return timestamp.match(/T(\d{2}:\d{2}:\d{2})/)?.[1] ?? timestamp
+}
+
+function parseLogMessage(message: string) {
+  const annotation = message.match(
+    /^##\[(error|warning|notice|debug)(?: [^\]]*)?\](.*)$/i
+  )
+  if (annotation) {
+    return {
+      level: annotation[1]?.toLowerCase() ?? 'default',
+      message: annotation[2] ?? '',
+    }
+  }
+
+  return {
+    level: 'default',
+    message: message.replace(/^##\[group\]/, ''),
+  }
+}
+
+function logLineClass(level: string) {
+  if (level === 'error') return 'bg-red-500/10 hover:bg-red-500/15'
+  if (level === 'warning') return 'bg-yellow-500/10 hover:bg-yellow-500/15'
+  if (level === 'notice') return 'bg-blue-500/10 hover:bg-blue-500/15'
+  return 'hover:bg-white/5'
+}
+
+function logMessageClass(level: string) {
+  if (level === 'error') return 'font-semibold text-red-400'
+  if (level === 'warning') return 'font-semibold text-yellow-300'
+  if (level === 'notice') return 'text-blue-300'
+  if (level === 'debug') return 'text-[#8b949e]'
+  return ''
+}
+
+function isVisibleLogLine(line: WorkflowJobLogLine) {
+  return line.message.trim() !== '##[endgroup]'
+}
+
+function matchesDefinition(jobName: string, definition: WorkflowJobDefinition) {
+  return [definition.name, definition.id].some(
+    candidate =>
+      jobName === candidate ||
+      jobName.startsWith(`${candidate} (`) ||
+      jobName.startsWith(`${candidate} /`)
+  )
+}
+
+interface GraphNode {
+  job: WorkflowRunJob
+  dependencies: number[]
+  level: number
+  x: number
+  y: number
+}
+
+function buildGraph(
+  jobs: WorkflowRunJob[],
+  definitions: WorkflowJobDefinition[]
+): GraphNode[] {
+  const definitionByJob = new Map<number, WorkflowJobDefinition>()
+  const jobsByDefinition = new Map<string, WorkflowRunJob[]>()
+
+  for (const job of jobs) {
+    const definition = definitions.find(item =>
+      matchesDefinition(job.name, item)
+    )
+    if (!definition) continue
+    definitionByJob.set(job.databaseId, definition)
+    jobsByDefinition.set(definition.id, [
+      ...(jobsByDefinition.get(definition.id) ?? []),
+      job,
+    ])
+  }
+
+  const dependenciesByJob = new Map<number, number[]>()
+  for (const job of jobs) {
+    const definition = definitionByJob.get(job.databaseId)
+    const dependencies =
+      definition?.needs.flatMap(
+        dependency =>
+          jobsByDefinition.get(dependency)?.map(item => item.databaseId) ?? []
+      ) ?? []
+    dependenciesByJob.set(job.databaseId, dependencies)
+  }
+
+  const levels = new Map<number, number>()
+  const resolveLevel = (
+    jobId: number,
+    visiting = new Set<number>()
+  ): number => {
+    const existing = levels.get(jobId)
+    if (existing != null) return existing
+    if (visiting.has(jobId)) return 0
+
+    const nextVisiting = new Set(visiting).add(jobId)
+    const dependencies = dependenciesByJob.get(jobId) ?? []
+    const level =
+      dependencies.length === 0
+        ? 0
+        : Math.max(
+            ...dependencies.map(dependency =>
+              resolveLevel(dependency, nextVisiting)
+            )
+          ) + 1
+    levels.set(jobId, level)
+    return level
+  }
+
+  jobs.forEach(job => resolveLevel(job.databaseId))
+  const jobsByLevel = new Map<number, WorkflowRunJob[]>()
+  for (const job of jobs) {
+    const level = levels.get(job.databaseId) ?? 0
+    jobsByLevel.set(level, [...(jobsByLevel.get(level) ?? []), job])
+  }
+
+  return jobs.map(job => {
+    const level = levels.get(job.databaseId) ?? 0
+    const row = jobsByLevel
+      .get(level)
+      ?.findIndex(item => item.databaseId === job.databaseId)
+    return {
+      job,
+      dependencies: dependenciesByJob.get(job.databaseId) ?? [],
+      level,
+      x: GRAPH_PADDING + level * (NODE_WIDTH + COLUMN_GAP),
+      y: GRAPH_PADDING + Math.max(0, row ?? 0) * (NODE_HEIGHT + ROW_GAP),
+    }
+  })
+}
+
+function WorkflowGraph({
+  jobs,
+  definitions,
+  selectedJobId,
+  onSelectJob,
+}: {
+  jobs: WorkflowRunJob[]
+  definitions: WorkflowJobDefinition[]
+  selectedJobId: number | null
+  onSelectJob: (jobId: number) => void
+}) {
+  const nodes = useMemo(
+    () => buildGraph(jobs, definitions),
+    [jobs, definitions]
+  )
+  const nodeById = useMemo(
+    () => new Map(nodes.map(node => [node.job.databaseId, node])),
+    [nodes]
+  )
+  const maxLevel = Math.max(0, ...nodes.map(node => node.level))
+  const maxRows = Math.max(
+    1,
+    ...Array.from(
+      { length: maxLevel + 1 },
+      (_, level) => nodes.filter(node => node.level === level).length
+    )
+  )
+  const width =
+    GRAPH_PADDING * 2 + (maxLevel + 1) * NODE_WIDTH + maxLevel * COLUMN_GAP
+  const height =
+    GRAPH_PADDING * 2 + maxRows * NODE_HEIGHT + (maxRows - 1) * ROW_GAP
+
+  return (
+    <div className="overflow-auto rounded-lg border border-border bg-background">
+      <div
+        className="relative min-h-[250px] min-w-full"
+        style={{ width, height: Math.max(250, height) }}
+      >
+        <svg
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0"
+          width={width}
+          height={Math.max(250, height)}
+        >
+          {nodes.flatMap(node =>
+            node.dependencies.map(dependencyId => {
+              const dependency = nodeById.get(dependencyId)
+              if (!dependency) return null
+              const startX = dependency.x + NODE_WIDTH
+              const startY = dependency.y + NODE_HEIGHT / 2
+              const endX = node.x
+              const endY = node.y + NODE_HEIGHT / 2
+              const curve = Math.max(32, (endX - startX) / 2)
+              return (
+                <path
+                  key={`${dependencyId}-${node.job.databaseId}`}
+                  d={`M ${startX} ${startY} C ${startX + curve} ${startY}, ${endX - curve} ${endY}, ${endX} ${endY}`}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  className="text-border"
+                />
+              )
+            })
+          )}
+        </svg>
+
+        {nodes.map(node => {
+          const selected = node.job.databaseId === selectedJobId
+          return (
+            <button
+              key={node.job.databaseId}
+              type="button"
+              aria-label={`View ${node.job.name} job details`}
+              onClick={() => onSelectJob(node.job.databaseId)}
+              className={`absolute flex items-center gap-3 rounded-lg border bg-muted/50 px-4 text-left shadow-sm transition-colors hover:border-muted-foreground/50 hover:bg-muted ${
+                selected
+                  ? 'border-blue-500 ring-2 ring-blue-500/20'
+                  : 'border-border'
+              }`}
+              style={{
+                left: node.x,
+                top: node.y,
+                width: NODE_WIDTH,
+                height: NODE_HEIGHT,
+              }}
+            >
+              {node.dependencies.length > 0 && (
+                <span className="absolute -left-2 h-4 w-4 rounded-full border-2 border-background bg-muted-foreground" />
+              )}
+              <StateIcon
+                status={node.job.status}
+                conclusion={node.job.conclusion}
+                className="h-5 w-5"
+              />
+              <span className="min-w-0 flex-1 truncate text-sm font-semibold">
+                {node.job.name}
+              </span>
+              <span className="shrink-0 text-xs text-muted-foreground">
+                {formatDuration(node.job.startedAt, node.job.completedAt)}
+              </span>
+              {nodes.some(item =>
+                item.dependencies.includes(node.job.databaseId)
+              ) && (
+                <span className="absolute -right-2 h-4 w-4 rounded-full border-2 border-background bg-muted-foreground" />
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function StepRow({
+  step,
+  expanded,
+  logs,
+  isLoading,
+  error,
+  onToggle,
+}: {
+  step: WorkflowRunStep
+  expanded: boolean
+  logs: WorkflowJobLogLine[]
+  isLoading: boolean
+  error: unknown
+  onToggle: () => void
+}) {
+  const visibleLogs = logs.filter(isVisibleLogLine)
+
+  return (
+    <div className="border-b border-border/70 last:border-b-0">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={onToggle}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/30"
+      >
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+        <StateIcon status={step.status} conclusion={step.conclusion} />
+        <span className="min-w-0 flex-1 truncate text-sm">{step.name}</span>
+        <span className="text-xs text-muted-foreground">
+          {formatDuration(step.startedAt, step.completedAt)}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-border/70 bg-[#0d1117] text-[#e6edf3]">
+          {isLoading ? (
+            <div className="flex items-center gap-2 px-4 py-6 text-xs text-[#8b949e]">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading logs…
+            </div>
+          ) : error ? (
+            <p className="px-4 py-6 text-xs text-red-400">
+              Failed to load logs: {String(error)}
+            </p>
+          ) : visibleLogs.length === 0 ? (
+            <p className="px-4 py-6 text-xs text-[#8b949e]">
+              No logs were returned for this step.
+            </p>
+          ) : (
+            <div className="max-h-96 overflow-auto py-2 font-mono text-[11px] leading-5">
+              {visibleLogs.map((line, index) => {
+                const parsed = parseLogMessage(line.message)
+                return (
+                  <div
+                    key={`${line.timestamp ?? 'line'}-${index}`}
+                    className={`grid w-full grid-cols-[4rem_minmax(0,1fr)] gap-2 px-3 ${logLineClass(parsed.level)}`}
+                  >
+                    <span className="select-none text-right text-[#6e7681] tabular-nums">
+                      {logTimestamp(line.timestamp)}
+                    </span>
+                    <span
+                      className={`whitespace-pre-wrap break-words ${logMessageClass(parsed.level)}`}
+                    >
+                      {parsed.message}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function WorkflowRunDetailsModal({
+  open,
+  projectPath,
+  run,
+  onOpenChange,
+}: {
+  open: boolean
+  projectPath: string | null
+  run: WorkflowRun | null
+  onOpenChange: (open: boolean) => void
+}) {
+  const [selectedJobId, setSelectedJobId] = useState<number | null>(null)
+  const [selectedStepNumber, setSelectedStepNumber] = useState<number | null>(
+    null
+  )
+  const { data, isLoading } = useWorkflowRun(
+    projectPath,
+    run?.databaseId ?? null,
+    {
+      enabled: open && !!projectPath && !!run,
+    }
+  )
+  const selectedJob =
+    data?.jobs.find(job => job.databaseId === selectedJobId) ?? null
+  const {
+    data: jobLogs = [],
+    isLoading: isLoadingJobLogs,
+    error: jobLogsError,
+  } = useWorkflowJobLogs(
+    projectPath,
+    run?.databaseId ?? null,
+    selectedJob?.databaseId ?? null,
+    {
+      enabled: open && selectedStepNumber != null,
+    }
+  )
+
+  const handleSelectJob = (jobId: number | null) => {
+    setSelectedJobId(jobId)
+    setSelectedStepNumber(null)
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) handleSelectJob(null)
+    onOpenChange(nextOpen)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="flex h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-[calc(100vw-2rem)]"
+      >
+        <DialogHeader className="border-b border-border px-5 py-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              aria-label="Back to workflow runs"
+              onClick={() => handleOpenChange(false)}
+            >
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+            {run && (
+              <StateIcon
+                status={run.status}
+                conclusion={run.conclusion}
+                className="h-6 w-6"
+              />
+            )}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-xs text-muted-foreground">
+                {run?.workflowName ?? 'Workflow run'}
+              </p>
+              <DialogTitle className="truncate text-base">
+                {run?.displayTitle ?? 'Workflow run details'}
+              </DialogTitle>
+            </div>
+            {run && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => openExternal(run.url)}
+              >
+                <ExternalLink className="mr-2 h-4 w-4" />
+                Open on GitHub
+              </Button>
+            )}
+            <ModalCloseButton onClick={() => handleOpenChange(false)} />
+          </div>
+        </DialogHeader>
+
+        {!run || isLoading ? (
+          <div className="flex flex-1 items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[240px_minmax(0,1fr)]">
+            <aside className="hidden min-h-0 border-r border-border bg-muted/20 lg:flex lg:flex-col">
+              <div className="p-3">
+                <button
+                  type="button"
+                  onClick={() => handleSelectJob(null)}
+                  className={`w-full rounded-md px-3 py-2 text-left text-sm font-medium transition-colors ${
+                    selectedJobId == null ? 'bg-accent' : 'hover:bg-accent/60'
+                  }`}
+                >
+                  Summary
+                </button>
+              </div>
+              <div className="border-t border-border px-3 py-2 text-xs font-semibold text-muted-foreground">
+                All jobs
+              </div>
+              <ScrollArea className="min-h-0 flex-1">
+                <div className="space-y-1 px-3 pb-3">
+                  {data?.jobs.map(job => (
+                    <button
+                      key={job.databaseId}
+                      type="button"
+                      onClick={() => handleSelectJob(job.databaseId)}
+                      className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors ${
+                        selectedJobId === job.databaseId
+                          ? 'bg-accent'
+                          : 'hover:bg-accent/60'
+                      }`}
+                    >
+                      <StateIcon
+                        status={job.status}
+                        conclusion={job.conclusion}
+                      />
+                      <span className="min-w-0 truncate">{job.name}</span>
+                    </button>
+                  ))}
+                </div>
+              </ScrollArea>
+            </aside>
+
+            <ScrollArea className="min-h-0">
+              <main className="space-y-5 p-5">
+                <section className="grid gap-4 rounded-lg border border-border bg-muted/20 p-4 sm:grid-cols-4">
+                  <div className="sm:col-span-2">
+                    <p className="text-xs text-muted-foreground">
+                      Triggered via
+                    </p>
+                    <p className="mt-1 text-sm font-medium">
+                      {run.event} · {timeAgo(run.createdAt)}
+                    </p>
+                    <p className="mt-1 truncate text-xs text-muted-foreground">
+                      {run.headBranch}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground">Status</p>
+                    <p className="mt-1 text-sm font-semibold">
+                      {stateLabel(run.status, run.conclusion)}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground">Jobs</p>
+                    <p className="mt-1 text-sm font-semibold">
+                      {data?.jobs.length ?? 0}
+                    </p>
+                  </div>
+                </section>
+
+                <section className="rounded-lg border border-border bg-muted/10 p-4">
+                  <div className="mb-4">
+                    <h2 className="text-base font-semibold">
+                      {run.workflowName}
+                    </h2>
+                    <p className="text-xs text-muted-foreground">
+                      on: {run.event}
+                    </p>
+                  </div>
+                  {data?.jobs.length ? (
+                    <WorkflowGraph
+                      jobs={data.jobs}
+                      definitions={data.jobDefinitions ?? []}
+                      selectedJobId={selectedJobId}
+                      onSelectJob={handleSelectJob}
+                    />
+                  ) : (
+                    <div className="rounded-lg border border-dashed border-border px-4 py-12 text-center text-sm text-muted-foreground">
+                      GitHub has not reported any jobs for this run yet.
+                    </div>
+                  )}
+                </section>
+
+                {selectedJob && (
+                  <section className="overflow-hidden rounded-lg border border-border">
+                    <div className="flex items-center gap-3 border-b border-border bg-muted/30 px-4 py-3">
+                      <StateIcon
+                        status={selectedJob.status}
+                        conclusion={selectedJob.conclusion}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <h2 className="truncate text-sm font-semibold">
+                          {selectedJob.name}
+                        </h2>
+                        <p className="text-xs text-muted-foreground">
+                          {stateLabel(
+                            selectedJob.status,
+                            selectedJob.conclusion
+                          )}
+                          {formatDuration(
+                            selectedJob.startedAt,
+                            selectedJob.completedAt
+                          )
+                            ? ` · ${formatDuration(
+                                selectedJob.startedAt,
+                                selectedJob.completedAt
+                              )}`
+                            : ''}
+                        </p>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => openExternal(selectedJob.url)}
+                      >
+                        <ExternalLink className="mr-2 h-4 w-4" />
+                        Open job
+                      </Button>
+                    </div>
+                    {selectedJob.steps.length > 0 ? (
+                      selectedJob.steps.map(step => (
+                        <StepRow
+                          key={`${selectedJob.databaseId}-${step.number}`}
+                          step={step}
+                          expanded={selectedStepNumber === step.number}
+                          logs={logsForStep(jobLogs, step)}
+                          isLoading={isLoadingJobLogs}
+                          error={jobLogsError}
+                          onToggle={() =>
+                            setSelectedStepNumber(current =>
+                              current === step.number ? null : step.number
+                            )
+                          }
+                        />
+                      ))
+                    ) : (
+                      <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+                        No steps reported for this job.
+                      </p>
+                    )}
+                  </section>
+                )}
+              </main>
+            </ScrollArea>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/shared/WorkflowRunsModal.test.tsx
+++ b/src/components/shared/WorkflowRunsModal.test.tsx
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@/test/test-utils'
+import { useUIStore } from '@/store/ui-store'
+import { WorkflowRunsModal } from './WorkflowRunsModal'
+
+const mockUseWorkflowRuns = vi.hoisted(() => vi.fn())
+const mockUseWorkflowRun = vi.hoisted(() => vi.fn())
+const mockUseWorkflowJobLogs = vi.hoisted(() => vi.fn())
+const mockUsePreferences = vi.hoisted(() => vi.fn())
+const mockUseCreateSession = vi.hoisted(() => vi.fn())
+const mockUseSendMessage = vi.hoisted(() => vi.fn())
+const mockUseSetSessionBackend = vi.hoisted(() => vi.fn())
+const mockUseSetSessionModel = vi.hoisted(() => vi.fn())
+const mockUseSetSessionProvider = vi.hoisted(() => vi.fn())
+
+vi.mock('@/services/github', async () => {
+  const actual = await vi.importActual('@/services/github')
+  return {
+    ...actual,
+    useWorkflowRuns: mockUseWorkflowRuns,
+    useWorkflowRun: mockUseWorkflowRun,
+    useWorkflowJobLogs: mockUseWorkflowJobLogs,
+  }
+})
+
+vi.mock('@/services/preferences', () => ({
+  usePreferences: mockUsePreferences,
+}))
+
+vi.mock('@/services/chat', () => ({
+  useCreateSession: mockUseCreateSession,
+  useSendMessage: mockUseSendMessage,
+  useSetSessionBackend: mockUseSetSessionBackend,
+  useSetSessionModel: mockUseSetSessionModel,
+  useSetSessionProvider: mockUseSetSessionProvider,
+  chatQueryKeys: {
+    sessions: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/transport', () => ({
+  invoke: vi.fn(),
+}))
+
+vi.mock('@/lib/platform', async () => {
+  const actual = await vi.importActual('@/lib/platform')
+  return {
+    ...actual,
+    openExternal: vi.fn(),
+  }
+})
+
+function makeMutation() {
+  return { mutate: vi.fn(), mutateAsync: vi.fn() }
+}
+
+function makeRun(id: number, workflowName: string, displayTitle: string) {
+  return {
+    databaseId: id,
+    name: workflowName.toLowerCase(),
+    displayTitle,
+    status: 'completed',
+    conclusion: 'success',
+    event: 'push',
+    headBranch: 'main',
+    createdAt: '2026-07-03T09:00:00Z',
+    url: `https://github.com/acme/project/actions/runs/${id}`,
+    workflowName,
+  }
+}
+
+function renderModal() {
+  useUIStore.setState({
+    workflowRunsModalOpen: true,
+    workflowRunsModalProjectPath: '/tmp/project-1',
+    workflowRunsModalBranch: null,
+    workflowRunsModalWorkflowName: null,
+  })
+  render(<WorkflowRunsModal />)
+}
+
+describe('WorkflowRunsModal', () => {
+  beforeEach(() => {
+    HTMLElement.prototype.scrollIntoView = vi.fn()
+    mockUseWorkflowRuns.mockReset()
+    mockUseWorkflowRun.mockReset()
+    mockUseWorkflowJobLogs.mockReset()
+    mockUsePreferences.mockReset()
+    mockUseCreateSession.mockReset()
+    mockUseSendMessage.mockReset()
+    mockUseSetSessionBackend.mockReset()
+    mockUseSetSessionModel.mockReset()
+    mockUseSetSessionProvider.mockReset()
+
+    mockUsePreferences.mockReturnValue({
+      data: {
+        magic_prompts: {},
+        magic_prompt_models: {},
+        magic_prompt_modes: {},
+        magic_prompt_providers: {},
+        custom_cli_profiles: [],
+        parallel_execution_prompt_enabled: false,
+        chrome_enabled: false,
+      },
+      isLoading: false,
+      isFetching: false,
+    })
+
+    mockUseCreateSession.mockReturnValue(makeMutation())
+    mockUseSendMessage.mockReturnValue(makeMutation())
+    mockUseSetSessionBackend.mockReturnValue(makeMutation())
+    mockUseSetSessionModel.mockReturnValue(makeMutation())
+    mockUseSetSessionProvider.mockReturnValue(makeMutation())
+    mockUseWorkflowJobLogs.mockReturnValue({
+      data: [
+        {
+          stepName: 'Checkout',
+          timestamp: '2026-07-03T09:01:02Z',
+          message: 'Fetching repository',
+        },
+        {
+          stepName: 'Checkout',
+          timestamp: '2026-07-03T09:01:03Z',
+          message: '##[group]Runner Image',
+        },
+        {
+          stepName: 'Checkout',
+          timestamp: '2026-07-03T09:01:04Z',
+          message: '##[endgroup]',
+        },
+        {
+          stepName: 'Checkout',
+          timestamp: '2026-07-03T09:01:05Z',
+          message: '##[error]Process completed with exit code 1.',
+        },
+      ],
+      isLoading: false,
+      error: null,
+    })
+
+    useUIStore.setState({
+      workflowRunsModalOpen: false,
+      workflowRunsModalProjectPath: null,
+      workflowRunsModalBranch: null,
+      workflowRunsModalWorkflowName: null,
+    })
+  })
+
+  it('opens a dedicated run modal with job nodes and selectable steps', async () => {
+    const runs = [
+      makeRun(101, 'CI', 'CI workflow'),
+      makeRun(102, 'Deploy', 'Deploy workflow'),
+    ]
+
+    mockUseWorkflowRuns.mockReturnValue({
+      data: { runs, failedCount: 0 },
+      isLoading: false,
+      isFetching: false,
+    })
+    mockUseWorkflowRun.mockImplementation((projectPath, runId) => {
+      if (!projectPath || !runId) {
+        return { data: undefined, isLoading: false, isFetching: false }
+      }
+
+      if (runId === 101) {
+        return {
+          data: {
+            jobDefinitions: [{ id: 'build', name: 'build', needs: [] }],
+            jobs: [
+              {
+                databaseId: 201,
+                name: 'build',
+                status: 'completed',
+                conclusion: 'success',
+                startedAt: '2026-07-03T09:01:00Z',
+                completedAt: '2026-07-03T09:03:00Z',
+                url: 'https://github.com/acme/project/actions/jobs/201',
+                steps: [
+                  {
+                    name: 'Checkout',
+                    number: 1,
+                    status: 'completed',
+                    conclusion: 'success',
+                  },
+                  {
+                    name: 'Run tests',
+                    number: 2,
+                    status: 'completed',
+                    conclusion: 'success',
+                  },
+                ],
+              },
+            ],
+          },
+          isLoading: false,
+          isFetching: false,
+        }
+      }
+
+      return {
+        data: {
+          jobDefinitions: [{ id: 'deploy', name: 'deploy', needs: [] }],
+          jobs: [
+            {
+              databaseId: 202,
+              name: 'deploy',
+              status: 'completed',
+              conclusion: 'success',
+              startedAt: '2026-07-03T09:05:00Z',
+              completedAt: '2026-07-03T09:07:00Z',
+              url: 'https://github.com/acme/project/actions/jobs/202',
+              steps: [
+                {
+                  name: 'Prepare release',
+                  number: 1,
+                  status: 'completed',
+                  conclusion: 'success',
+                },
+                {
+                  name: 'Ship release',
+                  number: 2,
+                  status: 'completed',
+                  conclusion: 'success',
+                },
+              ],
+            },
+          ],
+        },
+        isLoading: false,
+        isFetching: false,
+      }
+    })
+
+    const user = userEvent.setup()
+    renderModal()
+
+    expect(screen.queryByText('Checkout')).not.toBeInTheDocument()
+    await user.click(screen.getByText('CI workflow'))
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'View build job details',
+      })
+    )
+
+    expect(await screen.findByText('Checkout')).toBeInTheDocument()
+    expect(screen.getByText('Run tests')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Checkout' }))
+    expect(await screen.findByText('Fetching repository')).toBeInTheDocument()
+    expect(screen.getByText('Runner Image')).toBeInTheDocument()
+    expect(screen.queryByText('##[endgroup]')).not.toBeInTheDocument()
+    expect(screen.getByText('Process completed with exit code 1.')).toHaveClass(
+      'text-red-400'
+    )
+    expect(screen.queryByText(/##\[error\]/)).not.toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Back to workflow runs'))
+    await user.click(screen.getByText('Deploy workflow'))
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'View deploy job details',
+      })
+    )
+
+    expect(await screen.findByText('Prepare release')).toBeInTheDocument()
+    expect(screen.getByText('Ship release')).toBeInTheDocument()
+    expect(screen.queryByText('Checkout')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/shared/WorkflowRunsModal.tsx
+++ b/src/components/shared/WorkflowRunsModal.tsx
@@ -46,8 +46,8 @@ import {
 } from '@/services/chat'
 import type { WorktreeSessions } from '@/types/chat'
 import { usePreferences } from '@/services/preferences'
-import { openExternal } from '@/lib/platform'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { WorkflowRunDetailsModal } from './WorkflowRunDetailsModal'
 import { resolveBackend } from '@/lib/model-utils'
 import {
   DEFAULT_INVESTIGATE_WORKFLOW_RUN_PROMPT,
@@ -75,6 +75,40 @@ function isFailedRun(run: WorkflowRun): boolean {
   return run.conclusion === 'failure' || run.conclusion === 'startup_failure'
 }
 
+type WorkflowStateKind =
+  | 'running'
+  | 'success'
+  | 'failure'
+  | 'skipped'
+  | 'pending'
+
+function getWorkflowStateKind(
+  status: string,
+  conclusion?: string | null
+): WorkflowStateKind {
+  if (status === 'in_progress' || status === 'queued') return 'running'
+  if (conclusion === 'success') return 'success'
+  if (conclusion === 'failure' || conclusion === 'startup_failure')
+    return 'failure'
+  if (conclusion === 'cancelled' || conclusion === 'skipped') return 'skipped'
+  return 'pending'
+}
+
+function getWorkflowStateIcon(kind: WorkflowStateKind) {
+  switch (kind) {
+    case 'running':
+      return <Clock className="h-4 w-4 shrink-0 text-yellow-500" />
+    case 'success':
+      return <CheckCircle2 className="h-4 w-4 shrink-0 text-green-500" />
+    case 'failure':
+      return <XCircle className="h-4 w-4 shrink-0 text-red-500" />
+    case 'skipped':
+      return <MinusCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
+    default:
+      return <MinusCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
+  }
+}
+
 /** Extract the numeric run ID from a GitHub Actions URL */
 function extractRunId(url: string): string {
   const match = url.match(/\/runs\/(\d+)/)
@@ -82,21 +116,7 @@ function extractRunId(url: string): string {
 }
 
 function RunStatusIcon({ run }: { run: WorkflowRun }) {
-  if (run.status === 'in_progress' || run.status === 'queued') {
-    return <Clock className="h-4 w-4 shrink-0 text-yellow-500" />
-  }
-  switch (run.conclusion) {
-    case 'success':
-      return <CheckCircle2 className="h-4 w-4 shrink-0 text-green-500" />
-    case 'failure':
-    case 'startup_failure':
-      return <XCircle className="h-4 w-4 shrink-0 text-red-500" />
-    case 'cancelled':
-    case 'skipped':
-      return <MinusCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
-    default:
-      return <MinusCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
-  }
+  return getWorkflowStateIcon(getWorkflowStateKind(run.status, run.conclusion))
 }
 
 interface WorkflowGroup {
@@ -161,6 +181,9 @@ export function WorkflowRunsModal() {
   const workflowRunsModalBranch = useUIStore(
     state => state.workflowRunsModalBranch
   )
+  const workflowRunsModalWorkflowName = useUIStore(
+    state => state.workflowRunsModalWorkflowName
+  )
   const setWorkflowRunsModalOpen = useUIStore(
     state => state.setWorkflowRunsModalOpen
   )
@@ -174,6 +197,9 @@ export function WorkflowRunsModal() {
     workflowRunsModalBranch ?? undefined
   )
 
+  const [selectedWorkflow, setSelectedWorkflow] = useState<string | null>(null)
+  const [selectedRunId, setSelectedRunId] = useState<number | null>(null)
+
   const handleRefresh = useCallback(() => {
     if (workflowRunsModalProjectPath) {
       queryClient.invalidateQueries({
@@ -186,7 +212,6 @@ export function WorkflowRunsModal() {
   }, [queryClient, workflowRunsModalProjectPath, workflowRunsModalBranch])
 
   const runs = useMemo(() => result?.runs ?? [], [result?.runs])
-  const [selectedWorkflow, setSelectedWorkflow] = useState<string | null>(null)
   const [focusedIndex, setFocusedIndex] = useState(0)
   const [focusedPane, setFocusedPane] = useState<'sidebar' | 'list'>('sidebar')
   const [sidebarFocusedIndex, setSidebarFocusedIndex] = useState(0)
@@ -230,11 +255,18 @@ export function WorkflowRunsModal() {
     return runs.filter(run => run.workflowName === selectedWorkflow)
   }, [runs, selectedWorkflow])
 
+  const selectedRun = useMemo(() => {
+    if (selectedRunId == null) return null
+    return runs.find(run => run.databaseId === selectedRunId) ?? null
+  }, [runs, selectedRunId])
+
   // Reset focus when modal opens or runs change
   useEffect(() => {
     if (workflowRunsModalOpen) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      setSelectedWorkflow(null)
+      setSelectedWorkflow(workflowRunsModalWorkflowName ?? null)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSelectedRunId(null)
 
       setFocusedIndex(0)
 
@@ -243,7 +275,7 @@ export function WorkflowRunsModal() {
       setSidebarFocusedIndex(0)
       requestAnimationFrame(() => sidebarRef.current?.focus())
     }
-  }, [workflowRunsModalOpen, runs.length])
+  }, [workflowRunsModalOpen, workflowRunsModalWorkflowName])
 
   // Reset focus when filter changes
   useEffect(() => {
@@ -263,11 +295,14 @@ export function WorkflowRunsModal() {
   }, [sidebarFocusedIndex])
 
   const title = useMemo(() => {
-    if (workflowRunsModalBranch) {
-      return `Workflow Runs — ${workflowRunsModalBranch}`
+    const suffixParts: string[] = []
+    if (selectedWorkflow) suffixParts.push(selectedWorkflow)
+    if (workflowRunsModalBranch) suffixParts.push(workflowRunsModalBranch)
+    if (suffixParts.length > 0) {
+      return `Workflow Runs — ${suffixParts.join(' • ')}`
     }
     return 'Workflow Runs'
-  }, [workflowRunsModalBranch])
+  }, [selectedWorkflow, workflowRunsModalBranch])
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -276,8 +311,9 @@ export function WorkflowRunsModal() {
     [setWorkflowRunsModalOpen]
   )
 
-  const handleRunClick = useCallback((url: string) => {
-    openExternal(url)
+  const handleRunClick = useCallback((runId: number) => {
+    setSelectedRunId(runId)
+    setFocusedPane('list')
   }, [])
 
   const handleInvestigate = useCallback(
@@ -620,7 +656,7 @@ export function WorkflowRunsModal() {
           case 'Enter': {
             e.preventDefault()
             const run = displayedRuns[focusedIndex]
-            if (run) handleRunClick(run.url)
+            if (run) handleRunClick(run.databaseId)
             break
           }
           case 'm': {
@@ -741,8 +777,8 @@ export function WorkflowRunsModal() {
                     ref={el => {
                       itemRefs.current[index] = el
                     }}
-                    className={`group relative flex cursor-pointer items-center rounded-md px-2 py-2 transition-colors hover:bg-accent ${focusedPane === 'list' && index === focusedIndex ? 'bg-accent' : ''}`}
-                    onClick={() => handleRunClick(run.url)}
+                    className={`group relative flex cursor-pointer items-center rounded-md px-2 py-2 transition-colors hover:bg-accent ${selectedRunId === run.databaseId || (focusedPane === 'list' && index === focusedIndex) ? 'bg-accent' : ''}`}
+                    onClick={() => handleRunClick(run.databaseId)}
                     onMouseEnter={() => {
                       setFocusedIndex(index)
                       setFocusedPane('list')
@@ -795,6 +831,14 @@ export function WorkflowRunsModal() {
             </div>
           </div>
         )}
+        <WorkflowRunDetailsModal
+          open={selectedRun != null}
+          projectPath={workflowRunsModalProjectPath}
+          run={selectedRun}
+          onOpenChange={open => {
+            if (!open) setSelectedRunId(null)
+          }}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/src/hooks/useUIStatePersistence.test.tsx
+++ b/src/hooks/useUIStatePersistence.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useTerminalStore } from '@/store/terminal-store'
 import { useUIStore } from '@/store/ui-store'
 import { useChatStore } from '@/store/chat-store'
+import { useProjectsStore } from '@/store/projects-store'
 import type { UIState } from '@/types/ui-state'
 
 let nativeApp = false
@@ -18,9 +19,11 @@ const { mockInvoke, mockUseUIState, mockUseSaveUIState, mockUseProjects } =
   vi.hoisted(() => ({
     mockInvoke: vi.fn(),
     mockUseUIState: vi.fn(),
-    mockUseSaveUIState: vi.fn(() => ({ mutate: vi.fn() })),
+    mockUseSaveUIState: vi.fn(),
     mockUseProjects: vi.fn(),
   }))
+
+const mockSaveUIStateMutate = vi.fn()
 
 vi.mock('@/lib/transport', () => ({
   invoke: mockInvoke,
@@ -63,6 +66,7 @@ function buildUiState(overrides: Partial<UIState> = {}): UIState {
 describe('useUIStatePersistence — terminal restore on web refresh', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockSaveUIStateMutate.mockReset()
     nativeApp = false
     // Defaults: no live PTYs, empty persisted state.
     mockInvoke.mockImplementation(async (command: string) => {
@@ -74,6 +78,7 @@ describe('useUIStatePersistence — terminal restore on web refresh', () => {
       data: buildUiState(),
       isSuccess: true,
     })
+    mockUseSaveUIState.mockReturnValue({ mutate: mockSaveUIStateMutate })
     mockUseProjects.mockReturnValue({ data: [], isSuccess: true })
 
     useTerminalStore.setState({
@@ -95,6 +100,28 @@ describe('useUIStatePersistence — terminal restore on web refresh', () => {
       activeWorktreePath: null,
       activeSessionIds: {},
       sessionWorktreeMap: {},
+    })
+    useProjectsStore.setState({
+      selectedProjectId: null,
+      selectedWorktreeId: null,
+      expandedProjectIds: new Set<string>(),
+      expandedWorktreeIds: new Set<string>(),
+      dashboardWorktreeCollapseOverrides: {},
+      githubDashboardProjectCollapseOverrides: {},
+      expandedFolderIds: new Set<string>(),
+      projectAccessTimestamps: {},
+      projectCanvasSettings: {},
+      addProjectDialogOpen: false,
+      addProjectParentFolderId: null,
+      projectSettingsDialogOpen: false,
+      projectSettingsProjectId: null,
+      projectSettingsInitialPane: null,
+      gitInitModalOpen: false,
+      gitInitModalPath: null,
+      cloneModalOpen: false,
+      jeanConfigWizardOpen: false,
+      jeanConfigWizardProjectId: null,
+      editingFolderId: null,
     })
   })
 
@@ -197,6 +224,77 @@ describe('useUIStatePersistence — terminal restore on web refresh', () => {
       expect(uiState.sessionTerminalIds['session-1']).toBeUndefined()
       expect(uiState.sessionPrimarySurface['session-1']).toBeUndefined()
     })
+  })
+
+  it('restores GitHub dashboard project collapse overrides from persisted UI state', async () => {
+    mockUseProjects.mockReturnValue({
+      data: [
+        {
+          id: 'project-1',
+          name: 'Project 1',
+          path: '/tmp/project-1',
+        },
+      ],
+      isSuccess: true,
+    })
+    mockUseUIState.mockReturnValue({
+      data: buildUiState({
+        github_dashboard_project_collapse_overrides: {
+          'project-1': true,
+        },
+      }),
+      isSuccess: true,
+    })
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    renderHook(() => useUIStatePersistence(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => {
+      expect(
+        useProjectsStore.getState().githubDashboardProjectCollapseOverrides[
+          'project-1'
+        ]
+      ).toBe(true)
+    })
+  })
+
+  it('saves GitHub dashboard project collapse overrides when the store changes', async () => {
+    mockUseProjects.mockReturnValue({ data: [], isSuccess: true })
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    renderHook(() => useUIStatePersistence(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => {
+      expect(useUIStore.getState().uiStateInitialized).toBe(true)
+    })
+
+    useProjectsStore.setState({
+      githubDashboardProjectCollapseOverrides: { 'project-1': true },
+    })
+
+    await waitFor(() => {
+      expect(mockSaveUIStateMutate).toHaveBeenCalled()
+    })
+
+    expect(mockSaveUIStateMutate).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        github_dashboard_project_collapse_overrides: { 'project-1': true },
+      })
+    )
   })
 
   it('restores only persisted terminals whose IDs are still live on the backend', async () => {

--- a/src/hooks/useUIStatePersistence.ts
+++ b/src/hooks/useUIStatePersistence.ts
@@ -90,6 +90,7 @@ export function useUIStatePersistence() {
       selectedProjectId,
       projectAccessTimestamps,
       dashboardWorktreeCollapseOverrides,
+      githubDashboardProjectCollapseOverrides,
       projectCanvasSettings,
     } = useProjectsStore.getState()
     const {
@@ -182,6 +183,9 @@ export function useUIStatePersistence() {
       project_access_timestamps: projectAccessTimestamps,
       // Dashboard worktree collapse overrides
       dashboard_worktree_collapse_overrides: dashboardWorktreeCollapseOverrides,
+      // GitHub dashboard project collapse overrides
+      github_dashboard_project_collapse_overrides:
+        githubDashboardProjectCollapseOverrides,
       // Project canvas settings per project
       project_canvas_settings: Object.fromEntries(
         Object.entries(projectCanvasSettings).map(([projectId, settings]) => [
@@ -649,6 +653,29 @@ export function useUIStatePersistence() {
       })
     }
 
+    const githubDashboardCollapseOverrides =
+      uiState.github_dashboard_project_collapse_overrides ?? {}
+    if (Object.keys(githubDashboardCollapseOverrides).length > 0) {
+      const validProjectIds = Object.entries(githubDashboardCollapseOverrides)
+        .filter(([projectId]) => projects.some(p => p.id === projectId))
+        .reduce(
+          (acc, [projectId, collapsed]) => {
+            acc[projectId] = collapsed
+            return acc
+          },
+          {} as Record<string, boolean>
+        )
+
+      if (Object.keys(validProjectIds).length > 0) {
+        logger.debug('Restoring GitHub dashboard project collapse overrides', {
+          count: Object.keys(validProjectIds).length,
+        })
+        useProjectsStore.setState({
+          githubDashboardProjectCollapseOverrides: validProjectIds,
+        })
+      }
+    }
+
     const projectCanvasSettings = uiState.project_canvas_settings ?? {}
     if (Object.keys(projectCanvasSettings).length > 0) {
       logger.debug('Restoring project canvas settings', {
@@ -822,6 +849,8 @@ export function useUIStatePersistence() {
       useProjectsStore.getState().projectAccessTimestamps
     let prevDashboardCollapseOverrides =
       useProjectsStore.getState().dashboardWorktreeCollapseOverrides
+    let prevGitHubDashboardCollapseOverrides =
+      useProjectsStore.getState().githubDashboardProjectCollapseOverrides
     let prevProjectCanvasSettings =
       useProjectsStore.getState().projectCanvasSettings
     let prevLeftSidebarSize = useUIStore.getState().leftSidebarSize
@@ -870,6 +899,9 @@ export function useUIStatePersistence() {
       const collapseOverridesChanged =
         state.dashboardWorktreeCollapseOverrides !==
         prevDashboardCollapseOverrides
+      const githubDashboardCollapseOverridesChanged =
+        state.githubDashboardProjectCollapseOverrides !==
+        prevGitHubDashboardCollapseOverrides
       const projectCanvasSettingsChanged =
         state.projectCanvasSettings !== prevProjectCanvasSettings
 
@@ -879,6 +911,7 @@ export function useUIStatePersistence() {
         selectedProjectChanged ||
         accessTimestampsChanged ||
         collapseOverridesChanged ||
+        githubDashboardCollapseOverridesChanged ||
         projectCanvasSettingsChanged
       ) {
         prevExpandedProjectIds = state.expandedProjectIds
@@ -887,6 +920,8 @@ export function useUIStatePersistence() {
         prevProjectAccessTimestamps = state.projectAccessTimestamps
         prevDashboardCollapseOverrides =
           state.dashboardWorktreeCollapseOverrides
+        prevGitHubDashboardCollapseOverrides =
+          state.githubDashboardProjectCollapseOverrides
         prevProjectCanvasSettings = state.projectCanvasSettings
         const currentState = getCurrentUIState()
         debouncedSaveRef.current?.(currentState)

--- a/src/lib/commands/github-commands.ts
+++ b/src/lib/commands/github-commands.ts
@@ -80,7 +80,8 @@ export const githubCommands: AppCommand[] = [
   {
     id: 'open-github-dashboard',
     label: 'GitHub Dashboard',
-    description: 'View issues, PRs, and security across all projects',
+    description:
+      'View issues, PRs, workflows, and security across all projects',
     icon: LayoutDashboard,
     group: 'github',
     keywords: [
@@ -91,6 +92,8 @@ export const githubCommands: AppCommand[] = [
       'projects',
       'issues',
       'prs',
+      'workflows',
+      'actions',
       'security',
     ],
 

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -16,6 +16,8 @@ import type {
   LoadedAdvisoryContext,
   AttachedSavedContext,
   WorkflowRunsResult,
+  WorkflowRunDetailsResult,
+  WorkflowJobLogLine,
 } from '@/types/github'
 import { isTauri } from './projects'
 
@@ -114,6 +116,16 @@ export const githubQueryKeys = {
       'workflow-runs',
       projectPath,
       branch ?? '',
+    ] as const,
+  workflowRun: (projectPath: string, runId: number) =>
+    [...githubQueryKeys.all, 'workflow-run', projectPath, runId] as const,
+  workflowJobLogs: (projectPath: string, runId: number, jobId: number) =>
+    [
+      ...githubQueryKeys.all,
+      'workflow-job-logs',
+      projectPath,
+      runId,
+      jobId,
     ] as const,
   securityAlerts: (projectPath: string, state: string) =>
     [...githubQueryKeys.all, 'security-alerts', projectPath, state] as const,
@@ -1323,6 +1335,71 @@ export function useWorkflowRuns(
     enabled: (options?.enabled ?? true) && !!projectPath,
     staleTime: options?.staleTime ?? 1000 * 60 * 3, // 3 minutes
     gcTime: 1000 * 60 * 10, // 10 minutes
+    retry: 1,
+  })
+}
+
+/**
+ * Hook to load a single workflow run with jobs and steps.
+ */
+export function useWorkflowRun(
+  projectPath: string | null,
+  runId: number | null,
+  options?: { enabled?: boolean; staleTime?: number }
+) {
+  return useQuery({
+    queryKey: githubQueryKeys.workflowRun(projectPath ?? '', runId ?? 0),
+    queryFn: async (): Promise<WorkflowRunDetailsResult> => {
+      if (!isTauri() || !projectPath || !runId) {
+        return { jobs: [], jobDefinitions: [] }
+      }
+
+      try {
+        logger.debug('Fetching workflow run details', { projectPath, runId })
+        return await invoke<WorkflowRunDetailsResult>('get_workflow_run', {
+          projectPath,
+          runId,
+        })
+      } catch (error) {
+        logger.error('Failed to load workflow run details', {
+          error,
+          projectPath,
+          runId,
+        })
+        throw error
+      }
+    },
+    enabled: (options?.enabled ?? true) && !!projectPath && !!runId,
+    staleTime: options?.staleTime ?? 1000 * 60 * 3,
+    gcTime: 1000 * 60 * 10,
+    retry: 1,
+  })
+}
+
+export function useWorkflowJobLogs(
+  projectPath: string | null,
+  runId: number | null,
+  jobId: number | null,
+  options?: { enabled?: boolean; staleTime?: number }
+) {
+  return useQuery({
+    queryKey: githubQueryKeys.workflowJobLogs(
+      projectPath ?? '',
+      runId ?? 0,
+      jobId ?? 0
+    ),
+    queryFn: async (): Promise<WorkflowJobLogLine[]> => {
+      if (!isTauri() || !projectPath || !runId || !jobId) return []
+
+      return await invoke<WorkflowJobLogLine[]>('get_workflow_job_logs', {
+        projectPath,
+        runId,
+        jobId,
+      })
+    },
+    enabled: (options?.enabled ?? true) && !!projectPath && !!runId && !!jobId,
+    staleTime: options?.staleTime ?? 1000 * 60 * 10,
+    gcTime: 1000 * 60 * 30,
     retry: 1,
   })
 }

--- a/src/store/projects-store.test.ts
+++ b/src/store/projects-store.test.ts
@@ -8,6 +8,7 @@ describe('ProjectsStore', () => {
       selectedWorktreeId: null,
       expandedProjectIds: new Set<string>(),
       expandedFolderIds: new Set<string>(),
+      githubDashboardProjectCollapseOverrides: {},
       projectCanvasSettings: {},
       addProjectDialogOpen: false,
       projectSettingsDialogOpen: false,
@@ -159,6 +160,41 @@ describe('ProjectsStore', () => {
       expect(
         useProjectsStore.getState().expandedFolderIds.has('folder-1')
       ).toBe(false)
+    })
+  })
+
+  describe('GitHub dashboard project collapse', () => {
+    it('sets project collapsed state explicitly', () => {
+      const { setGitHubDashboardProjectCollapsed } =
+        useProjectsStore.getState()
+
+      setGitHubDashboardProjectCollapsed('project-1', true)
+      expect(
+        useProjectsStore.getState().githubDashboardProjectCollapseOverrides[
+          'project-1'
+        ]
+      ).toBe(true)
+
+      setGitHubDashboardProjectCollapsed('project-1', false)
+      expect(
+        useProjectsStore.getState().githubDashboardProjectCollapseOverrides[
+          'project-1'
+        ]
+      ).toBe(false)
+    })
+
+    it('is idempotent when setting the same collapsed state twice', () => {
+      const { setGitHubDashboardProjectCollapsed } =
+        useProjectsStore.getState()
+
+      setGitHubDashboardProjectCollapsed('project-1', true)
+      const firstRef =
+        useProjectsStore.getState().githubDashboardProjectCollapseOverrides
+      setGitHubDashboardProjectCollapsed('project-1', true)
+      const secondRef =
+        useProjectsStore.getState().githubDashboardProjectCollapseOverrides
+
+      expect(secondRef).toBe(firstRef)
     })
   })
 

--- a/src/store/projects-store.ts
+++ b/src/store/projects-store.ts
@@ -23,6 +23,9 @@ interface ProjectsUIState {
   // Dashboard worktree collapse overrides (list view): true=collapsed, false=expanded
   dashboardWorktreeCollapseOverrides: Record<string, boolean>
 
+  // GitHub dashboard project collapse overrides: true=collapsed, false=expanded
+  githubDashboardProjectCollapseOverrides: Record<string, boolean>
+
   // Expansion state for folders
   expandedFolderIds: Set<string>
 
@@ -75,6 +78,12 @@ interface ProjectsUIState {
     overrides: Record<string, boolean>
   ) => void
 
+  // GitHub dashboard project collapse actions
+  setGitHubDashboardProjectCollapsed: (id: string, collapsed: boolean) => void
+  setGitHubDashboardProjectCollapseOverrides: (
+    overrides: Record<string, boolean>
+  ) => void
+
   // Folder expansion actions
   toggleFolderExpanded: (id: string) => void
   expandFolder: (id: string) => void
@@ -123,6 +132,7 @@ export const useProjectsStore = create<ProjectsUIState>()(
       expandedProjectIds: new Set<string>(),
       expandedWorktreeIds: new Set<string>(),
       dashboardWorktreeCollapseOverrides: {},
+      githubDashboardProjectCollapseOverrides: {},
       expandedFolderIds: new Set<string>(),
       projectAccessTimestamps: {},
       projectCanvasSettings: {},
@@ -259,6 +269,34 @@ export const useProjectsStore = create<ProjectsUIState>()(
               : { dashboardWorktreeCollapseOverrides: overrides },
           undefined,
           'setDashboardWorktreeCollapseOverrides'
+        ),
+
+      // GitHub dashboard project collapse actions
+      setGitHubDashboardProjectCollapsed: (id, collapsed) =>
+        set(
+          state => {
+            const current =
+              state.githubDashboardProjectCollapseOverrides[id] ?? false
+            if (current === collapsed) return state
+            return {
+              githubDashboardProjectCollapseOverrides: {
+                ...state.githubDashboardProjectCollapseOverrides,
+                [id]: collapsed,
+              },
+            }
+          },
+          undefined,
+          'setGitHubDashboardProjectCollapsed'
+        ),
+
+      setGitHubDashboardProjectCollapseOverrides: overrides =>
+        set(
+          state =>
+            state.githubDashboardProjectCollapseOverrides === overrides
+              ? state
+              : { githubDashboardProjectCollapseOverrides: overrides },
+          undefined,
+          'setGitHubDashboardProjectCollapseOverrides'
         ),
 
       setProjectCanvasSettings: settings =>

--- a/src/store/ui-store.ts
+++ b/src/store/ui-store.ts
@@ -87,6 +87,7 @@ interface UIState {
   workflowRunsModalOpen: boolean
   workflowRunsModalProjectPath: string | null
   workflowRunsModalBranch: string | null
+  workflowRunsModalWorkflowName: string | null
   cliUpdateModalOpen: boolean
   cliUpdateModalType: CliUpdateModalType
   cliLoginModalOpen: boolean
@@ -175,7 +176,8 @@ interface UIState {
   setWorkflowRunsModalOpen: (
     open: boolean,
     projectPath?: string | null,
-    branch?: string | null
+    branch?: string | null,
+    workflowName?: string | null
   ) => void
   openCliUpdateModal: (type: Exclude<CliUpdateModalType, null>) => void
   closeCliUpdateModal: () => void
@@ -269,6 +271,7 @@ export const useUIStore = create<UIState>()(
       workflowRunsModalOpen: false,
       workflowRunsModalProjectPath: null,
       workflowRunsModalBranch: null,
+      workflowRunsModalWorkflowName: null,
       cliUpdateModalOpen: false,
       cliUpdateModalType: null,
       cliLoginModalOpen: false,
@@ -532,12 +535,15 @@ export const useUIStore = create<UIState>()(
           'setReviewCommentsModalOpen'
         ),
 
-      setWorkflowRunsModalOpen: (open, projectPath, branch) =>
+      setWorkflowRunsModalOpen: (open, projectPath, branch, workflowName) =>
         set(
           {
             workflowRunsModalOpen: open,
             workflowRunsModalProjectPath: open ? (projectPath ?? null) : null,
             workflowRunsModalBranch: open ? (branch ?? null) : null,
+            workflowRunsModalWorkflowName: open
+              ? (workflowName ?? null)
+              : null,
           },
           undefined,
           'setWorkflowRunsModalOpen'

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -252,6 +252,43 @@ export interface WorkflowRunsResult {
   failedCount: number
 }
 
+export interface WorkflowRunStep {
+  name: string
+  number: number
+  status: string
+  conclusion: string | null
+  startedAt?: string | null
+  completedAt?: string | null
+}
+
+export interface WorkflowRunJob {
+  databaseId: number
+  name: string
+  status: string
+  conclusion: string | null
+  startedAt?: string | null
+  completedAt?: string | null
+  steps: WorkflowRunStep[]
+  url: string
+}
+
+export interface WorkflowJobDefinition {
+  id: string
+  name: string
+  needs: string[]
+}
+
+export interface WorkflowRunDetailsResult {
+  jobs: WorkflowRunJob[]
+  jobDefinitions: WorkflowJobDefinition[]
+}
+
+export interface WorkflowJobLogLine {
+  stepName: string
+  timestamp: string | null
+  message: string
+}
+
 // =============================================================================
 // Attached Saved Context Types
 // =============================================================================

--- a/src/types/ui-state.ts
+++ b/src/types/ui-state.ts
@@ -96,6 +96,8 @@ export interface UIState {
   project_access_timestamps?: Record<string, number>
   /** Dashboard worktree collapse overrides: worktreeId → collapsed (true/false) */
   dashboard_worktree_collapse_overrides?: Record<string, boolean>
+  /** GitHub dashboard project collapse overrides: projectId → collapsed (true/false) */
+  github_dashboard_project_collapse_overrides?: Record<string, boolean>
   /** Project canvas settings per project */
   project_canvas_settings?: Record<string, ProjectCanvasSettingsState>
   /** Last opened worktree+session per project: projectId → { worktree_id, session_id } */


### PR DESCRIPTION
## Summary

Adds a global GitHub Actions dashboard so users working across multiple Jean projects can monitor all workflows from one place.

## What you can do

- View workflow activity across every GitHub project in Jean without opening projects individually.
- See which workflows are running, successful, or failing, grouped by project.
- Collapse or expand each project; the chosen state is restored after restarting Jean.
- Click a workflow to open its recent runs, filtered to that workflow.
- Click a run to open a dedicated, full-window run details view.
- Inspect a GitHub-style job dependency graph built from the workflow's `needs` relationships.
- Select a job node to view its status, duration, and individual steps.
- Expand a step to load its logs on demand, including timestamps and GitHub annotation styling for errors, warnings, notices, and debug output.
- Open the run or an individual job directly on GitHub when deeper investigation is needed.
- Start Jean's existing AI investigation flow directly from failed runs.

## Implementation notes

- Uses the authenticated GitHub CLI to fetch runs, jobs, workflow definitions, dependencies, and job logs.
- Registers the new run-detail and log commands for both native Tauri IPC and web access.
- Keeps log retrieval lazy so large job logs are downloaded only when a step is expanded.
- Includes frontend and Rust tests for dashboard navigation, persisted project collapse state, run details, workflow parsing, and log parsing.

## Validation

- `bun run check:all`
- 1,046 frontend tests passed.
- 607 Rust tests passed, with 1 ignored.

## Type

feat
