### PR TITLE
feat(scheduled-prompts): fire a queued prompt when the usage window resets

### DIFF
--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -2675,6 +2675,41 @@ pub async fn dispatch_command(
             let entries = crate::chat::list_pending_wakeups().await?;
             to_value(entries)
         }
+        "create_scheduled_prompt" => {
+            let session_id: String = field(&args, "sessionId", "session_id")?;
+            let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
+            let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
+            let prompt: String = from_field(&args, "prompt")?;
+            let backend: String = from_field(&args, "backend")?;
+            let model: Option<String> = from_field_opt(&args, "model")?;
+            let trigger: crate::scheduled_prompts::ScheduleTrigger = serde_json::from_value(
+                args.get("trigger").cloned().unwrap_or(Value::Null),
+            )
+            .map_err(|e| format!("Invalid trigger: {e}"))?;
+            let result = crate::scheduled_prompts::create_scheduled_prompt(
+                app.clone(),
+                session_id,
+                worktree_id,
+                worktree_path,
+                prompt,
+                backend,
+                model,
+                trigger,
+            )
+            .await?;
+            emit_cache_invalidation(app, &["scheduled-prompts"]);
+            to_value(result)
+        }
+        "list_scheduled_prompts" => {
+            let entries = crate::scheduled_prompts::list_scheduled_prompts(app.clone()).await?;
+            to_value(entries)
+        }
+        "cancel_scheduled_prompt" => {
+            let id: String = from_field(&args, "id")?;
+            let removed = crate::scheduled_prompts::cancel_scheduled_prompt(app.clone(), id).await?;
+            emit_cache_invalidation(app, &["scheduled-prompts"]);
+            to_value(removed)
+        }
 
         // =====================================================================
         // Chat (additional)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,6 +57,7 @@ mod opinionated;
 mod pi_cli;
 mod platform;
 mod projects;
+mod scheduled_prompts;
 mod terminal;
 
 // Validation functions
@@ -4335,6 +4336,7 @@ pub fn run() {
             task_manager.start();
             app.manage(task_manager);
             auto_fix::scheduler::start_auto_fix_scheduler(app.handle().clone());
+            scheduled_prompts::start_scheduled_prompts_scheduler(app.handle().clone());
             log::trace!("Background task manager initialized");
 
             // Initialize HTTP server infrastructure
@@ -4703,6 +4705,9 @@ pub fn run() {
             chat::cancel_session_wakeup,
             chat::get_scheduled_wakeup,
             chat::list_pending_wakeups,
+            scheduled_prompts::create_scheduled_prompt,
+            scheduled_prompts::list_scheduled_prompts,
+            scheduled_prompts::cancel_scheduled_prompt,
             // Chat commands - Image handling
             chat::read_clipboard_image,
             chat::write_clipboard_text,

--- a/src-tauri/src/scheduled_prompts/mod.rs
+++ b/src-tauri/src/scheduled_prompts/mod.rs
@@ -1,0 +1,403 @@
+//! Scheduled prompts — fire a queued chat prompt when a backend usage window
+//! resets (or at an explicit timestamp).
+//!
+//! Flow:
+//! 1. `create_scheduled_prompt` resolves the requested trigger to a concrete
+//!    `fire_at` unix timestamp. For `sessionReset`/`weeklyReset` it reads the
+//!    live Claude/Codex usage snapshot (`resets_at`, already fetched + cached by
+//!    the CLI modules) — no chat-message parsing. For `explicit` it uses the
+//!    caller-provided timestamp.
+//! 2. Entries persist to `scheduled_prompts.json` in the app data dir so they
+//!    survive restarts (a prompt whose reset elapsed while the app was closed
+//!    fires on the next tick after launch).
+//! 3. `start_scheduled_prompts_scheduler` runs a ~30 s tokio tick loop that
+//!    fires every due entry via `crate::chat::send_chat_message` — the exact
+//!    call Mr. Robot (`auto_fix`) uses, so it works with the app in background.
+//!
+//! Resolving the reset to a concrete timestamp at creation time (rather than
+//! re-reading a live `resets_at` each tick) is what makes "fire when the window
+//! resets" robust: the active window's `resets_at` is a fixed future instant,
+//! and once it passes the API reports the *next* window — so a live comparison
+//! could never observe the crossing. Capturing the target up front sidesteps
+//! that and handles the app-closed-through-reset case for free.
+
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+const TICK_SECONDS: u64 = 30;
+/// Fire slightly after the reset instant — quota refresh is not always instant.
+const RESET_BUFFER_SECONDS: u64 = 30;
+/// After a failed send, wait this long before retrying (avoids per-tick spam).
+const RETRY_BACKOFF_SECONDS: u64 = 300;
+
+/// Which usage window (or explicit instant) a scheduled prompt waits for.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum ScheduleTrigger {
+    /// Claude/Codex short "session" window (e.g. 5-hour) reset.
+    SessionReset,
+    /// Weekly window reset.
+    WeeklyReset,
+    /// A caller-provided unix timestamp.
+    Explicit {
+        #[serde(rename = "fireAt")]
+        fire_at: u64,
+    },
+}
+
+/// A persisted prompt waiting to fire.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduledPrompt {
+    pub id: String,
+    pub session_id: String,
+    pub worktree_id: String,
+    pub worktree_path: String,
+    pub prompt: String,
+    /// Backend to send with (e.g. "claude", "codex"). Also selects the usage
+    /// window read for reset triggers.
+    pub backend: String,
+    pub model: Option<String>,
+    pub trigger: ScheduleTrigger,
+    /// Concrete unix timestamp the entry fires at (buffer added on top).
+    pub fire_at: u64,
+    pub created_at: u64,
+    /// Last send error, if the most recent fire attempt failed.
+    pub last_error: Option<String>,
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Sessions whose send is currently in flight — guards against a slow send
+/// being started twice by consecutive ticks.
+static IN_FLIGHT: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+/// Serializes read-modify-write of the on-disk store.
+static STORE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn in_flight() -> &'static Mutex<HashSet<String>> {
+    IN_FLIGHT.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+fn store_lock() -> &'static Mutex<()> {
+    STORE_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn store_path(app: &AppHandle) -> Result<std::path::PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {e}"))?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("Failed to create app data directory: {e}"))?;
+    Ok(dir.join("scheduled_prompts.json"))
+}
+
+fn read_store(app: &AppHandle) -> Result<Vec<ScheduledPrompt>, String> {
+    let path = store_path(app)?;
+    match std::fs::read_to_string(&path) {
+        Ok(contents) if !contents.trim().is_empty() => serde_json::from_str(&contents)
+            .map_err(|e| format!("Failed to parse scheduled_prompts.json: {e}")),
+        Ok(_) => Ok(Vec::new()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(e) => Err(format!("Failed to read scheduled_prompts.json: {e}")),
+    }
+}
+
+fn write_store(app: &AppHandle, prompts: &[ScheduledPrompt]) -> Result<(), String> {
+    let path = store_path(app)?;
+    let json = serde_json::to_string_pretty(prompts)
+        .map_err(|e| format!("Failed to serialize scheduled prompts: {e}"))?;
+    std::fs::write(&path, json)
+        .map_err(|e| format!("Failed to write scheduled_prompts.json: {e}"))
+}
+
+/// Read-modify-write the store under the store lock.
+fn mutate_store<F, R>(app: &AppHandle, f: F) -> Result<R, String>
+where
+    F: FnOnce(&mut Vec<ScheduledPrompt>) -> R,
+{
+    let _guard = store_lock().lock().expect("scheduled prompts store lock");
+    let mut prompts = read_store(app)?;
+    let result = f(&mut prompts);
+    write_store(app, &prompts)?;
+    Ok(result)
+}
+
+fn default_model_for_backend(backend: &str) -> String {
+    match backend {
+        "codex" => "gpt-5.3-codex".to_string(),
+        "opencode" => "opencode/gpt-5.5".to_string(),
+        "cursor" => "cursor/auto".to_string(),
+        "pi" => "pi/sonnet".to_string(),
+        "commandcode" => "commandcode/default".to_string(),
+        _ => "claude-opus-4-8[1m]".to_string(),
+    }
+}
+
+/// Read the `resets_at` for the requested window from the backend's usage
+/// snapshot. `weekly` selects the weekly window instead of the session window.
+async fn resolve_reset_timestamp(
+    app: &AppHandle,
+    backend: &str,
+    weekly: bool,
+) -> Result<u64, String> {
+    let window_label = if weekly { "weekly" } else { "session" };
+    match backend {
+        "codex" => {
+            let usage = crate::codex_cli::get_codex_usage(app.clone()).await?;
+            let window = if weekly { usage.weekly } else { usage.session };
+            let window = window.ok_or_else(|| {
+                format!("Codex usage snapshot has no {window_label} window yet")
+            })?;
+            // Codex only reports an explicit reset timestamp once some quota is
+            // consumed; at low usage it sends the window length instead. Fall
+            // back to `now + window_length` so scheduling still works (this is a
+            // conservative upper bound — it never fires before the real reset).
+            if let Some(resets_at) = window.resets_at {
+                return Ok(resets_at);
+            }
+            if let Some(window_secs) = window.limit_window_seconds {
+                return Ok(now_unix().saturating_add(window_secs));
+            }
+            Err(format!(
+                "Codex hasn't reported a {window_label} reset time yet. Use it a little, then retry — or pick an explicit time."
+            ))
+        }
+        // Claude is the default backend for reset triggers; other backends do
+        // not expose a usage window, so fall back to the Claude snapshot.
+        _ => {
+            let usage = crate::claude_cli::get_claude_usage().await?;
+            let window = if weekly { usage.weekly } else { usage.session };
+            window.and_then(|w| w.resets_at).ok_or_else(|| {
+                format!("Claude usage snapshot has no {window_label} reset time")
+            })
+        }
+    }
+}
+
+/// Create + persist a scheduled prompt. Resolves the trigger to a concrete
+/// `fire_at` timestamp up front (reading the live usage snapshot for reset
+/// triggers).
+#[allow(clippy::too_many_arguments)]
+#[tauri::command]
+pub async fn create_scheduled_prompt(
+    app: AppHandle,
+    session_id: String,
+    worktree_id: String,
+    worktree_path: String,
+    prompt: String,
+    backend: String,
+    model: Option<String>,
+    trigger: ScheduleTrigger,
+) -> Result<ScheduledPrompt, String> {
+    if prompt.trim().is_empty() {
+        return Err("Prompt cannot be empty".to_string());
+    }
+    if worktree_path.trim().is_empty() {
+        return Err("Worktree path cannot be empty".to_string());
+    }
+
+    let fire_at = match &trigger {
+        ScheduleTrigger::SessionReset => resolve_reset_timestamp(&app, &backend, false).await?,
+        ScheduleTrigger::WeeklyReset => resolve_reset_timestamp(&app, &backend, true).await?,
+        ScheduleTrigger::Explicit { fire_at } => *fire_at,
+    };
+
+    let entry = ScheduledPrompt {
+        id: uuid::Uuid::new_v4().to_string(),
+        session_id,
+        worktree_id,
+        worktree_path,
+        prompt,
+        backend,
+        model,
+        trigger,
+        fire_at,
+        created_at: now_unix(),
+        last_error: None,
+    };
+
+    mutate_store(&app, |prompts| prompts.push(entry.clone()))?;
+    log::info!(
+        "scheduled_prompts: queued {} (session={}) firing at {}",
+        entry.id,
+        entry.session_id,
+        entry.fire_at
+    );
+    Ok(entry)
+}
+
+/// List every pending scheduled prompt.
+#[tauri::command]
+pub async fn list_scheduled_prompts(app: AppHandle) -> Result<Vec<ScheduledPrompt>, String> {
+    read_store(&app)
+}
+
+/// Cancel (remove) a scheduled prompt by id. Returns true if one was removed.
+#[tauri::command]
+pub async fn cancel_scheduled_prompt(app: AppHandle, id: String) -> Result<bool, String> {
+    mutate_store(&app, |prompts| {
+        let before = prompts.len();
+        prompts.retain(|p| p.id != id);
+        prompts.len() != before
+    })
+}
+
+/// Spawn the background tick loop. Called once at app startup.
+pub fn start_scheduled_prompts_scheduler(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            fire_due(&app).await;
+            tokio::time::sleep(Duration::from_secs(TICK_SECONDS)).await;
+        }
+    });
+}
+
+/// Fire every entry whose `fire_at + buffer <= now` and that is not already
+/// in flight.
+async fn fire_due(app: &AppHandle) {
+    let prompts = match read_store(app) {
+        Ok(p) => p,
+        Err(err) => {
+            log::warn!("scheduled_prompts: failed to read store: {err}");
+            return;
+        }
+    };
+    if prompts.is_empty() {
+        return;
+    }
+
+    let now = now_unix();
+    for entry in prompts {
+        if now < entry.fire_at.saturating_add(RESET_BUFFER_SECONDS) {
+            continue;
+        }
+        // Claim the send slot; skip if a prior tick's send is still running.
+        {
+            let mut set = in_flight().lock().expect("scheduled prompts in flight");
+            if !set.insert(entry.id.clone()) {
+                continue;
+            }
+        }
+        spawn_fire(app.clone(), entry);
+    }
+}
+
+fn spawn_fire(app: AppHandle, entry: ScheduledPrompt) {
+    tauri::async_runtime::spawn(async move {
+        let result = send_scheduled_prompt(&app, &entry).await;
+
+        match result {
+            Ok(()) => {
+                log::info!("scheduled_prompts: fired {} (session={})", entry.id, entry.session_id);
+                if let Err(err) = mutate_store(&app, |prompts| prompts.retain(|p| p.id != entry.id)) {
+                    log::warn!("scheduled_prompts: failed to remove fired entry {}: {err}", entry.id);
+                }
+            }
+            Err(err) => {
+                log::warn!("scheduled_prompts: send failed for {}: {err}", entry.id);
+                let retry_at = now_unix().saturating_add(RETRY_BACKOFF_SECONDS);
+                let _ = mutate_store(&app, |prompts| {
+                    if let Some(p) = prompts.iter_mut().find(|p| p.id == entry.id) {
+                        p.fire_at = retry_at;
+                        p.last_error = Some(err.clone());
+                    }
+                });
+            }
+        }
+
+        in_flight()
+            .lock()
+            .expect("scheduled prompts in flight")
+            .remove(&entry.id);
+    });
+}
+
+async fn send_scheduled_prompt(app: &AppHandle, entry: &ScheduledPrompt) -> Result<(), String> {
+    let model = entry
+        .model
+        .clone()
+        .or_else(|| Some(default_model_for_backend(&entry.backend)));
+
+    crate::chat::send_chat_message(
+        app.clone(),
+        entry.session_id.clone(),
+        entry.worktree_id.clone(),
+        entry.worktree_path.clone(),
+        entry.prompt.clone(),
+        model,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(entry.backend.clone()),
+    )
+    .await
+    .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trigger_serializes_tagged_camel_case() {
+        let json = serde_json::to_string(&ScheduleTrigger::SessionReset).unwrap();
+        assert_eq!(json, r#"{"kind":"sessionReset"}"#);
+        let json = serde_json::to_string(&ScheduleTrigger::Explicit { fire_at: 42 }).unwrap();
+        assert_eq!(json, r#"{"kind":"explicit","fireAt":42}"#);
+    }
+
+    #[test]
+    fn trigger_deserializes_from_frontend_shapes() {
+        let t: ScheduleTrigger = serde_json::from_str(r#"{"kind":"weeklyReset"}"#).unwrap();
+        assert_eq!(t, ScheduleTrigger::WeeklyReset);
+        let t: ScheduleTrigger =
+            serde_json::from_str(r#"{"kind":"explicit","fireAt":100}"#).unwrap();
+        assert_eq!(t, ScheduleTrigger::Explicit { fire_at: 100 });
+    }
+
+    #[test]
+    fn default_models_cover_backends() {
+        assert_eq!(default_model_for_backend("claude"), "claude-opus-4-8[1m]");
+        assert_eq!(default_model_for_backend("codex"), "gpt-5.3-codex");
+        assert_eq!(default_model_for_backend("unknown"), "claude-opus-4-8[1m]");
+    }
+
+    #[test]
+    fn prompt_round_trips_through_json() {
+        let entry = ScheduledPrompt {
+            id: "abc".to_string(),
+            session_id: "s1".to_string(),
+            worktree_id: "w1".to_string(),
+            worktree_path: "/tmp/w1".to_string(),
+            prompt: "do the thing".to_string(),
+            backend: "claude".to_string(),
+            model: None,
+            trigger: ScheduleTrigger::SessionReset,
+            fire_at: 1000,
+            created_at: 900,
+            last_error: None,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains(r#""fireAt":1000"#));
+        assert!(json.contains(r#""sessionId":"s1""#));
+        let back: ScheduledPrompt = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, "abc");
+        assert_eq!(back.trigger, ScheduleTrigger::SessionReset);
+    }
+}

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -103,11 +103,14 @@ import { FileContentModal } from './FileContentModal'
 import { FilePreview } from './FilePreview'
 import { ContextPreview } from './ContextPreview'
 import { ChatInput } from './ChatInput'
+import { ScheduleForResetButton } from './ScheduleForResetButton'
+import { useScheduledPrompts } from '@/services/scheduled-prompts'
 import { SessionDebugPanel } from './SessionDebugPanel'
 import { ChatToolbar } from './ChatToolbar'
 import { ReviewResultsPanel } from './ReviewResultsPanel'
 import { ReviewMethodModal } from './ReviewMethodModal'
 import { QueuedPromptsPanel } from './QueuedPromptsPanel'
+import { ScheduledPromptsPanel } from './ScheduledPromptsPanel'
 import { useQueuedPromptActions } from './hooks/useQueuedPromptActions'
 import { FloatingButtons } from './FloatingButtons'
 import { PlanDialog } from './PlanDialog'
@@ -877,6 +880,10 @@ export function ChatWindow({
       ? (state.messageQueues[deferredSessionId] ?? EMPTY_QUEUED_MESSAGES)
       : EMPTY_QUEUED_MESSAGES
   )
+  const { data: scheduledPromptsData } = useScheduledPrompts()
+  const hasScheduledForSession =
+    !!activeSessionId &&
+    (scheduledPromptsData ?? []).some(p => p.sessionId === activeSessionId)
   // Per-session pending permission denials (uses deferredSessionId for content consistency)
   const pendingDenials = useChatStore(state =>
     deferredSessionId
@@ -2965,7 +2972,13 @@ export function ChatWindow({
                     <div className="bg-background">
                       <div className="mx-auto max-w-7xl">
                         <div className="relative sm:mx-auto sm:mb-3 sm:max-w-3xl xl:max-w-4xl">
-                          {/* Queued prompts - rendered as an extension above the chat input */}
+                          {/* Scheduled + queued prompts - rendered as an extension above the chat input */}
+                          {activeSessionId && (
+                            <ScheduledPromptsPanel
+                              key={`scheduled-${activeSessionId}`}
+                              sessionId={activeSessionId}
+                            />
+                          )}
                           {activeSessionId &&
                             currentQueuedMessages.length > 0 && (
                               <QueuedPromptsPanel
@@ -2984,7 +2997,8 @@ export function ChatWindow({
                             className={cn(
                               'relative overflow-hidden border-t border-border bg-card transition-[background-color,box-shadow] duration-150 sm:rounded-lg sm:border',
                               activeSessionId &&
-                                currentQueuedMessages.length > 0 &&
+                                (currentQueuedMessages.length > 0 ||
+                                  hasScheduledForSession) &&
                                 'sm:rounded-t-none',
                               isDragging &&
                                 'ring-2 ring-primary ring-inset bg-primary/5'
@@ -3141,6 +3155,21 @@ export function ChatWindow({
                                 installedBackends={installedBackends}
                                 selectedBackend={selectedBackend}
                               />
+                              <div className="mt-1 flex justify-end">
+                                <ScheduleForResetButton
+                                  sessionId={activeSessionId}
+                                  worktreeId={activeWorktreeId ?? null}
+                                  worktreePath={activeWorktreePath}
+                                  backend={selectedBackend}
+                                  model={selectedModel}
+                                  getPromptText={() =>
+                                    inputRef.current?.value ?? ''
+                                  }
+                                  onScheduled={() =>
+                                    clearChatInputStateRef.current?.()
+                                  }
+                                />
+                              </div>
                             </div>
 
                             {/* Bottom toolbar */}

--- a/src/components/chat/ScheduleForResetButton.tsx
+++ b/src/components/chat/ScheduleForResetButton.tsx
@@ -1,0 +1,128 @@
+import { memo, useCallback } from 'react'
+import { AlarmClock } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { useCreateScheduledPrompt } from '@/services/scheduled-prompts'
+import type { ScheduleTrigger } from '@/types/scheduled-prompts'
+
+interface ScheduleForResetButtonProps {
+  sessionId: string | undefined
+  worktreeId: string | null | undefined
+  worktreePath: string | undefined
+  backend: string
+  model?: string | null
+  /** Reads the current draft prompt text from the composer. */
+  getPromptText: () => string
+  /** Clears the composer after a prompt is scheduled. */
+  onScheduled?: () => void
+}
+
+/**
+ * Compact composer control that queues the currently-typed prompt to fire
+ * automatically when the backend usage window resets. Backed by the
+ * `scheduled_prompts` Tauri commands.
+ */
+export const ScheduleForResetButton = memo(function ScheduleForResetButton({
+  sessionId,
+  worktreeId,
+  worktreePath,
+  backend,
+  model,
+  getPromptText,
+  onScheduled,
+}: ScheduleForResetButtonProps) {
+  const { mutateAsync: createScheduledPrompt, isPending } =
+    useCreateScheduledPrompt()
+
+  // Only Claude and Codex expose a usage window with a reset timestamp.
+  const supportsReset = backend === 'claude' || backend === 'codex'
+
+  const schedule = useCallback(
+    async (trigger: ScheduleTrigger) => {
+      const prompt = getPromptText().trim()
+      if (!prompt) {
+        toast.error('Type a prompt first, then schedule it.')
+        return
+      }
+      if (!sessionId || !worktreeId || !worktreePath) {
+        toast.error('No active session to schedule against.')
+        return
+      }
+
+      try {
+        const entry = await createScheduledPrompt({
+          sessionId,
+          worktreeId,
+          worktreePath,
+          prompt,
+          backend,
+          model,
+          trigger,
+        })
+        const when = new Date(entry.fireAt * 1000).toLocaleString()
+        toast.success(`Prompt scheduled — fires around ${when}.`)
+        onScheduled?.()
+      } catch (error) {
+        toast.error(`Failed to schedule prompt: ${error}`)
+      }
+    },
+    [
+      backend,
+      createScheduledPrompt,
+      getPromptText,
+      model,
+      onScheduled,
+      sessionId,
+      worktreeId,
+      worktreePath,
+    ]
+  )
+
+  if (!supportsReset) return null
+
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 shrink-0 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"
+              disabled={isPending}
+              aria-label="Schedule prompt for usage reset"
+            >
+              <AlarmClock className="h-3.5 w-3.5" />
+              Schedule for reset
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Send this prompt when my usage resets</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Send this prompt when…</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => schedule({ kind: 'sessionReset' })}>
+          My session window resets
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => schedule({ kind: 'weeklyReset' })}>
+          My weekly window resets
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+})

--- a/src/components/chat/ScheduledPromptsPanel.tsx
+++ b/src/components/chat/ScheduledPromptsPanel.tsx
@@ -1,0 +1,145 @@
+import { memo, useState } from 'react'
+import { AlarmClock, ChevronRight, X } from 'lucide-react'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { toast } from 'sonner'
+import {
+  useScheduledPrompts,
+  useCancelScheduledPrompt,
+} from '@/services/scheduled-prompts'
+import type { ScheduledPrompt } from '@/types/scheduled-prompts'
+
+interface ScheduledPromptsPanelProps {
+  sessionId: string
+}
+
+function triggerLabel(prompt: ScheduledPrompt): string {
+  switch (prompt.trigger.kind) {
+    case 'sessionReset':
+      return 'session reset'
+    case 'weeklyReset':
+      return 'weekly reset'
+    case 'explicit':
+      return 'scheduled time'
+  }
+}
+
+/** "in 2h 5m" / "in 40s" / "any moment" for a future unix timestamp (seconds). */
+function relativeFireLabel(fireAtSecs: number): string {
+  const deltaSecs = fireAtSecs - Math.floor(Date.now() / 1000)
+  if (deltaSecs <= 0) return 'any moment'
+  const hours = Math.floor(deltaSecs / 3600)
+  const minutes = Math.floor((deltaSecs % 3600) / 60)
+  if (hours > 0) return `in ${hours}h ${minutes}m`
+  if (minutes > 0) return `in ${minutes}m`
+  return `in ${deltaSecs}s`
+}
+
+/**
+ * Collapsible list of prompts scheduled to fire on a usage reset, shown above
+ * the chat input — mirrors {@link QueuedPromptsPanel}. Only entries for the
+ * active session are listed.
+ */
+export const ScheduledPromptsPanel = memo(function ScheduledPromptsPanel({
+  sessionId,
+}: ScheduledPromptsPanelProps) {
+  const [isOpen, setIsOpen] = useState(true)
+  const { data: allPrompts } = useScheduledPrompts()
+  const { mutateAsync: cancelScheduledPrompt } = useCancelScheduledPrompt()
+
+  const prompts = (allPrompts ?? []).filter(p => p.sessionId === sessionId)
+
+  const handleCancel = async (id: string) => {
+    try {
+      await cancelScheduledPrompt(id)
+      toast.success('Scheduled prompt cancelled.')
+    } catch (error) {
+      toast.error(`Failed to cancel: ${error}`)
+    }
+  }
+
+  if (prompts.length === 0) return null
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      {/* Styled to read as an extension of the chat input card below */}
+      <div className="border-t border-border bg-card sm:rounded-t-lg sm:border sm:border-b-0">
+        <div className="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground">
+          <CollapsibleTrigger className="flex flex-1 items-center gap-2 hover:bg-muted/50 select-none -ml-3 -my-2 pl-3 py-2 rounded-l-md">
+            <ChevronRight
+              className={cn(
+                'h-3.5 w-3.5 shrink-0 transition-transform duration-200',
+                isOpen && 'rotate-90'
+              )}
+            />
+            <AlarmClock className="h-4 w-4 shrink-0" />
+            <span className="font-medium">Scheduled for reset</span>
+            <span className="rounded bg-muted/50 px-1.5 py-0.5 text-xs">
+              {prompts.length}
+            </span>
+          </CollapsibleTrigger>
+        </div>
+        <CollapsibleContent>
+          <div className="max-h-48 overflow-y-auto border-t border-border/50">
+            {prompts.map((prompt, index) => (
+              <div
+                key={prompt.id}
+                className="group flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-muted/30"
+              >
+                <span className="shrink-0 text-muted-foreground/60 tabular-nums">
+                  #{index + 1}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-foreground">
+                  {prompt.prompt}
+                </span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="shrink-0 rounded bg-muted/50 px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                      {relativeFireLabel(prompt.fireAt)}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Fires on {triggerLabel(prompt)} —{' '}
+                    {new Date(prompt.fireAt * 1000).toLocaleString()}
+                  </TooltipContent>
+                </Tooltip>
+                {prompt.lastError && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="shrink-0 rounded bg-destructive/15 px-1.5 py-0.5 text-[10px] text-destructive">
+                        retrying
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>{prompt.lastError}</TooltipContent>
+                  </Tooltip>
+                )}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label="Cancel scheduled prompt"
+                      onClick={() => handleCancel(prompt.id)}
+                      className="shrink-0 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-destructive hover:text-white group-hover:opacity-100"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Cancel</TooltipContent>
+                </Tooltip>
+              </div>
+            ))}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  )
+})

--- a/src/services/scheduled-prompts.ts
+++ b/src/services/scheduled-prompts.ts
@@ -1,0 +1,73 @@
+/**
+ * Scheduled prompts service — TanStack Query hooks over the Tauri
+ * `scheduled_prompts` commands.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { invoke } from '@/lib/transport'
+import { hasBackend } from '@/lib/environment'
+import type {
+  ScheduledPrompt,
+  CreateScheduledPromptArgs,
+} from '@/types/scheduled-prompts'
+
+const isTauri = hasBackend
+
+export const scheduledPromptsQueryKeys = {
+  all: ['scheduled-prompts'] as const,
+  list: () => [...scheduledPromptsQueryKeys.all, 'list'] as const,
+}
+
+/** List every pending scheduled prompt. */
+export function useScheduledPrompts() {
+  return useQuery({
+    queryKey: scheduledPromptsQueryKeys.list(),
+    queryFn: async (): Promise<ScheduledPrompt[]> => {
+      if (!isTauri()) return []
+      return invoke<ScheduledPrompt[]>('list_scheduled_prompts')
+    },
+    // The scheduler fires + removes entries in the background, so poll to keep
+    // the panel roughly in sync (no backend event is emitted on fire).
+    refetchInterval: 20_000,
+  })
+}
+
+/** Create a scheduled prompt; invalidates the list on success. */
+export function useCreateScheduledPrompt() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (
+      args: CreateScheduledPromptArgs,
+    ): Promise<ScheduledPrompt> => {
+      return invoke<ScheduledPrompt>('create_scheduled_prompt', {
+        sessionId: args.sessionId,
+        worktreeId: args.worktreeId,
+        worktreePath: args.worktreePath,
+        prompt: args.prompt,
+        backend: args.backend,
+        model: args.model ?? null,
+        trigger: args.trigger,
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: scheduledPromptsQueryKeys.list(),
+      })
+    },
+  })
+}
+
+/** Cancel a scheduled prompt by id; invalidates the list on success. */
+export function useCancelScheduledPrompt() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: string): Promise<boolean> => {
+      return invoke<boolean>('cancel_scheduled_prompt', { id })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: scheduledPromptsQueryKeys.list(),
+      })
+    },
+  })
+}

--- a/src/types/scheduled-prompts.ts
+++ b/src/types/scheduled-prompts.ts
@@ -1,0 +1,35 @@
+/**
+ * Scheduled prompts — a chat prompt queued to fire when a backend usage
+ * window resets (or at an explicit timestamp). Mirrors the Rust
+ * `scheduled_prompts` module (camelCase serde).
+ */
+
+export type ScheduleTrigger =
+  | { kind: 'sessionReset' }
+  | { kind: 'weeklyReset' }
+  | { kind: 'explicit'; fireAt: number }
+
+export interface ScheduledPrompt {
+  id: string
+  sessionId: string
+  worktreeId: string
+  worktreePath: string
+  prompt: string
+  backend: string
+  model: string | null
+  trigger: ScheduleTrigger
+  /** Concrete unix timestamp (seconds) the prompt fires at. */
+  fireAt: number
+  createdAt: number
+  lastError: string | null
+}
+
+export interface CreateScheduledPromptArgs {
+  sessionId: string
+  worktreeId: string
+  worktreePath: string
+  prompt: string
+  backend: string
+  model?: string | null
+  trigger: ScheduleTrigger
+}


### PR DESCRIPTION
## What

Adds **scheduled prompts** — queue a chat prompt to send automatically when your Claude/Codex usage window resets (or at an explicit time). No chat-message parsing: the reset time comes straight from the usage API snapshot (`resets_at`), already fetched + cached by the CLI modules.

## How it works

- On create, the trigger (`sessionReset` / `weeklyReset` / `explicit`) is resolved to a **concrete `fire_at` timestamp** by reading the live usage snapshot. Resolving up front (rather than comparing a live `resets_at` each tick) is what makes "fire on reset" robust — the active window's `resets_at` is a fixed future instant, and once it passes the API reports the *next* window, so a live comparison could never observe the crossing. It also handles the app-closed-through-reset case for free.
- Entries persist to `scheduled_prompts.json` in the app data dir → survive restarts.
- A ~30s background tick loop fires every due entry via `crate::chat::send_chat_message` (same path Mr. Robot/`auto_fix` uses), so it works with the app in the background. Buffer of 30s after the reset; in-flight guard; 5-min retry backoff on send failure.
- **Codex fallback:** Codex omits an explicit reset timestamp until some quota is consumed; at low usage it only reports the window length. When `resets_at` is absent we fall back to `now + limit_window_seconds` (a conservative upper bound — never fires before the real reset).

## UI

- **"⏰ Schedule for reset"** button under the composer queues the currently-typed prompt (Claude/Codex only).
- **"Scheduled for reset"** collapsible panel above the chat input mirrors the existing queued-prompts block: shows prompt, relative fire time, a "retrying" badge on failure, and a cancel button. Per-session filtered.

## Backend wiring

- New `scheduled_prompts` module; `create_scheduled_prompt` / `list_scheduled_prompts` / `cancel_scheduled_prompt` registered in **both** `lib.rs` `generate_handler!` and the WebSocket `dispatch.rs` (web access), with cache invalidation on mutations.

## Tests / checks

- 4 Rust unit tests (serde shapes, model defaults, round-trip).
- `cargo build`, `cargo clippy --lib`, `bun run typecheck`, eslint all green.

## How to test

1. `bun run tauri dev`, open a Claude or Codex session.
2. Type a prompt → click **⏰ Schedule for reset** → pick a window. Toast shows the fire time; the **Scheduled for reset** panel appears above the input.
3. Cancel via the ✕ on the row; verify persistence in `scheduled_prompts.json`.
4. Fast path: schedule an `explicit` trigger a minute out → it sends into the session and the entry clears.