### PR TITLE
fix(sounds): unlock Web Audio on macOS and play waiting sounds mid-run

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,7 @@ import { useMagicPromptAutoDefaults } from './hooks/useMagicPromptAutoDefaults'
 import { usePreferences } from './services/preferences'
 import useStreamingEvents from './components/chat/hooks/useStreamingEvents'
 import { hydrateRunningSnapshot } from './lib/hydrate-running-snapshot'
-import { preloadAllSounds } from './lib/sounds'
+import { installAudioUnlockListeners, preloadAllSounds } from './lib/sounds'
 import {
   beginSessionStateHydration,
   endSessionStateHydration,
@@ -142,6 +142,9 @@ function App() {
 
   // Linux: route OS file drops (intercepted in Rust) to a terminal or the chat.
   useLinuxFileDrop()
+
+  // Unlock Web Audio on first interaction so background session sounds can play.
+  useEffect(() => installAudioUnlockListeners(), [])
 
   // Holds the update object so the title bar indicator can trigger install later
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -303,6 +303,16 @@ export default function useStreamingEvents({
       notifyIfBackground(title, name)
     }
 
+    const playWaitingSound = (): void => {
+      const prefs = queryClient.getQueryData<AppPreferences>(
+        preferencesQueryKeys.preferences()
+      )
+      const waitingSound = (prefs?.waiting_sound ?? 'none') as NotificationSound
+      playNotificationSound(waitingSound, {
+        webAccessSoundsEnabled: prefs?.web_access_sounds_enabled ?? true,
+      })
+    }
+
     // Hydrate ScheduleWakeup indicator store from backend so reloads do not
     // show historical tool_use blocks stuck in the "pending" spinner state.
     invoke<PendingWakeupEntry[]>('list_pending_wakeups')
@@ -660,6 +670,8 @@ export default function useStreamingEvents({
       const next = [...current, request]
       setPendingCodexMcpElicitationRequests(sessionId, next)
       setWaitingForInput(sessionId, true)
+      playWaitingSound()
+      notifySession(sessionId, 'Needs your input')
       persistCodexPendingState(sessionId, worktreeId, {
         pendingCodexMcpElicitationRequests: next,
       })
@@ -677,6 +689,7 @@ export default function useStreamingEvents({
         const next = [...current, request]
         setPendingCodexPermissionRequests(session_id, next)
         setWaitingForInput(session_id, true)
+        playWaitingSound()
         notifySession(session_id, 'Needs your input')
         persistCodexPendingState(session_id, worktree_id, {
           pendingCodexPermissionRequests: next,
@@ -698,6 +711,7 @@ export default function useStreamingEvents({
           const next = [...current, request]
           setPendingCodexCommandApprovalRequests(session_id, next)
           setWaitingForInput(session_id, true)
+          playWaitingSound()
           notifySession(session_id, 'Needs your input')
           persistCodexPendingState(session_id, worktree_id, {
             pendingCodexCommandApprovalRequests: next,
@@ -732,6 +746,7 @@ export default function useStreamingEvents({
         addToolCall(session_id, toolCall)
         addToolBlock(session_id, toolCall.id)
 
+        playWaitingSound()
         notifySession(session_id, 'Needs your input')
         persistCodexPendingState(session_id, worktree_id, {
           pendingCodexUserInputRequests: next,
@@ -779,6 +794,7 @@ export default function useStreamingEvents({
           const next = [...current, request]
           setPendingCodexDynamicToolCallRequests(session_id, next)
           setWaitingForInput(session_id, true)
+          playWaitingSound()
           notifySession(session_id, 'Needs your input')
           persistCodexPendingState(session_id, worktree_id, {
             pendingCodexDynamicToolCallRequests: next,

--- a/src/lib/sounds.test.ts
+++ b/src/lib/sounds.test.ts
@@ -122,6 +122,35 @@ describe('notification sounds', () => {
     expect(workworkOsc?.frequency.value).not.toBe(jobsdoneOsc?.frequency.value)
   })
 
+  it('awaits resume before playing when the audio context starts suspended', async () => {
+    nativeApp = true
+    let resolveResume: (() => void) | undefined
+    const resumePromise = new Promise<void>(resolve => {
+      resolveResume = resolve
+    })
+
+    class SuspendedAudioContext extends MockAudioContext {
+      override state = 'suspended'
+      override resume = vi.fn(() => {
+        const promise = resumePromise.then(() => {
+          this.state = 'running'
+        })
+        return promise
+      })
+    }
+
+    vi.stubGlobal('AudioContext', SuspendedAudioContext)
+
+    const { playNotificationSound } = await import('./sounds')
+
+    playNotificationSound('workwork')
+    expect(startedBuffers).toHaveLength(0)
+
+    resolveResume?.()
+    await resumePromise
+    await vi.waitFor(() => expect(startedBuffers).toHaveLength(1))
+  })
+
   it('ignores a stale decode so only the latest requested sound plays', async () => {
     nativeApp = true
 

--- a/src/lib/sounds.ts
+++ b/src/lib/sounds.ts
@@ -64,12 +64,52 @@ function getAudioContext(): AudioContext | null {
     }
   }
 
-  // Resume if suspended (the context is unlocked by any prior user gesture).
-  if (audioContext.state === 'suspended') {
-    void audioContext.resume().catch(() => undefined)
+  return audioContext
+}
+
+/** Kick off resume synchronously (must run inside the user-gesture call stack). */
+function beginAudioContextResume(ctx: AudioContext): void {
+  if (ctx.state === 'suspended') {
+    void ctx.resume().catch(() => undefined)
+  }
+}
+
+/** Await a running context before starting playback. */
+async function ensureAudioContextRunning(
+  ctx: AudioContext
+): Promise<boolean> {
+  if (ctx.state === 'running') return true
+  if (ctx.state === 'closed') return false
+
+  try {
+    await ctx.resume()
+  } catch {
+    // Still attempt playback — some webviews report non-running state incorrectly.
   }
 
-  return audioContext
+  return true
+}
+
+/**
+ * Unlock notification audio on the first user interaction.
+ * Call once at app startup so background session events can play sounds later.
+ */
+export function installAudioUnlockListeners(): () => void {
+  if (typeof document === 'undefined') return () => undefined
+
+  const unlock = () => {
+    const ctx = getAudioContext()
+    if (ctx) beginAudioContextResume(ctx)
+  }
+
+  const options: AddEventListenerOptions = { capture: true, passive: true }
+  document.addEventListener('pointerdown', unlock, options)
+  document.addEventListener('keydown', unlock, options)
+
+  return () => {
+    document.removeEventListener('pointerdown', unlock, options)
+    document.removeEventListener('keydown', unlock, options)
+  }
 }
 
 function loadBuffer(
@@ -169,24 +209,29 @@ export function playNotificationSound(
   const ctx = getAudioContext()
   if (!ctx) return
 
+  // Resume while the click/key handler is still on the stack (settings preview).
+  beginAudioContextResume(ctx)
+
   // Claim the latest request slot so stale async loads can be discarded.
   const requestId = ++playRequestId
 
   // Stop any currently playing sound to prevent overlap.
   stopCurrentSource()
 
-  loadBuffer(sound, ctx)
-    .then(buffer => {
+  void loadBuffer(sound, ctx)
+    .then(async buffer => {
       // A newer request superseded this one — drop the stale completion.
       if (requestId !== playRequestId) return
+      await ensureAudioContextRunning(ctx)
       if (buffer) {
         playBuffer(ctx, buffer)
       } else {
         playFallbackBeep(ctx, sound)
       }
     })
-    .catch(() => {
+    .catch(async () => {
       if (requestId !== playRequestId) return
+      await ensureAudioContextRunning(ctx)
       playFallbackBeep(ctx, sound)
     })
 }


### PR DESCRIPTION
## Summary

- Resume `AudioContext` synchronously on user gestures so the Settings Play preview works on macOS WebKit (v0.1.63 bundles the WAV assets correctly, but playback was silently blocked).
- Install audio unlock listeners at app startup so background session notifications can play after the first interaction.
- Always attempt fallback beep when WAV decode fails instead of aborting playback.
- Play the waiting sound on Codex mid-run approval events (permission, command approval, user input, MCP elicitation, dynamic tool call), not only on `chat:done`.

## Type

fix

## Testing

- Settings → General → Play next to Waiting/Review sounds (macOS native app)
- Run a session to completion in the background and confirm review sound plays
- Trigger a Codex approval mid-run and confirm waiting sound plays