### PR TITLE
fix(chat): deduplicate Codex user input prompts

### DIFF
--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -89,6 +89,8 @@ import type {
   CodexDynamicToolCallRequest,
   PermissionDenial,
   PendingFile,
+  Question,
+  QuestionAnswer,
 } from '@/types/chat'
 import {
   isAskUserQuestion,
@@ -224,11 +226,17 @@ import { usePendingAttachments } from './hooks/usePendingAttachments'
 import { dedupeInFlightAssistantMessage } from './in-flight-message-dedupe'
 import { shouldShowPermissionApproval } from './permission-approval-utils'
 import { navigateToForkedSession } from './fork-session-navigation'
+import {
+  findCodexUserInputRequestByToolCallId,
+  getCodexUserInputRequestToolCallId,
+  shouldRenderCodexUserInputFallback,
+} from './codex-user-input-utils'
 
 // PERFORMANCE: Stable empty array references to prevent infinite render loops
 // When Zustand selectors return [], a new reference is created each time
 // Using these constants ensures referential equality for empty states
 const EMPTY_TOOL_CALLS: ToolCall[] = []
+const EMPTY_CHAT_MESSAGES: ChatMessage[] = []
 const EMPTY_CONTENT_BLOCKS: ContentBlock[] = []
 const EMPTY_PENDING_IMAGES: PendingImage[] = []
 const EMPTY_PENDING_TEXT_FILES: PendingTextFile[] = []
@@ -1037,6 +1045,21 @@ export function ChatWindow({
   const activeCodexUserInputQuestions = useMemo(
     () => normalizeCodexQuestions(activeCodexUserInputRequest?.questions),
     [activeCodexUserInputRequest]
+  )
+  const showActiveCodexUserInputFallback = useMemo(
+    () =>
+      activeCodexUserInputQuestions.length > 0 &&
+      shouldRenderCodexUserInputFallback(
+        activeCodexUserInputRequest,
+        currentToolCalls,
+        session?.messages ?? EMPTY_CHAT_MESSAGES
+      ),
+    [
+      activeCodexUserInputQuestions.length,
+      activeCodexUserInputRequest,
+      currentToolCalls,
+      session?.messages,
+    ]
   )
 
   // PERFORMANCE: Pre-compute last assistant message to avoid rescanning in multiple memos
@@ -2374,6 +2397,48 @@ export function ChatWindow({
     projectIdRef,
   })
 
+  const handleQuestionAnswerForActiveRequest = useCallback(
+    (toolCallId: string, answers: QuestionAnswer[], questions: Question[]) => {
+      const sessionId = activeSessionIdRef.current
+      const pendingRequest = sessionId
+        ? findCodexUserInputRequestByToolCallId(
+            useChatStore.getState().pendingCodexUserInputRequests[sessionId] ??
+              EMPTY_CODEX_USER_INPUT_REQUESTS,
+            toolCallId
+          )
+        : undefined
+
+      if (pendingRequest) {
+        handleCodexUserInputAnswer(pendingRequest, answers, toolCallId)
+        return
+      }
+
+      handleQuestionAnswer(toolCallId, answers, questions)
+    },
+    [handleCodexUserInputAnswer, handleQuestionAnswer]
+  )
+
+  const handleQuestionSkipForActiveRequest = useCallback(
+    (toolCallId: string) => {
+      const sessionId = activeSessionIdRef.current
+      const pendingRequest = sessionId
+        ? findCodexUserInputRequestByToolCallId(
+            useChatStore.getState().pendingCodexUserInputRequests[sessionId] ??
+              EMPTY_CODEX_USER_INPUT_REQUESTS,
+            toolCallId
+          )
+        : undefined
+
+      if (pendingRequest) {
+        handleCodexUserInputAnswer(pendingRequest, [], toolCallId)
+        return
+      }
+
+      handleSkipQuestion(toolCallId)
+    },
+    [handleCodexUserInputAnswer, handleSkipQuestion]
+  )
+
   // Copy a sent user message to the clipboard with attachment metadata
   // When pasted back, ChatInput detects the custom format and restores attachments
   const handleCopyToInput = useCallback(async (message: ChatMessage) => {
@@ -2890,8 +2955,12 @@ export function ChatWindow({
                                         ? handleWorktreeYoloApproval
                                         : undefined
                                     }
-                                    onQuestionAnswer={handleQuestionAnswer}
-                                    onQuestionSkip={handleSkipQuestion}
+                                    onQuestionAnswer={
+                                      handleQuestionAnswerForActiveRequest
+                                    }
+                                    onQuestionSkip={
+                                      handleQuestionSkipForActiveRequest
+                                    }
                                     onFileClick={setViewingFilePath}
                                     onFixFinding={handleFixFinding}
                                     onFixAllFindings={handleFixAllFindings}
@@ -2963,8 +3032,12 @@ export function ChatWindow({
                                         ? handleWorktreeYoloApproval
                                         : undefined
                                     }
-                                    onQuestionAnswer={handleQuestionAnswer}
-                                    onQuestionSkip={handleSkipQuestion}
+                                    onQuestionAnswer={
+                                      handleQuestionAnswerForActiveRequest
+                                    }
+                                    onQuestionSkip={
+                                      handleQuestionSkipForActiveRequest
+                                    }
                                     onFileClick={setViewingFilePath}
                                     onFixFinding={handleFixFinding}
                                     onFixAllFindings={handleFixAllFindings}
@@ -3000,8 +3073,12 @@ export function ChatWindow({
                                       }
                                       toolCalls={currentToolCalls}
                                       streamingContent={streamingContent}
-                                      onQuestionAnswer={handleQuestionAnswer}
-                                      onQuestionSkip={handleSkipQuestion}
+                                      onQuestionAnswer={
+                                        handleQuestionAnswerForActiveRequest
+                                      }
+                                      onQuestionSkip={
+                                        handleQuestionSkipForActiveRequest
+                                      }
                                       onFileClick={setViewingFilePath}
                                       worktreePath={activeWorktreePath}
                                       isQuestionAnswered={isQuestionAnswered}
@@ -3017,8 +3094,12 @@ export function ChatWindow({
                                       }
                                       toolCalls={currentToolCalls}
                                       streamingContent={streamingContent}
-                                      onQuestionAnswer={handleQuestionAnswer}
-                                      onQuestionSkip={handleSkipQuestion}
+                                      onQuestionAnswer={
+                                        handleQuestionAnswerForActiveRequest
+                                      }
+                                      onQuestionSkip={
+                                        handleQuestionSkipForActiveRequest
+                                      }
                                       onFileClick={setViewingFilePath}
                                       worktreePath={activeWorktreePath}
                                       isQuestionAnswered={isQuestionAnswered}
@@ -3106,18 +3187,18 @@ export function ChatWindow({
                               />
                             )}
 
-                            {activeCodexUserInputRequest &&
-                              activeCodexUserInputQuestions.length > 0 && (
+                            {showActiveCodexUserInputFallback &&
+                              activeCodexUserInputRequest && (
                                 <AskUserQuestion
-                                  toolCallId={
-                                    activeCodexUserInputRequest.item_id ||
-                                    `codex-user-input-${activeCodexUserInputRequest.rpc_id}`
-                                  }
+                                  toolCallId={getCodexUserInputRequestToolCallId(
+                                    activeCodexUserInputRequest
+                                  )}
                                   questions={activeCodexUserInputQuestions}
-                                  onSubmit={(_toolCallId, answers) =>
+                                  onSubmit={(toolCallId, answers) =>
                                     handleCodexUserInputAnswer(
                                       activeCodexUserInputRequest,
-                                      answers
+                                      answers,
+                                      toolCallId
                                     )
                                   }
                                   isSkipped={false}

--- a/src/components/chat/codex-user-input-utils.test.ts
+++ b/src/components/chat/codex-user-input-utils.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatMessage, CodexUserInputRequest, ToolCall } from '@/types/chat'
+import {
+  findCodexUserInputRequestByToolCallId,
+  resolveCodexUserInputResponseToolCallId,
+  shouldRenderCodexUserInputFallback,
+  upsertCodexUserInputRequest,
+} from './codex-user-input-utils'
+
+function createRequest(
+  overrides: Partial<CodexUserInputRequest> = {}
+): CodexUserInputRequest {
+  return {
+    rpc_id: 42,
+    item_id: 'item-42',
+    questions: [
+      {
+        id: 'choice',
+        question: 'Which option?',
+        options: [{ label: 'One' }, { label: 'Two' }],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function createQuestionToolCall(id: string): ToolCall {
+  return {
+    id,
+    name: 'AskUserQuestion',
+    input: {
+      questions: [
+        {
+          question: 'Which option?',
+          multiSelect: false,
+          options: [{ label: 'One' }, { label: 'Two' }],
+        },
+      ],
+    },
+  }
+}
+
+function createAssistantMessage(toolCalls: ToolCall[]): ChatMessage {
+  return {
+    id: 'assistant-1',
+    session_id: 'session-1',
+    role: 'assistant',
+    content: '',
+    timestamp: 1,
+    tool_calls: toolCalls,
+  }
+}
+
+describe('upsertCodexUserInputRequest', () => {
+  it('returns the existing array for an identical replay', () => {
+    const request = createRequest()
+    const requests = [request]
+
+    expect(upsertCodexUserInputRequest(requests, createRequest())).toBe(
+      requests
+    )
+  })
+
+  it('replaces a matching item_id replay with the latest request', () => {
+    const request = createRequest()
+
+    expect(
+      upsertCodexUserInputRequest([request], createRequest({ rpc_id: 99 }))
+    ).toEqual([expect.objectContaining({ item_id: 'item-42', rpc_id: 99 })])
+  })
+
+  it('keeps different non-empty item IDs even when rpc_id matches', () => {
+    const request = createRequest()
+
+    expect(
+      upsertCodexUserInputRequest(
+        [request],
+        createRequest({ item_id: 'different-item' })
+      )
+    ).toHaveLength(2)
+  })
+
+  it('falls back to rpc_id when item_id is absent', () => {
+    const request = createRequest({ item_id: '' })
+
+    expect(
+      upsertCodexUserInputRequest(
+        [request],
+        createRequest({ item_id: '', questions: [] })
+      )
+    ).toEqual([expect.objectContaining({ rpc_id: 42, questions: [] })])
+  })
+})
+
+describe('shouldRenderCodexUserInputFallback', () => {
+  it('hides the fallback when the active streaming tool calls represent the request', () => {
+    const request = createRequest()
+
+    expect(
+      shouldRenderCodexUserInputFallback(
+        request,
+        [createQuestionToolCall(request.item_id)],
+        []
+      )
+    ).toBe(false)
+  })
+
+  it('hides the fallback when a persisted assistant tool call represents the request', () => {
+    const request = createRequest({ item_id: '' })
+
+    expect(
+      shouldRenderCodexUserInputFallback(
+        request,
+        [],
+        [
+          createAssistantMessage([
+            createQuestionToolCall(`codex-user-input-${request.rpc_id}`),
+          ]),
+        ]
+      )
+    ).toBe(false)
+  })
+
+  it('keeps the fallback for hydrated pending state without a matching tool call', () => {
+    const request = createRequest()
+
+    expect(
+      shouldRenderCodexUserInputFallback(
+        request,
+        [createQuestionToolCall('unrelated-tool')],
+        [createAssistantMessage([createQuestionToolCall('older-request')])]
+      )
+    ).toBe(true)
+  })
+})
+
+describe('findCodexUserInputRequestByToolCallId', () => {
+  it('resolves the pending request used to route represented-card answer and skip actions', () => {
+    const request = createRequest()
+
+    expect(
+      findCodexUserInputRequestByToolCallId([request], request.item_id)
+    ).toBe(request)
+    expect(
+      findCodexUserInputRequestByToolCallId([request], 'unrelated-tool')
+    ).toBeUndefined()
+  })
+})
+
+describe('resolveCodexUserInputResponseToolCallId', () => {
+  it('keeps the clicked rpc-only rendered ID after the request gains an item_id', () => {
+    const enrichedRequest = createRequest({ item_id: 'item-42' })
+
+    expect(
+      resolveCodexUserInputResponseToolCallId(
+        enrichedRequest,
+        'codex-user-input-42'
+      )
+    ).toBe('codex-user-input-42')
+    expect(resolveCodexUserInputResponseToolCallId(enrichedRequest)).toBe(
+      'item-42'
+    )
+  })
+})

--- a/src/components/chat/codex-user-input-utils.ts
+++ b/src/components/chat/codex-user-input-utils.ts
@@ -1,0 +1,102 @@
+import type { ChatMessage, CodexUserInputRequest, ToolCall } from '@/types/chat'
+import { isAskUserQuestion } from '@/types/chat'
+
+export function getCodexUserInputRequestToolCallId(
+  request: CodexUserInputRequest
+): string {
+  return request.item_id || `codex-user-input-${request.rpc_id}`
+}
+
+export function resolveCodexUserInputResponseToolCallId(
+  request: CodexUserInputRequest,
+  renderedToolCallId?: string
+): string {
+  return renderedToolCallId ?? getCodexUserInputRequestToolCallId(request)
+}
+
+export function isSameCodexUserInputRequest(
+  first: CodexUserInputRequest,
+  second: CodexUserInputRequest
+): boolean {
+  const firstItemId = first.item_id
+  const secondItemId = second.item_id
+
+  if (firstItemId.length > 0 && secondItemId.length > 0) {
+    return firstItemId === secondItemId
+  }
+
+  return first.rpc_id === second.rpc_id
+}
+
+export function upsertCodexUserInputRequest(
+  requests: CodexUserInputRequest[],
+  request: CodexUserInputRequest
+): CodexUserInputRequest[] {
+  const existingIndex = requests.findIndex(existing =>
+    isSameCodexUserInputRequest(existing, request)
+  )
+  if (existingIndex === -1) return [...requests, request]
+
+  const existing = requests[existingIndex]
+  if (!existing) return requests
+
+  const nextRequest =
+    request.item_id.length === 0 && existing.item_id.length > 0
+      ? { ...request, item_id: existing.item_id }
+      : request
+  if (JSON.stringify(existing) === JSON.stringify(nextRequest)) return requests
+
+  const next = [...requests]
+  next[existingIndex] = nextRequest
+  return next
+}
+
+function toolCallRepresentsCodexUserInputRequest(
+  toolCall: ToolCall,
+  request: CodexUserInputRequest
+): boolean {
+  if (!isAskUserQuestion(toolCall)) return false
+
+  const fallbackId = `codex-user-input-${request.rpc_id}`
+  return (
+    toolCall.id === getCodexUserInputRequestToolCallId(request) ||
+    toolCall.id === fallbackId
+  )
+}
+
+export function findCodexUserInputRequestByToolCallId(
+  requests: CodexUserInputRequest[],
+  toolCallId: string
+): CodexUserInputRequest | undefined {
+  return requests.find(request => {
+    const fallbackId = `codex-user-input-${request.rpc_id}`
+    return (
+      toolCallId === getCodexUserInputRequestToolCallId(request) ||
+      toolCallId === fallbackId
+    )
+  })
+}
+
+export function shouldRenderCodexUserInputFallback(
+  request: CodexUserInputRequest | undefined,
+  activeToolCalls: ToolCall[],
+  persistedMessages: ChatMessage[]
+): boolean {
+  if (!request) return false
+
+  if (
+    activeToolCalls.some(toolCall =>
+      toolCallRepresentsCodexUserInputRequest(toolCall, request)
+    )
+  ) {
+    return false
+  }
+
+  return !persistedMessages.some(
+    message =>
+      message.role === 'assistant' &&
+      message.tool_calls.some(toolCall =>
+        toolCallRepresentsCodexUserInputRequest(toolCall, request)
+      )
+  )
+}

--- a/src/components/chat/hooks/useMessageHandlers.ts
+++ b/src/components/chat/hooks/useMessageHandlers.ts
@@ -44,6 +44,7 @@ import type {
 } from '@/types/projects'
 import { clearPlanApprovalTransientState } from './plan-approval-state'
 import type { ApprovalModelOverride } from '../ApprovalModelSubmenu'
+import { resolveCodexUserInputResponseToolCallId } from '../codex-user-input-utils'
 
 /** Git commands to auto-approve for magic prompts (no permission prompts needed) */
 export const GIT_ALLOWED_TOOLS = [
@@ -172,7 +173,8 @@ interface MessageHandlers {
   handleCodexPermissionRequestDecline: (request: CodexPermissionRequest) => void
   handleCodexUserInputAnswer: (
     request: CodexUserInputRequest,
-    answers: QuestionAnswer[]
+    answers: QuestionAnswer[],
+    renderedToolCallId?: string
   ) => void
   handleCodexMcpElicitationAccept: (
     request: CodexMcpElicitationRequest,
@@ -2916,14 +2918,21 @@ export function useMessageHandlers({
   )
 
   const handleCodexUserInputAnswer = useCallback(
-    (request: CodexUserInputRequest, answers: QuestionAnswer[]) => {
+    (
+      request: CodexUserInputRequest,
+      answers: QuestionAnswer[],
+      renderedToolCallId?: string
+    ) => {
       const sessionId = activeSessionIdRef.current
       const worktreeId = activeWorktreeIdRef.current
       const worktreePath = activeWorktreePathRef.current
       if (!sessionId || !worktreeId || !worktreePath) return
 
       const store = useChatStore.getState()
-      const toolCallId = request.item_id || `codex-user-input-${request.rpc_id}`
+      const toolCallId = resolveCodexUserInputResponseToolCallId(
+        request,
+        renderedToolCallId
+      )
       store.markQuestionAnswered(sessionId, toolCallId, answers)
       store.updateToolCallOutput(sessionId, toolCallId, JSON.stringify(answers))
       store.setPendingCodexUserInputRequests(

--- a/src/components/chat/hooks/useStreamingEvents.test.tsx
+++ b/src/components/chat/hooks/useStreamingEvents.test.tsx
@@ -176,6 +176,121 @@ describe('useStreamingEvents Codex MCP elicitation', () => {
   })
 })
 
+describe('useStreamingEvents Codex user input', () => {
+  beforeEach(() => {
+    setupListenMock()
+
+    useChatStore.setState({
+      pendingCodexUserInputRequests: {},
+      waitingForInputSessionIds: {},
+      activeToolCalls: {},
+      streamingContentBlocks: {},
+      worktreePaths: { 'worktree-1': '/tmp/worktree' },
+    })
+  })
+
+  it('deduplicates identical replays and retains the latest request for an item_id', async () => {
+    const queryClient = createQueryClient()
+    const wrapper = createWrapper(queryClient)
+
+    renderHook(() => useStreamingEvents({ queryClient }), { wrapper })
+
+    await waitFor(() =>
+      expect(registeredListeners.has('chat:codex_user_input_request')).toBe(
+        true
+      )
+    )
+
+    const emitRequest = (rpcId: number, itemId: string) => {
+      registeredListeners.get('chat:codex_user_input_request')?.({
+        payload: {
+          session_id: 'session-1',
+          worktree_id: 'worktree-1',
+          request: {
+            rpc_id: rpcId,
+            item_id: itemId,
+            questions: [
+              {
+                id: 'choice',
+                question: 'Which option?',
+                options: [{ label: 'One' }, { label: 'Two' }],
+              },
+            ],
+          },
+        },
+      })
+    }
+
+    emitRequest(42, 'item-42')
+    emitRequest(42, 'item-42')
+    emitRequest(99, 'item-42')
+
+    expect(
+      useChatStore.getState().pendingCodexUserInputRequests['session-1']
+    ).toEqual([expect.objectContaining({ rpc_id: 99, item_id: 'item-42' })])
+    expect(useChatStore.getState().activeToolCalls['session-1']).toEqual([
+      expect.objectContaining({ id: 'item-42', name: 'AskUserQuestion' }),
+    ])
+    expect(useChatStore.getState().streamingContentBlocks['session-1']).toEqual(
+      [{ type: 'tool_use', tool_call_id: 'item-42' }]
+    )
+    expect(
+      mockInvoke.mock.calls.filter(
+        ([command]) => command === 'update_session_state'
+      )
+    ).toHaveLength(2)
+  })
+
+  it('keeps one tool-call representation when a rpc-only request gains an item_id', async () => {
+    const queryClient = createQueryClient()
+    const wrapper = createWrapper(queryClient)
+
+    renderHook(() => useStreamingEvents({ queryClient }), { wrapper })
+
+    await waitFor(() =>
+      expect(registeredListeners.has('chat:codex_user_input_request')).toBe(
+        true
+      )
+    )
+
+    const basePayload = {
+      session_id: 'session-1',
+      worktree_id: 'worktree-1',
+      request: {
+        rpc_id: 42,
+        item_id: '',
+        questions: [
+          {
+            id: 'choice',
+            question: 'Which option?',
+            options: [{ label: 'One' }, { label: 'Two' }],
+          },
+        ],
+      },
+    }
+
+    registeredListeners.get('chat:codex_user_input_request')?.({
+      payload: basePayload,
+    })
+    registeredListeners.get('chat:codex_user_input_request')?.({
+      payload: {
+        ...basePayload,
+        request: { ...basePayload.request, item_id: 'item-42' },
+      },
+    })
+
+    expect(
+      useChatStore.getState().pendingCodexUserInputRequests['session-1']
+    ).toEqual([expect.objectContaining({ rpc_id: 42, item_id: 'item-42' })])
+    expect(useChatStore.getState().activeToolCalls['session-1']).toEqual([
+      expect.objectContaining({ id: 'codex-user-input-42' }),
+    ])
+    expect(useChatStore.getState().streamingContentBlocks['session-1']).toEqual(
+      [{ type: 'tool_use', tool_call_id: 'codex-user-input-42' }]
+    )
+  })
+})
+
 describe('useStreamingEvents cancellation sanitization', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -67,6 +67,11 @@ import {
   hasMeaningfulAssistantPayload,
   shouldHydrateCompletedSessionFromBackend,
 } from '@/components/chat/hooks/completion-hydration'
+import {
+  getCodexUserInputRequestToolCallId,
+  isSameCodexUserInputRequest,
+  upsertCodexUserInputRequest,
+} from '@/components/chat/codex-user-input-utils'
 
 interface UseStreamingEventsParams {
   queryClient: QueryClient
@@ -718,14 +723,19 @@ export default function useStreamingEvents({
         const current =
           useChatStore.getState().pendingCodexUserInputRequests[session_id] ??
           []
-        const next = [...current, request]
+        const previousRequest = current.find(existing =>
+          isSameCodexUserInputRequest(existing, request)
+        )
+        const next = upsertCodexUserInputRequest(current, request)
+        if (next === current) return
+
         setPendingCodexUserInputRequests(session_id, next)
         setWaitingForInput(session_id, true)
 
         const questions = normalizeCodexQuestions(request.questions)
 
         const toolCall = {
-          id: request.item_id || `codex-user-input-${request.rpc_id}`,
+          id: getCodexUserInputRequestToolCallId(previousRequest ?? request),
           name: 'AskUserQuestion',
           input: { questions },
         }
@@ -2073,7 +2083,14 @@ export default function useStreamingEvents({
         case 'effortLevel':
           store.setEffortLevel(
             session_id,
-            value as 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra' | 'ultracode'
+            value as
+              | 'low'
+              | 'medium'
+              | 'high'
+              | 'xhigh'
+              | 'max'
+              | 'ultra'
+              | 'ultracode'
           )
           break
         case 'executionMode':


### PR DESCRIPTION
## Summary

- make Codex `request_user_input` event handling idempotent across repeated or replayed events
- render one interactive question card by preferring the streaming or persisted tool-call representation and keeping the pending fallback only for hydration gaps
- route Answer and Skip from represented Codex cards through the dedicated RPC response path
- preserve the actual rendered tool-call identity when RPC-only requests are later enriched with `item_id`
- add focused regression coverage for replay, enrichment, fallback rendering, and response identity

## Root cause

Each Codex user-input event was stored twice in presentation state: as a pending request and as a synthetic `AskUserQuestion` tool call. `ChatWindow` rendered both independently, while the pending queue also appended repeated events without a stable identity check. This produced duplicate cards and could leave orphaned pending state after answering or skipping.

## Validation

- `bun run test:run src/components/chat/codex-user-input-utils.test.ts src/components/chat/hooks/useStreamingEvents.test.tsx`
- `bun run test:run` (200 files, 1234 tests)
- `bun run typecheck`
- touched-file ESLint with zero warnings
- Prettier check
- `git diff --check`

Fixes #477
