### PR TITLE
fix(chat): clear stale question waiting indicators

### DIFF
--- a/src/components/chat/hooks/useMessageHandlers.ts
+++ b/src/components/chat/hooks/useMessageHandlers.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner'
 import { invoke, listen } from '@/lib/transport'
 import {
   chatQueryKeys,
+  clearQuestionWaitingStateInSessionListCache,
   markPlanApproved as markPlanApprovedService,
   readPlanFile,
   persistEnqueue,
@@ -338,6 +339,11 @@ export function useMessageHandlers({
         clearStreamingContentBlocks,
       } = useChatStore.getState()
       markQuestionAnswered(sessionId, toolCallId, answers)
+      clearQuestionWaitingStateInSessionListCache(
+        queryClient,
+        worktreeId,
+        sessionId
+      )
 
       // Persist answer data as JSON in the tool output so the collapsed view
       // can reconstruct which options were selected (Zustand state is ephemeral)
@@ -497,6 +503,11 @@ export function useMessageHandlers({
 
       // Mark this question as answered (empty answers = skipped)
       markQuestionAnswered(sessionId, toolCallId, [])
+      clearQuestionWaitingStateInSessionListCache(
+        queryClient,
+        worktreeId,
+        sessionId
+      )
 
       // Set session-level skip state to auto-skip all subsequent questions
       // No message is sent to Claude - the flow is simply cancelled

--- a/src/components/projects/WorktreeItem.test.tsx
+++ b/src/components/projects/WorktreeItem.test.tsx
@@ -195,4 +195,22 @@ describe('WorktreeItem question indicator', () => {
       'idle'
     )
   })
+
+  it('keeps an inactive persisted question answered after reload', () => {
+    sessionMocks.sessions = [
+      {
+        ...questionSession,
+        id: 'session-2',
+        name: 'Inactive answered question',
+        answered_questions: ['question-1'],
+      },
+    ]
+
+    renderWorktreeItem()
+
+    expect(screen.getByTestId('worktree-status')).toHaveAttribute(
+      'data-status',
+      'idle'
+    )
+  })
 })

--- a/src/components/projects/WorktreeItem.test.tsx
+++ b/src/components/projects/WorktreeItem.test.tsx
@@ -1,0 +1,198 @@
+import { act, render, screen } from '@/test/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useChatStore } from '@/store/chat-store'
+import { useProjectsStore } from '@/store/projects-store'
+import type { Worktree } from '@/types/projects'
+import type { QuestionAnswer, Session } from '@/types/chat'
+import { WorktreeItem } from './WorktreeItem'
+
+const sessionMocks = vi.hoisted(() => ({
+  sessions: [] as unknown[],
+}))
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}))
+
+vi.mock('@/hooks/useRemotePicker', () => ({
+  pushNeedsRemotePicker: () => false,
+  useRemotePicker: () => vi.fn(),
+}))
+
+vi.mock('@/hooks/useWorktreeTerminalStatus', () => ({
+  TerminalStatusIndicator: () => null,
+}))
+
+vi.mock('@/components/ui/status-indicator', () => ({
+  StatusIndicator: ({ status }: { status: string }) => (
+    <span data-testid="worktree-status" data-status={status} />
+  ),
+}))
+
+vi.mock('./WorktreeContextMenu', () => ({
+  WorktreeContextMenu: ({ children }: { children: React.ReactNode }) =>
+    children,
+}))
+
+vi.mock('./useWorktreeMenuActions', () => ({
+  useWorktreeMenuActions: () => ({
+    handleArchiveOrClose: vi.fn(),
+    preferences: {},
+  }),
+}))
+
+vi.mock('@/components/chat/hooks/useSessionArchive', () => ({
+  useSessionArchive: () => ({ handleDeleteSession: vi.fn() }),
+}))
+
+vi.mock('@/components/chat/CloseWorktreeDialog', () => ({
+  CloseWorktreeDialog: () => null,
+}))
+
+vi.mock('@/components/chat/hooks/useCanvasStoreState', () => ({
+  useCanvasStoreState: () => ({}),
+}))
+
+vi.mock('@/components/layout/SidebarWidthContext', () => ({
+  useSidebarWidth: () => 250,
+}))
+
+vi.mock('@/services/projects', () => ({
+  useRenameWorktree: () => ({ mutate: vi.fn() }),
+}))
+
+vi.mock('@/services/chat', () => ({
+  useSessions: () => ({
+    data: {
+      worktree_id: 'worktree-1',
+      sessions: sessionMocks.sessions,
+      active_session_id: 'session-1',
+      version: 2,
+    },
+  }),
+}))
+
+vi.mock('@/services/git-status', () => ({
+  useGitStatus: () => ({ data: undefined }),
+  gitPush: vi.fn(),
+  fetchWorktreesStatus: vi.fn(),
+  triggerImmediateGitPoll: vi.fn(),
+  performGitPull: vi.fn(),
+}))
+
+const worktree: Worktree = {
+  id: 'worktree-1',
+  project_id: 'project-1',
+  name: 'feature-question-state',
+  path: '/tmp/project/feature-question-state',
+  branch: 'feature-question-state',
+  base_branch: 'main',
+  created_at: 1,
+  order: 0,
+}
+
+const questionSession: Session = {
+  id: 'session-1',
+  name: 'Question session',
+  order: 0,
+  created_at: 1,
+  updated_at: 1,
+  messages: [
+    {
+      id: 'message-1',
+      session_id: 'session-1',
+      role: 'assistant',
+      content: '',
+      timestamp: 1,
+      tool_calls: [
+        {
+          id: 'question-1',
+          name: 'AskUserQuestion',
+          input: {
+            questions: [
+              {
+                question: 'Continue?',
+                multiSelect: false,
+                options: [{ label: 'Yes' }, { label: 'No' }],
+              },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+}
+
+function renderWorktreeItem() {
+  render(
+    <WorktreeItem
+      worktree={worktree}
+      projectId="project-1"
+      projectPath="/tmp/project"
+      defaultBranch="main"
+    />
+  )
+}
+
+describe('WorktreeItem question indicator', () => {
+  beforeEach(() => {
+    sessionMocks.sessions = [questionSession]
+    useProjectsStore.setState({
+      selectedProjectId: null,
+      selectedWorktreeId: null,
+      expandedWorktreeIds: new Set(),
+    })
+    useChatStore.setState({
+      sendingSessionIds: {},
+      sessionWorktreeMap: { 'session-1': 'worktree-1' },
+      activeToolCalls: {},
+      answeredQuestions: {},
+      waitingForInputSessionIds: {},
+      reviewingSessions: {},
+      executingModes: {},
+      executionModes: {},
+      worktreeLoadingOperations: {},
+    })
+  })
+
+  it('clears the waiting indicator after the question is answered', () => {
+    renderWorktreeItem()
+    expect(screen.getByTestId('worktree-status')).toHaveAttribute(
+      'data-status',
+      'waiting'
+    )
+
+    const answers: QuestionAnswer[] = [
+      { questionIndex: 0, selectedOptions: [0] },
+    ]
+    act(() => {
+      useChatStore
+        .getState()
+        .markQuestionAnswered('session-1', 'question-1', answers)
+    })
+
+    expect(screen.getByTestId('worktree-status')).toHaveAttribute(
+      'data-status',
+      'idle'
+    )
+  })
+
+  it('clears the waiting indicator after the question is skipped', () => {
+    renderWorktreeItem()
+    expect(screen.getByTestId('worktree-status')).toHaveAttribute(
+      'data-status',
+      'waiting'
+    )
+
+    act(() => {
+      useChatStore
+        .getState()
+        .markQuestionAnswered('session-1', 'question-1', [])
+    })
+
+    expect(screen.getByTestId('worktree-status')).toHaveAttribute(
+      'data-status',
+      'idle'
+    )
+  })
+})

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -190,7 +190,8 @@ export function WorktreeItem({
         lastAssistantMsg?.tool_calls?.some(
           tc =>
             isAskUserQuestion(tc) &&
-            !state.answeredQuestions[session.id]?.has(tc.id)
+            !state.answeredQuestions[session.id]?.has(tc.id) &&
+            !session.answered_questions?.includes(tc.id)
         )
       ) {
         return true

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -72,7 +72,6 @@ export function WorktreeItem({
   const isChatRunning = useChatStore(state =>
     state.isWorktreeRunning(worktree.id)
   )
-  const isQuestionAnswered = useChatStore(state => state.isQuestionAnswered)
   const sendingSessionKey = useChatStore(state => {
     const ids: string[] = []
     for (const [sessionId, isSending] of Object.entries(
@@ -173,11 +172,11 @@ export function WorktreeItem({
   })
 
   // Check if any session has unanswered AskUserQuestion in persisted messages (blinks)
-  const hasPendingQuestion = useMemo(() => {
+  const hasPendingQuestion = useChatStore(state => {
     const sessions = sessionsData?.sessions ?? []
     for (const session of sessions) {
       // Skip sessions that are currently streaming (handled by isStreamingWaitingQuestion)
-      if (useChatStore.getState().sendingSessionIds[session.id]) continue
+      if (state.sendingSessionIds[session.id]) continue
 
       // Find last assistant message by iterating from end (avoids array copy from .reverse())
       let lastAssistantMsg = null
@@ -189,19 +188,16 @@ export function WorktreeItem({
       }
       if (
         lastAssistantMsg?.tool_calls?.some(
-          tc => isAskUserQuestion(tc) && !isQuestionAnswered(session.id, tc.id)
+          tc =>
+            isAskUserQuestion(tc) &&
+            !state.answeredQuestions[session.id]?.has(tc.id)
         )
       ) {
         return true
       }
     }
     return false
-  }, [
-    sessionsData?.sessions,
-    sendingSessionKey,
-    isQuestionAnswered,
-    useChatStore,
-  ])
+  })
 
   // Check if any session has unanswered ExitPlanMode in persisted messages (solid)
   // Uses plan_approved / approved_plan_message_ids (matching session-card-utils.tsx)

--- a/src/services/chat.test.ts
+++ b/src/services/chat.test.ts
@@ -62,7 +62,19 @@ describe('question waiting session cache', () => {
       active_session_id: 'session-1',
       version: 2,
     }
+    const withCountsSession: Session = {
+      ...waitingSession,
+      message_count: 3,
+    }
+    const sessionsWithCounts: WorktreeSessions = {
+      ...sessions,
+      sessions: [withCountsSession, { ...otherSession, message_count: 1 }],
+    }
     queryClient.setQueryData(chatQueryKeys.sessions('wt-1'), sessions)
+    queryClient.setQueryData(
+      [...chatQueryKeys.sessions('wt-1'), 'with-counts'],
+      sessionsWithCounts
+    )
 
     clearQuestionWaitingStateInSessionListCache(
       queryClient,
@@ -78,6 +90,16 @@ describe('question waiting session cache', () => {
       waiting_for_input_type: undefined,
     })
     expect(updated?.sessions[1]).toBe(otherSession)
+    const updatedWithCounts = queryClient.getQueryData<WorktreeSessions>([
+      ...chatQueryKeys.sessions('wt-1'),
+      'with-counts',
+    ])
+    expect(updatedWithCounts?.sessions[0]).toMatchObject({
+      waiting_for_input: false,
+      waiting_for_input_type: undefined,
+      message_count: 3,
+    })
+    expect(updatedWithCounts?.sessions[1]).toBe(sessionsWithCounts.sessions[1])
 
     clearQuestionWaitingStateInSessionListCache(
       queryClient,
@@ -87,6 +109,12 @@ describe('question waiting session cache', () => {
     expect(queryClient.getQueryData(chatQueryKeys.sessions('wt-1'))).toBe(
       updated
     )
+    expect(
+      queryClient.getQueryData([
+        ...chatQueryKeys.sessions('wt-1'),
+        'with-counts',
+      ])
+    ).toBe(updatedWithCounts)
   })
 
   it('clears a legacy typeless question wait', () => {
@@ -125,6 +153,13 @@ describe('question waiting session cache', () => {
       {
         waiting_for_input: true,
         waiting_for_input_type: 'plan' as const,
+      },
+    ],
+    [
+      'legacy plan',
+      {
+        waiting_for_input: true,
+        pending_plan_message_id: 'plan-message-1',
       },
     ],
     [

--- a/src/services/chat.test.ts
+++ b/src/services/chat.test.ts
@@ -20,6 +20,8 @@ vi.mock('sonner', () => ({
 
 import {
   canReconnectSession,
+  chatQueryKeys,
+  clearQuestionWaitingStateInSessionListCache,
   prefetchSessions,
   reconnectNativeCliSession,
 } from './chat'
@@ -29,12 +31,146 @@ import { useUIStore } from '@/store/ui-store'
 import { useTerminalStore } from '@/store/terminal-store'
 import { toast } from 'sonner'
 import { disposeTerminal } from '@/lib/terminal-instances'
-import type { Session } from '@/types/chat'
+import type { Session, WorktreeSessions } from '@/types/chat'
 
 const toastMock = toast as unknown as {
   success: ReturnType<typeof vi.fn>
   error: ReturnType<typeof vi.fn>
 }
+
+describe('question waiting session cache', () => {
+  it('clears only the target session and preserves the cache on repeated clears', () => {
+    const queryClient = new QueryClient()
+    const waitingSession: Session = {
+      id: 'session-1',
+      name: 'Waiting',
+      order: 0,
+      created_at: 1,
+      updated_at: 1,
+      messages: [],
+      waiting_for_input: true,
+      waiting_for_input_type: 'question',
+    }
+    const otherSession: Session = {
+      ...waitingSession,
+      id: 'session-2',
+      name: 'Other',
+    }
+    const sessions: WorktreeSessions = {
+      worktree_id: 'wt-1',
+      sessions: [waitingSession, otherSession],
+      active_session_id: 'session-1',
+      version: 2,
+    }
+    queryClient.setQueryData(chatQueryKeys.sessions('wt-1'), sessions)
+
+    clearQuestionWaitingStateInSessionListCache(
+      queryClient,
+      'wt-1',
+      'session-1'
+    )
+
+    const updated = queryClient.getQueryData<WorktreeSessions>(
+      chatQueryKeys.sessions('wt-1')
+    )
+    expect(updated?.sessions[0]).toMatchObject({
+      waiting_for_input: false,
+      waiting_for_input_type: undefined,
+    })
+    expect(updated?.sessions[1]).toBe(otherSession)
+
+    clearQuestionWaitingStateInSessionListCache(
+      queryClient,
+      'wt-1',
+      'session-1'
+    )
+    expect(queryClient.getQueryData(chatQueryKeys.sessions('wt-1'))).toBe(
+      updated
+    )
+  })
+
+  it('clears a legacy typeless question wait', () => {
+    const queryClient = new QueryClient()
+    const legacySession: Session = {
+      id: 'session-1',
+      name: 'Legacy question',
+      order: 0,
+      created_at: 1,
+      updated_at: 1,
+      messages: [],
+      waiting_for_input: true,
+    }
+    queryClient.setQueryData<WorktreeSessions>(chatQueryKeys.sessions('wt-1'), {
+      worktree_id: 'wt-1',
+      sessions: [legacySession],
+      active_session_id: 'session-1',
+      version: 2,
+    })
+
+    clearQuestionWaitingStateInSessionListCache(
+      queryClient,
+      'wt-1',
+      'session-1'
+    )
+
+    expect(
+      queryClient.getQueryData<WorktreeSessions>(chatQueryKeys.sessions('wt-1'))
+        ?.sessions[0]
+    ).toMatchObject({ waiting_for_input: false })
+  })
+
+  it.each([
+    [
+      'plan',
+      {
+        waiting_for_input: true,
+        waiting_for_input_type: 'plan' as const,
+      },
+    ],
+    [
+      'permission',
+      {
+        waiting_for_input: true,
+        waiting_for_input_type: 'question' as const,
+        pending_permission_denials: [
+          {
+            tool_name: 'Bash',
+            tool_use_id: 'tool-1',
+            tool_input: { command: 'echo test' },
+          },
+        ],
+      },
+    ],
+  ])('does not clear a %s wait', (_kind, waitingState) => {
+    const queryClient = new QueryClient()
+    const session: Session = {
+      id: 'session-1',
+      name: 'Other wait',
+      order: 0,
+      created_at: 1,
+      updated_at: 1,
+      messages: [],
+      ...waitingState,
+    }
+    const sessions: WorktreeSessions = {
+      worktree_id: 'wt-1',
+      sessions: [session],
+      active_session_id: 'session-1',
+      version: 2,
+    }
+    queryClient.setQueryData(chatQueryKeys.sessions('wt-1'), sessions)
+
+    clearQuestionWaitingStateInSessionListCache(
+      queryClient,
+      'wt-1',
+      'session-1'
+    )
+
+    expect(queryClient.getQueryData(chatQueryKeys.sessions('wt-1'))).toBe(
+      sessions
+    )
+  })
+})
 
 describe('transient WebSocket query failures', () => {
   it('rethrows disconnects so TanStack Query preserves cached session data', () => {

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -270,8 +270,8 @@ export function clearQuestionWaitingStateInSessionListCache(
   worktreeId: string,
   sessionId: string
 ): void {
-  queryClient.setQueryData<WorktreeSessions>(
-    chatQueryKeys.sessions(worktreeId),
+  queryClient.setQueriesData<WorktreeSessions>(
+    { queryKey: chatQueryKeys.sessions(worktreeId) },
     old => {
       if (!old) return old
 
@@ -285,6 +285,7 @@ export function clearQuestionWaitingStateInSessionListCache(
         session.waiting_for_input === true &&
         (session.waiting_for_input_type === null ||
           session.waiting_for_input_type === undefined) &&
+        !session.pending_plan_message_id &&
         !hasPermissionInput
       if (!isExplicitQuestionWait && !isLegacyQuestionWait) {
         return old

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -254,6 +254,58 @@ export const chatQueryKeys = {
     ] as const,
 }
 
+function hasPendingPermissionInput(session: Session): boolean {
+  return [
+    session.pending_permission_denials,
+    session.pending_codex_permission_requests,
+    session.pending_codex_command_approval_requests,
+    session.pending_codex_user_input_requests,
+    session.pending_codex_mcp_elicitation_requests,
+    session.pending_codex_dynamic_tool_call_requests,
+  ].some(requests => (requests?.length ?? 0) > 0)
+}
+
+export function clearQuestionWaitingStateInSessionListCache(
+  queryClient: QueryClient,
+  worktreeId: string,
+  sessionId: string
+): void {
+  queryClient.setQueryData<WorktreeSessions>(
+    chatQueryKeys.sessions(worktreeId),
+    old => {
+      if (!old) return old
+
+      const session = old.sessions.find(item => item.id === sessionId)
+      if (!session) return old
+
+      const hasPermissionInput = hasPendingPermissionInput(session)
+      const isExplicitQuestionWait =
+        session.waiting_for_input_type === 'question' && !hasPermissionInput
+      const isLegacyQuestionWait =
+        session.waiting_for_input === true &&
+        (session.waiting_for_input_type === null ||
+          session.waiting_for_input_type === undefined) &&
+        !hasPermissionInput
+      if (!isExplicitQuestionWait && !isLegacyQuestionWait) {
+        return old
+      }
+
+      return {
+        ...old,
+        sessions: old.sessions.map(item =>
+          item.id === sessionId
+            ? {
+                ...item,
+                waiting_for_input: false,
+                waiting_for_input_type: undefined,
+              }
+            : item
+        ),
+      }
+    }
+  )
+}
+
 export interface NativeCliHistorySession {
   backend: NonNullable<Session['backend']>
   id: string


### PR DESCRIPTION
## Summary

- subscribe worktree rows to the primitive question-answer state so answering or skipping immediately clears the waiting indicator
- synchronize both session-list cache variants after an answer or skip
- honor persisted answered question IDs after reload
- keep permission and plan waits distinct, including legacy plan entries without an explicit wait type
- add regression coverage for live state, persisted state, cache updates, and wait-type guards

## Root cause

The worktree row selected a stable Zustand getter function rather than the underlying answer state, so state changes did not trigger a re-render. The answer path also left cached session-list copies stale until a later refetch.

## User impact

The question waiting indicator now clears immediately and remains correct after cache updates or an app restart, without hiding unrelated permission or plan waits.

## Validation

- `VITEST_MAX_WORKERS=2 bun run check:all`
- `git diff --check main...HEAD`

This is a code-derived regression fix and is not linked to an existing issue.
