### PR TITLE
fix(web): enable host open actions in headless mode

### DIFF
--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -75,6 +75,34 @@ fn parse_worktree_path_args(args: &Value) -> Result<WorktreePathArgs, String> {
     })
 }
 
+#[derive(Debug, PartialEq)]
+struct OpenWorktreeInTerminalArgs {
+    worktree_path: String,
+    terminal: Option<String>,
+}
+
+fn parse_open_worktree_in_terminal_args(
+    args: &Value,
+) -> Result<OpenWorktreeInTerminalArgs, String> {
+    Ok(OpenWorktreeInTerminalArgs {
+        worktree_path: field(args, "worktreePath", "worktree_path")?,
+        terminal: from_field_opt(args, "terminal")?,
+    })
+}
+
+#[derive(Debug, PartialEq)]
+struct OpenWorktreeInEditorArgs {
+    worktree_path: String,
+    editor: Option<String>,
+}
+
+fn parse_open_worktree_in_editor_args(args: &Value) -> Result<OpenWorktreeInEditorArgs, String> {
+    Ok(OpenWorktreeInEditorArgs {
+        worktree_path: field(args, "worktreePath", "worktree_path")?,
+        editor: from_field_opt(args, "editor")?,
+    })
+}
+
 /// Dispatch a command by name to the corresponding Rust handler.
 /// This mirrors Tauri's invoke system but routes through WebSocket.
 ///
@@ -1701,19 +1729,24 @@ pub async fn dispatch_command(
             to_value(result)
         }
         "open_worktree_in_finder" => {
-            // NATIVE ONLY: Finder doesn't exist in browser mode
+            let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
+            crate::projects::open_worktree_in_finder(worktree_path).await?;
             Ok(Value::Null)
         }
         "open_project_worktrees_folder" => {
-            // NATIVE ONLY: Finder doesn't exist in browser mode
+            let project_id: String = field(&args, "projectId", "project_id")?;
+            crate::projects::open_project_worktrees_folder(app.clone(), project_id).await?;
             Ok(Value::Null)
         }
         "open_worktree_in_terminal" => {
-            // NATIVE ONLY: Cannot open native terminal from browser
+            let parsed = parse_open_worktree_in_terminal_args(&args)?;
+            crate::projects::open_worktree_in_terminal(parsed.worktree_path, parsed.terminal)
+                .await?;
             Ok(Value::Null)
         }
         "open_worktree_in_editor" => {
-            // NATIVE ONLY: Cannot open native editor from browser
+            let parsed = parse_open_worktree_in_editor_args(&args)?;
+            crate::projects::open_worktree_in_editor(parsed.worktree_path, parsed.editor).await?;
             Ok(Value::Null)
         }
         "open_pull_request" => {
@@ -3499,6 +3532,32 @@ mod tests {
             parse_worktree_path_args(&json!({ "worktree_path": "/tmp/b" })).unwrap(),
             WorktreePathArgs {
                 worktree_path: "/tmp/b".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_open_worktree_args_accept_web_transport_fields() {
+        assert_eq!(
+            parse_open_worktree_in_editor_args(&json!({
+                "worktreePath": "/tmp/editor",
+                "editor": "zed"
+            }))
+            .unwrap(),
+            OpenWorktreeInEditorArgs {
+                worktree_path: "/tmp/editor".to_string(),
+                editor: Some("zed".to_string()),
+            }
+        );
+        assert_eq!(
+            parse_open_worktree_in_terminal_args(&json!({
+                "worktree_path": "/tmp/terminal",
+                "terminal": null
+            }))
+            .unwrap(),
+            OpenWorktreeInTerminalArgs {
+                worktree_path: "/tmp/terminal".to_string(),
+                terminal: None,
             }
         );
     }

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -4624,39 +4624,67 @@ pub async fn open_log_directory(app: AppHandle) -> Result<(), String> {
 }
 
 /// Open a worktree path in the system file explorer
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileManagerLaunchPlan {
+    program: String,
+    args: Vec<String>,
+    cwd: Option<std::path::PathBuf>,
+    display_name: &'static str,
+}
+
+fn file_manager_launch_plan(
+    worktree_path: &str,
+    target_os: &str,
+    running_in_wsl: bool,
+) -> Result<FileManagerLaunchPlan, String> {
+    match target_os {
+        "macos" => Ok(FileManagerLaunchPlan {
+            program: "open".to_string(),
+            args: vec![worktree_path.to_string()],
+            cwd: None,
+            display_name: "Finder",
+        }),
+        "windows" => Ok(FileManagerLaunchPlan {
+            program: "explorer".to_string(),
+            args: vec![worktree_path.to_string()],
+            cwd: None,
+            display_name: "Explorer",
+        }),
+        "linux" if running_in_wsl => Ok(FileManagerLaunchPlan {
+            program: "explorer.exe".to_string(),
+            args: vec![".".to_string()],
+            cwd: Some(std::path::PathBuf::from(worktree_path)),
+            display_name: "Explorer",
+        }),
+        "linux" => Ok(FileManagerLaunchPlan {
+            program: "xdg-open".to_string(),
+            args: vec![worktree_path.to_string()],
+            cwd: None,
+            display_name: "file manager",
+        }),
+        _ => Err("File explorer not supported on this platform".to_string()),
+    }
+}
+
+fn is_running_in_wsl() -> bool {
+    cfg!(target_os = "linux")
+        && (std::env::var_os("WSL_DISTRO_NAME").is_some()
+            || std::env::var_os("WSL_INTEROP").is_some())
+}
+
 #[tauri::command]
 pub async fn open_worktree_in_finder(worktree_path: String) -> Result<(), String> {
     log::trace!("Opening worktree in file explorer: {worktree_path}");
 
-    #[cfg(target_os = "macos")]
-    {
-        std::process::Command::new("open")
-            .arg(&worktree_path)
-            .spawn()
-            .map_err(|e| format!("Failed to open Finder: {e}"))?;
+    let plan = file_manager_launch_plan(&worktree_path, std::env::consts::OS, is_running_in_wsl())?;
+    let mut command = std::process::Command::new(&plan.program);
+    command.args(&plan.args);
+    if let Some(cwd) = &plan.cwd {
+        command.current_dir(cwd);
     }
-
-    #[cfg(target_os = "windows")]
-    {
-        std::process::Command::new("explorer")
-            .arg(&worktree_path)
-            .spawn()
-            .map_err(|e| format!("Failed to open Explorer: {e}"))?;
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        std::process::Command::new("xdg-open")
-            .arg(&worktree_path)
-            .spawn()
-            .map_err(|e| format!("Failed to open file manager: {e}"))?;
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
-    {
-        log::warn!("File explorer not supported on this platform");
-        return Err("File explorer not supported on this platform".to_string());
-    }
+    command
+        .spawn()
+        .map_err(|e| format!("Failed to open {}: {e}", plan.display_name))?;
 
     Ok(())
 }
@@ -12781,6 +12809,58 @@ mod tests {
             "git {} failed: {}",
             args.join(" "),
             String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn file_manager_launch_plan_uses_windows_explorer_inside_wsl() {
+        assert_eq!(
+            file_manager_launch_plan("/home/alice/project", "linux", true).unwrap(),
+            FileManagerLaunchPlan {
+                program: "explorer.exe".to_string(),
+                args: vec![".".to_string()],
+                cwd: Some(std::path::PathBuf::from("/home/alice/project")),
+                display_name: "Explorer",
+            }
+        );
+    }
+
+    #[test]
+    fn file_manager_launch_plan_keeps_native_platform_openers() {
+        assert_eq!(
+            file_manager_launch_plan("/tmp/project", "linux", false).unwrap(),
+            FileManagerLaunchPlan {
+                program: "xdg-open".to_string(),
+                args: vec!["/tmp/project".to_string()],
+                cwd: None,
+                display_name: "file manager",
+            }
+        );
+        assert_eq!(
+            file_manager_launch_plan("C:\\project", "windows", false).unwrap(),
+            FileManagerLaunchPlan {
+                program: "explorer".to_string(),
+                args: vec!["C:\\project".to_string()],
+                cwd: None,
+                display_name: "Explorer",
+            }
+        );
+        assert_eq!(
+            file_manager_launch_plan("/tmp/project", "macos", false).unwrap(),
+            FileManagerLaunchPlan {
+                program: "open".to_string(),
+                args: vec!["/tmp/project".to_string()],
+                cwd: None,
+                display_name: "Finder",
+            }
+        );
+    }
+
+    #[test]
+    fn file_manager_launch_plan_rejects_unsupported_platforms() {
+        assert_eq!(
+            file_manager_launch_plan("/tmp/project", "unknown", false),
+            Err("File explorer not supported on this platform".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary

- route web/headless open-in-editor, open-in-terminal, and open-folder requests through the existing host-side commands
- propagate launch failures through the existing WebSocket error path instead of reporting a silent success
- open WSL worktree folders with `explorer.exe .` from the selected directory while preserving native platform launch behavior
- add dispatch argument and platform launch-plan coverage

## Root cause

The WebSocket dispatch returned success for host-open commands without invoking them, so browser actions were intentional no-ops and could not report launch errors.

## User impact

Headless web clients can now launch the configured editor, terminal, and file manager on the Jean host. Windows users running Jean inside WSL get the expected Explorer behavior.

## Validation

- `VITEST_MAX_WORKERS=2 bun run check:all`
- `git diff --check main...HEAD`

Fixes #481
