### PR TITLE
fix(notifications): restore app from Windows toast

### DIFF
--- a/docs/developer/notifications.md
+++ b/docs/developer/notifications.md
@@ -45,6 +45,7 @@ notify('Update Available', 'Click to install', { native: true })
 
 - **macOS**: Appear in Notification Center
 - **Platform-aware**: Handled by OS notification system
+- **Windows activation**: Clicking a notification restores and focuses Jean
 - **Permissions**: Automatically request permission when needed
 - **Fallback**: Falls back to toast if native notification fails
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2528,6 +2528,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "tauri-winrt-notification",
  "tempfile",
  "tokio",
  "tokio-tungstenite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,6 +74,7 @@ webkit2gtk = "=2.0.2"
 gtk = "=0.18.2"
 
 [target.'cfg(windows)'.dependencies]
+tauri-winrt-notification = "0.7.2"
 windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_Foundation"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
@@ -99,3 +100,4 @@ incremental = true       # Reuse compilation across local rebuilds
 
 [dev-dependencies]
 tempfile = "3.23.0"
+tauri = { version = "2", features = ["test"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3058,7 +3058,12 @@ async fn send_native_notification(
 ) -> Result<(), String> {
     log::trace!("Sending native notification: {title}");
 
-    #[cfg(not(mobile))]
+    #[cfg(target_os = "windows")]
+    {
+        return platform::notifications::show_notification(&app, title, body);
+    }
+
+    #[cfg(all(not(target_os = "windows"), not(mobile)))]
     {
         use tauri_plugin_notification::NotificationExt;
 

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1,6 +1,7 @@
 // Cross-platform abstractions for shell execution and process management
 
 pub mod cli_detect;
+pub mod notifications;
 pub mod process;
 pub mod shell;
 pub mod wsl;

--- a/src-tauri/src/platform/notifications.rs
+++ b/src-tauri/src/platform/notifications.rs
@@ -1,0 +1,63 @@
+use tauri::{AppHandle, Manager, Runtime};
+
+/// Restore Jean's main window after the user activates a native notification.
+pub fn restore_main_window<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+/// Show a Windows notification and restore Jean when its body is clicked.
+#[cfg(target_os = "windows")]
+pub fn show_notification(
+    app: &AppHandle,
+    title: String,
+    body: Option<String>,
+) -> Result<(), String> {
+    use tauri_winrt_notification::Toast;
+
+    let exe = tauri::utils::platform::current_exe().map_err(|error| error.to_string())?;
+    let exe_dir = exe
+        .parent()
+        .ok_or_else(|| "Failed to resolve the Jean executable directory".to_string())?;
+    let is_unbundled_build =
+        exe_dir.ends_with("target\\debug") || exe_dir.ends_with("target\\release");
+    let app_id = if is_unbundled_build {
+        Toast::POWERSHELL_APP_ID.to_string()
+    } else {
+        app.config().identifier.clone()
+    };
+    let app = app.clone();
+
+    Toast::new(&app_id)
+        .title(&title)
+        .text2(body.as_deref().unwrap_or_default())
+        .on_activated(move |_| {
+            restore_main_window(&app);
+            Ok(())
+        })
+        .show()
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use tauri::{WebviewUrl, WebviewWindowBuilder};
+
+    #[test]
+    fn restore_main_window_shows_and_unminimizes_it() {
+        let app = tauri::test::mock_app();
+        let window = WebviewWindowBuilder::new(&app, "main", WebviewUrl::default())
+            .build()
+            .unwrap();
+        window.minimize().unwrap();
+        window.hide().unwrap();
+
+        super::restore_main_window(app.handle());
+
+        assert!(window.is_visible().unwrap());
+        assert!(!window.is_minimized().unwrap());
+    }
+}


### PR DESCRIPTION
## Summary

- Restore, show, and focus Jean when a Windows native notification is clicked.
- Support notifications in bundled and local development builds.
- Add coverage for restoring a hidden or minimized window and document Windows notification activation.
- Fixes #470.

---

Fixes #470