### PR TITLE
fix(chat): dedupe Codex user-input prompts

### DIFF
--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -89,8 +89,12 @@ import type {
   CodexDynamicToolCallRequest,
   PermissionDenial,
   PendingFile,
+  Question,
+  QuestionAnswer,
 } from '@/types/chat'
 import {
+  findCodexUserInputRequest,
+  getCodexUserInputRequestId,
   isAskUserQuestion,
   isPlanToolCall,
   normalizeCodexQuestions,
@@ -1051,6 +1055,18 @@ export function ChatWindow({
     }
     return undefined
   }, [session?.messages])
+
+  const activeCodexUserInputToolCallId = activeCodexUserInputRequest
+    ? getCodexUserInputRequestId(activeCodexUserInputRequest)
+    : null
+  const hasInlineCodexUserInput = Boolean(
+    activeCodexUserInputToolCallId &&
+    (isSending ? currentToolCalls : lastAssistantMessage?.tool_calls)?.some(
+      toolCall =>
+        toolCall.id === activeCodexUserInputToolCallId &&
+        isAskUserQuestion(toolCall)
+    )
+  )
 
   // Check if there are pending (unanswered) questions
   // Look at the last assistant message's tool_calls since streaming tool calls
@@ -2378,6 +2394,58 @@ export function ChatWindow({
     projectIdRef,
   })
 
+  const handleResolvedQuestionAnswer = useCallback(
+    (toolCallId: string, answers: QuestionAnswer[], questions: Question[]) => {
+      const sessionId = activeSessionIdRef.current
+      if (
+        sessionId &&
+        useChatStore.getState().isQuestionAnswered(sessionId, toolCallId)
+      ) {
+        return
+      }
+      const pendingRequest = sessionId
+        ? findCodexUserInputRequest(
+            useChatStore.getState().pendingCodexUserInputRequests[sessionId] ??
+              [],
+            toolCallId
+          )
+        : undefined
+
+      if (pendingRequest) {
+        handleCodexUserInputAnswer(pendingRequest, answers)
+        return
+      }
+      handleQuestionAnswer(toolCallId, answers, questions)
+    },
+    [handleCodexUserInputAnswer, handleQuestionAnswer]
+  )
+
+  const handleResolvedQuestionSkip = useCallback(
+    (toolCallId: string) => {
+      const sessionId = activeSessionIdRef.current
+      if (
+        sessionId &&
+        useChatStore.getState().isQuestionAnswered(sessionId, toolCallId)
+      ) {
+        return
+      }
+      const pendingRequest = sessionId
+        ? findCodexUserInputRequest(
+            useChatStore.getState().pendingCodexUserInputRequests[sessionId] ??
+              [],
+            toolCallId
+          )
+        : undefined
+
+      if (pendingRequest) {
+        handleCodexUserInputAnswer(pendingRequest, [])
+        return
+      }
+      handleSkipQuestion(toolCallId)
+    },
+    [handleCodexUserInputAnswer, handleSkipQuestion]
+  )
+
   // Copy a sent user message to the clipboard with attachment metadata
   // When pasted back, ChatInput detects the custom format and restores attachments
   const handleCopyToInput = useCallback(async (message: ChatMessage) => {
@@ -2895,8 +2963,10 @@ export function ChatWindow({
                                         ? handleWorktreeYoloApproval
                                         : undefined
                                     }
-                                    onQuestionAnswer={handleQuestionAnswer}
-                                    onQuestionSkip={handleSkipQuestion}
+                                    onQuestionAnswer={
+                                      handleResolvedQuestionAnswer
+                                    }
+                                    onQuestionSkip={handleResolvedQuestionSkip}
                                     onFileClick={setViewingFilePath}
                                     onFixFinding={handleFixFinding}
                                     onFixAllFindings={handleFixAllFindings}
@@ -2968,8 +3038,10 @@ export function ChatWindow({
                                         ? handleWorktreeYoloApproval
                                         : undefined
                                     }
-                                    onQuestionAnswer={handleQuestionAnswer}
-                                    onQuestionSkip={handleSkipQuestion}
+                                    onQuestionAnswer={
+                                      handleResolvedQuestionAnswer
+                                    }
+                                    onQuestionSkip={handleResolvedQuestionSkip}
                                     onFileClick={setViewingFilePath}
                                     onFixFinding={handleFixFinding}
                                     onFixAllFindings={handleFixAllFindings}
@@ -3005,8 +3077,12 @@ export function ChatWindow({
                                       }
                                       toolCalls={currentToolCalls}
                                       streamingContent={streamingContent}
-                                      onQuestionAnswer={handleQuestionAnswer}
-                                      onQuestionSkip={handleSkipQuestion}
+                                      onQuestionAnswer={
+                                        handleResolvedQuestionAnswer
+                                      }
+                                      onQuestionSkip={
+                                        handleResolvedQuestionSkip
+                                      }
                                       onFileClick={setViewingFilePath}
                                       worktreePath={activeWorktreePath}
                                       isQuestionAnswered={isQuestionAnswered}
@@ -3022,8 +3098,12 @@ export function ChatWindow({
                                       }
                                       toolCalls={currentToolCalls}
                                       streamingContent={streamingContent}
-                                      onQuestionAnswer={handleQuestionAnswer}
-                                      onQuestionSkip={handleSkipQuestion}
+                                      onQuestionAnswer={
+                                        handleResolvedQuestionAnswer
+                                      }
+                                      onQuestionSkip={
+                                        handleResolvedQuestionSkip
+                                      }
                                       onFileClick={setViewingFilePath}
                                       worktreePath={activeWorktreePath}
                                       isQuestionAnswered={isQuestionAnswered}
@@ -3112,17 +3192,23 @@ export function ChatWindow({
                             )}
 
                             {activeCodexUserInputRequest &&
+                              !hasInlineCodexUserInput &&
                               activeCodexUserInputQuestions.length > 0 && (
                                 <AskUserQuestion
                                   toolCallId={
-                                    activeCodexUserInputRequest.item_id ||
-                                    `codex-user-input-${activeCodexUserInputRequest.rpc_id}`
+                                    activeCodexUserInputToolCallId as string
                                   }
                                   questions={activeCodexUserInputQuestions}
                                   onSubmit={(_toolCallId, answers) =>
                                     handleCodexUserInputAnswer(
                                       activeCodexUserInputRequest,
                                       answers
+                                    )
+                                  }
+                                  onSkip={() =>
+                                    handleCodexUserInputAnswer(
+                                      activeCodexUserInputRequest,
+                                      []
                                     )
                                   }
                                   isSkipped={false}

--- a/src/components/chat/CompactStreamingTicker.test.tsx
+++ b/src/components/chat/CompactStreamingTicker.test.tsx
@@ -178,4 +178,34 @@ describe('CompactStreamingTicker', () => {
       })
     ).toBeVisible()
   })
+
+  it('renders a blocking user-input question without requiring ticker expansion', () => {
+    const { rerender } = render(<CompactStreamingTicker {...baseProps} />)
+
+    rerender(
+      <CompactStreamingTicker
+        {...baseProps}
+        contentBlocks={[{ type: 'tool_use', tool_call_id: 'codex-question-1' }]}
+        toolCalls={[
+          {
+            id: 'codex-question-1',
+            name: 'AskUserQuestion',
+            input: {
+              questions: [
+                {
+                  header: 'Agent model',
+                  question: 'How should I continue?',
+                  multiSelect: false,
+                  options: [{ label: 'Wait' }, { label: 'Use Codex' }],
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('How should I continue?')).toBeVisible()
+    expect(screen.getAllByRole('button', { name: /Answer/ })).toHaveLength(1)
+  })
 })

--- a/src/components/chat/CompactStreamingTicker.tsx
+++ b/src/components/chat/CompactStreamingTicker.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo, useState } from 'react'
 import { Loader2, Activity, Brain, ChevronRight } from 'lucide-react'
 import type { ContentBlock, ToolCall } from '@/types/chat'
-import { isPlanToolCall } from '@/types/chat'
+import { isAskUserQuestion, isPlanToolCall } from '@/types/chat'
 import {
   Collapsible,
   CollapsibleContent,
@@ -264,6 +264,43 @@ export const CompactStreamingTicker = memo(function CompactStreamingTicker(
       splitAtSteeredInputs(orderedActivityBlocks, activityToolCalls, !hasPlan),
     [orderedActivityBlocks, activityToolCalls, hasPlan]
   )
+
+  const questionToolCalls = toolCalls.filter(isAskUserQuestion)
+  if (questionToolCalls.length > 0) {
+    const questionIds = new Set(questionToolCalls.map(tool => tool.id))
+    const questionBlocks = contentBlocks.filter(
+      block => block.type === 'tool_use' && questionIds.has(block.tool_call_id)
+    )
+    const remainingBlocks = contentBlocks.filter(
+      block => block.type !== 'tool_use' || !questionIds.has(block.tool_call_id)
+    )
+    const remainingToolCalls = toolCalls.filter(
+      tool => !questionIds.has(tool.id)
+    )
+    const hasOtherActivity = hasVisibleActivity(
+      remainingBlocks,
+      remainingToolCalls,
+      streamingContent
+    )
+
+    return (
+      <div className="space-y-3">
+        {hasOtherActivity && (
+          <CompactStreamingTicker
+            {...props}
+            contentBlocks={remainingBlocks}
+            toolCalls={remainingToolCalls}
+          />
+        )}
+        <StreamingMessage
+          {...props}
+          contentBlocks={questionBlocks}
+          toolCalls={questionToolCalls}
+          streamingContent=""
+        />
+      </div>
+    )
+  }
 
   if (steeredTexts.length > 0) {
     let lastActivityIndex = -1

--- a/src/components/chat/DevToolsDropdown.tsx
+++ b/src/components/chat/DevToolsDropdown.tsx
@@ -21,7 +21,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { normalizeCodexQuestions } from '@/types/chat'
+import {
+  getCodexUserInputRequestId,
+  normalizeCodexQuestions,
+  upsertCodexUserInputRequest,
+} from '@/types/chat'
 import { usePreferences } from '@/services/preferences'
 import { chatQueryKeys, useSendMessage } from '@/services/chat'
 import type { EffortLevel, ExecutionMode, Session } from '@/types/chat'
@@ -54,8 +58,8 @@ export function DevToolsDropdown({
       const request = buildCodexDevUserInputRequest(flow)
       const store = useChatStore.getState()
       const pending = store.getPendingCodexUserInputRequests(sessionId)
-      const next = [...pending, request]
-      const toolCallId = request.item_id || `codex-user-input-${request.rpc_id}`
+      const next = upsertCodexUserInputRequest(pending, request)
+      const toolCallId = getCodexUserInputRequestId(request)
 
       store.setPendingCodexUserInputRequests(sessionId, next)
       store.setWaitingForInput(sessionId, true)

--- a/src/components/chat/hooks/useMessageHandlers.ts
+++ b/src/components/chat/hooks/useMessageHandlers.ts
@@ -9,7 +9,10 @@ import {
   persistEnqueue,
 } from '@/services/chat'
 import { useChatStore } from '@/store/chat-store'
-import { buildCodexUserInputAnswerMap } from '@/types/chat'
+import {
+  buildCodexUserInputAnswerMap,
+  getCodexUserInputRequestId,
+} from '@/types/chat'
 import type {
   ChatMessage,
   CodexCommandApprovalRequest,
@@ -44,6 +47,8 @@ import type {
 } from '@/types/projects'
 import { clearPlanApprovalTransientState } from './plan-approval-state'
 import type { ApprovalModelOverride } from '../ApprovalModelSubmenu'
+
+const respondingCodexUserInputRequests = new Set<string>()
 
 /** Git commands to auto-approve for magic prompts (no permission prompts needed) */
 export const GIT_ALLOWED_TOOLS = [
@@ -2923,20 +2928,25 @@ export function useMessageHandlers({
       if (!sessionId || !worktreeId || !worktreePath) return
 
       const store = useChatStore.getState()
-      const toolCallId = request.item_id || `codex-user-input-${request.rpc_id}`
-      store.markQuestionAnswered(sessionId, toolCallId, answers)
-      store.updateToolCallOutput(sessionId, toolCallId, JSON.stringify(answers))
-      store.setPendingCodexUserInputRequests(
-        sessionId,
-        store
-          .getPendingCodexUserInputRequests(sessionId)
-          .filter(item => item.rpc_id !== request.rpc_id)
-      )
-      store.setWaitingForInput(sessionId, false)
+      const toolCallId = getCodexUserInputRequestId(request)
+      const responseKey = `${sessionId}:${request.rpc_id}`
+      if (respondingCodexUserInputRequests.has(responseKey)) return
+      respondingCodexUserInputRequests.add(responseKey)
 
       const answerMap = buildCodexUserInputAnswerMap(request.questions, answers)
 
-      const persistAnsweredState = () => {
+      const completeResponse = () => {
+        store.markQuestionAnswered(sessionId, toolCallId, answers)
+        store.updateToolCallOutput(
+          sessionId,
+          toolCallId,
+          JSON.stringify(answers)
+        )
+        const remainingRequests = store
+          .getPendingCodexUserInputRequests(sessionId)
+          .filter(item => getCodexUserInputRequestId(item) !== toolCallId)
+        store.setPendingCodexUserInputRequests(sessionId, remainingRequests)
+        store.setWaitingForInput(sessionId, remainingRequests.length > 0)
         persistCodexPendingState(sessionId, worktreeId, worktreePath)
         invoke('update_session_state', {
           worktreeId,
@@ -2948,10 +2958,11 @@ export function useMessageHandlers({
           submittedAnswers:
             useChatStore.getState().submittedAnswers[sessionId] ?? {},
         }).catch(() => undefined)
+        respondingCodexUserInputRequests.delete(responseKey)
       }
 
       if (isCodexDevUserInputRequest(request)) {
-        persistAnsweredState()
+        completeResponse()
         console.info('[Codex Dev Flow] ToolRequestUserInputResponse', {
           answers: answerMap,
         })
@@ -2965,9 +2976,10 @@ export function useMessageHandlers({
         answers: answerMap,
       })
         .then(() => {
-          persistAnsweredState()
+          completeResponse()
         })
         .catch(err => {
+          respondingCodexUserInputRequests.delete(responseKey)
           console.error(
             '[useMessageHandlers] Failed to answer Codex user-input request:',
             err

--- a/src/components/chat/hooks/useStreamingEvents.test.tsx
+++ b/src/components/chat/hooks/useStreamingEvents.test.tsx
@@ -176,6 +176,62 @@ describe('useStreamingEvents Codex MCP elicitation', () => {
   })
 })
 
+describe('useStreamingEvents Codex user input', () => {
+  beforeEach(() => {
+    setupListenMock()
+
+    useChatStore.setState({
+      pendingCodexUserInputRequests: {},
+      waitingForInputSessionIds: {},
+      activeToolCalls: {},
+      streamingContentBlocks: {},
+      worktreePaths: { 'worktree-1': '/tmp/worktree' },
+    })
+  })
+
+  it('upserts a repeated request instead of rendering a second prompt', async () => {
+    const queryClient = createQueryClient()
+    const wrapper = createWrapper(queryClient)
+
+    renderHook(() => useStreamingEvents({ queryClient }), { wrapper })
+
+    await waitFor(() =>
+      expect(registeredListeners.has('chat:codex_user_input_request')).toBe(
+        true
+      )
+    )
+
+    const event = {
+      payload: {
+        session_id: 'session-1',
+        worktree_id: 'worktree-1',
+        request: {
+          rpc_id: 42,
+          item_id: 'question-1',
+          questions: [
+            {
+              id: 'model',
+              question: 'How should I continue?',
+              options: [{ label: 'Wait' }, { label: 'Use Codex' }],
+            },
+          ],
+        },
+      },
+    }
+    const listener = registeredListeners.get('chat:codex_user_input_request')
+    listener?.(event)
+    listener?.(event)
+
+    expect(
+      useChatStore.getState().pendingCodexUserInputRequests['session-1']
+    ).toHaveLength(1)
+    expect(useChatStore.getState().activeToolCalls['session-1']).toHaveLength(1)
+    expect(useChatStore.getState().streamingContentBlocks['session-1']).toEqual(
+      [{ type: 'tool_use', tool_call_id: 'question-1' }]
+    )
+  })
+})
+
 describe('useStreamingEvents cancellation sanitization', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -17,9 +17,11 @@ import {
 } from '@/types/preferences'
 import { triggerImmediateGitPoll } from '@/services/git-status'
 import {
+  getCodexUserInputRequestId,
   isAskUserQuestion,
   isPlanToolCall,
   normalizeCodexQuestions,
+  upsertCodexUserInputRequest,
 } from '@/types/chat'
 import { playNotificationSound } from '@/lib/sounds'
 import { notifyIfBackground } from '@/lib/session-notifications'
@@ -718,19 +720,21 @@ export default function useStreamingEvents({
         const current =
           useChatStore.getState().pendingCodexUserInputRequests[session_id] ??
           []
-        const next = [...current, request]
+        const next = upsertCodexUserInputRequest(current, request)
         setPendingCodexUserInputRequests(session_id, next)
         setWaitingForInput(session_id, true)
 
         const questions = normalizeCodexQuestions(request.questions)
 
         const toolCall = {
-          id: request.item_id || `codex-user-input-${request.rpc_id}`,
+          id: getCodexUserInputRequestId(request),
           name: 'AskUserQuestion',
           input: { questions },
         }
         addToolCall(session_id, toolCall)
         addToolBlock(session_id, toolCall.id)
+
+        if (next === current) return
 
         notifySession(session_id, 'Needs your input')
         persistCodexPendingState(session_id, worktree_id, {

--- a/src/store/chat-store.ts
+++ b/src/store/chat-store.ts
@@ -2814,6 +2814,7 @@ export const useChatStore = create<ChatUIState>()(
           state => {
             const current = state.pendingCodexUserInputRequests[sessionId]
             if (!current && requests.length === 0) return state
+            if (current === requests) return state
             return {
               pendingCodexUserInputRequests: {
                 ...state.pendingCodexUserInputRequests,

--- a/src/types/chat.test.ts
+++ b/src/types/chat.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildCodexUserInputAnswerMap,
+  findCodexUserInputRequest,
   getAskUserQuestions,
+  getCodexUserInputRequestId,
   getTodoWriteTodos,
   hasQuestionAnswerOutput,
   isAskUserQuestion,
   isTodoWrite,
   normalizeCodexQuestions,
   normalizeTodoItem,
+  upsertCodexUserInputRequest,
 } from './chat'
 
 describe('hasQuestionAnswerOutput', () => {
@@ -58,6 +61,43 @@ describe('normalizeCodexQuestions', () => {
         ],
       },
     ])
+  })
+})
+
+describe('Codex user-input request identity', () => {
+  const request = {
+    rpc_id: 42,
+    item_id: 'item-1',
+    questions: [{ question: 'Pick one' }],
+  }
+
+  it('uses item_id when available and rpc_id as a fallback', () => {
+    expect(getCodexUserInputRequestId(request)).toBe('item-1')
+    expect(
+      getCodexUserInputRequestId({ ...request, item_id: '', rpc_id: 77 })
+    ).toBe('codex-user-input-77')
+  })
+
+  it('finds the pending request represented by an inline question tool', () => {
+    expect(findCodexUserInputRequest([request], 'item-1')).toEqual(request)
+    expect(findCodexUserInputRequest([request], 'missing')).toBeUndefined()
+  })
+
+  it('upserts repeated logical requests without duplicating the queue', () => {
+    const updated = {
+      ...request,
+      rpc_id: 43,
+      questions: [{ question: 'Pick one', header: 'Updated' }],
+    }
+
+    expect(upsertCodexUserInputRequest([request], updated)).toEqual([updated])
+    expect(
+      upsertCodexUserInputRequest([request], {
+        ...request,
+        item_id: 'item-2',
+        rpc_id: 44,
+      })
+    ).toHaveLength(2)
   })
 })
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -700,6 +700,41 @@ export interface CodexUserInputRequestEvent {
   request: CodexUserInputRequest
 }
 
+export function getCodexUserInputRequestId(
+  request: Pick<CodexUserInputRequest, 'item_id' | 'rpc_id'>
+): string {
+  return request.item_id || `codex-user-input-${request.rpc_id}`
+}
+
+export function findCodexUserInputRequest(
+  requests: CodexUserInputRequest[],
+  toolCallId: string
+): CodexUserInputRequest | undefined {
+  return requests.find(
+    request => getCodexUserInputRequestId(request) === toolCallId
+  )
+}
+
+export function upsertCodexUserInputRequest(
+  requests: CodexUserInputRequest[],
+  request: CodexUserInputRequest
+): CodexUserInputRequest[] {
+  const existingIndex = requests.findIndex(existing =>
+    request.item_id && existing.item_id
+      ? existing.item_id === request.item_id
+      : existing.rpc_id === request.rpc_id
+  )
+
+  if (existingIndex === -1) return [...requests, request]
+  if (JSON.stringify(requests[existingIndex]) === JSON.stringify(request)) {
+    return requests
+  }
+
+  const next = [...requests]
+  next[existingIndex] = request
+  return next
+}
+
 export interface CodexMcpElicitationRequest {
   rpc_id: number
   server_name: string


### PR DESCRIPTION
## Summary

- Render Codex user-input questions inline, including in compact chat view.
- Deduplicate repeated prompt events so only one question card appears.
- Route answers and skips through the matching request while preventing duplicate submissions.
- Add coverage for repeated requests and inline question rendering.

fixes #477

---

Fixes #477