### PR TITLE
fix(projects): enable worktree open actions in WSL web

### DIFF
--- a/src-tauri/src/http_server/dispatch.rs
+++ b/src-tauri/src/http_server/dispatch.rs
@@ -75,6 +75,19 @@ fn parse_worktree_path_args(args: &Value) -> Result<WorktreePathArgs, String> {
     })
 }
 
+#[derive(Debug, PartialEq)]
+struct OpenWorktreeInEditorArgs {
+    worktree_path: String,
+    editor: Option<String>,
+}
+
+fn parse_open_worktree_in_editor_args(args: &Value) -> Result<OpenWorktreeInEditorArgs, String> {
+    Ok(OpenWorktreeInEditorArgs {
+        worktree_path: field(args, "worktreePath", "worktree_path")?,
+        editor: from_field_opt(args, "editor")?,
+    })
+}
+
 /// Dispatch a command by name to the corresponding Rust handler.
 /// This mirrors Tauri's invoke system but routes through WebSocket.
 ///
@@ -1712,11 +1725,13 @@ pub async fn dispatch_command(
             to_value(result)
         }
         "open_worktree_in_finder" => {
-            // NATIVE ONLY: Finder doesn't exist in browser mode
+            let parsed = parse_worktree_path_args(&args)?;
+            crate::projects::open_worktree_in_finder(parsed.worktree_path).await?;
             Ok(Value::Null)
         }
         "open_project_worktrees_folder" => {
-            // NATIVE ONLY: Finder doesn't exist in browser mode
+            let project_id: String = field(&args, "projectId", "project_id")?;
+            crate::projects::open_project_worktrees_folder(app.clone(), project_id).await?;
             Ok(Value::Null)
         }
         "open_worktree_in_terminal" => {
@@ -1724,7 +1739,8 @@ pub async fn dispatch_command(
             Ok(Value::Null)
         }
         "open_worktree_in_editor" => {
-            // NATIVE ONLY: Cannot open native editor from browser
+            let parsed = parse_open_worktree_in_editor_args(&args)?;
+            crate::projects::open_worktree_in_editor(parsed.worktree_path, parsed.editor).await?;
             Ok(Value::Null)
         }
         "open_pull_request" => {
@@ -3555,6 +3571,31 @@ mod tests {
             parse_worktree_path_args(&json!({ "worktree_path": "/tmp/b" })).unwrap(),
             WorktreePathArgs {
                 worktree_path: "/tmp/b".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_open_worktree_in_editor_args_accepts_web_transport_fields() {
+        assert_eq!(
+            parse_open_worktree_in_editor_args(&json!({
+                "worktreePath": "/tmp/a",
+                "editor": "zed"
+            }))
+            .unwrap(),
+            OpenWorktreeInEditorArgs {
+                worktree_path: "/tmp/a".to_string(),
+                editor: Some("zed".to_string()),
+            }
+        );
+        assert_eq!(
+            parse_open_worktree_in_editor_args(&json!({
+                "worktree_path": "/tmp/b"
+            }))
+            .unwrap(),
+            OpenWorktreeInEditorArgs {
+                worktree_path: "/tmp/b".to_string(),
+                editor: None,
             }
         );
     }

--- a/src-tauri/src/platform/wsl.rs
+++ b/src-tauri/src/platform/wsl.rs
@@ -55,6 +55,33 @@ pub fn get_wsl_config() -> WslConfig {
         .unwrap_or_default()
 }
 
+#[cfg(any(target_os = "linux", test))]
+fn detect_wsl_runtime(
+    has_wsl_interop: bool,
+    has_wsl_distro_name: bool,
+    kernel_release: Option<&str>,
+) -> bool {
+    has_wsl_interop
+        || has_wsl_distro_name
+        || kernel_release.is_some_and(|release| release.to_ascii_lowercase().contains("microsoft"))
+}
+
+#[cfg(target_os = "linux")]
+pub fn is_running_in_wsl() -> bool {
+    detect_wsl_runtime(
+        std::env::var_os("WSL_INTEROP").is_some(),
+        std::env::var_os("WSL_DISTRO_NAME").is_some(),
+        std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .ok()
+            .as_deref(),
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn is_running_in_wsl() -> bool {
+    false
+}
+
 /// Update WSL config at runtime (e.g., when preferences change).
 pub fn update_wsl_config(enabled: bool, distro: String) {
     let config = normalize_wsl_config(enabled, distro);
@@ -624,6 +651,26 @@ pub fn get_wsl_home_dir(_distro: &str) -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn detect_wsl_runtime_accepts_environment_markers() {
+        assert!(detect_wsl_runtime(true, false, None));
+        assert!(detect_wsl_runtime(false, true, None));
+    }
+
+    #[test]
+    fn detect_wsl_runtime_accepts_microsoft_kernel_release() {
+        assert!(detect_wsl_runtime(
+            false,
+            false,
+            Some("5.15.153.1-microsoft-standard-WSL2")
+        ));
+    }
+
+    #[test]
+    fn detect_wsl_runtime_rejects_native_linux() {
+        assert!(!detect_wsl_runtime(false, false, Some("6.8.0-52-generic")));
+    }
 
     #[test]
     fn test_normalize_wsl_config_disables_empty_enabled_distro() {

--- a/src-tauri/src/projects/commands.rs
+++ b/src-tauri/src/projects/commands.rs
@@ -4700,8 +4700,14 @@ pub async fn open_worktree_in_finder(worktree_path: String) -> Result<(), String
 
     #[cfg(target_os = "linux")]
     {
-        std::process::Command::new("xdg-open")
-            .arg(&worktree_path)
+        let plan =
+            linux_file_manager_launch_plan(&worktree_path, crate::platform::is_running_in_wsl());
+        let mut command = std::process::Command::new(plan.program);
+        command.args(plan.args);
+        if let Some(current_dir) = plan.current_dir {
+            command.current_dir(current_dir);
+        }
+        command
             .spawn()
             .map_err(|e| format!("Failed to open file manager: {e}"))?;
     }
@@ -4713,6 +4719,31 @@ pub async fn open_worktree_in_finder(worktree_path: String) -> Result<(), String
     }
 
     Ok(())
+}
+
+#[cfg(any(target_os = "linux", test))]
+#[derive(Debug, PartialEq)]
+struct LinuxFileManagerLaunchPlan {
+    program: &'static str,
+    args: Vec<String>,
+    current_dir: Option<String>,
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn linux_file_manager_launch_plan(worktree_path: &str, is_wsl: bool) -> LinuxFileManagerLaunchPlan {
+    if is_wsl {
+        LinuxFileManagerLaunchPlan {
+            program: "explorer.exe",
+            args: vec![".".to_string()],
+            current_dir: Some(worktree_path.to_string()),
+        }
+    } else {
+        LinuxFileManagerLaunchPlan {
+            program: "xdg-open",
+            args: vec![worktree_path.to_string()],
+            current_dir: None,
+        }
+    }
 }
 
 /// Format a spawn error with a user-friendly message when the executable is not found
@@ -12968,6 +12999,30 @@ mod tests {
             "git {} failed: {}",
             args.join(" "),
             String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn linux_file_manager_uses_windows_explorer_inside_wsl() {
+        assert_eq!(
+            linux_file_manager_launch_plan("/home/user/project", true),
+            LinuxFileManagerLaunchPlan {
+                program: "explorer.exe",
+                args: vec![".".to_string()],
+                current_dir: Some("/home/user/project".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn linux_file_manager_uses_xdg_open_outside_wsl() {
+        assert_eq!(
+            linux_file_manager_launch_plan("/home/user/project", false),
+            LinuxFileManagerLaunchPlan {
+                program: "xdg-open",
+                args: vec!["/home/user/project".to_string()],
+                current_dir: None,
+            }
         );
     }
 


### PR DESCRIPTION
## Summary

- Wire editor and worktree-folder actions through the web transport instead of silently ignoring them.
- Open worktree folders with Windows Explorer when Jean runs inside WSL, while preserving native Linux behavior.
- Add coverage for web arguments, WSL detection, and file-manager selection.

Fixes #481.

---

Fixes #481