### PR TITLE
feat(markdown): highlight C# code

### DIFF
--- a/src/components/ui/markdown.test.tsx
+++ b/src/components/ui/markdown.test.tsx
@@ -1,6 +1,31 @@
-import { describe, expect, it } from 'vitest'
-import { render, screen } from '@/test/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@/test/test-utils'
 import { Markdown } from './markdown'
+
+const mocks = vi.hoisted(() => ({
+  copyToClipboard: vi.fn(),
+  useSyntaxHighlighting: vi.fn(),
+}))
+
+vi.mock('@/lib/clipboard', () => ({
+  copyToClipboard: mocks.copyToClipboard,
+}))
+
+vi.mock('@/hooks/useSyntaxHighlighting', () => ({
+  useSyntaxHighlighting: mocks.useSyntaxHighlighting,
+}))
+
+beforeEach(() => {
+  mocks.copyToClipboard.mockReset()
+  mocks.useSyntaxHighlighting.mockReset()
+  mocks.useSyntaxHighlighting.mockImplementation(
+    (code: string, language: string) => ({
+      html: `<pre class="shiki"><code><span data-language="${language}">${code}</span></code></pre>`,
+      isLoading: false,
+      error: null,
+    })
+  )
+})
 
 describe('Markdown', () => {
   it('preserves ordered-list start attributes from parsed markdown', () => {
@@ -57,6 +82,45 @@ describe('Markdown', () => {
     expect(container.querySelector('pre')).not.toBeNull()
   })
 
+  it.each(['csharp', 'cs'])(
+    'highlights completed C# fences using the %s info string',
+    infoString => {
+      const { container } = render(
+        <Markdown>{`\`\`\`${infoString}\npublic class Bird {}\n\`\`\``}</Markdown>
+      )
+
+      expect(mocks.useSyntaxHighlighting).toHaveBeenCalledWith(
+        'public class Bird {}\n',
+        'csharp',
+        'github-light'
+      )
+      expect(container.querySelector('.shiki')).not.toBeNull()
+      expect(
+        container.querySelector('[data-language="csharp"]')
+      ).toHaveTextContent('public class Bird {}')
+    }
+  )
+
+  it('keeps C# fences plain and skips highlighting while streaming', () => {
+    const { container } = render(
+      <Markdown streaming>{'```cs\npublic class Bird {}'}</Markdown>
+    )
+
+    expect(mocks.useSyntaxHighlighting).not.toHaveBeenCalled()
+    expect(container.querySelector('.shiki')).toBeNull()
+    expect(container.querySelector('pre')).toHaveTextContent(
+      'public class Bird {}'
+    )
+  })
+
+  it('copies the original code text after highlighting', () => {
+    render(<Markdown>{'```csharp\npublic class Bird {}\n```'}</Markdown>)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy code' }))
+
+    expect(mocks.copyToClipboard).toHaveBeenCalledWith('public class Bird {}\n')
+  })
+
   it('renders raw HTML in completed messages', () => {
     const { container } = render(
       <Markdown>{'before <b>bold</b> after'}</Markdown>
@@ -90,5 +154,4 @@ describe('Markdown', () => {
       '/api/files/linear-context-images/ENG-123/image.png'
     )
   })
-
 })

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -29,6 +29,10 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { cn } from '@/lib/utils'
 import { useChatStore } from '@/store/chat-store'
 import { convertFileSrc } from '@/lib/transport'
+import { useSyntaxHighlighting } from '@/hooks/useSyntaxHighlighting'
+import { useTheme } from '@/hooks/use-theme'
+import { usePreferences } from '@/services/preferences'
+import type { SyntaxTheme } from '@/types/preferences'
 
 interface MarkdownProps {
   children: string
@@ -82,7 +86,12 @@ function extractText(node: ReactNode): string {
   return ''
 }
 
-function CodeBlock({ children }: { children: ReactNode }) {
+interface CodeBlockFrameProps {
+  children: ReactNode
+  highlightedHtml?: string | null
+}
+
+function CodeBlockFrame({ children, highlightedHtml }: CodeBlockFrameProps) {
   const [copied, setCopied] = useState(false)
 
   const handleCopy = useCallback(() => {
@@ -95,12 +104,21 @@ function CodeBlock({ children }: { children: ReactNode }) {
 
   return (
     <div className="relative my-5 min-w-0 max-w-full">
-      <pre className="max-w-full overflow-x-auto rounded-lg bg-muted p-4 pr-10 text-sm">
-        {children}
-      </pre>
+      {highlightedHtml ? (
+        <div
+          className="max-w-full overflow-x-auto rounded-lg bg-muted p-4 pr-10 text-sm [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:!p-0"
+          dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+        />
+      ) : (
+        <pre className="max-w-full overflow-x-auto rounded-lg bg-muted p-4 pr-10 text-sm">
+          {children}
+        </pre>
+      )}
       <Tooltip>
         <TooltipTrigger asChild>
           <button
+            type="button"
+            aria-label="Copy code"
             onClick={handleCopy}
             className="absolute right-2 top-2 opacity-50 hover:opacity-100 transition-opacity p-1.5 rounded-md hover:bg-background/80 text-muted-foreground hover:text-foreground cursor-pointer"
           >
@@ -115,6 +133,57 @@ function CodeBlock({ children }: { children: ReactNode }) {
       </Tooltip>
     </div>
   )
+}
+
+function getCSharpLanguage(children: ReactNode): 'csharp' | null {
+  const codeElement = Children.toArray(children).find(child =>
+    isValidElement(child)
+  ) as ReactElement<{ className?: string }> | undefined
+  const className = codeElement?.props.className
+  const language = className
+    ?.match(/(?:^|\s)language-([^\s]+)/)?.[1]
+    ?.toLowerCase()
+
+  return language === 'csharp' || language === 'cs' ? 'csharp' : null
+}
+
+function HighlightedCodeBlock({
+  children,
+  language,
+}: {
+  children: ReactNode
+  language: 'csharp'
+}) {
+  const code = extractText(children)
+  const { theme } = useTheme()
+  const { data: preferences } = usePreferences()
+  const resolvedTheme =
+    theme === 'system'
+      ? window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light'
+      : theme
+  const syntaxTheme: SyntaxTheme =
+    resolvedTheme === 'dark'
+      ? (preferences?.syntax_theme_dark ?? 'vitesse-black')
+      : (preferences?.syntax_theme_light ?? 'github-light')
+  const { html } = useSyntaxHighlighting(code, language, syntaxTheme)
+
+  return <CodeBlockFrame highlightedHtml={html}>{children}</CodeBlockFrame>
+}
+
+function CodeBlock({ children }: { children: ReactNode }) {
+  const language = getCSharpLanguage(children)
+
+  return language ? (
+    <HighlightedCodeBlock language={language}>{children}</HighlightedCodeBlock>
+  ) : (
+    <CodeBlockFrame>{children}</CodeBlockFrame>
+  )
+}
+
+function StreamingCodeBlock({ children }: { children: ReactNode }) {
+  return <CodeBlockFrame>{children}</CodeBlockFrame>
 }
 
 function extractTableData(table: HTMLTableElement): string[][] {
@@ -485,6 +554,7 @@ const components: Components = {
 
 const streamingComponents: Components = {
   ...components,
+  pre: ({ children }) => <StreamingCodeBlock>{children}</StreamingCodeBlock>,
   p: ({ children }) => (
     <p className="my-0 leading-relaxed first:mt-0 last:mb-0">{children}</p>
   ),
@@ -504,6 +574,7 @@ const toolCallComponents: Components = {
 
 const toolCallStreamingComponents: Components = {
   ...toolCallComponents,
+  pre: ({ children }) => <StreamingCodeBlock>{children}</StreamingCodeBlock>,
   p: ({ children }) => (
     <p className="my-0 leading-relaxed first:mt-0 last:mb-0">{children}</p>
   ),

--- a/src/hooks/useSyntaxHighlighting.test.ts
+++ b/src/hooks/useSyntaxHighlighting.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { highlightCode } from './useSyntaxHighlighting'
+
+describe('highlightCode', () => {
+  it('loads the C# grammar and returns tokenized Shiki markup', async () => {
+    const html = await highlightCode(
+      'public class Bird {}',
+      'csharp',
+      'github-light'
+    )
+
+    expect(html).toContain('class="shiki github-light"')
+    expect(html).toContain('public')
+    expect(html).toMatch(/<span style="color:#[A-Fa-f0-9]+">/)
+  })
+})

--- a/src/hooks/useSyntaxHighlighting.ts
+++ b/src/hooks/useSyntaxHighlighting.ts
@@ -49,6 +49,7 @@ async function getHighlighter(): Promise<Highlighter> {
         'html',
         'css',
         'rust',
+        'csharp',
         'python',
         'go',
         'bash',

--- a/src/lib/language-detection.test.ts
+++ b/src/lib/language-detection.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { getLanguageFromPath } from './language-detection'
+
+describe('getLanguageFromPath', () => {
+  it('detects C# source files for syntax highlighting', () => {
+    expect(getLanguageFromPath('/projects/Birds/Program.cs')).toBe('csharp')
+    expect(getLanguageFromPath('COMPONENT.CS')).toBe('csharp')
+  })
+})

--- a/src/lib/language-detection.ts
+++ b/src/lib/language-detection.ts
@@ -35,6 +35,7 @@ const EXTENSION_TO_LANGUAGE: Record<string, string> = {
   cxx: 'cpp',
   hpp: 'cpp',
   hxx: 'cpp',
+  cs: 'csharp',
   zig: 'zig',
 
   // JVM


### PR DESCRIPTION
## Summary

- highlight completed `csharp` and `cs` fenced code blocks with the existing Shiki pipeline and the user's configured syntax theme
- keep streaming code blocks on the lightweight plain renderer while preserving original-text copy behavior
- map `.cs` file previews to Shiki's `csharp` grammar and preload that grammar

## Validation

- `bun run check:all`
  - TypeScript, ESLint, Rust format, and Clippy passed
  - frontend: 208 files / 1,278 tests passed
  - Rust: 730 passed, 0 failed, 1 ignored
- focused Markdown, Shiki, and file-detection coverage for `csharp`, `cs`, streaming, copy, and `.cs` paths

Fixes #319
