### PR TITLE
Fix web terminal fast-typing input ordering

### DIFF
--- a/jean-core/src/http_server/websocket.rs
+++ b/jean-core/src/http_server/websocket.rs
@@ -33,6 +33,10 @@ fn command_should_run_on_blocking_pool(command: &str) -> bool {
     )
 }
 
+fn command_must_run_in_ws_order(command: &str) -> bool {
+    matches!(command, "terminal_write")
+}
+
 async fn dispatch_invoke_response(
     app: AppHandle,
     id: String,
@@ -88,7 +92,7 @@ fn spawn_dispatch_response(
 
 #[cfg(test)]
 mod tests {
-    use super::command_should_run_on_blocking_pool;
+    use super::{command_must_run_in_ws_order, command_should_run_on_blocking_pool};
 
     #[test]
     fn commit_generation_runs_on_blocking_pool() {
@@ -106,6 +110,13 @@ mod tests {
     #[test]
     fn lightweight_session_creation_stays_on_async_runtime() {
         assert!(!command_should_run_on_blocking_pool("create_session"));
+    }
+
+    #[test]
+    fn terminal_input_writes_run_in_websocket_order() {
+        assert!(command_must_run_in_ws_order("terminal_write"));
+        assert!(!command_must_run_in_ws_order("terminal_resize"));
+        assert!(!command_must_run_in_ws_order("create_session"));
     }
 }
 
@@ -216,15 +227,35 @@ pub async fn handle_ws_connection(
                     Some(Ok(Message::Text(text))) => {
                         match serde_json::from_str::<WsClientMessage>(&text) {
                             Ok(WsClientMessage::Invoke { id, command, args }) => {
-                                // Spawn dispatch as a separate task so the
-                                // select loop stays free to drain events.
-                                spawn_dispatch_response(
-                                    app.clone(),
-                                    id,
-                                    command,
-                                    args,
-                                    resp_tx.clone(),
-                                );
+                                if command_must_run_in_ws_order(&command) {
+                                    // Terminal input must preserve websocket
+                                    // message order. Spawning each write as an
+                                    // independent task lets fast input chunks
+                                    // race for the PTY writer lock, which can
+                                    // reorder typed text in browser access.
+                                    let resp = dispatch_invoke_response(
+                                        app.clone(),
+                                        id,
+                                        command,
+                                        args,
+                                    )
+                                    .await;
+                                    if let Ok(json) = serde_json::to_string(&resp) {
+                                        if feed_and_drain(&mut ws_tx, &mut event_rx, &mut resp_rx, json).await.is_err() {
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    // Spawn dispatch as a separate task so the
+                                    // select loop stays free to drain events.
+                                    spawn_dispatch_response(
+                                        app.clone(),
+                                        id,
+                                        command,
+                                        args,
+                                        resp_tx.clone(),
+                                    );
+                                }
                             }
                             Ok(WsClientMessage::TerminalReplay { terminal_id, last_seq }) => {
                                 // Restore terminal output after a full page refresh.
@@ -241,13 +272,28 @@ pub async fn handle_ws_connection(
                                 // Try legacy format (no "type" field — old clients send bare invoke)
                                 match serde_json::from_str::<InvokeRequest>(&text) {
                                     Ok(req) => {
-                                        spawn_dispatch_response(
-                                            app.clone(),
-                                            req.id,
-                                            req.command,
-                                            req.args,
-                                            resp_tx.clone(),
-                                        );
+                                        if command_must_run_in_ws_order(&req.command) {
+                                            let resp = dispatch_invoke_response(
+                                                app.clone(),
+                                                req.id,
+                                                req.command,
+                                                req.args,
+                                            )
+                                            .await;
+                                            if let Ok(json) = serde_json::to_string(&resp) {
+                                                if feed_and_drain(&mut ws_tx, &mut event_rx, &mut resp_rx, json).await.is_err() {
+                                                    break;
+                                                }
+                                            }
+                                        } else {
+                                            spawn_dispatch_response(
+                                                app.clone(),
+                                                req.id,
+                                                req.command,
+                                                req.args,
+                                                resp_tx.clone(),
+                                            );
+                                        }
                                     }
                                     Err(_) => {
                                         let resp = InvokeResponse {

--- a/jean-core/src/http_server/websocket.rs
+++ b/jean-core/src/http_server/websocket.rs
@@ -33,6 +33,12 @@ fn command_should_run_on_blocking_pool(command: &str) -> bool {
     )
 }
 
+/// Commands that must preserve WebSocket receive order.
+///
+/// Terminal input is the critical case: xterm.js emits small `onData` chunks
+/// that the browser forwards as independent `terminal_write` invokes. If each
+/// invoke is spawned as an independent task, those tasks can race for the PTY
+/// writer lock and reorder typed characters (e.g. `hello world` → `hewollo ld`).
 fn command_must_run_in_ws_order(command: &str) -> bool {
     matches!(command, "terminal_write")
 }
@@ -88,6 +94,57 @@ fn spawn_dispatch_response(
             let _ = tx.send(json);
         }
     });
+}
+
+/// Spawn a command that must preserve WebSocket receive order.
+///
+/// Each task waits for the previous ordered task before dispatching, so
+/// independent PTY writer lock acquisitions cannot reorder input chunks.
+/// The connection select loop stays free for heartbeats and broadcast events
+/// (unlike awaiting dispatch inline in the receive arm).
+fn spawn_ordered_dispatch_response(
+    app: AppHandle,
+    id: String,
+    command: String,
+    args: Value,
+    tx: mpsc::UnboundedSender<String>,
+    previous: Option<tokio::task::JoinHandle<()>>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Some(previous) = previous {
+            // A cancelled/panicked predecessor must not drop subsequent ordered
+            // input forever — continue the chain regardless of join outcome.
+            let _ = previous.await;
+        }
+        let resp = dispatch_invoke_response(app, id, command, args).await;
+        if let Ok(json) = serde_json::to_string(&resp) {
+            let _ = tx.send(json);
+        }
+    })
+}
+
+/// Route a client invoke: ordered commands chain serially; everything else
+/// dispatches independently so long-running work cannot block the WS loop.
+fn dispatch_client_invoke(
+    app: &AppHandle,
+    id: String,
+    command: String,
+    args: Value,
+    resp_tx: &mpsc::UnboundedSender<String>,
+    ordered_tail: &mut Option<tokio::task::JoinHandle<()>>,
+) {
+    if command_must_run_in_ws_order(&command) {
+        *ordered_tail = Some(spawn_ordered_dispatch_response(
+            app.clone(),
+            id,
+            command,
+            args,
+            resp_tx.clone(),
+            ordered_tail.take(),
+        ));
+    } else {
+        spawn_dispatch_response(app.clone(), id, command, args, resp_tx.clone());
+    }
 }
 
 #[cfg(test)]
@@ -166,6 +223,9 @@ struct InvokeResponse {
 ///
 /// 2. **Command dispatch is spawned** as separate tokio tasks so it never
 ///    blocks event delivery. Responses come back via an unbounded channel.
+///    Order-sensitive commands (`terminal_write`) chain through
+///    `spawn_ordered_dispatch_response` so receive order is preserved without
+///    awaiting inline in the select loop.
 ///
 /// 3. **Batched writes** — after receiving the first message, we drain
 ///    additional pending messages with `try_recv()` and write them all with
@@ -183,6 +243,11 @@ pub async fn handle_ws_connection(
     // Channel for command dispatch responses. Unbounded because command
     // responses are infrequent (user-initiated) and must never be dropped.
     let (resp_tx, mut resp_rx) = mpsc::unbounded_channel::<String>();
+
+    // Tail of the per-connection ordered-command chain. Only `terminal_write`
+    // (and any future `command_must_run_in_ws_order` entries) use this; other
+    // commands still fan out independently.
+    let mut ordered_dispatch_tail: Option<tokio::task::JoinHandle<()>> = None;
 
     // Heartbeat: server-driven protocol ping every PING_INTERVAL. If no
     // inbound traffic (pong, text, ping) for PONG_TIMEOUT, treat connection as
@@ -227,35 +292,14 @@ pub async fn handle_ws_connection(
                     Some(Ok(Message::Text(text))) => {
                         match serde_json::from_str::<WsClientMessage>(&text) {
                             Ok(WsClientMessage::Invoke { id, command, args }) => {
-                                if command_must_run_in_ws_order(&command) {
-                                    // Terminal input must preserve websocket
-                                    // message order. Spawning each write as an
-                                    // independent task lets fast input chunks
-                                    // race for the PTY writer lock, which can
-                                    // reorder typed text in browser access.
-                                    let resp = dispatch_invoke_response(
-                                        app.clone(),
-                                        id,
-                                        command,
-                                        args,
-                                    )
-                                    .await;
-                                    if let Ok(json) = serde_json::to_string(&resp) {
-                                        if feed_and_drain(&mut ws_tx, &mut event_rx, &mut resp_rx, json).await.is_err() {
-                                            break;
-                                        }
-                                    }
-                                } else {
-                                    // Spawn dispatch as a separate task so the
-                                    // select loop stays free to drain events.
-                                    spawn_dispatch_response(
-                                        app.clone(),
-                                        id,
-                                        command,
-                                        args,
-                                        resp_tx.clone(),
-                                    );
-                                }
+                                dispatch_client_invoke(
+                                    &app,
+                                    id,
+                                    command,
+                                    args,
+                                    &resp_tx,
+                                    &mut ordered_dispatch_tail,
+                                );
                             }
                             Ok(WsClientMessage::TerminalReplay { terminal_id, last_seq }) => {
                                 // Restore terminal output after a full page refresh.
@@ -272,28 +316,14 @@ pub async fn handle_ws_connection(
                                 // Try legacy format (no "type" field — old clients send bare invoke)
                                 match serde_json::from_str::<InvokeRequest>(&text) {
                                     Ok(req) => {
-                                        if command_must_run_in_ws_order(&req.command) {
-                                            let resp = dispatch_invoke_response(
-                                                app.clone(),
-                                                req.id,
-                                                req.command,
-                                                req.args,
-                                            )
-                                            .await;
-                                            if let Ok(json) = serde_json::to_string(&resp) {
-                                                if feed_and_drain(&mut ws_tx, &mut event_rx, &mut resp_rx, json).await.is_err() {
-                                                    break;
-                                                }
-                                            }
-                                        } else {
-                                            spawn_dispatch_response(
-                                                app.clone(),
-                                                req.id,
-                                                req.command,
-                                                req.args,
-                                                resp_tx.clone(),
-                                            );
-                                        }
+                                        dispatch_client_invoke(
+                                            &app,
+                                            req.id,
+                                            req.command,
+                                            req.args,
+                                            &resp_tx,
+                                            &mut ordered_dispatch_tail,
+                                        );
                                     }
                                     Err(_) => {
                                         let resp = InvokeResponse {


### PR DESCRIPTION
## Issue

In Jean web access, the embedded xterm.js terminal could display typed characters in the wrong order when the user typed quickly. For example, typing `hello world` could sometimes appear as `hewollo ld`.

The visible symptom looked like terminal lag or xterm.js processing keystrokes incorrectly, but the terminal UI was not the root cause. xterm.js emitted input chunks in order through `onData`; the ordering problem happened after Jean forwarded those chunks to the backend PTY.

## Root cause

In web mode, terminal input is sent over the WebSocket transport as `terminal_write` invocations.

Before this fix, every WebSocket `invoke` was dispatched through its own async task. That worked for ordinary commands, but it was unsafe for terminal input: fast typing can produce multiple small input chunks, and each chunk could race independently to acquire the PTY writer lock.

Example input flow:

```text
xterm.js onData emits: "he" -> "llo" -> " wo" -> "rld"
WebSocket receives:      "he" -> "llo" -> " wo" -> "rld"
Spawned tasks write:     "he" -> " wo" -> "llo" -> "rld"
Terminal displays:       "hewollo rld" / similar corruption
```

The WebSocket preserved receive order, but Jean lost that ordering by spawning the writes as independent tasks.

## Solution

`terminal_write` now runs inline inside the WebSocket connection loop instead of being spawned as a separate task.

This keeps PTY writes in the same order as the WebSocket messages received from the browser. Other commands still use the existing spawned-dispatch path so long-running or unrelated commands do not block event delivery.

Implementation details:

- Added `command_must_run_in_ws_order("terminal_write")`.
- Routed ordered commands through `dispatch_invoke_response(...).await` directly in the WebSocket loop.
- Kept legacy invoke handling consistent with the typed WebSocket message path.
- Added a regression test proving `terminal_write` is treated as an ordered command while commands like `terminal_resize` and `create_session` are not.

## Scope

This fix intentionally targets the common single-browser-connection case that caused fast typing to be reordered in Jean web access.

It does not introduce a per-`terminal_id` backend input queue for multi-tab or multi-client shared terminal editing. That would be a larger architectural change and should be handled separately if Jean decides to support stronger
multi-client terminal input semantics.

## Test plan

- [x] `cargo test --manifest-path jean-core/Cargo.toml http_server::websocket::tests`
- [x] `cargo test --manifest-path jean-core/Cargo.toml http_server::`
- [x] `cargo test --manifest-path jean-core/Cargo.toml terminal::`
- [x] `git diff --check`

Manual smoke test:

1. Open Jean web access in a browser.
2. Focus an xterm.js terminal.
3. Type `hello world` quickly several times.
4. Confirm the terminal echoes characters in the same order typed.

<img width="1946" height="452" alt="CleanShot 2026-07-19 at 12 13 42@2x" src="https://github.com/user-attachments/assets/cf011426-5c0f-42ad-b449-606c56114794" />

<img width="1552" height="670" alt="CleanShot 2026-07-19 at 12 14 03@2x" src="https://github.com/user-attachments/assets/14a0277f-6c3e-4d0e-869c-e362339a6d4c" />

<img width="1690" height="434" alt="CleanShot 2026-07-19 at 12 14 23@2x" src="https://github.com/user-attachments/assets/626b8012-3a96-4dd9-926a-623f55754b74" />

