### PR TITLE
feat(remote): add native Jean server connections

### DIFF
--- a/docs/headless-server.md
+++ b/docs/headless-server.md
@@ -260,4 +260,15 @@ Nothing is installed in the background — apply only runs after you click
 - Prefer `127.0.0.1` behind Caddy/Nginx, SSH tunnel, or Tailscale.
 - Keep token auth enabled for every non-localhost bind.
 - Use a long random token, for example `openssl rand -base64 32`.
-- Set `JEAN_ALLOWED_ORIGINS=https://jean.example.com` only when you need cross-origin browser access; otherwise keep the default same-origin behavior.
+- Set `JEAN_ALLOWED_ORIGINS=https://jean.example.com` only when you need additional cross-origin browser access; native Jean client origins are allowed by default.
+
+## Connect from the native Jean app
+
+In the desktop app, click the server icon in the title bar, choose **Add
+remote**, and enter either the full Web Access URL (including `?token=...`) or
+the server URL and token separately. Selecting the remote switches the entire
+Jean UI to that server. Select **Local** from the same dialog to return to the
+desktop app's local backend.
+
+Native Jean client origins are allowed automatically. HTTP and HTTPS server
+URLs are both supported; keep token authentication enabled on remote servers.

--- a/docs/superpowers/plans/2026-07-18-jean-ios-remote-client.md
+++ b/docs/superpowers/plans/2026-07-18-jean-ios-remote-client.md
@@ -1,0 +1,1123 @@
+# Jean iOS Remote Client Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship an iPhone/iPad Jean client that stores multiple remote Jean Web Access instances, connects to one instance at a time, and displays the existing mobile Jean UI without running a local Jean backend.
+
+**Architecture:** Reuse the existing React UI, remote-connection profiles, HTTP bootstrap, and WebSocket transport inside a minimal Tauri v2 iOS shell. Compile desktop-only Rust, `jean-core`, CLI, terminal, browser-pane, updater, and window integrations out of the iOS target. Persist connection metadata locally, keep access tokens in iOS Keychain, and require an explicitly selected remote before application bootstrap begins.
+
+**Tech Stack:** React 19, TypeScript, Vitest 4, Tauri 2.10, Rust, iOS WebKit, iOS Keychain, Axum HTTP/WebSocket.
+
+## Product assumptions
+
+- V1 opens the complete existing Jean mobile UI after the user selects a server; it is not a status-only dashboard.
+- The iOS application is remote-only. It never offers `Local`, initializes `jean-core`, executes a CLI, or owns a repository.
+- Multiple connection profiles are stored on the device, but exactly one is active.
+- Non-development iOS connections require HTTPS/WSS. Desktop Jean continues accepting HTTP and HTTPS.
+- Server-owned jobs continue when iOS disconnects or is suspended. The client refreshes persisted state after reconnecting.
+- Push notifications, offline mutation queues, QR pairing, universal links, and App Store automation are excluded from V1. They are separate follow-up features.
+- The first distribution target is TestFlight. iOS 16.0 is the minimum supported version.
+
+## Global Constraints
+
+- Use Tauri v2 APIs only.
+- Preserve desktop native, browser Web Access, and headless `jean-server` behavior.
+- Do not store Jean access tokens in `localStorage`, logs, URLs, analytics, or React Query caches on iOS.
+- Do not add mobile fallbacks that pretend unsupported desktop commands succeeded.
+- Do not cancel a server job merely because the iOS app disconnects, backgrounds, or switches instances.
+- Keep mobile-only Rust dependencies under `cfg(target_os = "ios")` and desktop-only dependencies under `cfg(not(any(target_os = "android", target_os = "ios")))`.
+- Use `isLocalBackend()` for local-backend capabilities and `isNativeApp()` only for shell capabilities available on both desktop and iOS.
+- Register any new Tauri command in the active platform's `generate_handler![]`. Keychain commands are intentionally local-shell-only and must not be added to Web Access dispatch.
+- Run `bun run check:all` after implementation and an Xcode simulator/device build before calling the feature complete.
+
+---
+
+## File map
+
+**New focused units**
+
+- `src/lib/client-mode.ts` — compile-time distinction between the desktop client and remote-only iOS client.
+- `src/lib/connection-secrets.ts` — frontend adapter for iOS Keychain commands; contains no profile/UI state.
+- `src/components/remote/MobileConnectionsScreen.tsx` — remote-only first-launch and instance-selection surface.
+- `src-tauri/src/desktop.rs` — existing desktop/server Tauri runtime moved behind a desktop-only compilation gate.
+- `src-tauri/src/mobile.rs` — minimal mobile Tauri builder and Keychain commands.
+- `src-tauri/capabilities/mobile.json` — minimal iOS capability set.
+- `src-tauri/tauri.ios.conf.json` — iOS identifier, frontend build mode, and iOS bundle settings.
+- `docs/developer/ios-remote-client.md` — local development, signing, server prerequisites, and TestFlight smoke test.
+
+**Existing units to extend**
+
+- `src/lib/remote-connections.ts` — profile persistence, secure-token hydration, active selection.
+- `src/lib/environment.ts` — remote-only clients never report a local backend.
+- `src/lib/transport.ts` — require a configured remote and reconnect after iOS suspension.
+- `src/App.tsx` — render connection setup before starting queries/listeners and gate local CLI checks.
+- `src/components/remote/RemoteConnectionsDialog.tsx` — asynchronous secret-aware CRUD and no Local row on iOS.
+- `src/components/remote/RemoteConnectionRecovery.tsx` — choose-another-server recovery for remote-only clients.
+- `src/components/titlebar/TitleBar.tsx` — keep instance switching reachable on mobile.
+- `src-tauri/src/lib.rs` and `src-tauri/Cargo.toml` — desktop/mobile compilation boundary.
+- `jean-core/src/http_server/server.rs` — retain/test the iOS WebView origin in native-client CORS.
+
+---
+
+### Task 1: Define the remote-only client mode and iOS build entry points
+
+**Files:**
+
+- Create: `src/lib/client-mode.ts`
+- Test: `src/lib/client-mode.test.ts`
+- Create: `src-tauri/tauri.ios.conf.json`
+- Modify: `package.json`
+
+**Interfaces:**
+
+- Produces: `ClientMode = 'desktop' | 'remote-only'`
+- Produces: `getClientMode(): ClientMode`
+- Produces: `isRemoteOnlyClient(): boolean`
+- Consumes: Vite variable `VITE_JEAN_CLIENT_MODE=remote-only`
+
+- [ ] **Step 1: Write the failing client-mode test**
+
+```ts
+// src/lib/client-mode.test.ts
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('client mode', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('defaults to desktop', async () => {
+    vi.stubEnv('VITE_JEAN_CLIENT_MODE', '')
+    vi.resetModules()
+    const { getClientMode, isRemoteOnlyClient } = await import('./client-mode')
+    expect(getClientMode()).toBe('desktop')
+    expect(isRemoteOnlyClient()).toBe(false)
+  })
+
+  it('recognizes the remote-only iOS build', async () => {
+    vi.stubEnv('VITE_JEAN_CLIENT_MODE', 'remote-only')
+    vi.resetModules()
+    const { getClientMode, isRemoteOnlyClient } = await import('./client-mode')
+    expect(getClientMode()).toBe('remote-only')
+    expect(isRemoteOnlyClient()).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run the focused test and confirm the missing-module failure**
+
+Run: `bun run test:run src/lib/client-mode.test.ts`
+
+Expected: FAIL because `src/lib/client-mode.ts` does not exist.
+
+- [ ] **Step 3: Implement the minimal client-mode module**
+
+```ts
+// src/lib/client-mode.ts
+export type ClientMode = 'desktop' | 'remote-only'
+
+export function getClientMode(): ClientMode {
+  return import.meta.env.VITE_JEAN_CLIENT_MODE === 'remote-only'
+    ? 'remote-only'
+    : 'desktop'
+}
+
+export function isRemoteOnlyClient(): boolean {
+  return getClientMode() === 'remote-only'
+}
+```
+
+- [ ] **Step 4: Add explicit iOS scripts**
+
+Add these `package.json` scripts without changing existing desktop scripts:
+
+```json
+{
+  "ios:init": "VITE_JEAN_CLIENT_MODE=remote-only tauri ios init",
+  "ios:dev": "VITE_JEAN_CLIENT_MODE=remote-only tauri ios dev --config src-tauri/tauri.ios.conf.json",
+  "ios:build": "VITE_JEAN_CLIENT_MODE=remote-only tauri ios build --config src-tauri/tauri.ios.conf.json"
+}
+```
+
+- [ ] **Step 5: Add the iOS configuration**
+
+Create `src-tauri/tauri.ios.conf.json` as an override of `tauri.conf.json`:
+
+```json
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Jean",
+  "identifier": "com.jean.mobile",
+  "build": {
+    "beforeDevCommand": "VITE_JEAN_CLIENT_MODE=remote-only bun run dev",
+    "beforeBuildCommand": "VITE_JEAN_CLIENT_MODE=remote-only bun run build"
+  },
+  "bundle": {
+    "iOS": {
+      "minimumSystemVersion": "16.0"
+    }
+  }
+}
+```
+
+- [ ] **Step 6: Initialize the generated Apple project**
+
+Run: `bun run ios:init`
+
+Expected: Tauri creates `src-tauri/gen/apple/` and prints the generated Xcode project location. Do not hand-create a git worktree.
+
+- [ ] **Step 7: Re-run the focused test**
+
+Run: `bun run test:run src/lib/client-mode.test.ts`
+
+Expected: PASS for desktop default and remote-only mode.
+
+- [ ] **Step 8: Commit the build-mode boundary**
+
+```bash
+git add package.json src/lib/client-mode.ts src/lib/client-mode.test.ts src-tauri/tauri.ios.conf.json src-tauri/gen/apple
+git commit -m "feat(ios): add remote client build mode"
+```
+
+---
+
+### Task 2: Split the desktop runtime from the minimal iOS shell
+
+**Files:**
+
+- Create: `src-tauri/src/mobile.rs`
+- Create: `src-tauri/src/desktop.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src-tauri/Cargo.toml`
+- Modify: `src-tauri/capabilities/default.json`
+- Create: `src-tauri/capabilities/mobile.json`
+
+**Interfaces:**
+
+- Produces: `mobile::run()` for `cfg(mobile)`
+- Preserves: existing desktop `run()` behavior for macOS, Windows, and Linux
+- Produces local commands used in Task 3:
+  - `save_mobile_connection_token(connection_id: String, token: String) -> Result<(), String>`
+  - `load_mobile_connection_token(connection_id: String) -> Result<Option<String>, String>`
+  - `delete_mobile_connection_token(connection_id: String) -> Result<(), String>`
+
+- [ ] **Step 1: Move desktop-only dependencies behind a desktop target gate**
+
+In `src-tauri/Cargo.toml`, keep only Tauri and plugins used by both shells in `[dependencies]`. Move `jean-core`, updater/process/window-state/fs/persisted-scope/clipboard dependencies, `dirs`, `tokio`, `image`, and `arboard` into the existing non-mobile target section. Add Keychain support only for iOS:
+
+```toml
+[target.'cfg(target_os = "ios")'.dependencies]
+keyring = { version = "3", default-features = false, features = ["apple-native"] }
+
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+jean-core = { path = "../jean-core" }
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
+tauri-plugin-window-state = "2"
+tauri-plugin-fs = "2"
+tauri-plugin-persisted-scope = "2"
+tauri-plugin-clipboard-manager = "2"
+dirs = "5.0"
+tokio = { version = "1", features = ["rt-multi-thread"] }
+image = { version = "0.25", default-features = false, features = ["png"] }
+arboard = { version = "3", features = ["wayland-data-control"] }
+```
+
+Keep `tauri-plugin-log`, `tauri-plugin-notification`, `tauri-plugin-dialog`, and `tauri-plugin-opener` shared only after confirming `cargo check` resolves their iOS implementations.
+
+- [ ] **Step 2: Put the existing desktop implementation behind a non-mobile module boundary**
+
+Move the current contents of `src-tauri/src/lib.rs`—except the public entry point and module declarations—into `src-tauri/src/desktop.rs`. Gate the existing crate-level modules so their current file paths remain valid. The resulting `src-tauri/src/lib.rs` is:
+
+```rust
+#[cfg(not(mobile))]
+mod browser;
+#[cfg(not(mobile))]
+mod desktop;
+#[cfg(not(mobile))]
+mod desktop_commands;
+#[cfg(not(mobile))]
+mod http_server;
+#[cfg(not(mobile))]
+mod platform;
+
+#[cfg(mobile)]
+mod mobile;
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    #[cfg(mobile)]
+    mobile::run();
+
+    #[cfg(not(mobile))]
+    desktop::run();
+}
+```
+
+Make the moved `run()` in `desktop.rs` public within the crate and update moved module references to `crate::browser`, `crate::desktop_commands`, `crate::http_server`, and `crate::platform`. Do not leave a reference to `jean_core`, updater, browser panes, desktop commands, or server CLI arguments in the mobile compilation path.
+
+- [ ] **Step 3: Create the minimal mobile builder and Keychain commands**
+
+```rust
+// src-tauri/src/mobile.rs
+const KEYCHAIN_SERVICE: &str = "com.jean.mobile.remote-connections";
+
+fn entry(connection_id: &str) -> Result<keyring::Entry, String> {
+    keyring::Entry::new(KEYCHAIN_SERVICE, connection_id).map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+fn save_mobile_connection_token(connection_id: String, token: String) -> Result<(), String> {
+    entry(&connection_id)?
+        .set_password(&token)
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+fn load_mobile_connection_token(connection_id: String) -> Result<Option<String>, String> {
+    match entry(&connection_id)?.get_password() {
+        Ok(token) => Ok(Some(token)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+#[tauri::command]
+fn delete_mobile_connection_token(connection_id: String) -> Result<(), String> {
+    match entry(&connection_id)?.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+pub fn run() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_log::Builder::new().build())
+        .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_opener::init())
+        .invoke_handler(tauri::generate_handler![
+            save_mobile_connection_token,
+            load_mobile_connection_token,
+            delete_mobile_connection_token,
+        ])
+        .run(tauri::generate_context!())
+        .expect("error running Jean iOS client");
+}
+```
+
+- [ ] **Step 4: Restrict iOS capabilities to the shared mobile plugins**
+
+Add `"platforms": ["macOS", "windows", "linux"]` to `src-tauri/capabilities/default.json` so its updater, process, filesystem, window-state, clipboard-manager, and child-webview permissions never apply to iOS. Create `src-tauri/capabilities/mobile.json`:
+
+```json
+{
+  "identifier": "mobile-capability",
+  "platforms": ["iOS"],
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "opener:default",
+    "dialog:default",
+    "log:default",
+    "notification:default"
+  ]
+}
+```
+
+- [ ] **Step 5: Install the iOS Rust targets and compile the shell**
+
+Run:
+
+```bash
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim
+cargo check --manifest-path src-tauri/Cargo.toml --target aarch64-apple-ios-sim
+```
+
+Expected: PASS without compiling `jean-core`, updater, browser-pane code, or desktop commands.
+
+- [ ] **Step 6: Re-run the desktop Rust checks**
+
+Run:
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+Expected: PASS with existing desktop behavior unchanged.
+
+- [ ] **Step 7: Commit the runtime split**
+
+```bash
+git add src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/src/lib.rs src-tauri/src/desktop.rs src-tauri/src/mobile.rs src-tauri/capabilities/default.json src-tauri/capabilities/mobile.json
+git commit -m "feat(ios): add remote-only native shell"
+```
+
+---
+
+### Task 3: Store iOS connection tokens in Keychain
+
+**Files:**
+
+- Create: `src/lib/connection-secrets.ts`
+- Test: `src/lib/connection-secrets.test.ts`
+- Modify: `src/lib/remote-connections.ts`
+- Modify: `src/lib/remote-connections.test.ts`
+- Modify: `src/main.tsx`
+
+**Interfaces:**
+
+- Produces:
+  - `loadConnectionSecret(connectionId: string): Promise<string>`
+  - `saveConnectionSecret(connectionId: string, token: string): Promise<void>`
+  - `deleteConnectionSecret(connectionId: string): Promise<void>`
+  - `initializeRemoteConnections(): Promise<void>`
+- Changes to async:
+  - `addRemoteConnection(input): Promise<RemoteConnection>`
+  - `updateRemoteConnection(id, input): Promise<RemoteConnection>`
+  - `removeRemoteConnection(id): Promise<void>`
+- Preserves synchronous reads after initialization:
+  - `getRemoteConnections()`
+  - `getActiveRemoteConnection()`
+  - `selectConnection(id)`
+
+- [ ] **Step 1: Write failing tests for the Keychain adapter**
+
+Mock `@tauri-apps/api/core` and verify the exact local commands and camelCase arguments:
+
+```ts
+expect(invoke).toHaveBeenCalledWith('save_mobile_connection_token', {
+  connectionId: 'remote-1',
+  token: 'secret',
+})
+expect(invoke).toHaveBeenCalledWith('load_mobile_connection_token', {
+  connectionId: 'remote-1',
+})
+expect(invoke).toHaveBeenCalledWith('delete_mobile_connection_token', {
+  connectionId: 'remote-1',
+})
+```
+
+Also verify desktop mode never invokes a mobile Keychain command.
+
+- [ ] **Step 2: Run the secret-store test and confirm failure**
+
+Run: `bun run test:run src/lib/connection-secrets.test.ts`
+
+Expected: FAIL because the module does not exist.
+
+- [ ] **Step 3: Implement the isolated Keychain adapter**
+
+Use a dynamic direct Tauri import, not `@/lib/transport`, because these commands always belong to the local iOS shell:
+
+```ts
+import { isRemoteOnlyClient } from './client-mode'
+
+async function localInvoke<T>(command: string, args: Record<string, unknown>) {
+  const { invoke } = await import('@tauri-apps/api/core')
+  return invoke<T>(command, args)
+}
+
+export async function loadConnectionSecret(id: string): Promise<string> {
+  if (!isRemoteOnlyClient()) return ''
+  return (
+    (await localInvoke<string | null>('load_mobile_connection_token', {
+      connectionId: id,
+    })) ?? ''
+  )
+}
+
+export async function saveConnectionSecret(
+  id: string,
+  token: string
+): Promise<void> {
+  if (!isRemoteOnlyClient()) return
+  await localInvoke('save_mobile_connection_token', {
+    connectionId: id,
+    token,
+  })
+}
+
+export async function deleteConnectionSecret(id: string): Promise<void> {
+  if (!isRemoteOnlyClient()) return
+  await localInvoke('delete_mobile_connection_token', { connectionId: id })
+}
+```
+
+- [ ] **Step 4: Extend remote-connection tests for secure mobile persistence**
+
+Add tests proving:
+
+1. iOS persisted JSON contains `id`, `name`, and `url`, but not `token`.
+2. `initializeRemoteConnections()` hydrates tokens before `getActiveRemoteConnection()` is used.
+3. add/update/delete call the secret adapter.
+4. desktop profiles preserve the current storage format and behavior.
+5. a Keychain failure rejects the mutation and does not select a half-saved profile.
+
+- [ ] **Step 5: Refactor the profile module around an initialization barrier**
+
+Keep hydrated profiles in memory. For remote-only mode, serialize metadata with the token removed and resolve every token from Keychain during `initializeRemoteConnections()`. Save the Keychain secret before publishing a newly added or updated in-memory snapshot. Delete the secret before removing the metadata.
+
+The persisted mobile shape must be:
+
+```ts
+interface PersistedMobileRemoteConnection {
+  id: string
+  name: string
+  url: string
+}
+```
+
+The transport-facing in-memory shape remains:
+
+```ts
+export interface RemoteConnection {
+  id: string
+  name: string
+  url: string
+  token: string
+}
+```
+
+- [ ] **Step 6: Bootstrap secrets before rendering React**
+
+Refactor `src/main.tsx` so the root renders only after profile initialization completes:
+
+```tsx
+import { initializeRemoteConnections } from './lib/remote-connections'
+
+async function start() {
+  await initializeRemoteConnections()
+  ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+    <QueryClientProvider client={queryClient}>
+      <App />
+      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+    </QueryClientProvider>
+  )
+}
+
+void start()
+```
+
+Render a fatal startup message if Keychain initialization rejects; do not silently continue with an empty token:
+
+```tsx
+void start().catch(error => {
+  const message = error instanceof Error ? error.message : String(error)
+  ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+    <main className="flex min-h-dvh items-center justify-center p-6 text-center">
+      <div>
+        <h1 className="font-semibold">Jean could not access secure storage</h1>
+        <p className="mt-2 text-sm text-muted-foreground">{message}</p>
+      </div>
+    </main>
+  )
+})
+```
+
+- [ ] **Step 7: Run the secure-profile tests**
+
+Run:
+
+```bash
+bun run test:run src/lib/connection-secrets.test.ts src/lib/remote-connections.test.ts
+```
+
+Expected: PASS, including the assertion that iOS `localStorage` contains no token.
+
+- [ ] **Step 8: Commit secure profile storage**
+
+```bash
+git add src/lib/connection-secrets.ts src/lib/connection-secrets.test.ts src/lib/remote-connections.ts src/lib/remote-connections.test.ts src/main.tsx
+git commit -m "feat(ios): protect remote tokens in Keychain"
+```
+
+---
+
+### Task 4: Add the remote-only instance selection experience
+
+**Files:**
+
+- Create: `src/components/remote/MobileConnectionsScreen.tsx`
+- Test: `src/components/remote/MobileConnectionsScreen.test.tsx`
+- Modify: `src/components/remote/RemoteConnectionsDialog.tsx`
+- Modify: `src/components/remote/RemoteConnectionsDialog.test.tsx`
+- Modify: `src/components/remote/RemoteConnectionRecovery.tsx`
+- Modify: `src/components/titlebar/TitleBar.tsx`
+- Modify: `src/App.tsx`
+
+**Interfaces:**
+
+- Produces: `<MobileConnectionsScreen />`
+- Consumes: async connection CRUD from Task 3
+- Consumes: `isRemoteOnlyClient()` from Task 1
+- Behavior: connection selection persists, marks an intentional switch, and reloads the frontend
+
+- [ ] **Step 1: Write failing mobile selection tests**
+
+Cover these user-visible cases:
+
+```ts
+it('shows saved remote instances without a Local row')
+it('adds an HTTPS server and connects after the save resolves')
+it('does not select a profile when secure save fails')
+it('rejects non-HTTPS URLs in a production remote-only build')
+it('allows editing and deleting a non-active server')
+it('offers Choose another server instead of Switch to Local after failure')
+```
+
+For the add test, assert the sequence by resolving the mocked `addRemoteConnection()` promise manually and verifying `selectConnection()` is not called before resolution.
+
+- [ ] **Step 2: Run the component tests and confirm failure**
+
+Run:
+
+```bash
+bun run test:run src/components/remote/MobileConnectionsScreen.test.tsx src/components/remote/RemoteConnectionsDialog.test.tsx
+```
+
+Expected: FAIL because the mobile screen is missing and dialog mutations are synchronous.
+
+- [ ] **Step 3: Implement the full-screen instance picker**
+
+`MobileConnectionsScreen` must:
+
+- Show the Jean name and concise “Connect to a Jean server” copy.
+- List saved profiles with name, hostname, and active/selected state.
+- Provide Add, Edit, Delete, and Connect actions.
+- Await secure CRUD before changing selection or reloading.
+- Disable repeated submit while a mutation is pending.
+- Show the actual mutation/network validation error inline.
+- Never render a Local option.
+
+Use the existing `parseRemoteConnectionInput()` normalization. Add a `requireHttps` option so production remote-only mode accepts only `https:`; keep desktop behavior unchanged. Permit `http://127.0.0.1` and `http://localhost` only when `import.meta.env.DEV` is true for simulator development.
+
+- [ ] **Step 4: Make the existing dialog secret-aware and remote-only-aware**
+
+Convert submit/delete handlers to `async`, await mutations, and keep the dialog open on failure. When `isRemoteOnlyClient()` is true:
+
+- Hide the Local row.
+- Prevent deletion of the active profile until another is selected, or return to `MobileConnectionsScreen` after deletion.
+- Label the trigger `Jean servers`.
+- Leave token input blank when editing; blank means keep the stored Keychain value.
+
+- [ ] **Step 5: Adapt recovery actions**
+
+In `RemoteConnectionRecovery`, branch on `isRemoteOnlyClient()`:
+
+- Desktop: retain Retry, Edit connection, Switch to Local.
+- iOS: show Retry, Edit server, Choose another server.
+
+“Choose another server” clears only the active selection and returns to the picker. It must not delete the saved profile or its token.
+
+- [ ] **Step 6: Gate the main application before hooks that query a backend**
+
+Split `App` into a small outer bootstrap and the existing connected application:
+
+```tsx
+export default function App() {
+  if (isRemoteOnlyClient() && !getActiveRemoteConnection()) {
+    return <MobileConnectionsScreen />
+  }
+  return <ConnectedApp />
+}
+```
+
+The existing query hooks, streaming listeners, preload effect, and WebSocket connection must live inside `ConnectedApp`, so first launch does not issue requests against `tauri://localhost`.
+
+- [ ] **Step 7: Keep server switching available after connection**
+
+Render `RemoteConnectionsDialog` in the mobile title bar as well as desktop native mode. Ensure safe-area padding does not place the trigger under the iPhone status bar or Dynamic Island.
+
+- [ ] **Step 8: Run the remote UI tests**
+
+Run:
+
+```bash
+bun run test:run src/components/remote/MobileConnectionsScreen.test.tsx src/components/remote/RemoteConnectionsDialog.test.tsx src/lib/remote-connections.test.ts
+```
+
+Expected: PASS for first launch, async save failure, HTTPS validation, switching, and recovery.
+
+- [ ] **Step 9: Commit the mobile connection UX**
+
+```bash
+git add src/App.tsx src/components/remote src/components/titlebar/TitleBar.tsx src/lib/remote-connections.ts src/lib/remote-connections.test.ts
+git commit -m "feat(ios): add remote server selection"
+```
+
+---
+
+### Task 5: Route all iOS application data through the selected remote
+
+**Files:**
+
+- Modify: `src/lib/environment.ts`
+- Modify: `src/lib/environment.test.ts`
+- Modify: `src/lib/transport.ts`
+- Modify: `src/lib/transport.test.ts`
+- Modify: `src/App.tsx`
+- Test: `src/App.ios-remote.test.tsx`
+
+**Interfaces:**
+
+- Produces: `isLocalBackend() === false` for remote-only builds, even before selection
+- Produces: `usesWebSocketBackend() === true` only when remote-only mode has a selected remote
+- Preserves: desktop Local/remote switching and browser Web Access routing
+
+- [ ] **Step 1: Write failing environment and transport tests**
+
+Add a mode matrix covering:
+
+| Shell           | Selected remote | Expected backend              |
+| --------------- | --------------- | ----------------------------- |
+| Desktop Tauri   | No              | Local IPC                     |
+| Desktop Tauri   | Yes             | Remote HTTP/WebSocket         |
+| Browser         | n/a             | Current-origin HTTP/WebSocket |
+| Remote-only iOS | No              | Unconfigured; no transport    |
+| Remote-only iOS | Yes             | Remote HTTP/WebSocket         |
+
+Assert that iOS never invokes `dispatch_core_command` and that remote `/api/init`, `/api/files`, `/api/project-files`, and `/ws` URLs use the active profile's absolute base URL/token.
+
+- [ ] **Step 2: Run the focused tests and confirm the incorrect local-backend behavior**
+
+Run:
+
+```bash
+bun run test:run src/lib/environment.test.ts src/lib/transport.test.ts
+```
+
+Expected: FAIL because a native shell with no selected remote currently reports a local backend.
+
+- [ ] **Step 3: Correct environment semantics**
+
+Implement the following rules:
+
+```ts
+export const isLocalBackend = (): boolean =>
+  !isRemoteOnlyClient() && isNativeApp() && getActiveRemoteConnection() === null
+
+export const hasBackendTransport = (): boolean => {
+  if (isRemoteOnlyClient()) return getActiveRemoteConnection() !== null
+  return isLocalBackend() || _webAccessEnabled
+}
+```
+
+Update `usesWebSocketBackend()` so an unconfigured remote-only client is not mistaken for current-origin Web Access. Throw `No Jean server selected.` if transport entry points are called before selection; this is a programming error protected by the outer `App` gate.
+
+- [ ] **Step 4: Treat native remote disconnects like Web Access disconnects**
+
+Remove the blanket `isNativeApp()` exclusion from the established-disconnect effect. Exclude only `isLocalBackend()`. On a remote disconnect:
+
+1. capture reload state,
+2. wait for foreground/online state,
+3. reload the frontend,
+4. recover from server-persisted state.
+
+Do not keep an iOS WebSocket alive with background timers; iOS suspension is expected.
+
+- [ ] **Step 5: Add iOS foreground recovery coverage**
+
+In `src/lib/transport.test.ts`, simulate:
+
+```ts
+Object.defineProperty(document, 'visibilityState', {
+  configurable: true,
+  value: 'hidden',
+})
+document.dispatchEvent(new Event('visibilitychange'))
+
+Object.defineProperty(document, 'visibilityState', {
+  configurable: true,
+  value: 'visible',
+})
+document.dispatchEvent(new Event('visibilitychange'))
+```
+
+Assert a stale socket is closed and exactly one reconnect/reload path starts after foregrounding.
+
+- [ ] **Step 6: Add an App regression test**
+
+`src/App.ios-remote.test.tsx` must prove the unconfigured picker mounts without calling preload, WebSocket connect, CLI-status queries, or streaming listeners. With a selected profile, it must prove the connected app starts the remote preload/transport path.
+
+- [ ] **Step 7: Run the complete transport matrix**
+
+Run:
+
+```bash
+bun run test:run src/lib/environment.test.ts src/lib/transport.test.ts src/App.ios-remote.test.tsx src/App.web-reload-regression.test.ts
+```
+
+Expected: PASS for desktop local, desktop remote, browser, unconfigured iOS, configured iOS, and foreground reconnect.
+
+- [ ] **Step 8: Commit transport routing**
+
+```bash
+git add src/App.tsx src/App.ios-remote.test.tsx src/lib/environment.ts src/lib/environment.test.ts src/lib/transport.ts src/lib/transport.test.ts
+git commit -m "feat(ios): route client through remote transport"
+```
+
+---
+
+### Task 6: Gate desktop-only capabilities from the iOS UI
+
+**Files:**
+
+- Modify: `src/App.tsx`
+- Modify: `src/components/titlebar/TitleBar.tsx`
+- Modify: `src/lib/transport.ts`
+- Modify: affected component tests discovered by the audit
+- Create: `src/lib/client-capabilities.ts`
+- Test: `src/lib/client-capabilities.test.ts`
+
+**Interfaces:**
+
+- Produces:
+  - `canUseLocalBackendCommands(): boolean`
+  - `canUseDesktopWindowFeatures(): boolean`
+  - `canUseMobileNativeFeatures(): boolean`
+
+- [ ] **Step 1: Inventory native/local checks before editing**
+
+Run:
+
+```bash
+rg -n "isNativeApp\(|isLocalBackend\(|LOCAL_SHELL_COMMANDS|DESKTOP_ONLY_COMMANDS" src
+```
+
+Classify every match as local-backend, desktop-shell, or mobile-native. Record the classification in the Task 6 commit body; do not replace every `isNativeApp()` mechanically.
+
+- [ ] **Step 2: Write the failing capability matrix test**
+
+Test these outcomes:
+
+```ts
+expect(capabilities.desktopLocal.canUseLocalBackendCommands).toBe(true)
+expect(capabilities.desktopRemote.canUseLocalBackendCommands).toBe(false)
+expect(capabilities.iosRemote.canUseLocalBackendCommands).toBe(false)
+expect(capabilities.iosRemote.canUseMobileNativeFeatures).toBe(true)
+expect(capabilities.browser.canUseMobileNativeFeatures).toBe(false)
+```
+
+- [ ] **Step 3: Implement explicit capability helpers**
+
+Keep the helper small and derived from client mode, native shell, and local backend. It must not duplicate individual backend feature lists.
+
+```ts
+export const canUseLocalBackendCommands = () => isLocalBackend()
+export const canUseDesktopWindowFeatures = () =>
+  isNativeApp() && !isRemoteOnlyClient()
+export const canUseMobileNativeFeatures = () =>
+  isNativeApp() && isRemoteOnlyClient()
+```
+
+- [ ] **Step 4: Fix startup checks that incorrectly use native-shell identity**
+
+In `App.tsx`, enable local CLI installation/auth/version checks only when `canUseLocalBackendCommands()` is true. Remote server CLI status continues through normal remote query services where supported. Do not run desktop update checks, local HTTP-server startup, window state, embedded browser-pane initialization, or filesystem scope setup on iOS.
+
+- [ ] **Step 5: Audit local-shell transport commands**
+
+Keep only commands actually registered by the iOS builder callable as local-shell commands on iOS. Unsupported actions must be hidden/disabled by capabilities or return the existing explicit desktop-only error. Do not route Finder/editor/terminal/browser-pane/file-picker commands to the remote server as a fallback.
+
+- [ ] **Step 6: Adapt title bar and safe areas**
+
+On iOS:
+
+- hide desktop window controls, desktop app version/update affordances, and keyboard shortcut hints,
+- retain server picker, unread state, settings that affect the remote UI, and external-link opening,
+- apply `env(safe-area-inset-top)` and horizontal safe-area padding.
+
+- [ ] **Step 7: Run capability and affected component tests**
+
+Run:
+
+```bash
+bun run test:run src/lib/client-capabilities.test.ts src/components/titlebar src/components/open-in src/hooks/useBrowserPane.test.tsx
+```
+
+Expected: PASS; iOS exposes only remote and supported mobile-native actions.
+
+- [ ] **Step 8: Commit capability gating**
+
+```bash
+git add src/App.tsx src/components/titlebar/TitleBar.tsx src/lib/client-capabilities.ts src/lib/client-capabilities.test.ts src/lib/transport.ts
+git add -u src
+git commit -m "fix(ios): gate desktop-only capabilities"
+```
+
+---
+
+### Task 7: Enforce iOS networking and server compatibility
+
+**Files:**
+
+- Modify: `src/lib/remote-connections.ts`
+- Modify: `src/lib/remote-connections.test.ts`
+- Modify: `jean-core/src/http_server/server.rs`
+- Modify: `docs/headless-server.md`
+- Modify: `src/components/remote/MobileConnectionsScreen.tsx`
+
+**Interfaces:**
+
+- Produces production iOS validation: HTTPS/WSS only
+- Preserves desktop HTTP/HTTPS support
+- Preserves default native origin: `tauri://localhost`
+
+- [ ] **Step 1: Add failing scheme-policy tests**
+
+Test that production remote-only parsing rejects `http://server.example`, accepts `https://server.example`, and that desktop parsing still accepts both. In development, accept only `http://localhost` and `http://127.0.0.1` as HTTP exceptions.
+
+- [ ] **Step 2: Implement scheme policy as an explicit parser option**
+
+Use an options object rather than reading build mode inside the generic parser:
+
+```ts
+interface ParseRemoteConnectionOptions {
+  requireHttps?: boolean
+  allowDevelopmentLoopback?: boolean
+}
+```
+
+The mobile UI passes `{ requireHttps: true, allowDevelopmentLoopback: import.meta.env.DEV }`; desktop callers use the default options.
+
+- [ ] **Step 3: Strengthen the existing native-origin Rust test**
+
+Retain `tauri://localhost`, `http://tauri.localhost`, and `https://tauri.localhost` in `NATIVE_CLIENT_ORIGINS`. Add an Axum request test with `Origin: tauri://localhost` that reaches an authenticated endpoint and receives the expected CORS allow-origin header. Do not replace token authentication with CORS trust.
+
+- [ ] **Step 4: Document secure exposure**
+
+Update `docs/headless-server.md` with an iOS section covering:
+
+- HTTPS reverse proxy as the production requirement,
+- token authentication remaining mandatory,
+- Caddy/Nginx examples already in the document,
+- Tailscale Serve as the HTTPS option for private networks,
+- development simulator loopback exception,
+- the fact that backgrounding disconnects the client but not server jobs.
+
+- [ ] **Step 5: Run networking tests**
+
+Run:
+
+```bash
+bun run test:run src/lib/remote-connections.test.ts src/components/remote/MobileConnectionsScreen.test.tsx
+cargo test --manifest-path jean-core/Cargo.toml http_server::server
+```
+
+Expected: PASS for scheme policy, token auth, and native-origin CORS.
+
+- [ ] **Step 6: Commit network policy**
+
+```bash
+git add src/lib/remote-connections.ts src/lib/remote-connections.test.ts src/components/remote/MobileConnectionsScreen.tsx jean-core/src/http_server/server.rs docs/headless-server.md
+git commit -m "feat(ios): enforce secure remote connections"
+```
+
+---
+
+### Task 8: Verify the existing Jean UI on iPhone and iPad sizes
+
+**Files:**
+
+- Modify: only components with a reproduced mobile defect
+- Test: matching colocated component tests
+- Modify: `e2e/playwright.config.ts`
+- Create: `e2e/ios-remote-client.spec.ts`
+
+**Interfaces:**
+
+- Consumes: existing responsive Jean UI and E2E mock transport
+- Produces: deterministic browser-level coverage for the remote-only build mode
+
+- [ ] **Step 1: Add iPhone and iPad E2E projects**
+
+Configure Playwright projects with representative viewports:
+
+```ts
+{
+  name: 'ios-iphone',
+  use: { viewport: { width: 393, height: 852 }, isMobile: true, hasTouch: true },
+},
+{
+  name: 'ios-ipad',
+  use: { viewport: { width: 820, height: 1180 }, isMobile: true, hasTouch: true },
+}
+```
+
+Run the E2E Vite server with `VITE_JEAN_CLIENT_MODE=remote-only` for this spec.
+
+- [ ] **Step 2: Write the end-to-end remote-client flow**
+
+Cover:
+
+1. first launch shows server selection,
+2. adding a server stores/selects it,
+3. mocked HTTP bootstrap and WebSocket data render projects,
+4. a session opens and accepts a message,
+5. switching servers reloads without showing stale project/session data,
+6. disconnect recovery can choose another server,
+7. no Local/Finder/editor/terminal/browser-pane action is present.
+
+- [ ] **Step 3: Run the new E2E test and fix only reproduced defects**
+
+Run:
+
+```bash
+VITE_JEAN_CLIENT_MODE=remote-only bun run test:e2e -- e2e/ios-remote-client.spec.ts
+```
+
+Expected: PASS in both `ios-iphone` and `ios-ipad` projects.
+
+- [ ] **Step 4: Perform simulator interaction checks**
+
+Run: `bun run ios:dev`
+
+In the iOS simulator verify:
+
+- safe areas and rotation,
+- software keyboard send/newline behavior,
+- scrolling while a response streams,
+- sheets/modals remain within the screen,
+- copy/paste text,
+- external links leave Jean via the system browser,
+- background for 30 seconds, foreground, and recover current session state.
+
+- [ ] **Step 5: Commit mobile UI verification fixes**
+
+```bash
+git add e2e/ios-remote-client.spec.ts e2e/playwright.config.ts src
+git commit -m "test(ios): cover remote client workflows"
+```
+
+---
+
+### Task 9: Document development and prepare a TestFlight build
+
+**Files:**
+
+- Create: `docs/developer/ios-remote-client.md`
+- Modify: `README.md`
+- Modify: generated Xcode signing/project files under `src-tauri/gen/apple/` only where Tauri requires checked-in settings
+
+**Interfaces:**
+
+- Produces repeatable local simulator, device, archive, and TestFlight instructions
+
+- [ ] **Step 1: Write the iOS developer guide**
+
+Document exact prerequisites and commands:
+
+```bash
+xcode-select --install
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim
+bun install
+bun run ios:init
+bun run ios:dev
+bun run ios:build
+```
+
+Include bundle id `com.jean.mobile`, iOS 16.0 minimum, Apple development team selection, Keychain behavior, HTTPS requirement, simulator loopback, server setup, and device log collection from Xcode.
+
+- [ ] **Step 2: Add a concise README entry**
+
+Link to `docs/developer/ios-remote-client.md` and state that the iOS build is a remote client requiring an existing Jean desktop/headless server.
+
+- [ ] **Step 3: Configure signing in the generated Xcode project**
+
+Open the project printed by `bun run ios:init`, select the Jean iOS target, use automatic signing, select the coolLabs Apple developer team, and confirm the bundle id remains `com.jean.mobile`. Store no personal provisioning profile UUID in source control.
+
+- [ ] **Step 4: Create an archive and upload to TestFlight**
+
+Run `bun run ios:build`, open the generated Xcode workspace/project, choose **Any iOS Device (arm64)**, then use **Product → Archive → Distribute App → App Store Connect → Upload**.
+
+Expected: App Store Connect accepts the archive without missing icon, privacy manifest, entitlement, or unsupported-architecture errors.
+
+- [ ] **Step 5: Execute the TestFlight smoke test on a physical device**
+
+Verify:
+
+1. clean install opens server selection,
+2. valid HTTPS URL/token connects,
+3. relaunch restores the active profile and retrieves its token from Keychain,
+4. wrong token shows recovery without leaking it,
+5. server switch isolates project/session caches,
+6. background/foreground reconnects and server work continues,
+7. deleting the app removes local profile metadata; document that iOS Keychain items can survive uninstall and that V1 makes no reinstall-migration guarantee.
+
+- [ ] **Step 6: Commit documentation and non-personal project metadata**
+
+```bash
+git add README.md docs/developer/ios-remote-client.md src-tauri/gen/apple
+git commit -m "docs(ios): add remote client release guide"
+```
+
+---
+
+### Task 10: Final verification
+
+**Files:**
+
+- No planned source changes; fix only failures attributable to this feature.
+
+- [ ] **Step 1: Run focused frontend tests**
+
+```bash
+bun run test:run \
+  src/lib/client-mode.test.ts \
+  src/lib/client-capabilities.test.ts \
+  src/lib/connection-secrets.test.ts \
+  src/lib/remote-connections.test.ts \
+  src/lib/environment.test.ts \
+  src/lib/transport.test.ts \
+  src/components/remote/MobileConnectionsScreen.test.tsx \
+  src/components/remote/RemoteConnectionsDialog.test.tsx \
+  src/App.ios-remote.test.tsx
+```
+
+Expected: all focused tests PASS.
+
+- [ ] **Step 2: Run the project quality gate**
+
+Run: `bun run check:all`
+
+Expected: TypeScript, ESLint, formatting, Rust formatting, Clippy, frontend tests, and Rust tests all PASS.
+
+- [ ] **Step 3: Compile desktop and iOS targets**
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo check --manifest-path src-tauri/Cargo.toml --target aarch64-apple-ios-sim
+bun run build
+bun run ios:build
+```
+
+Expected: desktop and iOS builds PASS; iOS does not compile/link `jean-core` or desktop-only plugins.
+
+- [ ] **Step 4: Run remote-client E2E coverage**
+
+Run:
+
+```bash
+VITE_JEAN_CLIENT_MODE=remote-only bun run test:e2e -- e2e/ios-remote-client.spec.ts
+```
+
+Expected: iPhone and iPad projects PASS.
+
+- [ ] **Step 5: Inspect security-sensitive output**
+
+Run:
+
+```bash
+rg -n 'jean-remote-connections|token' src/lib src/components/remote
+git diff --check
+git status --short
+```
+
+Confirm iOS persisted profile JSON and logs never contain access tokens, no personal signing material is staged, and only intended feature files changed.
+
+- [ ] **Step 6: Perform a two-server physical-device smoke test**
+
+Connect to server A, open a session, switch to server B, verify A data disappears, start/open a B session, switch back to A, and verify A's server-persisted state returns. Background Jean during an active server job and confirm the job completes independently.
+
+- [ ] **Step 7: Record deferred follow-ups without expanding V1**
+
+Create separate task files under `tasks-todo/` only for follow-ups the team chooses to pursue: push notifications, QR/deep-link pairing, offline queued prompts, App Store CI automation, and a lightweight monitoring-only home screen.

--- a/docs/superpowers/plans/2026-07-18-remote-jean-connections.md
+++ b/docs/superpowers/plans/2026-07-18-remote-jean-connections.md
@@ -1,0 +1,78 @@
+# Remote Jean Connections Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow the native Jean UI to switch between its local core and saved remote Jean Web Access servers.
+
+**Architecture:** Add a small persisted connection-profile module and teach the existing transport to use an explicit remote base URL/token in native mode. Switching instances reloads the frontend to isolate all backend state. A title-bar dialog manages profiles and a recovery screen handles unavailable remotes.
+
+**Tech Stack:** React 19, TypeScript, Vitest, Tauri v2, Rust, Axum WebSocket/HTTP.
+
+## Global Constraints
+
+- Preserve existing Web Access behavior for browser clients.
+- Support both HTTP and HTTPS without warnings.
+- Do not cancel backend operations when switching.
+- Do not commit unrelated existing worktree changes.
+
+---
+
+### Task 1: Connection profiles
+
+**Files:**
+
+- Create: `src/lib/remote-connections.ts`
+- Test: `src/lib/remote-connections.test.ts`
+
+- [ ] Write failing tests for full-URL token extraction, separate tokens, normalization, CRUD, and restored active selection.
+- [ ] Run the focused test and confirm failure because the module is missing.
+- [ ] Implement the minimal local profile store and subscription API.
+- [ ] Run the focused test and confirm it passes.
+
+### Task 2: Switchable transport
+
+**Files:**
+
+- Modify: `src/lib/transport.ts`
+- Modify: `src/lib/environment.ts`
+- Test: `src/lib/transport.test.ts`
+
+- [ ] Write failing tests proving native shared commands use WebSocket when a remote is active and remote URLs are absolute.
+- [ ] Run the focused tests and confirm the expected failures.
+- [ ] Parameterize the existing WebSocket transport with the active base URL/token and add disconnect/retry behavior.
+- [ ] Run focused transport tests and existing browser transport tests.
+
+### Task 3: Connection UI and recovery
+
+**Files:**
+
+- Create: `src/components/remote/RemoteConnectionsDialog.tsx`
+- Create: `src/components/remote/RemoteConnectionRecovery.tsx`
+- Test: `src/components/remote/RemoteConnectionsDialog.test.tsx`
+- Modify: `src/components/titlebar/TitleBar.tsx`
+- Modify: `src/App.tsx`
+
+- [ ] Write failing component tests for icon/dialog, adding via either input style, selection, and recovery actions.
+- [ ] Run focused tests and confirm failures.
+- [ ] Implement the dialog, title-bar trigger, startup restoration, and recovery view.
+- [ ] Run the focused component tests.
+
+### Task 4: Server/browser permissions and documentation
+
+**Files:**
+
+- Modify: `jean-core/src/http_server/server.rs`
+- Modify: `src-tauri/tauri.conf.json`
+- Modify: `docs/headless-server.md`
+
+- [ ] Add a failing Rust test for native Jean origins in the default CORS policy where feasible.
+- [ ] Permit Tauri desktop origins and outbound HTTP(S)/WS(S) in the desktop CSP.
+- [ ] Document connecting from a native Jean client.
+- [ ] Run Rust and frontend focused checks.
+
+### Task 5: Verification
+
+- [ ] Run all focused remote-connection and transport tests.
+- [ ] Run `bun run check:all`.
+- [ ] Inspect `git diff` to ensure existing unrelated work remains intact.
+- [ ] Smoke test switching Local → remote → Local and remote startup recovery.

--- a/docs/superpowers/specs/2026-07-18-remote-jean-connections-design.md
+++ b/docs/superpowers/specs/2026-07-18-remote-jean-connections-design.md
@@ -1,0 +1,37 @@
+# Remote Jean Connections Design
+
+## Goal
+
+Let the native Jean desktop client switch its entire application backend between Local and one saved remote Jean Web Access server.
+
+## Decisions
+
+- The title bar shows a connection/server icon immediately before Sponsor.
+- Exactly one instance is active: Local or one remote.
+- Add connections using either a full Web Access URL containing `?token=...` or separate URL and token fields.
+- Accept HTTP and HTTPS without warnings.
+- Restore the last selected instance after restart.
+- An unavailable restored remote shows recovery actions: Retry, Edit connection, and Switch to Local. It never silently falls back.
+- Switching disconnects only the client; jobs and terminals continue on the previous Jean.
+
+## Architecture
+
+The native shell remains local and owns connection profiles and instance selection. Shared Jean commands and events route through a switchable backend transport: Tauri core dispatch for Local and authenticated HTTP/WebSocket for remote instances. Switching persists the selection and reloads the frontend, which gives every instance fresh TanStack Query and Zustand state and prevents stale events crossing instance boundaries.
+
+Connection profiles contain an id, display name, normalized HTTP(S) base URL, and token. Local is an immutable built-in profile. The desktop WebView stores profiles in its private local storage; tokens are removed from pasted URLs before persistence and never displayed after saving.
+
+## User interface
+
+The title-bar icon opens a dialog listing Local and saved remotes with connection status. Users can select, add, edit, or delete remotes. Selecting the active profile is a no-op. Deleting the active remote first switches to Local. A remote connection failure replaces application content with a recovery view while retaining the native title bar and connection dialog.
+
+## Transport and capabilities
+
+Remote HTTP bootstrap, file URLs, authentication, and WebSocket URLs use the selected absolute base URL. The server allows the standard Tauri desktop origins through CORS. Tauri CSP allows outbound HTTP(S) and WS(S). Native window and clipboard capabilities remain local; backend-side desktop operations are unavailable while a remote is active.
+
+## Error handling
+
+Invalid connection input is rejected before save. Authentication, network, and WebSocket errors appear in the recovery view. Retry recreates the remote transport attempt. Edit opens the selected profile. Switch to Local is always available. No operation on the previous backend is cancelled when switching.
+
+## Testing
+
+Unit tests cover URL/token normalization, profile persistence, active selection, transport routing/base URLs, and title-bar dialog behavior. Rust tests cover default CORS origins where practical. The full TypeScript/Rust quality gate and a manual two-instance smoke test verify integration.

--- a/jean-core/src/http_server/server.rs
+++ b/jean-core/src/http_server/server.rs
@@ -287,10 +287,29 @@ pub async fn start_server(
 fn cors_layer_from_env() -> CorsLayer {
     let mut layer = CorsLayer::new().allow_methods(Any).allow_headers(Any);
     let raw = std::env::var("JEAN_ALLOWED_ORIGINS").unwrap_or_default();
-    let origins: Vec<HeaderValue> = raw
-        .split(',')
+    let origins = cors_origins(&raw);
+
+    if raw.trim() == "*" {
+        layer = layer.allow_origin(AllowOrigin::any());
+    } else {
+        layer = layer.allow_origin(AllowOrigin::list(origins));
+    }
+
+    layer
+}
+
+fn cors_origins(raw: &str) -> Vec<HeaderValue> {
+    const NATIVE_CLIENT_ORIGINS: &[&str] = &[
+        "tauri://localhost",
+        "http://tauri.localhost",
+        "https://tauri.localhost",
+        "http://localhost:1420",
+    ];
+
+    raw.split(',')
         .map(str::trim)
         .filter(|origin| !origin.is_empty())
+        .chain(NATIVE_CLIENT_ORIGINS.iter().copied())
         .filter_map(|origin| match HeaderValue::from_str(origin) {
             Ok(value) => Some(value),
             Err(e) => {
@@ -298,15 +317,7 @@ fn cors_layer_from_env() -> CorsLayer {
                 None
             }
         })
-        .collect();
-
-    if raw.trim() == "*" {
-        layer = layer.allow_origin(AllowOrigin::any());
-    } else if !origins.is_empty() {
-        layer = layer.allow_origin(AllowOrigin::list(origins));
-    }
-
-    layer
+        .collect()
 }
 
 async fn health_handler() -> Response {
@@ -1583,6 +1594,19 @@ mod tests {
             crate::server_platform_name(),
             "mac" | "windows" | "linux"
         ));
+    }
+
+    #[test]
+    fn default_cors_origins_allow_native_jean_clients() {
+        let origins: Vec<String> = super::cors_origins("")
+            .into_iter()
+            .map(|value| value.to_str().expect("valid origin").to_string())
+            .collect();
+
+        assert!(origins.contains(&"tauri://localhost".to_string()));
+        assert!(origins.contains(&"http://tauri.localhost".to_string()));
+        assert!(origins.contains(&"https://tauri.localhost".to_string()));
+        assert!(origins.contains(&"http://localhost:1420".to_string()));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,23 +30,18 @@
         "shadow": true,
         "dragDropEnabled": false,
         "windowEffects": {
-          "effects": [
-            "sidebar"
-          ],
+          "effects": ["sidebar"],
           "radius": 12,
           "state": "active"
         }
       }
     ],
     "security": {
-      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' ipc: http://ipc.localhost https://ipc.localhost; img-src 'self' asset: http://asset.localhost https://asset.localhost data: blob: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'",
+      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' ipc: http://ipc.localhost https://ipc.localhost; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost http: https: ws: wss:; img-src 'self' asset: http://asset.localhost https://asset.localhost data: blob: http: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'",
       "assetProtocol": {
         "enable": true,
         "scope": {
-          "allow": [
-            "**/.jean/images/**",
-            "$APPDATA/**"
-          ],
+          "allow": ["**/.jean/images/**", "$APPDATA/**"],
           "requireLiteralLeadingDot": false
         }
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -172,8 +172,6 @@ function App() {
   const pendingUpdateRef = useRef<any>(null)
 
   useEffect(() => {
-    if (!webBackend) return
-
     invoke<'mac' | 'windows' | 'linux'>('get_server_platform')
       .then(platform => {
         setServerPlatform(platform)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import {
   hasPreloadedData,
   listen,
   onEstablishedWsDisconnect,
+  usesWebSocketBackend,
   type InitialData,
 } from '@/lib/transport'
 import { isNativeApp } from '@/lib/environment'
@@ -70,6 +71,12 @@ import {
 import { useExternalLinkInterceptor } from './hooks/useExternalLinkInterceptor'
 import { WebAccessAuthScreen } from './components/web/WebAccessAuthScreen'
 import { peekWebReloadState, saveWebReloadState } from './lib/web-reload-state'
+import {
+  clearConnectionSwitch,
+  getActiveRemoteConnection,
+  isConnectionSwitchPending,
+} from './lib/remote-connections'
+import { RemoteConnectionRecovery } from './components/remote/RemoteConnectionRecovery'
 
 interface AutoFixStoppedEvent {
   projectId: string
@@ -97,8 +104,13 @@ function WebLoadingScreen({ label }: { label: string }) {
 /** Full-screen auth error overlay for web access mode. */
 function WsAuthErrorOverlay() {
   const authError = useWsAuthError()
+  const remote = getActiveRemoteConnection()
 
   if (!authError) return null
+
+  if (remote) {
+    return <RemoteConnectionRecovery connection={remote} error={authError} />
+  }
 
   const handleTokenSubmit = (token: string) => {
     localStorage.setItem('jean-http-token', token)
@@ -116,8 +128,10 @@ function WsAuthErrorOverlay() {
 }
 
 function App() {
+  const webBackend = usesWebSocketBackend()
+  const wsAuthError = useWsAuthError()
   // Track preloading state for web view
-  const [isPreloading, setIsPreloading] = useState(!isNativeApp())
+  const [isPreloading, setIsPreloading] = useState(webBackend)
   const [platformVersion, setPlatformVersion] = useState(0)
   const queryClient = useQueryClient()
   const { data: preferences } = usePreferences()
@@ -158,7 +172,7 @@ function App() {
   const pendingUpdateRef = useRef<any>(null)
 
   useEffect(() => {
-    if (!isNativeApp()) return
+    if (!webBackend) return
 
     invoke<'mac' | 'windows' | 'linux'>('get_server_platform')
       .then(platform => {
@@ -168,7 +182,7 @@ function App() {
       .catch(error => {
         logger.warn('Failed to load server platform', { error })
       })
-  }, [])
+  }, [webBackend])
 
   useEffect(() => {
     let unlisten: (() => void) | undefined
@@ -567,7 +581,7 @@ function App() {
 
   // Preload initial data via HTTP for web view (faster than waiting for WebSocket)
   useEffect(() => {
-    if (isNativeApp()) return
+    if (!webBackend) return
 
     const initialSelectedProjectId =
       peekWebReloadState()?.projectId ??
@@ -589,7 +603,7 @@ function App() {
       .finally(() => {
         setIsPreloading(false)
       })
-  }, [queryClient, seedCache])
+  }, [queryClient, seedCache, webBackend])
 
   // Global safety net for uncaught async errors / promise rejections.
   // Without this, a thrown invoke() (e.g. auth/network failure) can leave the
@@ -683,20 +697,20 @@ function App() {
   // Browser mode: only open WebSocket after preload + listener registration.
   // This lets us replay buffered server events before live events start arriving.
   useEffect(() => {
-    if (isNativeApp()) return
+    if (!webBackend || isNativeApp()) return
 
     return onEstablishedWsDisconnect(() => {
       logger.info('WebSocket disconnected, reloading web app')
       captureWebReloadState()
       window.location.reload()
     })
-  }, [captureWebReloadState])
+  }, [captureWebReloadState, webBackend])
 
   useEffect(() => {
-    if (isNativeApp() || isPreloading || hasStartedTransportRef.current) return
+    if (!webBackend || isPreloading || hasStartedTransportRef.current) return
     hasStartedTransportRef.current = true
     connectTransport()
-  }, [isPreloading])
+  }, [isPreloading, webBackend])
 
   // Global queue processor - must be at App level so queued messages execute
   // even when the worktree is not focused (ChatWindow unmounted)
@@ -718,7 +732,7 @@ function App() {
   // backend work.
   const wsConnected = useWsConnectionStatus()
   useEffect(() => {
-    if (isNativeApp() || !wsConnected) return
+    if (!webBackend || !wsConnected) return
 
     // First connect: invalidate non-preloaded queries. If the HTTP preload
     // failed, invalidate everything so it fetches over the open WebSocket.
@@ -741,7 +755,7 @@ function App() {
       )
       queryClient.invalidateQueries()
     }
-  }, [wsConnected, queryClient])
+  }, [wsConnected, queryClient, webBackend])
 
   // Add native-app class to body for desktop-only CSS (cursor, user-select, etc.)
   useEffect(() => {
@@ -965,9 +979,10 @@ function App() {
 
   // Kill all terminals on page refresh/close (backup for Rust-side cleanup)
   useEffect(() => {
-    if (!isNativeApp()) return
+    if (!isNativeApp() || webBackend) return
 
     const handleBeforeUnload = () => {
+      if (isConnectionSwitchPending()) return
       // Best-effort sync cleanup for refresh scenarios
       // Note: async operations may not complete, but Rust-side RunEvent::Exit
       // will handle proper cleanup on app quit
@@ -977,7 +992,7 @@ function App() {
     }
     window.addEventListener('beforeunload', handleBeforeUnload)
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [])
+  }, [webBackend])
 
   // Initialize command system and cleanup on app startup
   useEffect(() => {
@@ -1043,7 +1058,7 @@ function App() {
         webAccessSoundsEnabled: prefs?.web_access_sounds_enabled ?? true,
       })
 
-      if (isNativeApp()) {
+      if (isNativeApp() && !webBackend && !isConnectionSwitchPending()) {
         // Kill any orphaned terminals from previous native app session/reload.
         // Web access clients must not kill server-owned terminals when their
         // browser tab reloads, sleeps, or is discarded.
@@ -1210,6 +1225,8 @@ function App() {
         .catch(error => {
           logger.error('Failed to check resumable sessions', { error })
         })
+
+      clearConnectionSwitch()
     }, 2500)
 
     // Check for updates 5 seconds after app loads, then every 30 minutes
@@ -1222,7 +1239,7 @@ function App() {
       window.removeEventListener('install-pending-update', handleInstallPending)
       window.removeEventListener('update-available', handleUpdateAvailable)
     }
-  }, [installAppUpdate])
+  }, [installAppUpdate, webBackend])
 
   // Show loading screen while preloading initial data (web view only)
   if (isPreloading) {
@@ -1233,10 +1250,10 @@ function App() {
     <ErrorBoundary>
       <ThemeProvider>
         <MainWindow />
-        {!isNativeApp() && !wsConnected && (
+        {webBackend && !wsConnected && !wsAuthError && (
           <WebLoadingScreen label="Loading Jean..." />
         )}
-        {!isNativeApp() && <WsAuthErrorOverlay />}
+        {webBackend && <WsAuthErrorOverlay />}
       </ThemeProvider>
     </ErrorBoundary>
   )

--- a/src/App.web-connecting-overlay.test.ts
+++ b/src/App.web-connecting-overlay.test.ts
@@ -5,7 +5,7 @@ describe('web connecting overlay', () => {
   const source = readFileSync(`${process.cwd()}/src/App.tsx`, 'utf8')
 
   it('uses the same opaque theme background as initial loading', () => {
-    expect(source).toContain('!isNativeApp() && !wsConnected')
+    expect(source).toContain('webBackend && !wsConnected && !wsAuthError')
     expect(source).toContain(
       'fixed inset-0 z-[70] flex items-center justify-center bg-background'
     )

--- a/src/App.web-connecting-overlay.test.ts
+++ b/src/App.web-connecting-overlay.test.ts
@@ -34,4 +34,10 @@ describe('web connecting overlay', () => {
       'fontFamily: \'system-ui, -apple-system, "Segoe UI", sans-serif\''
     )
   })
+
+  it('loads the server platform for both local and remote backends', () => {
+    expect(source).toMatch(
+      /useEffect\(\(\) => \{\s*invoke<'mac' \| 'windows' \| 'linux'>\('get_server_platform'\)/
+    )
+  })
 })

--- a/src/components/chat/hooks/useDragAndDropImages.ts
+++ b/src/components/chat/hooks/useDragAndDropImages.ts
@@ -8,7 +8,7 @@ import {
   MAX_IMAGE_SIZE,
   SVG_EXTENSION,
 } from '../image-constants'
-import { isNativeApp } from '@/lib/environment'
+import { isLocalBackend } from '@/lib/environment'
 import { dragHasFiles } from '@/lib/drag-drop-utils'
 import { processAttachmentFiles } from '../attachment-processing'
 
@@ -96,7 +96,7 @@ export function useDragAndDropImages(
   }, [sessionId, options?.disabled])
 
   useEffect(() => {
-    if (options?.disabled || !isNativeApp()) return
+    if (options?.disabled || !isLocalBackend()) return
 
     let cancelled = false
     let unlisten: (() => void) | null = null

--- a/src/components/remote/RemoteConnectionRecovery.tsx
+++ b/src/components/remote/RemoteConnectionRecovery.tsx
@@ -1,0 +1,60 @@
+import { ServerOff } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  LOCAL_CONNECTION_ID,
+  markConnectionSwitch,
+  selectConnection,
+  type RemoteConnection,
+} from '@/lib/remote-connections'
+
+export function RemoteConnectionRecovery({
+  connection,
+  error,
+}: {
+  connection: RemoteConnection
+  error: string
+}) {
+  const reload = () => window.location.reload()
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 top-8 z-[55] flex items-center justify-center bg-background">
+      <div className="mx-4 w-full max-w-md rounded-lg border bg-card p-6 shadow-lg">
+        <div className="flex items-center gap-2">
+          <ServerOff className="size-5 text-destructive" />
+          <h2 className="font-semibold">
+            Couldn&apos;t connect to {connection.name}
+          </h2>
+        </div>
+        <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+        <p className="mt-1 truncate text-xs text-muted-foreground">
+          {connection.url}
+        </p>
+        <div className="mt-5 flex flex-wrap gap-2">
+          <Button onClick={reload}>Retry</Button>
+          <Button
+            variant="outline"
+            onClick={() =>
+              window.dispatchEvent(
+                new CustomEvent('open-remote-connections', {
+                  detail: { id: connection.id },
+                })
+              )
+            }
+          >
+            Edit connection
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => {
+              markConnectionSwitch()
+              selectConnection(LOCAL_CONNECTION_ID)
+              reload()
+            }}
+          >
+            Switch to Local
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/remote/RemoteConnectionsDialog.test.tsx
+++ b/src/components/remote/RemoteConnectionsDialog.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RemoteConnectionsDialog } from './RemoteConnectionsDialog'
+
+const { addRemoteConnection, selectConnection } = vi.hoisted(() => ({
+  addRemoteConnection: vi.fn(() => ({ id: 'remote-1' })),
+  selectConnection: vi.fn(),
+}))
+
+vi.mock('@/lib/remote-connections', () => ({
+  LOCAL_CONNECTION_ID: 'local',
+  addRemoteConnection,
+  getActiveConnectionId: () => 'local',
+  removeRemoteConnection: vi.fn(),
+  markConnectionSwitch: vi.fn(),
+  selectConnection,
+  updateRemoteConnection: vi.fn(),
+  useRemoteConnections: () => [],
+}))
+
+describe('RemoteConnectionsDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('adds and selects a remote from a complete Web Access URL', () => {
+    render(<RemoteConnectionsDialog reloadApp={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Jean connections' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Add remote' }))
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'Build server' },
+    })
+    fireEvent.change(screen.getByLabelText('Web Access URL'), {
+      target: { value: 'https://jean.example.com/?token=secret' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save & Connect' }))
+
+    expect(addRemoteConnection).toHaveBeenCalledWith({
+      name: 'Build server',
+      url: 'https://jean.example.com/?token=secret',
+      token: '',
+    })
+    expect(selectConnection).toHaveBeenCalledWith('remote-1')
+  })
+})

--- a/src/components/remote/RemoteConnectionsDialog.tsx
+++ b/src/components/remote/RemoteConnectionsDialog.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useState, type FormEvent } from 'react'
+import { Check, Pencil, Plus, Server, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  LOCAL_CONNECTION_ID,
+  addRemoteConnection,
+  getActiveConnectionId,
+  markConnectionSwitch,
+  removeRemoteConnection,
+  selectConnection,
+  updateRemoteConnection,
+  useRemoteConnections,
+  type RemoteConnection,
+} from '@/lib/remote-connections'
+
+const EMPTY_FORM = { name: '', url: '', token: '' }
+
+export function RemoteConnectionsDialog({
+  reloadApp = () => window.location.reload(),
+}: {
+  reloadApp?: () => void
+}) {
+  const connections = useRemoteConnections()
+  const activeId = getActiveConnectionId()
+  const remoteActive = activeId !== LOCAL_CONNECTION_ID
+  const [open, setOpen] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [form, setForm] = useState(EMPTY_FORM)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const handleOpen = (event: Event) => {
+      setOpen(true)
+      const id = (event as CustomEvent<{ id?: string }>).detail?.id
+      const connection = connections.find(item => item.id === id)
+      if (connection) {
+        setEditingId(connection.id)
+        setForm({
+          name: connection.name,
+          url: connection.url,
+          token: connection.token,
+        })
+        setError(null)
+      }
+    }
+    window.addEventListener('open-remote-connections', handleOpen)
+    return () =>
+      window.removeEventListener('open-remote-connections', handleOpen)
+  }, [connections])
+
+  const beginAdd = () => {
+    setEditingId('new')
+    setForm(EMPTY_FORM)
+    setError(null)
+  }
+
+  const beginEdit = (connection: RemoteConnection) => {
+    setEditingId(connection.id)
+    setForm({
+      name: connection.name,
+      url: connection.url,
+      token: connection.token,
+    })
+    setError(null)
+  }
+
+  const switchTo = (id: string) => {
+    if (id === activeId) return
+    markConnectionSwitch()
+    selectConnection(id)
+    reloadApp()
+  }
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    try {
+      if (editingId === 'new') {
+        const connection = addRemoteConnection(form)
+        markConnectionSwitch()
+        selectConnection(connection.id)
+        reloadApp()
+        return
+      }
+      if (editingId) {
+        updateRemoteConnection(editingId, form)
+        if (editingId === activeId) {
+          markConnectionSwitch()
+          reloadApp()
+        }
+        setEditingId(null)
+      }
+    } catch (submitError) {
+      setError(
+        submitError instanceof Error ? submitError.message : String(submitError)
+      )
+    }
+  }
+
+  const handleDelete = (id: string) => {
+    const wasActive = id === activeId
+    removeRemoteConnection(id)
+    if (wasActive) {
+      markConnectionSwitch()
+      reloadApp()
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          aria-label="Jean connections"
+          title="Jean connections"
+          variant="ghost"
+          size="icon"
+          className="relative h-6 w-6 rounded-none text-foreground/70 hover:text-foreground"
+        >
+          <Server className="size-3.5" />
+          {remoteActive && (
+            <span className="absolute right-0.5 top-0.5 size-1.5 rounded-full bg-green-500" />
+          )}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Jean connections</DialogTitle>
+          <DialogDescription>
+            Switch this client between Local and a remote Jean Web Access
+            server.
+          </DialogDescription>
+        </DialogHeader>
+
+        {editingId ? (
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-1.5">
+              <Label htmlFor="remote-name">Name</Label>
+              <Input
+                id="remote-name"
+                value={form.name}
+                onChange={event =>
+                  setForm(current => ({ ...current, name: event.target.value }))
+                }
+                placeholder="Build server"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="remote-url">Web Access URL</Label>
+              <Input
+                id="remote-url"
+                value={form.url}
+                onChange={event =>
+                  setForm(current => ({ ...current, url: event.target.value }))
+                }
+                placeholder="https://jean.example.com/?token=..."
+                required
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="remote-token">Access token</Label>
+              <Input
+                id="remote-token"
+                type="password"
+                value={form.token}
+                onChange={event =>
+                  setForm(current => ({
+                    ...current,
+                    token: event.target.value,
+                  }))
+                }
+                placeholder="Optional when included in the URL"
+              />
+            </div>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setEditingId(null)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit">
+                {editingId === 'new' ? 'Save & Connect' : 'Save'}
+              </Button>
+            </DialogFooter>
+          </form>
+        ) : (
+          <div className="space-y-2">
+            <ConnectionRow
+              name="Local"
+              detail="This computer"
+              active={activeId === LOCAL_CONNECTION_ID}
+              onSelect={() => switchTo(LOCAL_CONNECTION_ID)}
+            />
+            {connections.map(connection => (
+              <ConnectionRow
+                key={connection.id}
+                name={connection.name}
+                detail={connection.url}
+                active={activeId === connection.id}
+                onSelect={() => switchTo(connection.id)}
+                onEdit={() => beginEdit(connection)}
+                onDelete={() => handleDelete(connection.id)}
+              />
+            ))}
+            <Button
+              type="button"
+              variant="outline"
+              className="mt-2 w-full"
+              onClick={beginAdd}
+            >
+              <Plus className="mr-2 size-4" />
+              Add remote
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ConnectionRow({
+  name,
+  detail,
+  active,
+  onSelect,
+  onEdit,
+  onDelete,
+}: {
+  name: string
+  detail: string
+  active: boolean
+  onSelect: () => void
+  onEdit?: () => void
+  onDelete?: () => void
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-md border p-2">
+      <button
+        type="button"
+        className="min-w-0 flex-1 text-left"
+        onClick={onSelect}
+      >
+        <span className="flex items-center gap-2 text-sm font-medium">
+          <span
+            className={`size-2 rounded-full ${active ? 'bg-green-500' : 'bg-muted-foreground/35'}`}
+          />
+          {name}
+          {active && <Check className="size-3.5 text-green-500" />}
+        </span>
+        <span className="ml-4 block truncate text-xs text-muted-foreground">
+          {detail}
+        </span>
+      </button>
+      {onEdit && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-7"
+          aria-label={`Edit ${name}`}
+          onClick={onEdit}
+        >
+          <Pencil className="size-3.5" />
+        </Button>
+      )}
+      {onDelete && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-7 text-destructive"
+          aria-label={`Delete ${name}`}
+          onClick={onDelete}
+        >
+          <Trash2 className="size-3.5" />
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/components/titlebar/TitleBar.tsx
+++ b/src/components/titlebar/TitleBar.tsx
@@ -35,6 +35,7 @@ import { UnreadBell } from '@/components/unread/UnreadBell'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { FALLBACK_APP_VERSION } from '@/lib/app-version'
 import { LinuxWindowControls } from './LinuxWindowControls'
+import { RemoteConnectionsDialog } from '@/components/remote/RemoteConnectionsDialog'
 
 interface TitleBarProps {
   className?: string
@@ -150,6 +151,7 @@ export function TitleBar({
               <TooltipContent>GitHub</TooltipContent>
             </Tooltip>
           )}
+          {native && <RemoteConnectionsDialog />}
           <Tooltip>
             <TooltipTrigger asChild>
               <Button

--- a/src/components/titlebar/TitleBar.tsx
+++ b/src/components/titlebar/TitleBar.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { useState, useEffect, useCallback } from 'react'
 import { cn } from '@/lib/utils'
-import { isLinux, isMacOS, openExternal } from '@/lib/platform'
+import { isClientLinux, isClientMacOS, openExternal } from '@/lib/platform'
 import { Button } from '@/components/ui/button'
 import {
   Tooltip,
@@ -88,7 +88,7 @@ export function TitleBar({
         <div
           className={cn(
             'relative z-10 flex items-center gap-1 pt-1',
-            native && isMacOS ? 'pl-[80px]' : 'pl-2'
+            native && isClientMacOS ? 'pl-[80px]' : 'pl-2'
           )}
         >
           <Tooltip>
@@ -212,7 +212,7 @@ export function TitleBar({
             v{appVersion}
           </button>
         )}
-        {native && isLinux && <LinuxWindowControls />}
+        {native && isClientLinux && <LinuxWindowControls />}
       </div>
     </div>
   )

--- a/src/components/titlebar/TitleBar.web-connection.test.ts
+++ b/src/components/titlebar/TitleBar.web-connection.test.ts
@@ -15,4 +15,11 @@ describe('web connection header', () => {
       '<UnreadBell title={title} hideTitle={hideTitle} />'
     )
   })
+
+  it('uses the client platform for native window chrome', () => {
+    expect(source).toContain('isClientMacOS')
+    expect(source).toContain('isClientLinux')
+    expect(source).not.toContain('native && isMacOS')
+    expect(source).not.toContain('native && isLinux')
+  })
 })

--- a/src/hooks/useLinuxFileDrop.ts
+++ b/src/hooks/useLinuxFileDrop.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { toast } from 'sonner'
-import { isNativeApp } from '@/lib/environment'
+import { isLocalBackend } from '@/lib/environment'
 import { useChatStore } from '@/store/chat-store'
 import {
   classifyAttachmentFile,
@@ -90,7 +90,7 @@ function routeToChat(paths: string[], sessionId: string | undefined): void {
  */
 export function useLinuxFileDrop(): void {
   useEffect(() => {
-    if (!isNativeApp()) return
+    if (!isLocalBackend()) return
 
     let unlisten: (() => void) | null = null
     let cancelled = false

--- a/src/hooks/useQueueProcessor.test.tsx
+++ b/src/hooks/useQueueProcessor.test.tsx
@@ -15,6 +15,7 @@ const sendMessageMutate = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/environment', () => ({
   isNativeApp: () => env.isNativeApp,
+  isLocalBackend: () => env.isNativeApp,
   hasBackend: () => env.hasBackend,
 }))
 

--- a/src/hooks/useQueueProcessor.ts
+++ b/src/hooks/useQueueProcessor.ts
@@ -9,7 +9,7 @@ import {
 import { usePreferences } from '@/services/preferences'
 import { DEFAULT_PARALLEL_EXECUTION_PROMPT } from '@/types/preferences'
 import { isTauri } from '@/services/projects'
-import { isNativeApp } from '@/lib/environment'
+import { isLocalBackend } from '@/lib/environment'
 import { useWsConnectionStatus } from '@/lib/transport'
 import { logger } from '@/lib/logger'
 import { buildMessageWithRefs } from '@/components/chat/message-with-refs'
@@ -64,7 +64,7 @@ export function useQueueProcessor(): void {
     // disconnect between an atomic dequeue and the follow-up send request,
     // making the prompt disappear without executing. Native app processing is
     // kept for desktop-local queues; web clients only mirror queue updates.
-    if (!isNativeApp()) return
+    if (!isLocalBackend()) return
 
     // Read fresh state inside effect to avoid subscribing to full records.
     // Store actions are accessed via getState() inside the async callback

--- a/src/hooks/useServerUpdateCheck.ts
+++ b/src/hooks/useServerUpdateCheck.ts
@@ -8,7 +8,7 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { toast } from 'sonner'
 import { invoke } from '@/lib/transport'
-import { isNativeApp } from '@/lib/environment'
+import { isLocalBackend } from '@/lib/environment'
 import { logger } from '@/lib/logger'
 
 export interface ServerUpdateStatus {
@@ -102,7 +102,7 @@ export function useServerUpdateCheck() {
   )
 
   useEffect(() => {
-    if (isNativeApp()) return
+    if (isLocalBackend()) return
 
     let cancelled = false
 

--- a/src/hooks/useUIStatePersistence.test.tsx
+++ b/src/hooks/useUIStatePersistence.test.tsx
@@ -11,6 +11,7 @@ let nativeApp = false
 
 vi.mock('@/lib/environment', () => ({
   isNativeApp: () => nativeApp,
+  isLocalBackend: () => nativeApp,
   hasBackend: () => true,
 }))
 

--- a/src/hooks/useUIStatePersistence.ts
+++ b/src/hooks/useUIStatePersistence.ts
@@ -11,7 +11,7 @@ import {
 } from '@/store/terminal-store'
 import { useBrowserStore } from '@/store/browser-store'
 import { browserBackend } from '@/hooks/useBrowserPane'
-import { isNativeApp } from '@/lib/environment'
+import { isLocalBackend } from '@/lib/environment'
 import { invoke } from '@/lib/transport'
 import { logger } from '@/lib/logger'
 import type { BrowserTab } from '@/types/browser'
@@ -155,7 +155,7 @@ export function useUIStatePersistence() {
       modalTerminalWidth,
       modalTerminalHeight,
     } = useTerminalStore.getState()
-    const shouldPersistTerminalRuntime = !isNativeApp()
+    const shouldPersistTerminalRuntime = !isLocalBackend()
     const terminalInstancesForPersist = shouldPersistTerminalRuntime
       ? Object.fromEntries(
           Object.entries(terminals)
@@ -537,7 +537,7 @@ export function useUIStatePersistence() {
     }
 
     const restoreTerminalRuntimeState = async (shouldCancel: () => boolean) => {
-      if (isNativeApp() || shouldCancel()) return
+      if (isLocalBackend() || shouldCancel()) return
 
       // PHASE 1: Always restore the *user-intent* UI flags for terminal
       // surfaces. These are independent of whether any PTYs survived the
@@ -1203,7 +1203,7 @@ export function useUIStatePersistence() {
         bottomHeightChanged
       ) {
         // Detect tab removals — close their backing webviews
-        if (tabsChanged && isNativeApp()) {
+        if (tabsChanged && isLocalBackend()) {
           const prevIds = new Set<string>()
           for (const list of Object.values(prevBrowserTabs)) {
             for (const t of list) prevIds.add(t.id)

--- a/src/lib/environment.ts
+++ b/src/lib/environment.ts
@@ -1,3 +1,5 @@
+import { getActiveRemoteConnection } from './remote-connections'
+
 /**
  * Environment detection utilities.
  *
@@ -8,7 +10,8 @@
  *
  * Service queries should guard with hasBackendTransport(); mutations that
  * must run immediately should guard with hasBackend().
- * UI should use isNativeApp() to hide native-only features (Finder, external editors, etc.).
+ * UI should use isNativeApp() for local shell features and isLocalBackend()
+ * for backend-side desktop features (Finder, external editors, etc.).
  */
 
 /** Running inside the native Tauri desktop app with usable IPC.
@@ -19,9 +22,13 @@ export const isNativeApp = (): boolean =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   typeof (window as any).__TAURI_INTERNALS__?.invoke === 'function'
 
+/** Whether backend operations target this desktop app's local Jean core. */
+export const isLocalBackend = (): boolean =>
+  isNativeApp() && getActiveRemoteConnection() === null
+
 /** A backend is available (either Tauri IPC, WebSocket connection, or E2E mock). */
 export const hasBackend = (): boolean => {
-  if (isNativeApp()) return true
+  if (isLocalBackend()) return true
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (typeof window !== 'undefined' && (window as any).__JEAN_E2E_MOCK__)
     return true
@@ -45,7 +52,8 @@ export const setWebAccessEnabled = (enabled: boolean): void => {
  * Unlike hasBackend(), this stays true while web access is connecting so query
  * functions wait/fail instead of returning authoritative empty data. */
 export const hasBackendTransport = (): boolean =>
-  isNativeApp() ||
+  isLocalBackend() ||
+  getActiveRemoteConnection() !== null ||
   _webAccessEnabled ||
   (typeof window !== 'undefined' &&
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -57,13 +57,17 @@ describe('openExternal', () => {
 })
 
 describe('server platform detection', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+  })
+
   it('does not derive server platform flags from the browser platform', async () => {
     vi.stubGlobal('window', { open: vi.fn() })
     vi.stubGlobal('navigator', { platform: 'Win32' })
 
-    const { isMacOS, isWindows, isLinux, getServerPlatform } = await import(
-      './platform'
-    )
+    const { isMacOS, isWindows, isLinux, getServerPlatform } =
+      await import('./platform')
 
     expect(getServerPlatform()).toBe('linux')
     expect(isWindows).toBe(false)
@@ -86,5 +90,21 @@ describe('server platform detection', () => {
     platform.setServerPlatform('windows')
     expect(platform.isServerWindows()).toBe(true)
     expect(platform.isWindows).toBe(true)
+  })
+
+  it('keeps the native client platform separate from a remote server platform', async () => {
+    vi.stubGlobal('navigator', {
+      platform: 'MacIntel',
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+    })
+
+    const platform = await import('./platform')
+
+    platform.setServerPlatform('linux')
+
+    expect(platform.isClientMacOS).toBe(true)
+    expect(platform.isClientLinux).toBe(false)
+    expect(platform.isMacOS).toBe(false)
+    expect(platform.isLinux).toBe(true)
   })
 })

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -5,6 +5,16 @@ export type PlatformName = 'mac' | 'windows' | 'linux'
 
 let serverPlatform: PlatformName = 'linux'
 
+// Window chrome belongs to the local client, even when commands target a
+// remote Jean server running on a different operating system.
+const clientPlatform =
+  typeof navigator === 'undefined'
+    ? ''
+    : (navigator.platform || navigator.userAgent).toLowerCase()
+
+export const isClientMacOS = clientPlatform.includes('mac')
+export const isClientLinux = clientPlatform.includes('linux')
+
 export let isMacOS = false
 export let isWindows = false
 export let isLinux = true

--- a/src/lib/remote-connections.test.ts
+++ b/src/lib/remote-connections.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  addRemoteConnection,
+  clearConnectionSwitch,
+  getActiveConnectionId,
+  getActiveRemoteConnection,
+  getRemoteConnections,
+  isConnectionSwitchPending,
+  markConnectionSwitch,
+  parseRemoteConnectionInput,
+  removeRemoteConnection,
+  selectConnection,
+  updateRemoteConnection,
+} from './remote-connections'
+
+describe('remote connections', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('extracts a token from a complete Web Access URL', () => {
+    expect(
+      parseRemoteConnectionInput('https://jean.example.com/?token=secret', '')
+    ).toEqual({ url: 'https://jean.example.com', token: 'secret' })
+  })
+
+  it('accepts a separate token and normalizes the URL', () => {
+    expect(
+      parseRemoteConnectionInput('http://server.local:3456///', ' token ')
+    ).toEqual({ url: 'http://server.local:3456', token: 'token' })
+  })
+
+  it('rejects unsupported URL schemes', () => {
+    expect(() => parseRemoteConnectionInput('ftp://server', 'token')).toThrow(
+      'HTTP or HTTPS'
+    )
+  })
+
+  it('persists CRUD operations and the active selection', () => {
+    const remote = addRemoteConnection({
+      name: 'Build server',
+      url: 'https://jean.example.com?token=first',
+      token: '',
+    })
+
+    expect(getRemoteConnections()).toEqual([remote])
+
+    selectConnection(remote.id)
+    expect(getActiveConnectionId()).toBe(remote.id)
+    expect(getActiveRemoteConnection()).toEqual(remote)
+
+    const updated = updateRemoteConnection(remote.id, {
+      name: 'Production',
+      url: remote.url,
+      token: 'second',
+    })
+    expect(getRemoteConnections()).toEqual([updated])
+
+    removeRemoteConnection(remote.id)
+    expect(getRemoteConnections()).toEqual([])
+    expect(getActiveConnectionId()).toBe('local')
+  })
+
+  it('marks an intentional switch so unload cleanup can be skipped', () => {
+    markConnectionSwitch()
+    expect(isConnectionSwitchPending()).toBe(true)
+
+    clearConnectionSwitch()
+    expect(isConnectionSwitchPending()).toBe(false)
+  })
+})

--- a/src/lib/remote-connections.ts
+++ b/src/lib/remote-connections.ts
@@ -1,0 +1,185 @@
+import { useSyncExternalStore } from 'react'
+import { generateId } from './uuid'
+
+export const LOCAL_CONNECTION_ID = 'local'
+
+const CONNECTIONS_KEY = 'jean-remote-connections'
+const ACTIVE_CONNECTION_KEY = 'jean-active-connection'
+const SWITCHING_CONNECTION_KEY = 'jean-switching-connection-at'
+
+export interface RemoteConnection {
+  id: string
+  name: string
+  url: string
+  token: string
+}
+
+export interface RemoteConnectionInput {
+  name: string
+  url: string
+  token: string
+}
+
+const subscribers = new Set<() => void>()
+let connectionsSnapshot: RemoteConnection[] = readConnections()
+const savedActiveConnection =
+  storage()?.getItem(ACTIVE_CONNECTION_KEY) || LOCAL_CONNECTION_ID
+let activeConnectionSnapshot =
+  savedActiveConnection === LOCAL_CONNECTION_ID ||
+  connectionsSnapshot.some(
+    connection => connection.id === savedActiveConnection
+  )
+    ? savedActiveConnection
+    : LOCAL_CONNECTION_ID
+
+function storage(): Storage | null {
+  return typeof window === 'undefined' ? null : window.localStorage
+}
+
+function readConnections(): RemoteConnection[] {
+  const raw = storage()?.getItem(CONNECTIONS_KEY)
+  if (!raw) return []
+
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (item): item is RemoteConnection =>
+        typeof item?.id === 'string' &&
+        typeof item?.name === 'string' &&
+        typeof item?.url === 'string' &&
+        typeof item?.token === 'string'
+    )
+  } catch {
+    return []
+  }
+}
+
+function writeConnections(connections: RemoteConnection[]): void {
+  connectionsSnapshot = connections
+  storage()?.setItem(CONNECTIONS_KEY, JSON.stringify(connections))
+  for (const subscriber of subscribers) subscriber()
+}
+
+export function parseRemoteConnectionInput(
+  rawUrl: string,
+  rawToken: string
+): { url: string; token: string } {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl.trim())
+  } catch {
+    throw new Error('Enter a valid HTTP or HTTPS URL.')
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('Enter an HTTP or HTTPS URL.')
+  }
+
+  const token =
+    rawToken.trim() || parsed.searchParams.get('token')?.trim() || ''
+  parsed.search = ''
+  parsed.hash = ''
+  parsed.pathname = parsed.pathname.replace(/\/+$/, '')
+
+  return { url: parsed.toString().replace(/\/$/, ''), token }
+}
+
+export function getRemoteConnections(): RemoteConnection[] {
+  return connectionsSnapshot
+}
+
+export function addRemoteConnection(
+  input: RemoteConnectionInput
+): RemoteConnection {
+  const normalized = parseRemoteConnectionInput(input.url, input.token)
+  const connection: RemoteConnection = {
+    id: generateId(),
+    name: input.name.trim() || new URL(normalized.url).hostname,
+    ...normalized,
+  }
+  writeConnections([...getRemoteConnections(), connection])
+  return connection
+}
+
+export function updateRemoteConnection(
+  id: string,
+  input: RemoteConnectionInput
+): RemoteConnection {
+  const normalized = parseRemoteConnectionInput(input.url, input.token)
+  const updated: RemoteConnection = {
+    id,
+    name: input.name.trim() || new URL(normalized.url).hostname,
+    ...normalized,
+  }
+  const connections = getRemoteConnections()
+  if (!connections.some(connection => connection.id === id)) {
+    throw new Error('Remote connection not found.')
+  }
+  writeConnections(
+    connections.map(connection => (connection.id === id ? updated : connection))
+  )
+  return updated
+}
+
+export function removeRemoteConnection(id: string): void {
+  writeConnections(
+    getRemoteConnections().filter(connection => connection.id !== id)
+  )
+  if (getActiveConnectionId() === id) selectConnection(LOCAL_CONNECTION_ID)
+}
+
+export function getActiveConnectionId(): string {
+  return activeConnectionSnapshot
+}
+
+export function getActiveRemoteConnection(): RemoteConnection | null {
+  const activeId = getActiveConnectionId()
+  if (activeId === LOCAL_CONNECTION_ID) return null
+  return (
+    getRemoteConnections().find(connection => connection.id === activeId) ??
+    null
+  )
+}
+
+export function selectConnection(id: string): void {
+  const selected =
+    id === LOCAL_CONNECTION_ID ||
+    getRemoteConnections().some(connection => connection.id === id)
+      ? id
+      : LOCAL_CONNECTION_ID
+  activeConnectionSnapshot = selected
+  storage()?.setItem(ACTIVE_CONNECTION_KEY, selected)
+  for (const subscriber of subscribers) subscriber()
+}
+
+export function markConnectionSwitch(): void {
+  if (typeof window !== 'undefined') {
+    window.sessionStorage.setItem(SWITCHING_CONNECTION_KEY, String(Date.now()))
+  }
+}
+
+export function isConnectionSwitchPending(): boolean {
+  if (typeof window === 'undefined') return false
+  const switchedAt = Number(
+    window.sessionStorage.getItem(SWITCHING_CONNECTION_KEY) ?? 0
+  )
+  return switchedAt > 0 && Date.now() - switchedAt < 30_000
+}
+
+export function clearConnectionSwitch(): void {
+  if (typeof window !== 'undefined') {
+    window.sessionStorage.removeItem(SWITCHING_CONNECTION_KEY)
+  }
+}
+
+export function useRemoteConnections(): RemoteConnection[] {
+  return useSyncExternalStore(
+    callback => {
+      subscribers.add(callback)
+      return () => subscribers.delete(callback)
+    },
+    () => connectionsSnapshot,
+    () => []
+  )
+}

--- a/src/lib/transport.test.ts
+++ b/src/lib/transport.test.ts
@@ -36,6 +36,8 @@ class MockWebSocket {
 async function flushAsync() {
   await Promise.resolve()
   await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
 }
 
 function getWs(index: number): MockWebSocket {
@@ -54,7 +56,9 @@ async function loadTransportModule() {
   return import('./transport')
 }
 
-async function loadNativeTransportModule(tauriInvoke: ReturnType<typeof vi.fn>) {
+async function loadNativeTransportModule(
+  tauriInvoke: ReturnType<typeof vi.fn>
+) {
   vi.resetModules()
   vi.doMock('./environment', () => ({
     isNativeApp: () => true,
@@ -62,6 +66,24 @@ async function loadNativeTransportModule(tauriInvoke: ReturnType<typeof vi.fn>) 
     setWebAccessEnabled: vi.fn(),
   }))
   vi.doMock('@tauri-apps/api/core', () => ({ invoke: tauriInvoke }))
+  return import('./transport')
+}
+
+async function loadRemoteNativeTransportModule() {
+  vi.resetModules()
+  vi.doMock('./environment', () => ({
+    isNativeApp: () => true,
+    setWsConnected: setWsConnectedMock,
+    setWebAccessEnabled: vi.fn(),
+  }))
+  vi.doMock('./remote-connections', () => ({
+    getActiveRemoteConnection: () => ({
+      id: 'remote-1',
+      name: 'Server',
+      url: 'https://jean.example.com',
+      token: 'secret',
+    }),
+  }))
   return import('./transport')
 }
 
@@ -85,6 +107,29 @@ describe('transport bootstrap', () => {
     vi.unstubAllGlobals()
     vi.doUnmock('./environment')
     vi.doUnmock('@tauri-apps/api/core')
+    vi.doUnmock('./remote-connections')
+  })
+
+  it('routes native shared commands to the selected remote Jean', async () => {
+    const transport = await loadRemoteNativeTransportModule()
+
+    transport.connectTransport()
+    await flushAsync()
+    const ws = getWs(0)
+
+    const request = transport.invoke('list_projects')
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://jean.example.com/api/auth?token=secret',
+      expect.objectContaining({ signal: expect.anything() })
+    )
+    expect(ws.url).toBe('wss://jean.example.com/ws?token=secret')
+    expect(ws.send).toHaveBeenCalledWith(
+      expect.stringContaining('"command":"list_projects"')
+    )
+    const sent = JSON.parse(String(ws.send.mock.calls.at(-1)?.[0]))
+    ws.receive({ type: 'response', id: sent.id, data: [] })
+    await request
   })
 
   it('routes shared native commands through the jean-core dispatcher', async () => {

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -10,6 +10,37 @@ import { useSyncExternalStore } from 'react'
 import { isNativeApp, setWebAccessEnabled, setWsConnected } from './environment'
 import { generateId } from './uuid'
 import { isServerWindows } from './platform'
+import { getActiveRemoteConnection } from './remote-connections'
+
+export function usesWebSocketBackend(): boolean {
+  return !isNativeApp() || getActiveRemoteConnection() !== null
+}
+
+function getWebBackendBaseUrl(): string {
+  return getActiveRemoteConnection()?.url ?? window.location.origin
+}
+
+function getWebBackendToken(): string {
+  const remote = getActiveRemoteConnection()
+  if (remote) return remote.token
+  const urlToken = new URLSearchParams(window.location.search).get('token')
+  return urlToken || localStorage.getItem('jean-http-token') || ''
+}
+
+function backendUrl(path: string): string {
+  const base = `${getWebBackendBaseUrl().replace(/\/+$/, '')}/`
+  return new URL(path.replace(/^\/+/, ''), base).toString()
+}
+
+function fetchBackend(url: string): Promise<Response> {
+  if (!getActiveRemoteConnection()) return fetch(url)
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 12_000)
+  return fetch(url, { signal: controller.signal }).finally(() =>
+    clearTimeout(timeout)
+  )
+}
 
 // ---------------------------------------------------------------------------
 // File source URL conversion (drop-in for Tauri's convertFileSrc)
@@ -34,7 +65,7 @@ export function setAppDataDir(dir: string): void {
  * In browser mode, converts to /api/files/ URLs served by the HTTP server.
  */
 export function convertFileSrc(filePath: string, protocol = 'asset'): string {
-  if (isNativeApp()) {
+  if (!usesWebSocketBackend()) {
     // Use Tauri's native implementation which correctly percent-encodes paths
     // on all platforms (JS encodeURIComponent misses dots/hyphens/underscores
     // that Tauri's Rust encoder expects on Windows).
@@ -51,13 +82,14 @@ export function convertFileSrc(filePath: string, protocol = 'asset'): string {
   }
 
   // Browser mode: convert server filesystem path to /api/files/ URL
-  const token = localStorage.getItem('jean-http-token') || ''
+  const token = getWebBackendToken()
   const params = token ? `?token=${encodeURIComponent(token)}` : ''
+  const base = getActiveRemoteConnection()?.url ?? ''
 
   // Try exact prefix match with cached app data dir
   if (_appDataDir && filePath.startsWith(_appDataDir)) {
     const relativePath = filePath.substring(_appDataDir.length)
-    return `/api/files/${encodeURI(relativePath)}${params}`
+    return `${base}/api/files/${encodeURI(relativePath)}${params}`
   }
 
   // Fallback: detect app data dir marker in path (works before _appDataDir is set)
@@ -65,7 +97,7 @@ export function convertFileSrc(filePath: string, protocol = 'asset'): string {
     const idx = filePath.indexOf(marker)
     if (idx !== -1) {
       const relativePath = filePath.substring(idx + marker.length)
-      return `/api/files/${encodeURI(relativePath)}${params}`
+      return `${base}/api/files/${encodeURI(relativePath)}${params}`
     }
   }
 
@@ -80,13 +112,14 @@ export function convertFileSrc(filePath: string, protocol = 'asset'): string {
  * project/worktree roots before serving it.
  */
 export function convertProjectFileSrc(filePath: string): string {
-  if (isNativeApp()) {
+  if (!usesWebSocketBackend()) {
     return convertFileSrc(filePath)
   }
 
-  const token = localStorage.getItem('jean-http-token') || ''
+  const token = getWebBackendToken()
   const params = token ? `?token=${encodeURIComponent(token)}` : ''
-  return `/api/project-files/${encodeURIComponent(filePath)}${params}`
+  const base = getActiveRemoteConnection()?.url ?? ''
+  return `${base}/api/project-files/${encodeURIComponent(filePath)}${params}`
 }
 
 /** Unlisten function type — compatible with Tauri's UnlistenFn. */
@@ -127,6 +160,31 @@ const DESKTOP_ONLY_COMMANDS = new Set([
   'has_active_browser_tab',
 ])
 
+// These commands belong to the local desktop shell even when its application
+// content is connected to a remote Jean backend.
+const LOCAL_SHELL_COMMANDS = new Set([
+  'set_window_vibrancy',
+  'send_native_notification',
+  'read_clipboard_image',
+  'write_clipboard_text',
+  'browser_create',
+  'browser_navigate',
+  'browser_back',
+  'browser_forward',
+  'browser_reload',
+  'browser_stop',
+  'browser_set_bounds',
+  'browser_set_visible',
+  'browser_set_focus',
+  'browser_get_url',
+  'browser_close',
+  'browser_report_title',
+  'browser_enable_grab',
+  'browser_report_grab_context',
+  'get_active_browser_tabs',
+  'has_active_browser_tab',
+])
+
 // ---------------------------------------------------------------------------
 // Public API (same signatures as Tauri)
 // ---------------------------------------------------------------------------
@@ -148,7 +206,10 @@ export async function invoke<T>(
     return null as T
   }
 
-  if (isNativeApp()) {
+  if (
+    !usesWebSocketBackend() ||
+    (isNativeApp() && LOCAL_SHELL_COMMANDS.has(command))
+  ) {
     const { invoke: tauriInvoke } = await import('@tauri-apps/api/core')
     if (DESKTOP_ONLY_COMMANDS.has(command)) {
       return tauriInvoke<T>(command, args)
@@ -180,7 +241,7 @@ export async function listen<T>(
     return () => et.removeEventListener(event, wrapped)
   }
 
-  if (isNativeApp()) {
+  if (!usesWebSocketBackend()) {
     const { listen: tauriListen } = await import('@tauri-apps/api/event')
     return tauriListen<T>(event, handler)
   }
@@ -193,7 +254,7 @@ export async function listen<T>(
  * tracking was lost but the Rust PTY and replay buffer are still alive.
  */
 export function requestTerminalReplay(terminalId: string, lastSeq = 0): void {
-  if (isNativeApp()) return
+  if (!usesWebSocketBackend()) return
   wsTransport.requestTerminalReplay(terminalId, lastSeq)
 }
 
@@ -227,16 +288,15 @@ let initialDataResolved = false
  * Centralizes token and selected_project encoding.
  */
 function buildInitUrl(opts: { selectedProjectId?: string | null }): string {
-  const urlToken = new URLSearchParams(window.location.search).get('token')
-  const token = urlToken || localStorage.getItem('jean-http-token') || ''
-
+  const token = getWebBackendToken()
   const params = new URLSearchParams()
   if (token) params.set('token', token)
   if (opts.selectedProjectId) {
     params.set('selected_project', opts.selectedProjectId)
   }
   const qs = params.toString()
-  return qs ? `/api/init?${qs}` : '/api/init'
+  const url = backendUrl('api/init')
+  return qs ? `${url}?${qs}` : url
 }
 
 /**
@@ -253,7 +313,7 @@ function buildInitUrl(opts: { selectedProjectId?: string | null }): string {
 export async function preloadInitialData(
   selectedProjectId?: string | null
 ): Promise<InitialData | null> {
-  if (isNativeApp()) return null
+  if (!usesWebSocketBackend()) return null
   setWebAccessEnabled(true)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (typeof window !== 'undefined' && (window as any).__JEAN_E2E_MOCK__)
@@ -263,7 +323,7 @@ export async function preloadInitialData(
   initialDataPromise = (async () => {
     try {
       const url = buildInitUrl({ selectedProjectId })
-      const response = await fetch(url)
+      const response = await fetchBackend(url)
       if (!response.ok) {
         return null
       }
@@ -430,12 +490,14 @@ class WsTransport {
     )
       return
 
+    const remote = getActiveRemoteConnection()
     // Read token from URL query param or localStorage
     const urlToken = new URLSearchParams(window.location.search).get('token')
-    const token = urlToken || localStorage.getItem('jean-http-token') || ''
+    const token =
+      remote?.token || urlToken || localStorage.getItem('jean-http-token') || ''
 
     // Persist token from URL to localStorage for future page loads
-    if (urlToken) {
+    if (!remote && urlToken) {
       localStorage.setItem('jean-http-token', urlToken)
 
       // Remove token from URL for security (prevent history/bookmark exposure)
@@ -458,15 +520,18 @@ class WsTransport {
   }
 
   private async validateAndConnect(token: string): Promise<void> {
+    const authBaseUrl = backendUrl('api/auth')
     const authUrl = token
-      ? `${window.location.origin}/api/auth?token=${encodeURIComponent(token)}`
-      : `${window.location.origin}/api/auth`
+      ? `${authBaseUrl}?token=${encodeURIComponent(token)}`
+      : authBaseUrl
 
     try {
-      const res = await fetch(authUrl)
+      const res = await fetchBackend(authUrl)
       if (!res.ok) {
         // Invalid token — clear it and wait for the user to provide another.
-        localStorage.removeItem('jean-http-token')
+        if (!getActiveRemoteConnection()) {
+          localStorage.removeItem('jean-http-token')
+        }
         this.setAuthError(
           token
             ? "Invalid access token. Check the URL in Jean's Web Access settings."
@@ -475,6 +540,10 @@ class WsTransport {
         return
       }
     } catch {
+      if (getActiveRemoteConnection()) {
+        this.setAuthError('Unable to connect to the selected Jean server.')
+        return
+      }
       // The initial page load may race server startup. Retry connecting until
       // the first successful socket; established sockets use a page reload.
       this.setAuthError(null)
@@ -488,10 +557,10 @@ class WsTransport {
   }
 
   private connectWs(token: string): void {
-    // Derive WS URL from current page location
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const host = window.location.host
-    const url = `${protocol}//${host}/ws?token=${encodeURIComponent(token)}`
+    const base = new URL(backendUrl('ws'))
+    base.protocol = base.protocol === 'https:' ? 'wss:' : 'ws:'
+    base.searchParams.set('token', token)
+    const url = base.toString()
 
     this.ws = new WebSocket(url)
     this.clearConnectWatchdog()
@@ -555,6 +624,9 @@ class WsTransport {
       this.ws = null
 
       this.setConnected(false)
+      if (wasConnected && getActiveRemoteConnection()) {
+        this.setAuthError('Connection to the selected Jean server was lost.')
+      }
 
       // Clear event buffer — stale events from a dead connection
       // must not be delivered when the next connection opens.
@@ -951,7 +1023,7 @@ export function useWsConnectionStatus(): boolean {
 
 /** Start browser WebSocket transport after preload/bootstrap is complete. */
 export function connectTransport(): void {
-  if (isNativeApp() || isE2eMocked) return
+  if (!usesWebSocketBackend() || isE2eMocked) return
   setWebAccessEnabled(true)
   wsTransport.enableConnect()
 }
@@ -967,7 +1039,7 @@ export function onEstablishedWsDisconnect(callback: () => void): () => void {
  * Web mode: reflects current WebSocket connected state.
  */
 export function isTransportConnected(): boolean {
-  if (isNativeApp() || isE2eMocked) return true
+  if (!usesWebSocketBackend() || isE2eMocked) return true
   return wsTransport.connected
 }
 

--- a/src/services/claude-cli.ts
+++ b/src/services/claude-cli.ts
@@ -19,9 +19,9 @@ import type {
   ClaudeUsageSnapshot,
 } from '@/types/claude-cli'
 
-import { hasBackend } from '@/lib/environment'
+import { hasBackendTransport } from '@/lib/environment'
 
-const isTauri = hasBackend
+const isTauri = hasBackendTransport
 const USAGE_REFRESH_MS = 1000 * 60 * 5
 
 // Query keys for Claude CLI

--- a/src/services/coderabbit-cli.ts
+++ b/src/services/coderabbit-cli.ts
@@ -3,7 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { hasBackend } from '@/lib/environment'
+import { hasBackendTransport } from '@/lib/environment'
 import { invoke, listen, useWsConnectionStatus } from '@/lib/transport'
 import { logger } from '@/lib/logger'
 import type {
@@ -14,7 +14,7 @@ import type {
   CodeRabbitReleaseInfo,
 } from '@/types/coderabbit-cli'
 
-const isTauri = hasBackend
+const isTauri = hasBackendTransport
 
 export const coderabbitCliQueryKeys = {
   all: ['coderabbit-cli'] as const,

--- a/src/services/codex-cli.test.ts
+++ b/src/services/codex-cli.test.ts
@@ -1,18 +1,28 @@
-import { QueryClient } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { codexCliQueryKeys, installCodexUsageUpdateListener } from './codex-cli'
+import {
+  codexCliQueryKeys,
+  installCodexUsageUpdateListener,
+  useCodexCliStatus,
+} from './codex-cli'
 import type { CodexUsageSnapshot } from '@/types/codex-cli'
 
-const listenMock = vi.fn()
+const { invokeMock, listenMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  listenMock: vi.fn(),
+}))
 
 vi.mock('@/lib/transport', () => ({
-  invoke: vi.fn(),
+  invoke: (...args: unknown[]) => invokeMock(...args),
   listen: (...args: unknown[]) => listenMock(...args),
   useWsConnectionStatus: vi.fn(() => true),
 }))
 
 vi.mock('@/lib/environment', () => ({
-  hasBackend: () => true,
+  hasBackend: () => false,
+  hasBackendTransport: () => true,
 }))
 
 vi.mock('@/lib/logger', () => ({
@@ -75,5 +85,29 @@ describe('Codex usage update listener', () => {
     )
     cleanup()
     expect(unlisten).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('Codex CLI status', () => {
+  beforeEach(() => {
+    invokeMock.mockReset()
+  })
+
+  it('checks the configured remote backend before its WebSocket connects', async () => {
+    invokeMock.mockResolvedValue({
+      installed: true,
+      version: '1.2.3',
+      path: '/usr/local/bin/codex',
+    })
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children)
+
+    const { result } = renderHook(() => useCodexCliStatus(), { wrapper })
+
+    await waitFor(() => expect(result.current.data?.installed).toBe(true))
+    expect(invokeMock).toHaveBeenCalledWith('check_codex_cli_installed')
   })
 })

--- a/src/services/codex-cli.ts
+++ b/src/services/codex-cli.ts
@@ -24,9 +24,9 @@ import type {
   CodexUsageSnapshot,
 } from '@/types/codex-cli'
 
-import { hasBackend } from '@/lib/environment'
+import { hasBackendTransport } from '@/lib/environment'
 
-const isTauri = hasBackend
+const isTauri = hasBackendTransport
 const USAGE_REFRESH_MS = 1000 * 60 * 5
 
 // Query keys for Codex CLI

--- a/src/services/commandcode-cli.ts
+++ b/src/services/commandcode-cli.ts
@@ -14,9 +14,9 @@ import type {
   CommandCodeModelInfo,
   CommandCodeReleaseInfo,
 } from '@/types/commandcode-cli'
-import { hasBackend } from '@/lib/environment'
+import { hasBackendTransport } from '@/lib/environment'
 
-const isTauri = hasBackend
+const isTauri = hasBackendTransport
 
 export const commandcodeCliQueryKeys = {
   all: ['commandcode-cli'] as const,

--- a/src/services/cursor-cli.ts
+++ b/src/services/cursor-cli.ts
@@ -11,9 +11,9 @@ import type {
   CursorInstallCommand,
   CursorModelInfo,
 } from '@/types/cursor-cli'
-import { hasBackend } from '@/lib/environment'
+import { hasBackendTransport } from '@/lib/environment'
 
-const isTauri = hasBackend
+const isTauri = hasBackendTransport
 
 export const cursorCliQueryKeys = {
   all: ['cursor-cli'] as const,

--- a/src/services/gh-cli.ts
+++ b/src/services/gh-cli.ts
@@ -18,9 +18,9 @@ import type {
   GhInstallProgress,
 } from '@/types/gh-cli'
 
-import { hasBackend } from '@/lib/environment'
+import { hasBackendTransport } from '@/lib/environment'
 
-const isTauri = hasBackend
+const isTauri = hasBackendTransport
 
 // Query keys for GitHub CLI
 export const ghCliQueryKeys = {

--- a/src/services/grok-cli.ts
+++ b/src/services/grok-cli.ts
@@ -6,7 +6,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { invoke } from '@/lib/transport'
 import { logger } from '@/lib/logger'
 import { toast } from 'sonner'
-import { hasBackend } from '@/lib/environment'
+import { hasBackendTransport } from '@/lib/environment'
 import type {
   GrokAuthStatus,
   GrokCliStatus,
@@ -16,7 +16,7 @@ import type {
   GrokUsageSnapshot,
 } from '@/types/grok-cli'
 
-const isTauri = hasBackend
+const isTauri = hasBackendTransport
 const USAGE_REFRESH_MS = 1000 * 60 * 5
 
 export const grokCliQueryKeys = {

--- a/src/services/kimi-cli.ts
+++ b/src/services/kimi-cli.ts
@@ -6,7 +6,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { invoke } from '@/lib/transport'
 import { logger } from '@/lib/logger'
 import { toast } from 'sonner'
-import { hasBackend } from '@/lib/environment'
+import { hasBackendTransport } from '@/lib/environment'
 import type {
   KimiAuthStatus,
   KimiCliStatus,
@@ -15,7 +15,7 @@ import type {
   KimiReleaseInfo,
 } from '@/types/kimi-cli'
 
-const isTauri = hasBackend
+const isTauri = hasBackendTransport
 
 export const kimiCliQueryKeys = {
   all: ['kimi-cli'] as const,

--- a/src/services/opencode-cli.ts
+++ b/src/services/opencode-cli.ts
@@ -14,9 +14,9 @@ import type {
   OpencodeInstallProgress,
   OpencodeReleaseInfo,
 } from '@/types/opencode-cli'
-import { hasBackend } from '@/lib/environment'
+import { hasBackendTransport } from '@/lib/environment'
 
-const isTauri = hasBackend
+const isTauri = hasBackendTransport
 
 export const opencodeCliQueryKeys = {
   all: ['opencode-cli'] as const,

--- a/src/services/pi-cli.ts
+++ b/src/services/pi-cli.ts
@@ -13,11 +13,11 @@ import type {
   PiModelInfo,
   PiReleaseInfo,
 } from '@/types/pi-cli'
-import { hasBackend } from '@/lib/environment'
+import { hasBackendTransport } from '@/lib/environment'
 import { preferencesQueryKeys } from '@/services/preferences'
 import type { AppPreferences } from '@/types/preferences'
 
-const isTauri = hasBackend
+const isTauri = hasBackendTransport
 
 export const piCliQueryKeys = {
   all: ['pi-cli'] as const,


### PR DESCRIPTION
## Summary

- Add saved remote Jean connections with switching between local and remote servers.
- Route app data, commands, events, files, and authentication through the selected remote backend.
- Add connection management and recovery UI for unavailable servers.
- Support native client origins and remote HTTP(S)/WebSocket connections.
- Separate client window chrome from remote server platform detection.
- Document remote desktop setup and the planned iOS remote client.