### PR TITLE
fix(terminal): preserve unicode input in web access

### DIFF
--- a/jean-core/src/chat/codex.rs
+++ b/jean-core/src/chat/codex.rs
@@ -3686,14 +3686,13 @@ pub(crate) fn codex_run_log_has_visible_assistant_artifacts(
             .unwrap_or("")
         {
             "turn.plan_updated" | "item.plan.delta" if is_plan_mode => return true,
-            "turn.completed" => {
+            "turn.completed"
                 if msg
                     .get("output")
                     .and_then(extract_text_from_turn_output)
-                    .is_some_and(|text| !text.trim().is_empty())
-                {
-                    return true;
-                }
+                    .is_some_and(|text| !text.trim().is_empty()) =>
+            {
+                return true;
             }
             "item.started" | "item.completed" => {
                 let item = msg.get("item").unwrap_or(&serde_json::Value::Null);
@@ -3702,12 +3701,11 @@ pub(crate) fn codex_run_log_has_visible_assistant_artifacts(
                     .and_then(|value| value.as_str())
                     .unwrap_or("");
                 match item_type {
-                    "agent_message" => {
+                    "agent_message"
                         if extract_agent_message_text(item)
-                            .is_some_and(|text| !text.trim().is_empty())
-                        {
-                            return true;
-                        }
+                            .is_some_and(|text| !text.trim().is_empty()) =>
+                    {
+                        return true;
                     }
                     "plan" if is_plan_mode => return true,
                     "command_execution" | "file_change" | "mcp_tool_call" | "collab_tool_call"

--- a/jean-core/src/chat/grok.rs
+++ b/jean-core/src/chat/grok.rs
@@ -403,15 +403,14 @@ fn normalize_grok_tool_call(mut tool: ParsedToolCall) -> ParsedToolCall {
                     &["path", "target_directory", "targetDirectory", "directory"],
                 );
             }
-            "WebSearch" => {
+            "WebSearch"
                 if map
                     .get("query")
                     .and_then(Value::as_str)
-                    .is_none_or(|s| s.is_empty())
-                {
-                    if let Some(query) = query_from_web_search_title(&original_name) {
-                        map.insert("query".to_string(), Value::String(query));
-                    }
+                    .is_none_or(|s| s.is_empty()) =>
+            {
+                if let Some(query) = query_from_web_search_title(&original_name) {
+                    map.insert("query".to_string(), Value::String(query));
                 }
             }
             "WebFetch" => {

--- a/jean-core/src/chat/pi.rs
+++ b/jean-core/src/chat/pi.rs
@@ -385,12 +385,10 @@ fn merge_pi_line(response: &mut PiResponse, value: &Value) {
                 _ => {}
             }
         }
-        "message_update" => {
-            if value.get("role").and_then(Value::as_str) != Some("user") {
-                if let Some(text) = text_delta_from_value(value) {
-                    response.content.push_str(text);
-                    push_text_block(&mut response.content_blocks, text);
-                }
+        "message_update" if value.get("role").and_then(Value::as_str) != Some("user") => {
+            if let Some(text) = text_delta_from_value(value) {
+                response.content.push_str(text);
+                push_text_block(&mut response.content_blocks, text);
             }
         }
         "assistant" => {

--- a/jean-core/src/http_server/websocket.rs
+++ b/jean-core/src/http_server/websocket.rs
@@ -267,10 +267,10 @@ pub async fn handle_ws_connection(
                         }
                     }
                     Some(Ok(Message::Close(_))) | None => break,
-                    Some(Ok(Message::Ping(data))) => {
-                        if ws_tx.send(Message::Pong(data)).await.is_err() {
-                            break;
-                        }
+                    Some(Ok(Message::Ping(data)))
+                        if ws_tx.send(Message::Pong(data.clone())).await.is_err() =>
+                    {
+                        break;
                     }
                     Some(Ok(Message::Pong(_))) => {} // liveness already bumped above
                     _ => {} // Ignore binary

--- a/jean-core/src/terminal/pty.rs
+++ b/jean-core/src/terminal/pty.rs
@@ -25,6 +25,68 @@ fn is_windows_batch_file(path: &str) -> bool {
 }
 
 #[cfg(unix)]
+#[derive(Debug, PartialEq)]
+struct ParentLocale {
+    lang: Option<String>,
+    lc_all: Option<String>,
+    lc_ctype: Option<String>,
+}
+
+#[cfg(unix)]
+fn default_utf8_locale() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "en_US.UTF-8"
+    } else {
+        "C.UTF-8"
+    }
+}
+
+#[cfg(unix)]
+fn locale_value_is_utf8(value: Option<&str>) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    let normalized = value.to_ascii_lowercase();
+    normalized.contains("utf-8") || normalized.contains("utf8")
+}
+
+#[cfg(unix)]
+fn current_parent_locale() -> ParentLocale {
+    ParentLocale {
+        lang: std::env::var("LANG").ok().filter(|value| !value.is_empty()),
+        lc_all: std::env::var("LC_ALL")
+            .ok()
+            .filter(|value| !value.is_empty()),
+        lc_ctype: std::env::var("LC_CTYPE")
+            .ok()
+            .filter(|value| !value.is_empty()),
+    }
+}
+
+#[cfg(unix)]
+fn terminal_utf8_locale_overrides(parent: &ParentLocale) -> Vec<(&'static str, &'static str)> {
+    if locale_value_is_utf8(parent.lc_all.as_deref())
+        || locale_value_is_utf8(parent.lc_ctype.as_deref())
+        || locale_value_is_utf8(parent.lang.as_deref())
+    {
+        return Vec::new();
+    }
+
+    if parent.lc_all.is_some() || parent.lc_ctype.is_some() {
+        return Vec::new();
+    }
+
+    vec![("LC_CTYPE", default_utf8_locale())]
+}
+
+#[cfg(unix)]
+fn apply_terminal_locale_env(cmd: &mut CommandBuilder) {
+    for (key, value) in terminal_utf8_locale_overrides(&current_parent_locale()) {
+        cmd.env(key, value);
+    }
+}
+
+#[cfg(unix)]
 fn build_unix_shell_command(
     shell: &str,
     command: &str,
@@ -194,6 +256,8 @@ pub fn spawn_terminal(
     }
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
+    #[cfg(unix)]
+    apply_terminal_locale_env(&mut cmd);
     cmd.env("JEAN_WORKTREE_PATH", &worktree_path);
 
     // Spawn the shell
@@ -486,6 +550,8 @@ mod tests {
     #[cfg(unix)]
     use super::build_unix_shell_command;
     use super::is_windows_batch_file;
+    #[cfg(unix)]
+    use super::{terminal_utf8_locale_overrides, ParentLocale};
 
     #[cfg(unix)]
     #[test]
@@ -518,5 +584,47 @@ mod tests {
         assert!(is_windows_batch_file(r"C:\tools\run.bat"));
         assert!(!is_windows_batch_file(r"C:\tools\opencode.exe"));
         assert!(!is_windows_batch_file(r"C:\tools\opencode"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn terminal_sets_utf8_ctype_when_parent_locale_is_not_utf8() {
+        let overrides = terminal_utf8_locale_overrides(&ParentLocale {
+            lang: Some("C".to_string()),
+            lc_all: None,
+            lc_ctype: None,
+        });
+
+        assert_eq!(overrides, vec![("LC_CTYPE", super::default_utf8_locale())]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn terminal_keeps_existing_utf8_locale() {
+        let overrides = terminal_utf8_locale_overrides(&ParentLocale {
+            lang: Some("en_US.UTF-8".to_string()),
+            lc_all: None,
+            lc_ctype: None,
+        });
+
+        assert!(overrides.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn terminal_does_not_override_explicit_ctype_or_lc_all() {
+        let explicit_ctype = terminal_utf8_locale_overrides(&ParentLocale {
+            lang: Some("C".to_string()),
+            lc_all: None,
+            lc_ctype: Some("C".to_string()),
+        });
+        let explicit_lc_all = terminal_utf8_locale_overrides(&ParentLocale {
+            lang: Some("C".to_string()),
+            lc_all: Some("C".to_string()),
+            lc_ctype: None,
+        });
+
+        assert!(explicit_ctype.is_empty());
+        assert!(explicit_lc_all.is_empty());
     }
 }

--- a/src-tauri/src/platform/notifications.rs
+++ b/src-tauri/src/platform/notifications.rs
@@ -72,8 +72,7 @@ mod tests {
 
     #[test]
     fn packaged_builds_use_app_identifier() {
-        let app_id =
-            toast_app_id_for_exe_dir(Path::new(r"C:\Program Files\Jean"), "io.jean.app");
+        let app_id = toast_app_id_for_exe_dir(Path::new(r"C:\Program Files\Jean"), "io.jean.app");
         assert_eq!(app_id, "io.jean.app");
     }
 }


### PR DESCRIPTION
## Summary

- Fix Web Access terminal Unicode corruption when typing Vietnamese in xterm.js/zsh sessions.
- Add a Unix PTY locale fallback that sets `LC_CTYPE` to a UTF-8 locale only when the parent environment is not already UTF-8 and has not explicitly set `LC_ALL` or `LC_CTYPE`.
- Add regression coverage for the terminal locale fallback behavior.
- Apply required Rustfmt/Clippy cleanups so Rust quality gates pass.

## Root cause

Vietnamese input using decomposed combining marks could be corrupted by zsh when the PTY process started with a non-UTF-8 locale. The visible symptom was replacement/control-byte artifacts such as `<0080>` in Web Access terminal input. The terminal output decoder already preserves split UTF-8 output, so the fix belongs at PTY process locale setup.

## Verification

- `cargo test --manifest-path jean-core/Cargo.toml terminal_`
- `cargo test --manifest-path jean-core/Cargo.toml`
- `bun run rust:fmt:check`
- `bun run rust:clippy`
- `bun run rust:test`

## Manual test plan

1. Start Jean Web Access.
2. Open an xterm terminal.
3. Run `locale` and confirm `LC_CTYPE` is UTF-8.
4. Type `xin chào mẹ` using the Vietnamese input method.
5. Press Enter and confirm no `�`, `<0080>`, or other control-byte artifacts appear.