### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: Report a problem with Jean
+title: "[Bug]: "
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the issue
+      description: Tell us what happened and what you expected to happen.
+      placeholder: Please describe the issue and what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: replication
+    attributes:
+      label: Replication
+      description: What steps can we follow to reproduce the issue?
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+
+  - type: dropdown
+    id: running_mode
+    attributes:
+      label: How are you running Jean?
+      options:
+        - App
+        - Headless
+    validations:
+      required: true
+
+  - type: input
+    id: operating_system
+    attributes:
+      label: Operating system
+      description: If you are running the app, which OS are you using?
+      placeholder: macOS 15, Windows 11, Ubuntu 24.04, etc.
+
+  - type: input
+    id: jean_version
+    attributes:
+      label: Jean version
+      placeholder: 0.1.68
+    validations:
+      required: true
+
+  - type: dropdown
+    id: interaction_method
+    attributes:
+      label: How are you interacting with Jean?
+      options:
+        - Via the app
+        - Via the web
+        - Remotely via another Jean app
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: 🤔 Questions and Community Support
+    url: https://coollabs.io/discord
+    about: If you have any questions, reach out to us on Discord for community support.
+
+  - name: 🐛 Bug Report
+    url: https://github.com/coollabsio/jean/issues/new?template=bug_report.yml
+    about: Report a problem with Jean.
+
+  - name: 💡 Feature Request
+    url: https://github.com/coollabsio/jean/issues/new?template=feature_request.yml
+    about: Suggest an idea or improvement for Jean.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest an idea or improvement for Jean
+title: "[Feature]: "
+body:
+  - type: textarea
+    id: request
+    attributes:
+      label: Describe the feature
+      description: What would you like Jean to do?
+      placeholder: Tell us about the feature or improvement you would like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why would this be useful?
+      description: What problem would this solve, or what use case would it support?
+      placeholder: Describe the problem or workflow this feature would improve.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any alternative solutions or workarounds?
+      placeholder: Share any alternatives or workarounds you have tried.
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Add any other context, examples, or screenshots.


### PR DESCRIPTION
Adds GitHub issue templates, inspired by Coolify's templates plus taking the liberty to include some questions to specify for incoming requests if they are related to the upcoming headless version :eye emoji: