### PR TITLE
fix(chat): show project picker when last session closes

### DIFF
--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -1725,9 +1725,6 @@ pub async fn close_session(
     // Clean up combined-context files for this session
     cleanup_combined_context_files(&app, &session_id);
 
-    // Resolve default backend for fallback session creation
-    let fallback_backend = resolve_default_backend(&app, Some(&worktree_id));
-
     // Now atomically modify the sessions file
     let new_active = with_sessions_mut(&app, &worktree_path, &worktree_id, |sessions| {
         // Find index before removal to support deterministic neighbor selection.
@@ -1748,16 +1745,19 @@ pub async fn close_session(
             };
         }
 
-        // Ensure at least one non-archived session exists
-        let non_archived_count = sessions
+        // When the last non-archived session is closed, leave the worktree empty
+        // (active_session_id = None). Frontend navigates to the project picker
+        // (issue #501) instead of auto-creating a fallback "Session 1".
+        // If non-archived sessions remain but active is unset, pick the first.
+        let first_non_archived = sessions
             .sessions
             .iter()
-            .filter(|s| s.archived_at.is_none())
-            .count();
-        if non_archived_count == 0 {
-            let default_session = Session::default_session_with_backend(fallback_backend.clone());
-            sessions.active_session_id = Some(default_session.id.clone());
-            sessions.sessions.push(default_session);
+            .find(|s| s.archived_at.is_none())
+            .map(|s| s.id.clone());
+        if first_non_archived.is_none() {
+            sessions.active_session_id = None;
+        } else if sessions.active_session_id.is_none() {
+            sessions.active_session_id = first_non_archived;
         }
 
         log::trace!(
@@ -1789,9 +1789,6 @@ pub async fn archive_session(
     // Load messages from NDJSON to check if session has content (outside lock - read-only)
     let messages = run_log::load_session_messages(&app, &session_id).unwrap_or_default();
     let should_delete = messages.is_empty();
-
-    // Resolve default backend for fallback session creation
-    let fallback_backend = resolve_default_backend(&app, Some(&worktree_id));
 
     let new_active = with_sessions_mut(&app, &worktree_path, &worktree_id, |sessions| {
         // Find the index before archiving/deleting
@@ -1865,16 +1862,19 @@ pub async fn archive_session(
         };
         sessions.active_session_id = new_active;
 
-        // Ensure at least one session exists if all are archived or deleted
-        let non_archived_count = sessions
+        // When the last non-archived session is archived/deleted, leave the worktree
+        // empty (active_session_id = None). Frontend navigates to the project picker
+        // (issue #501) instead of auto-creating a fallback "Session 1".
+        // If non-archived sessions remain but active is unset, pick the first.
+        let first_non_archived = sessions
             .sessions
             .iter()
-            .filter(|s| s.archived_at.is_none())
-            .count();
-        if non_archived_count == 0 {
-            let default_session = Session::default_session_with_backend(fallback_backend.clone());
-            sessions.active_session_id = Some(default_session.id.clone());
-            sessions.sessions.push(default_session);
+            .find(|s| s.archived_at.is_none())
+            .map(|s| s.id.clone());
+        if first_non_archived.is_none() {
+            sessions.active_session_id = None;
+        } else if sessions.active_session_id.is_none() {
+            sessions.active_session_id = first_non_archived;
         }
 
         if should_delete {

--- a/src/components/chat/SessionChatModal.removal-behavior.test.ts
+++ b/src/components/chat/SessionChatModal.removal-behavior.test.ts
@@ -39,7 +39,7 @@ describe('SessionChatModal removal behavior', () => {
     )
   })
 
-  it('keeps the modal and session bar open when replacing the last session', () => {
+  it('closes the modal when removing the last session (project picker follows)', () => {
     const source = readSource('src/components/chat/SessionChatModal.tsx')
     const start = source.indexOf('const removeSessionTab = useCallback(')
     const end = source.indexOf('\n  const handleTabAuxClick', start)
@@ -47,7 +47,8 @@ describe('SessionChatModal removal behavior', () => {
       start === -1 || end === -1 ? '' : source.slice(start, end)
 
     expect(removeSessionTab).toContain('handleDeleteSession(session.id)')
-    expect(removeSessionTab).not.toContain('onClose()')
+    // Last-tab path closes the modal; service navigates to blank project picker
+    expect(removeSessionTab).toContain('onClose()')
   })
 
   it('uses terminal-like square tab styling for session header tabs', () => {

--- a/src/components/chat/SessionChatModal.removal-behavior.test.ts
+++ b/src/components/chat/SessionChatModal.removal-behavior.test.ts
@@ -39,7 +39,7 @@ describe('SessionChatModal removal behavior', () => {
     )
   })
 
-  it('closes the modal when removing the last session (project picker follows)', () => {
+  it('waits for last-session removal success before leaving the modal', () => {
     const source = readSource('src/components/chat/SessionChatModal.tsx')
     const start = source.indexOf('const removeSessionTab = useCallback(')
     const end = source.indexOf('\n  const handleTabAuxClick', start)
@@ -47,8 +47,8 @@ describe('SessionChatModal removal behavior', () => {
       start === -1 || end === -1 ? '' : source.slice(start, end)
 
     expect(removeSessionTab).toContain('handleDeleteSession(session.id)')
-    // Last-tab path closes the modal; service navigates to blank project picker
-    expect(removeSessionTab).toContain('onClose()')
+    expect(removeSessionTab).not.toContain('onClose()')
+    expect(removeSessionTab).not.toContain('navigateToProjectPicker(')
   })
 
   it('uses terminal-like square tab styling for session header tabs', () => {

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -112,7 +112,6 @@ import {
 import { WorktreeDropdownMenu } from '@/components/projects/WorktreeDropdownMenu'
 import { LabelModal } from './LabelModal'
 import { useSessionArchive } from './hooks/useSessionArchive'
-import { navigateToProjectPicker } from '@/lib/restore-navigation'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { pushNeedsRemotePicker, useRemotePicker } from '@/hooks/useRemotePicker'
 import { useIsTouchDevice } from '@/hooks/use-touch-device'
@@ -538,11 +537,9 @@ export function SessionChatModal({
     (session: Session) => {
       const activeSessions = sessions.filter(s => !s.archived_at)
       if (activeSessions.length <= 1) {
-        // Last tab: go straight to blank project picker (issue #501)
+        // The mutation navigates after success, provided navigation is unchanged.
         const action = () => {
           handleDeleteSession(session.id)
-          navigateToProjectPicker(worktreeId)
-          onClose()
         }
         const sessionIsEmpty = !session.message_count
         if (preferences?.confirm_session_close !== false && !sessionIsEmpty) {
@@ -561,8 +558,6 @@ export function SessionChatModal({
       handleDeleteSession,
       preferences?.confirm_session_close,
       selectVisualNeighbor,
-      worktreeId,
-      onClose,
     ]
   )
 
@@ -586,9 +581,6 @@ export function SessionChatModal({
           if (currentSessionId) {
             handleDeleteSession(currentSessionId)
           }
-          // Last tab: blank project picker (issue #501)
-          navigateToProjectPicker(worktreeId)
-          onClose()
         } else if (currentSessionId) {
           selectVisualNeighbor(currentSessionId)
           handleDeleteSession(currentSessionId)
@@ -614,8 +606,6 @@ export function SessionChatModal({
     isOpen,
     sessions,
     currentSessionId,
-    worktreeId,
-    onClose,
     handleDeleteSession,
     selectVisualNeighbor,
     preferences?.confirm_session_close,

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -112,6 +112,7 @@ import {
 import { WorktreeDropdownMenu } from '@/components/projects/WorktreeDropdownMenu'
 import { LabelModal } from './LabelModal'
 import { useSessionArchive } from './hooks/useSessionArchive'
+import { navigateToProjectPicker } from '@/lib/restore-navigation'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { pushNeedsRemotePicker, useRemotePicker } from '@/hooks/useRemotePicker'
 import { useIsTouchDevice } from '@/hooks/use-touch-device'
@@ -537,8 +538,11 @@ export function SessionChatModal({
     (session: Session) => {
       const activeSessions = sessions.filter(s => !s.archived_at)
       if (activeSessions.length <= 1) {
+        // Last tab: go straight to blank project picker (issue #501)
         const action = () => {
           handleDeleteSession(session.id)
+          navigateToProjectPicker(worktreeId)
+          onClose()
         }
         const sessionIsEmpty = !session.message_count
         if (preferences?.confirm_session_close !== false && !sessionIsEmpty) {
@@ -557,6 +561,8 @@ export function SessionChatModal({
       handleDeleteSession,
       preferences?.confirm_session_close,
       selectVisualNeighbor,
+      worktreeId,
+      onClose,
     ]
   )
 
@@ -580,6 +586,8 @@ export function SessionChatModal({
           if (currentSessionId) {
             handleDeleteSession(currentSessionId)
           }
+          // Last tab: blank project picker (issue #501)
+          navigateToProjectPicker(worktreeId)
           onClose()
         } else if (currentSessionId) {
           selectVisualNeighbor(currentSessionId)
@@ -606,6 +614,7 @@ export function SessionChatModal({
     isOpen,
     sessions,
     currentSessionId,
+    worktreeId,
     onClose,
     handleDeleteSession,
     selectVisualNeighbor,

--- a/src/components/chat/hooks/useSessionArchive.ts
+++ b/src/components/chat/hooks/useSessionArchive.ts
@@ -11,9 +11,9 @@ interface UseSessionArchiveParams {
 /**
  * Provides archive and delete handlers for sessions.
  *
- * When the last session is removed, the backend automatically creates a
- * fallback "Session 1" and the service layer switches to it via query
- * invalidation — no navigation needed.
+ * When the last non-archived session is removed, the backend leaves the
+ * worktree empty and the service layer navigates to the blank project picker
+ * (issue #501) instead of auto-creating a fallback "Session 1".
  *
  * - handleArchiveSession: always archives (context menu "Archive Session")
  * - handleDeleteSession: respects removalBehavior preference (context menu "Delete Session")

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -1684,6 +1684,10 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
         !!selectedWorktreeModal,
         selectedWorktreeModal?.worktreeId ?? null
       )
+    return () => {
+      // Clear global modal flag on unmount (e.g. last session → project picker)
+      useUIStore.getState().setSessionChatModalOpen(false)
+    }
   }, [selectedWorktreeModal])
 
   // Close modal when worktree is deleted/archived (e.g. PR merged)

--- a/src/lib/restore-navigation.test.ts
+++ b/src/lib/restore-navigation.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { navigateToProjectPicker } from './restore-navigation'
+import { useChatStore } from '@/store/chat-store'
+import { useProjectsStore } from '@/store/projects-store'
+import { useUIStore } from '@/store/ui-store'
+
+describe('navigateToProjectPicker', () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      activeWorktreeId: 'wt-1',
+      activeWorktreePath: '/tmp/wt-1',
+      activeSessionIds: { 'wt-1': 'session-1', 'wt-2': 'session-2' },
+    })
+    useProjectsStore.setState({
+      selectedProjectId: 'project-1',
+      selectedWorktreeId: 'wt-1',
+    })
+    useUIStore.setState({
+      sessionChatModalOpen: true,
+      sessionChatModalWorktreeId: 'wt-1',
+    })
+  })
+
+  it('clears worktree, project selection, and session modal', () => {
+    navigateToProjectPicker('wt-1')
+
+    const chat = useChatStore.getState()
+    expect(chat.activeWorktreeId).toBeNull()
+    expect(chat.activeWorktreePath).toBeNull()
+    expect(chat.activeSessionIds['wt-1']).toBeUndefined()
+    expect(chat.activeSessionIds['wt-2']).toBe('session-2')
+
+    const projects = useProjectsStore.getState()
+    expect(projects.selectedProjectId).toBeNull()
+    expect(projects.selectedWorktreeId).toBeNull()
+
+    const ui = useUIStore.getState()
+    expect(ui.sessionChatModalOpen).toBe(false)
+    expect(ui.sessionChatModalWorktreeId).toBeNull()
+  })
+
+  it('works without a worktreeId', () => {
+    navigateToProjectPicker()
+
+    expect(useChatStore.getState().activeWorktreeId).toBeNull()
+    expect(useProjectsStore.getState().selectedProjectId).toBeNull()
+    // Does not clear session map entries when worktreeId omitted
+    expect(useChatStore.getState().activeSessionIds['wt-1']).toBe('session-1')
+  })
+})

--- a/src/lib/restore-navigation.ts
+++ b/src/lib/restore-navigation.ts
@@ -1,5 +1,6 @@
 import { useChatStore } from '@/store/chat-store'
 import { useProjectsStore } from '@/store/projects-store'
+import { useUIStore } from '@/store/ui-store'
 
 /**
  * Check if the user is currently on a canvas view (ProjectCanvasView).
@@ -34,4 +35,26 @@ export function navigateToRestoredItem(
   // Navigate to ProjectCanvasView
   selectWorktree(worktreeId)
   clearActiveWorktree()
+}
+
+/**
+ * Show the blank project-picker page with nothing selected.
+ *
+ * Used when the last session in a worktree is closed/archived (issue #501)
+ * so Jean does not auto-recreate a session or leave the user on an empty chat.
+ *
+ * @param worktreeId - When provided, clears that worktree's active session id
+ */
+export function navigateToProjectPicker(worktreeId?: string | null): void {
+  useUIStore.getState().setSessionChatModalOpen(false)
+  useChatStore.getState().clearActiveWorktree()
+  useProjectsStore.getState().selectProject(null)
+
+  if (worktreeId) {
+    useChatStore.setState(state => {
+      if (!(worktreeId in state.activeSessionIds)) return state
+      const { [worktreeId]: _removed, ...rest } = state.activeSessionIds
+      return { activeSessionIds: rest }
+    })
+  }
 }

--- a/src/services/chat.test.ts
+++ b/src/services/chat.test.ts
@@ -20,6 +20,7 @@ vi.mock('sonner', () => ({
 
 import {
   canReconnectSession,
+  isSessionRemovalNavigationUnchanged,
   prefetchSessions,
   reconnectNativeCliSession,
 } from './chat'
@@ -30,6 +31,40 @@ import { useTerminalStore } from '@/store/terminal-store'
 import { toast } from 'sonner'
 import { disposeTerminal } from '@/lib/terminal-instances'
 import type { Session } from '@/types/chat'
+
+describe('session removal navigation guard', () => {
+  const navigation = {
+    activeWorktreeId: 'wt-1',
+    activeWorktreePath: '/tmp/wt-1',
+    activeSessionId: 'session-1',
+    selectedProjectId: 'project-1',
+    selectedWorktreeId: 'wt-1',
+  }
+
+  it('allows navigation when selection has not changed', () => {
+    expect(
+      isSessionRemovalNavigationUnchanged(navigation, { ...navigation })
+    ).toBe(true)
+  })
+
+  it('blocks delayed navigation after the user selects another session', () => {
+    expect(
+      isSessionRemovalNavigationUnchanged(navigation, {
+        ...navigation,
+        activeSessionId: 'session-2',
+      })
+    ).toBe(false)
+  })
+
+  it('blocks delayed navigation after the user selects another project', () => {
+    expect(
+      isSessionRemovalNavigationUnchanged(navigation, {
+        ...navigation,
+        selectedProjectId: 'project-2',
+      })
+    ).toBe(false)
+  })
+})
 
 const toastMock = toast as unknown as {
   success: ReturnType<typeof vi.fn>

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -35,6 +35,7 @@ import { hasBackendTransport } from '@/lib/environment'
 import { preferencesQueryKeys } from '@/services/preferences'
 import type { AppPreferences } from '@/types/preferences'
 import { useChatStore } from '@/store/chat-store'
+import { useProjectsStore } from '@/store/projects-store'
 import { useUIStore } from '@/store/ui-store'
 import { useTerminalStore } from '@/store/terminal-store'
 import { navigateToProjectPicker } from '@/lib/restore-navigation'
@@ -55,6 +56,41 @@ export const OLDER_RUN_BATCH = 10
 function isWsDisconnectError(error: unknown): boolean {
   const msg = error instanceof Error ? error.message : String(error)
   return msg.includes('WebSocket disconnected')
+}
+
+export interface SessionRemovalNavigationState {
+  activeWorktreeId: string | null
+  activeWorktreePath: string | null
+  activeSessionId: string | null
+  selectedProjectId: string | null
+  selectedWorktreeId: string | null
+}
+
+function getSessionRemovalNavigationState(
+  worktreeId: string
+): SessionRemovalNavigationState {
+  const chat = useChatStore.getState()
+  const projects = useProjectsStore.getState()
+  return {
+    activeWorktreeId: chat.activeWorktreeId,
+    activeWorktreePath: chat.activeWorktreePath,
+    activeSessionId: chat.activeSessionIds[worktreeId] ?? null,
+    selectedProjectId: projects.selectedProjectId,
+    selectedWorktreeId: projects.selectedWorktreeId,
+  }
+}
+
+export function isSessionRemovalNavigationUnchanged(
+  before: SessionRemovalNavigationState,
+  current: SessionRemovalNavigationState
+): boolean {
+  return (
+    before.activeWorktreeId === current.activeWorktreeId &&
+    before.activeWorktreePath === current.activeWorktreePath &&
+    before.activeSessionId === current.activeSessionId &&
+    before.selectedProjectId === current.selectedProjectId &&
+    before.selectedWorktreeId === current.selectedWorktreeId
+  )
 }
 
 export function cleanupSessionTerminalForRemovedSession(
@@ -1041,6 +1077,7 @@ export function useCloseSession() {
   const queryClient = useQueryClient()
 
   return useMutation({
+    onMutate: ({ worktreeId }) => getSessionRemovalNavigationState(worktreeId),
     mutationFn: async ({
       worktreeId,
       worktreePath,
@@ -1063,7 +1100,7 @@ export function useCloseSession() {
       logger.info('Session closed', { newActiveId })
       return newActiveId
     },
-    onSuccess: (newActiveId, { worktreeId, sessionId }) => {
+    onSuccess: (newActiveId, { worktreeId, sessionId }, navigationBefore) => {
       queryClient.invalidateQueries({
         queryKey: chatQueryKeys.sessions(worktreeId),
       })
@@ -1088,7 +1125,12 @@ export function useCloseSession() {
         if (!currentActive || currentActive === sessionId) {
           useChatStore.getState().setActiveSession(worktreeId, newActiveId)
         }
-      } else {
+      } else if (
+        isSessionRemovalNavigationUnchanged(
+          navigationBefore,
+          getSessionRemovalNavigationState(worktreeId)
+        )
+      ) {
         // Last non-archived session closed — show blank project picker (issue #501)
         logger.debug('Last session closed, navigating to project picker', {
           worktreeId,
@@ -1118,6 +1160,7 @@ export function useArchiveSession() {
   const queryClient = useQueryClient()
 
   return useMutation({
+    onMutate: ({ worktreeId }) => getSessionRemovalNavigationState(worktreeId),
     mutationFn: async ({
       worktreeId,
       worktreePath,
@@ -1140,7 +1183,7 @@ export function useArchiveSession() {
       logger.info('Session archived', { newActiveId })
       return newActiveId
     },
-    onSuccess: (newActiveId, { worktreeId, sessionId }) => {
+    onSuccess: (newActiveId, { worktreeId, sessionId }, navigationBefore) => {
       queryClient.invalidateQueries({
         queryKey: chatQueryKeys.sessions(worktreeId),
       })
@@ -1164,7 +1207,12 @@ export function useArchiveSession() {
         if (!currentActive || currentActive === sessionId) {
           useChatStore.getState().setActiveSession(worktreeId, newActiveId)
         }
-      } else {
+      } else if (
+        isSessionRemovalNavigationUnchanged(
+          navigationBefore,
+          getSessionRemovalNavigationState(worktreeId)
+        )
+      ) {
         // Last non-archived session archived — show blank project picker (issue #501)
         logger.debug('Last session archived, navigating to project picker', {
           worktreeId,
@@ -1465,15 +1513,6 @@ export function useCloseSessionOrWorktreeKeybinding(
       })
     }
 
-    // Last session: show blank project picker (issue #501). Mutation onSuccess
-    // also calls navigateToProjectPicker when backend returns no active session;
-    // navigate here immediately so the UI doesn't flash an empty chat.
-    if (sessionCount <= 1) {
-      logger.debug('Last session closed, navigating to project picker', {
-        worktreeId: activeWorktreeId,
-      })
-      navigateToProjectPicker(activeWorktreeId)
-    }
   }, [archiveSession, closeSession, queryClient])
 
   useEffect(() => {

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -37,6 +37,7 @@ import type { AppPreferences } from '@/types/preferences'
 import { useChatStore } from '@/store/chat-store'
 import { useUIStore } from '@/store/ui-store'
 import { useTerminalStore } from '@/store/terminal-store'
+import { navigateToProjectPicker } from '@/lib/restore-navigation'
 import { isNativeTerminalBackend } from '@/lib/native-cli-session'
 import { getResumeArgs } from '@/components/chat/session-card-utils'
 import type {
@@ -1087,6 +1088,12 @@ export function useCloseSession() {
         if (!currentActive || currentActive === sessionId) {
           useChatStore.getState().setActiveSession(worktreeId, newActiveId)
         }
+      } else {
+        // Last non-archived session closed — show blank project picker (issue #501)
+        logger.debug('Last session closed, navigating to project picker', {
+          worktreeId,
+        })
+        navigateToProjectPicker(worktreeId)
       }
     },
     onError: error => {
@@ -1157,6 +1164,12 @@ export function useArchiveSession() {
         if (!currentActive || currentActive === sessionId) {
           useChatStore.getState().setActiveSession(worktreeId, newActiveId)
         }
+      } else {
+        // Last non-archived session archived — show blank project picker (issue #501)
+        logger.debug('Last session archived, navigating to project picker', {
+          worktreeId,
+        })
+        navigateToProjectPicker(worktreeId)
       }
     },
     onError: error => {
@@ -1452,12 +1465,14 @@ export function useCloseSessionOrWorktreeKeybinding(
       })
     }
 
-    // Last session: navigate to project view instead of deleting the worktree
+    // Last session: show blank project picker (issue #501). Mutation onSuccess
+    // also calls navigateToProjectPicker when backend returns no active session;
+    // navigate here immediately so the UI doesn't flash an empty chat.
     if (sessionCount <= 1) {
-      logger.debug('Last session closed, navigating to project view', {
+      logger.debug('Last session closed, navigating to project picker', {
         worktreeId: activeWorktreeId,
       })
-      useChatStore.getState().clearActiveWorktree()
+      navigateToProjectPicker(activeWorktreeId)
     }
   }, [archiveSession, closeSession, queryClient])
 

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -197,7 +197,7 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     action: 'close_session_or_worktree',
     label: 'Close session',
     description:
-      'Close the current session, or remove worktree if last session',
+      'Close the current session, or show project picker if last session',
     default_shortcut: 'mod+w',
     category: 'chat',
   },


### PR DESCRIPTION
## Summary

- Closing or archiving the last session in a project no longer auto-creates a fallback "Session 1".
- Jean instead clears selection and navigates to the blank project picker so users can choose a project.
- Applies consistently for session tab close, Cmd+W / close-session keybinding, and modal last-tab removal.

fixes #501

---

Fixes #501