### PR TITLE
feat(chat): show Task/Agent subagent final reports

### DIFF
--- a/jean-core/src/chat/claude.rs
+++ b/jean-core/src/chat/claude.rs
@@ -1,4 +1,5 @@
 use super::coalesce::ChunkCoalescer;
+use super::run_log::tool_result_content_to_string;
 use super::types::{
     is_claude_compaction_summary_text, CompactMetadata, ContentBlock, EffortLevel,
     PermissionDenial, PermissionDeniedEvent, ThinkingLevel, ToolCall, UsageData,
@@ -1978,30 +1979,10 @@ pub fn tail_claude_output(
                                         continue;
                                     }
                                     // Content can be a string OR an array of content blocks
+                                    // (Task/Agent subagent reports use the array shape).
                                     let output = block
                                         .get("content")
-                                        .map(|v| {
-                                            if let Some(s) = v.as_str() {
-                                                s.to_string()
-                                            } else if let Some(arr) = v.as_array() {
-                                                arr.iter()
-                                                    .filter_map(|item| {
-                                                        if item.get("type").and_then(|t| t.as_str())
-                                                            == Some("text")
-                                                        {
-                                                            item.get("text")
-                                                                .and_then(|t| t.as_str())
-                                                                .map(|s| s.to_string())
-                                                        } else {
-                                                            None
-                                                        }
-                                                    })
-                                                    .collect::<Vec<_>>()
-                                                    .join("\n")
-                                            } else {
-                                                String::new()
-                                            }
-                                        })
+                                        .map(tool_result_content_to_string)
                                         .unwrap_or_default();
 
                                     // Update matching tool call's output

--- a/jean-core/src/chat/run_log.rs
+++ b/jean-core/src/chat/run_log.rs
@@ -522,6 +522,33 @@ pub fn read_run_log(
     lines.map_err(|e| format!("Failed to read run log: {e}"))
 }
 
+/// Extract plain text from a tool_result `content` field.
+///
+/// Content can be a plain string (most tools) OR an array of content blocks
+/// (Task/Agent subagent reports return `[{ "type": "text", "text": "..." }]`).
+/// Shared by live streaming and history rebuild so reloaded sessions keep reports.
+pub(crate) fn tool_result_content_to_string(content: &serde_json::Value) -> String {
+    if let Some(s) = content.as_str() {
+        return s.to_string();
+    }
+    if let Some(arr) = content.as_array() {
+        return arr
+            .iter()
+            .filter_map(|item| {
+                if item.get("type").and_then(|t| t.as_str()) == Some("text") {
+                    item.get("text")
+                        .and_then(|t| t.as_str())
+                        .map(|s| s.to_string())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+    String::new()
+}
+
 /// Parse JSONL lines and build a ChatMessage
 /// This replicates the parsing logic from execute_claude_streaming
 pub fn parse_run_to_message(lines: &[String], run: &RunEntry) -> Result<ChatMessage, String> {
@@ -792,8 +819,12 @@ pub fn parse_run_to_message(lines: &[String], run: &RunEntry) -> Result<ChatMess
                                     .get("tool_use_id")
                                     .and_then(|v| v.as_str())
                                     .unwrap_or("");
-                                let output =
-                                    block.get("content").and_then(|v| v.as_str()).unwrap_or("");
+                                // Content can be a string OR an array of content blocks
+                                // (Task/Agent subagent final reports use the array shape).
+                                let output = block
+                                    .get("content")
+                                    .map(tool_result_content_to_string)
+                                    .unwrap_or_default();
                                 let is_error = block
                                     .get("is_error")
                                     .and_then(|v| v.as_bool())
@@ -803,7 +834,7 @@ pub fn parse_run_to_message(lines: &[String], run: &RunEntry) -> Result<ChatMess
                                 if is_error && !tool_id.is_empty() {
                                     errored_tool_ids.insert(tool_id.to_string());
                                     errored_tool_outputs
-                                        .insert(tool_id.to_string(), output.to_string());
+                                        .insert(tool_id.to_string(), output.clone());
                                 }
 
                                 // For armed Monitors, capture the tool_result text
@@ -820,7 +851,7 @@ pub fn parse_run_to_message(lines: &[String], run: &RunEntry) -> Result<ChatMess
                                     tool_calls.iter_mut().find(|t| t.id == tool_id)
                                 {
                                     // Non-Monitor tool: normal output update
-                                    tc.output = Some(output.to_string());
+                                    tc.output = Some(output);
                                 }
                             }
                         }
@@ -1671,6 +1702,112 @@ mod tests {
             &message.content_blocks[2],
             ContentBlock::Text { text } if text == "done"
         ));
+    }
+
+    #[test]
+    fn parse_run_extracts_task_tool_result_from_content_blocks() {
+        let run = sample_run();
+        let tool_id = "toolu_task_report";
+        let lines = vec![
+            serde_json::json!({
+                "type": "assistant",
+                "message": {
+                    "content": [{
+                        "type": "tool_use",
+                        "id": tool_id,
+                        "name": "Task",
+                        "input": {
+                            "description": "Explore auth",
+                            "prompt": "Find how auth works",
+                            "subagent_type": "Explore"
+                        }
+                    }]
+                }
+            })
+            .to_string(),
+            serde_json::json!({
+                "type": "user",
+                "message": {
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": tool_id,
+                        "content": [
+                            { "type": "text", "text": "Findings: auth uses JWT middleware." },
+                            { "type": "text", "text": "Entry point is `src/auth.rs`." }
+                        ]
+                    }]
+                }
+            })
+            .to_string(),
+        ];
+
+        let msg = parse_run_to_message(&lines, &run).unwrap();
+
+        assert_eq!(msg.tool_calls.len(), 1);
+        assert_eq!(msg.tool_calls[0].name, "Task");
+        assert_eq!(
+            msg.tool_calls[0].output.as_deref(),
+            Some("Findings: auth uses JWT middleware.\nEntry point is `src/auth.rs`.")
+        );
+    }
+
+    #[test]
+    fn parse_run_extracts_tool_result_from_string_content() {
+        let run = sample_run();
+        let tool_id = "toolu_read_file";
+        let lines = vec![
+            serde_json::json!({
+                "type": "assistant",
+                "message": {
+                    "content": [{
+                        "type": "tool_use",
+                        "id": tool_id,
+                        "name": "Read",
+                        "input": { "file_path": "README.md" }
+                    }]
+                }
+            })
+            .to_string(),
+            serde_json::json!({
+                "type": "user",
+                "message": {
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": tool_id,
+                        "content": "# Hello\n\nWorld"
+                    }]
+                }
+            })
+            .to_string(),
+        ];
+
+        let msg = parse_run_to_message(&lines, &run).unwrap();
+
+        assert_eq!(msg.tool_calls.len(), 1);
+        assert_eq!(
+            msg.tool_calls[0].output.as_deref(),
+            Some("# Hello\n\nWorld")
+        );
+    }
+
+    #[test]
+    fn tool_result_content_to_string_handles_shapes() {
+        assert_eq!(
+            tool_result_content_to_string(&serde_json::json!("plain")),
+            "plain"
+        );
+        assert_eq!(
+            tool_result_content_to_string(&serde_json::json!([
+                { "type": "text", "text": "a" },
+                { "type": "image", "source": {} },
+                { "type": "text", "text": "b" }
+            ])),
+            "a\nb"
+        );
+        assert_eq!(
+            tool_result_content_to_string(&serde_json::json!({ "unexpected": true })),
+            ""
+        );
     }
 
     #[test]

--- a/src/components/chat/ToolCallInline.test.tsx
+++ b/src/components/chat/ToolCallInline.test.tsx
@@ -1,6 +1,10 @@
 import { fireEvent, render, screen } from '@/test/test-utils'
 import { describe, expect, it, vi } from 'vitest'
-import { normalizeToolCallForDisplay, ToolCallInline } from './ToolCallInline'
+import {
+  normalizeToolCallForDisplay,
+  TaskCallInline,
+  ToolCallInline,
+} from './ToolCallInline'
 import type { ComponentProps } from 'react'
 import type * as InlineFileDiffModule from './InlineFileDiff'
 
@@ -320,5 +324,115 @@ describe('normalizeToolCallForDisplay', () => {
     expect(screen.getByText('Grep')).toBeInTheDocument()
     expect(screen.getByText('"needle" in /tmp')).toBeInTheDocument()
     expect(screen.queryByText(/unhandled tool/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('TaskCallInline', () => {
+  it('shows the subagent final report when expanded', () => {
+    render(
+      <TaskCallInline
+        taskToolCall={{
+          id: 'task-1',
+          name: 'Task',
+          input: {
+            description: 'Explore auth',
+            prompt: 'Find how auth works',
+            subagent_type: 'Explore',
+          },
+          output:
+            'Findings: auth uses JWT middleware.\n\nEntry point is `src/auth.rs`.',
+        }}
+        subToolCalls={[
+          {
+            id: 'sub-read-1',
+            name: 'Read',
+            input: { file_path: 'src/auth.rs' },
+            parent_tool_use_id: 'task-1',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('Task (Explore)')).toBeInTheDocument()
+    expect(screen.getByText('Explore auth')).toBeInTheDocument()
+    expect(screen.queryByText('Report:')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('Report:')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Findings: auth uses JWT middleware/)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Find how auth works/)).toBeInTheDocument()
+  })
+
+  it('does not render a Report section when output is empty', () => {
+    render(
+      <TaskCallInline
+        taskToolCall={{
+          id: 'task-empty',
+          name: 'Task',
+          input: {
+            description: 'Still running',
+            prompt: 'Do research',
+          },
+          output: '   ',
+        }}
+        subToolCalls={[]}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('Do research')).toBeInTheDocument()
+    expect(screen.queryByText('Report:')).not.toBeInTheDocument()
+  })
+
+  it('labels Agent tool calls as Agent and nests them', () => {
+    render(
+      <TaskCallInline
+        taskToolCall={{
+          id: 'agent-1',
+          name: 'Agent',
+          input: {
+            description: 'Nested agent',
+            prompt: 'Delegate work',
+            subagent_type: 'general-purpose',
+          },
+          output: 'Nested agent finished.',
+        }}
+        subToolCalls={[
+          {
+            id: 'agent-nested',
+            name: 'Agent',
+            input: {
+              description: 'Child agent',
+              prompt: 'Child work',
+            },
+            parent_tool_use_id: 'agent-1',
+          },
+        ]}
+        allToolCalls={[
+          {
+            id: 'agent-nested',
+            name: 'Agent',
+            input: {
+              description: 'Child agent',
+              prompt: 'Child work',
+            },
+            parent_tool_use_id: 'agent-1',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('Agent (general-purpose)')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Agent (general-purpose)'))
+
+    expect(screen.getByText('Report:')).toBeInTheDocument()
+    expect(screen.getByText('Nested agent finished.')).toBeInTheDocument()
+    // Nested Agent renders as another TaskCallInline row, not a SubToolItem
+    expect(screen.getByText('Child agent')).toBeInTheDocument()
   })
 })

--- a/src/components/chat/ToolCallInline.tsx
+++ b/src/components/chat/ToolCallInline.tsx
@@ -204,6 +204,8 @@ export function TaskCallInline({
   const subagentType = input.subagent_type as string | undefined
   const description = input.description as string | undefined
   const prompt = input.prompt as string | undefined
+  const report = taskToolCall.output?.trim() || undefined
+  const toolLabel = taskToolCall.name === 'Agent' ? 'Agent' : 'Task'
 
   return (
     <Collapsible
@@ -220,7 +222,7 @@ export function TaskCallInline({
         <CollapsibleTrigger className={TOOL_CALL_ROW_CLASS}>
           <Bot className="h-3.5 w-3.5 shrink-0" />
           <span className="font-medium shrink-0 whitespace-nowrap">
-            {subagentType ? `Task (${subagentType})` : 'Task'}
+            {subagentType ? `${toolLabel} (${subagentType})` : toolLabel}
           </span>
           {description && (
             <code className={TOOL_CALL_DETAIL_PILL_CLASS}>{description}</code>
@@ -260,7 +262,8 @@ export function TaskCallInline({
             {subToolCalls.length > 0 ? (
               <div className="space-y-1">
                 {subToolCalls.map(subTool =>
-                  subTool.name === 'Task' && allToolCalls ? (
+                  (subTool.name === 'Task' || subTool.name === 'Agent') &&
+                  allToolCalls ? (
                     <TaskCallInline
                       key={subTool.id}
                       taskToolCall={subTool}
@@ -284,6 +287,16 @@ export function TaskCallInline({
               <p className="text-xs text-muted-foreground/60 italic">
                 No sub-tools recorded
               </p>
+            )}
+            {/* Subagent final report returned to the parent agent */}
+            {report && (
+              <div className="space-y-1">
+                <div className="border-t border-border/30" />
+                <div className="text-xs text-muted-foreground/60">Report:</div>
+                <div className="max-h-64 overflow-y-auto text-xs text-foreground/80 bg-muted/50 rounded p-2">
+                  <Markdown variant="tool-call">{report}</Markdown>
+                </div>
+              </div>
             )}
           </div>
         </CollapsibleContent>


### PR DESCRIPTION
## Summary

- Surface the subagent’s final report (findings/conclusion) in the expanded Task widget as markdown, not only the prompt and sub-tool list
- Parse Task/Agent tool results that return structured content blocks (not plain strings) so reloaded sessions keep the report, matching live runs
- Share content extraction between live streaming and history rebuild; treat nested `Agent` tools like `Task`
- Add tests for string and content-block tool_result shapes

closes #499

---

Fixes #499