### PR TITLE
fix(chat): make WSL Claude sessions survivable

### DIFF
--- a/jean-core/src/chat/claude.rs
+++ b/jean-core/src/chat/claude.rs
@@ -1298,6 +1298,40 @@ fn flush_pending_chunks(
     }
 }
 
+fn startup_failure_message(
+    startup_failed: bool,
+    user_cancelled: bool,
+    full_content: &str,
+    error_lines: &[String],
+) -> Option<String> {
+    if !startup_failed || user_cancelled || !full_content.is_empty() {
+        return None;
+    }
+
+    if !error_lines.is_empty() {
+        return Some(format!("Claude CLI failed: {}", error_lines.join("\n")));
+    }
+
+    Some(
+        "Claude CLI produced no output and was stopped. It may have failed to start; \
+         check the Claude CLI installation and, in WSL mode, the distro configuration."
+            .to_string(),
+    )
+}
+
+fn terminate_failed_startup(pid: u32) {
+    if pid <= 1 {
+        return;
+    }
+
+    if let Err(tree_error) = crate::platform::kill_process_tree(pid) {
+        log::warn!("Failed to terminate startup process group {pid}: {tree_error}");
+        if let Err(process_error) = crate::platform::kill_process(pid) {
+            log::warn!("Failed to terminate startup process {pid}: {process_error}");
+        }
+    }
+}
+
 /// Tail an NDJSON output file and emit events as new lines appear.
 ///
 /// This is used for detached Claude CLI processes where the CLI writes
@@ -1344,6 +1378,7 @@ pub fn tail_claude_output(
     let mut completed = false;
     let mut cancelled = false;
     let mut user_cancelled = false; // True only for explicit user cancel (not process death)
+    let mut startup_failed = false; // True when Claude produced no output before the startup timeout / died starting up
     let mut usage: Option<UsageData> = None;
     let mut error_lines: Vec<String> = Vec::new();
 
@@ -2344,6 +2379,7 @@ pub fn tail_claude_output(
                     elapsed.as_secs_f64()
                 );
                 cancelled = true;
+                startup_failed = true;
                 break;
             }
 
@@ -2353,6 +2389,7 @@ pub fn tail_claude_output(
                     startup_timeout
                 );
                 cancelled = true;
+                startup_failed = true;
                 break;
             }
 
@@ -2423,6 +2460,26 @@ pub fn tail_claude_output(
         }
     }
 
+    if let Some(error) =
+        startup_failure_message(startup_failed, user_cancelled, &full_content, &error_lines)
+    {
+        // A startup timeout can leave a live process behind. End the complete
+        // process group before returning the terminal error to the caller.
+        if is_process_alive(pid) {
+            terminate_failed_startup(pid);
+        }
+        log::warn!("Claude CLI startup failed for session {session_id}: {error}");
+        let _ = app.emit_all(
+            "chat:error",
+            &ErrorEvent {
+                session_id: session_id.to_string(),
+                worktree_id: worktree_id.to_string(),
+                error: error.clone(),
+            },
+        );
+        return Err(error);
+    }
+
     if !error_lines.is_empty() && full_content.is_empty() {
         let error_text = error_lines.join("\n");
         log::warn!("CLI error output for session {session_id}: {error_text}");
@@ -2471,6 +2528,32 @@ pub fn tail_claude_output(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn startup_failure_uses_cli_output_when_available() {
+        let lines = vec!["claude: command not found".to_string()];
+
+        assert_eq!(
+            startup_failure_message(true, false, "", &lines),
+            Some("Claude CLI failed: claude: command not found".to_string())
+        );
+    }
+
+    #[test]
+    fn startup_failure_without_output_has_actionable_message() {
+        let message = startup_failure_message(true, false, "", &[])
+            .expect("startup failure should be terminal");
+
+        assert!(message.contains("produced no output"));
+        assert!(message.contains("WSL"));
+    }
+
+    #[test]
+    fn startup_failure_message_ignores_user_cancel_and_completed_content() {
+        assert_eq!(startup_failure_message(true, true, "", &[]), None);
+        assert_eq!(startup_failure_message(true, false, "done", &[]), None);
+        assert_eq!(startup_failure_message(false, false, "", &[]), None);
+    }
 
     #[test]
     fn compact_metadata_accepts_snake_case_from_claude_cli() {

--- a/jean-core/src/chat/detached.rs
+++ b/jean-core/src/chat/detached.rs
@@ -51,10 +51,14 @@ const WSL_PATH_VALUE_FLAGS: &[&str] = &["--add-dir", "--append-system-prompt-fil
 
 #[cfg(any(windows, test))]
 fn looks_like_windows_path(value: &str) -> bool {
-    // UNC (`\\..`) or drive path (`C:\..`). Anything else is left untouched so
-    // non-path values are never mangled.
+    // UNC (`\\..`) or drive path (`C:\..` / `C:/..`). Anything else is left
+    // untouched so non-path values (models, inline `--settings` JSON) are never
+    // mangled.
     value.starts_with("\\\\")
-        || (value.len() >= 3 && value.as_bytes()[0].is_ascii_alphabetic() && &value[1..3] == ":\\")
+        || (value.len() >= 3
+            && value.as_bytes()[0].is_ascii_alphabetic()
+            && value.as_bytes()[1] == b':'
+            && matches!(value.as_bytes()[2], b'\\' | b'/'))
 }
 
 /// Translate Windows-form path values that follow known path flags into WSL
@@ -110,11 +114,16 @@ fn wslify_path_args(args: &[String]) -> Vec<String> {
 /// session is SIGHUP-reaped at teardown — before adoption ever applies — which
 /// is exactly why `setsid` (own session, no controlling terminal) is required.
 ///
-/// The inner session records its own pid to `pid_path` and then `exec`s Claude,
-/// so the reported pid is Claude's stable Linux pid — NOT `$!` of `setsid`,
-/// which is a short-lived parent that forks and exits (reading it yields a dead
-/// or zero pid and wedges recovery). The outer launcher waits for the pid file,
-/// prints the pid for Jean, then exits.
+/// The inner session records its own pid (`echo $$`) to `pid_path`, then runs
+/// Claude under that same session shell. The reported pid is the session-leader
+/// shell — NOT `$!` of `setsid`, which is a short-lived forking parent that
+/// yields a dead or zero pid and wedges recovery. Keeping the shell as leader
+/// also lets `kill_process_tree` reap the whole pipeline (cat + claude).
+///
+/// Stdin must be a pipe (`cat … | claude`), not file redirection: Claude CLI
+/// with `--print` does not accept stdin from `< file` (same constraint as the
+/// Unix spawn path). The outer launcher waits for the pid file, prints the pid
+/// for Jean, then exits.
 #[cfg(any(windows, test))]
 fn build_wsl_claude_script(
     cli_path: &str,
@@ -124,8 +133,13 @@ fn build_wsl_claude_script(
     pid_path: &str,
     env_vars: &[(&str, &str)],
 ) -> String {
-    // Inner command: record pid, then become Claude via `exec` so the pid holds.
-    let mut inner = format!("echo $$ > {}; exec ", wsl_shell_quote(pid_path));
+    // Inner command: record the session-leader pid, then pipe input into Claude.
+    // (Claude --print requires a pipe; plain `< file` redirection fails.)
+    let mut inner = format!(
+        "echo $$ > {}; cat {} | ",
+        wsl_shell_quote(pid_path),
+        wsl_shell_quote(input_path)
+    );
     if !env_vars.is_empty() {
         inner.push_str("env ");
         inner.push_str(
@@ -142,11 +156,7 @@ fn build_wsl_claude_script(
         inner.push(' ');
         inner.push_str(&wsl_shell_quote(arg));
     }
-    inner.push_str(&format!(
-        " < {} >> {} 2>&1",
-        wsl_shell_quote(input_path),
-        wsl_shell_quote(output_path)
-    ));
+    inner.push_str(&format!(" >> {} 2>&1", wsl_shell_quote(output_path)));
 
     // Outer launcher: detach the session, wait for the pid to land (≤2s), print
     // it, then exit — after which `wsl.exe` exits and Claude keeps running.
@@ -575,9 +585,18 @@ pub fn spawn_detached_claude(
         let _ = std::fs::remove_file(&pid_file);
 
         // Claude runs in its own session (setsid) and no longer needs wsl.exe.
-        // The launcher exits on its own after printing the pid; dropping the
-        // Child just releases Jean's handles.
-        drop(child);
+        // Wait for the short-lived launcher so handles are reaped cleanly; a
+        // non-zero exit after a valid pid is logged but not fatal (Claude may
+        // already be running under wslhost.exe).
+        match child.wait() {
+            Ok(status) if !status.success() => {
+                log::warn!(
+                    "WSL launcher exited with status {status} after reporting pid {pid}"
+                );
+            }
+            Err(e) => log::warn!("Failed to wait for WSL launcher: {e}"),
+            _ => {}
+        }
 
         log::debug!("Detached Claude CLI running in WSL with pid {pid}");
         Ok(pid)
@@ -734,6 +753,19 @@ mod tests {
     }
 
     #[test]
+    fn test_wslify_path_args_translates_forward_slash_drive_paths() {
+        let args = vec![
+            "--add-dir".to_string(),
+            "C:/Users/foo/proj".to_string(),
+            "--settings".to_string(),
+            r"C:\Users\foo\.claude\settings.json".to_string(),
+        ];
+        let out = wslify_path_args(&args);
+        assert_eq!(out[1], "/mnt/c/Users/foo/proj");
+        assert_eq!(out[3], "/mnt/c/Users/foo/.claude/settings.json");
+    }
+
+    #[test]
     fn test_wslify_path_args_leaves_inline_settings_json_unchanged() {
         let args = vec![
             "--settings".to_string(),
@@ -757,11 +789,13 @@ mod tests {
         // New session so Claude survives wsl.exe exiting, detached from stdin.
         assert!(script.starts_with("setsid sh -c "));
         assert!(script.contains("</dev/null &"));
-        // Inner command records the pid then becomes Claude via exec. (Inner
-        // single quotes are re-escaped by the outer `sh -c '...'` wrap, so match
-        // on the unquoted fragments that survive escaping.)
+        // Inner command records the session-leader pid, then pipes input into
+        // Claude. (Inner single quotes are re-escaped by the outer `sh -c '...'`
+        // wrap, so match on the unquoted fragments that survive escaping.)
         assert!(script.contains("echo $$ >"));
-        assert!(script.contains("exec env JEAN_MCP_TOKEN="));
+        assert!(script.contains("cat "));
+        assert!(script.contains(" | "));
+        assert!(script.contains("env JEAN_MCP_TOKEN="));
         assert!(script.contains("secret"));
         assert!(script.contains("/usr/bin/claude"));
         assert!(script.contains("--print"));
@@ -769,10 +803,25 @@ mod tests {
         assert!(script.contains("input.jsonl"));
         assert!(script.contains("output.jsonl"));
         assert!(script.contains("2>&1"));
+        // Must not use file redirection for Claude stdin (CLI --print rejects it).
+        assert!(!script.contains(" < '/mnt/c/tmp/input.jsonl'"));
         // Launcher waits for the pid file (outer, unescaped), then prints it.
         assert!(script.contains("while [ ! -s '/mnt/c/tmp/output.pid' ]"));
         assert!(script.contains("cat '/mnt/c/tmp/output.pid'"));
         // Never rely on `$!` of setsid (a short-lived forking parent).
         assert!(!script.contains("echo $!"));
+        // Do not exec-over the session shell: the shell must stay as leader so
+        // the cat|claude pipeline remains killable as one process group.
+        assert!(!script.contains("exec "));
+    }
+
+    #[test]
+    fn test_looks_like_windows_path_accepts_slash_and_backslash() {
+        assert!(looks_like_windows_path(r"C:\Users\foo"));
+        assert!(looks_like_windows_path("C:/Users/foo"));
+        assert!(looks_like_windows_path(r"\\wsl.localhost\Ubuntu\home\u"));
+        assert!(!looks_like_windows_path("/home/u"));
+        assert!(!looks_like_windows_path(r#"{"permissions":{}}"#));
+        assert!(!looks_like_windows_path("claude-opus-4-8[1m]"));
     }
 }

--- a/jean-core/src/chat/detached.rs
+++ b/jean-core/src/chat/detached.rs
@@ -42,6 +42,123 @@ fn wsl_shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
+/// Claude flags whose following argument is a filesystem path that Claude will
+/// open. When Claude runs inside WSL these must be WSL paths — a Windows-form
+/// value (e.g. `C:\Users\..`) is resolved relative to the Linux cwd and fails
+/// (notably `--append-system-prompt-file`, which aborts the whole run).
+#[cfg(any(windows, test))]
+const WSL_PATH_VALUE_FLAGS: &[&str] = &["--add-dir", "--append-system-prompt-file", "--settings"];
+
+#[cfg(any(windows, test))]
+fn looks_like_windows_path(value: &str) -> bool {
+    // UNC (`\\..`) or drive path (`C:\..`). Anything else is left untouched so
+    // non-path values are never mangled.
+    value.starts_with("\\\\")
+        || (value.len() >= 3 && value.as_bytes()[0].is_ascii_alphabetic() && &value[1..3] == ":\\")
+}
+
+/// Translate Windows-form path values that follow known path flags into WSL
+/// paths, leaving every other argument untouched.
+#[cfg(any(windows, test))]
+fn wslify_path_args(args: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(args.len());
+    let mut translate_next = false;
+    for arg in args {
+        if translate_next {
+            translate_next = false;
+            if looks_like_windows_path(arg) {
+                out.push(crate::platform::win_to_wsl_path(arg));
+                continue;
+            }
+        }
+        if WSL_PATH_VALUE_FLAGS.contains(&arg.as_str()) {
+            translate_next = true;
+        }
+        out.push(arg.clone());
+    }
+    out
+}
+
+/// Build the shell program fed to `wsl.exe -- sh -s` (via stdin, so wsl.exe
+/// never re-parses it) that launches Claude so it OUTLIVES the `wsl.exe`
+/// invocation.
+///
+/// A plain backgrounded child is SIGHUP-reaped when the launcher's session
+/// tears down as `wsl.exe` exits — verified empirically on WSL2. `setsid` gives
+/// Claude its own session with no controlling terminal, so it survives; the
+/// distro keeps the process (adopted by `wslhost.exe`) and Jean tails the
+/// output file. This lets `wsl.exe` return immediately instead of blocking for
+/// the whole run.
+///
+/// Why `wsl.exe` exiting does not kill Claude — the WSL process-lifetime model:
+/// - Interop: `wsl.exe` does not "contain" the Linux process. Each session
+///   leader inside the distro has an interop server — "special Linux processes
+///   that act as bridges between Linux and Windows [that] maintain secure
+///   communication channels (through hvsocket connections) with Windows
+///   processes (wsl.exe or wslhost.exe)" — and that server, not `wsl.exe`, is
+///   what tracks the running work.
+///   See <https://github.com/microsoft/WSL/blob/master/doc/docs/technical-documentation/interop.md>.
+/// - Adoption: when `wsl.exe` exits before the Linux process finishes, Windows
+///   transfers responsibility to `wslhost.exe` — "When wsl.exe terminates
+///   before the associated Linux process terminates, wslhost.exe takes over the
+///   lifetime of the Linux process" — which keeps it (and its interop/terminal
+///   access) alive.
+///   See <https://github.com/microsoft/WSL/blob/master/doc/docs/technical-documentation/wslhost.exe.md>.
+///
+/// The catch neither doc spells out: adoption only saves a process that is still
+/// alive when `wsl.exe` leaves. A plain backgrounded child sharing the launcher
+/// session is SIGHUP-reaped at teardown — before adoption ever applies — which
+/// is exactly why `setsid` (own session, no controlling terminal) is required.
+///
+/// The inner session records its own pid to `pid_path` and then `exec`s Claude,
+/// so the reported pid is Claude's stable Linux pid — NOT `$!` of `setsid`,
+/// which is a short-lived parent that forks and exits (reading it yields a dead
+/// or zero pid and wedges recovery). The outer launcher waits for the pid file,
+/// prints the pid for Jean, then exits.
+#[cfg(any(windows, test))]
+fn build_wsl_claude_script(
+    cli_path: &str,
+    args: &[String],
+    input_path: &str,
+    output_path: &str,
+    pid_path: &str,
+    env_vars: &[(&str, &str)],
+) -> String {
+    // Inner command: record pid, then become Claude via `exec` so the pid holds.
+    let mut inner = format!("echo $$ > {}; exec ", wsl_shell_quote(pid_path));
+    if !env_vars.is_empty() {
+        inner.push_str("env ");
+        inner.push_str(
+            &env_vars
+                .iter()
+                .map(|(key, value)| format!("{key}={}", wsl_shell_quote(value)))
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
+        inner.push(' ');
+    }
+    inner.push_str(&wsl_shell_quote(cli_path));
+    for arg in args {
+        inner.push(' ');
+        inner.push_str(&wsl_shell_quote(arg));
+    }
+    inner.push_str(&format!(
+        " < {} >> {} 2>&1",
+        wsl_shell_quote(input_path),
+        wsl_shell_quote(output_path)
+    ));
+
+    // Outer launcher: detach the session, wait for the pid to land (≤2s), print
+    // it, then exit — after which `wsl.exe` exits and Claude keeps running.
+    let inner_q = wsl_shell_quote(&inner);
+    let pid_q = wsl_shell_quote(pid_path);
+    format!(
+        "setsid sh -c {inner_q} </dev/null &\n\
+         i=0; while [ ! -s {pid_q} ] && [ $i -lt 40 ]; do sleep 0.05; i=$((i+1)); done\n\
+         cat {pid_q}\n"
+    )
+}
+
 /// Spawn an arbitrary CLI as a fully detached background process (Unix).
 ///
 /// Uses `nohup` and shell backgrounding so the process survives Jean quitting:
@@ -141,6 +258,12 @@ pub fn spawn_detached_process(
     let pid: u32 = pid_str
         .parse()
         .map_err(|e| format!("Failed to parse PID '{pid_str}': {e}"))?;
+
+    // pid 0 means the backgrounded job never started (is_process_alive(0)
+    // would report it alive forever). Fail loudly instead.
+    if pid == 0 {
+        return Err("Detached process spawn returned an invalid pid (0)".to_string());
+    }
 
     log::trace!("Detached process spawned with PID: {pid}");
 
@@ -291,6 +414,12 @@ pub fn spawn_detached_claude(
         .parse()
         .map_err(|e| format!("Failed to parse PID '{pid_str}': {e}"))?;
 
+    // pid 0 means the backgrounded job never started (is_process_alive(0)
+    // would report it alive forever). Fail loudly instead.
+    if pid == 0 {
+        return Err("Detached Claude CLI spawn returned an invalid pid (0)".to_string());
+    }
+
     log::trace!("Detached Claude CLI spawned with PID: {pid}");
 
     Ok(pid)
@@ -321,7 +450,8 @@ pub fn spawn_detached_claude(
     let wsl_config = crate::platform::get_wsl_config();
 
     if wsl_config.enabled {
-        // WSL mode: spawn via wsl.exe with shell backgrounding (similar to Unix)
+        // WSL mode: launch Claude in its own session (setsid) so it survives
+        // wsl.exe exiting, then let wsl.exe return immediately.
         use std::io::{BufRead, BufReader};
 
         let unix_cwd = crate::platform::win_to_wsl_path(&working_dir.to_string_lossy());
@@ -343,35 +473,36 @@ pub fn spawn_detached_claude(
         // Input/output files are on the Windows side — convert to /mnt/c/... paths
         let unix_input = crate::platform::win_to_wsl_path(&input_file.to_string_lossy());
         let unix_output = crate::platform::win_to_wsl_path(&output_file.to_string_lossy());
-        let unix_input_escaped = wsl_shell_quote(&unix_input);
-        let unix_output_escaped = wsl_shell_quote(&unix_output);
+        // Windows path args (e.g. --add-dir, --append-system-prompt-file) must be
+        // WSL paths so Claude, running inside the distro, can open them.
+        let wsl_args = wslify_path_args(args);
+        // The detached session writes its pid to a sibling file that both WSL
+        // (via a /mnt/c path) and Jean can see. Clear any stale file first so a
+        // failed spawn can't hand back a previous run's pid.
+        let pid_file = output_file.with_extension("pid");
+        let _ = std::fs::remove_file(&pid_file);
+        let unix_pid = crate::platform::win_to_wsl_path(&pid_file.to_string_lossy());
+        // Feeding the script through stdin avoids Windows-to-WSL argument
+        // rewriting. Only the run path lands in the pid file (deleted below);
+        // the MCP token stays in Claude's argv/env, never on disk.
+        let shell_cmd = build_wsl_claude_script(
+            cli_name,
+            &wsl_args,
+            &unix_input,
+            &unix_output,
+            &unix_pid,
+            env_vars,
+        );
 
-        // Build env exports
-        let env_exports = env_vars
-            .iter()
-            .map(|(k, v)| format!("{k}='{}'", v.replace('\'', "'\\''")))
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        let args_str = args
-            .iter()
-            .map(|a| format!("'{}'", a.replace('\'', "'\\''")))
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        let cli_quoted = format!("'{}'", cli_name.replace('\'', "'\\''"));
-        let shell_cmd = if env_exports.is_empty() {
-            format!(
-                "cat {unix_input_escaped} | nohup {cli_quoted} {args_str} >> {unix_output_escaped} 2>&1 & echo $!"
-            )
-        } else {
-            format!(
-                "cat {unix_input_escaped} | {env_exports} nohup {cli_quoted} {args_str} >> {unix_output_escaped} 2>&1 & echo $!"
-            )
-        };
-
-        log::trace!("Spawning detached Claude CLI via WSL");
-        log::trace!("WSL shell command: {shell_cmd}");
+        log::debug!(
+            "WSL Claude spawn: distro={} cwd={unix_cwd:?} input={unix_input:?} output={unix_output:?}",
+            wsl_config.distro,
+        );
+        let launcher_err = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(output_file)
+            .map_err(|e| format!("Failed to open WSL output file: {e}"))?;
 
         let mut child = silent_command("wsl.exe")
             .args([
@@ -381,38 +512,74 @@ pub fn spawn_detached_claude(
                 &unix_cwd,
                 "--",
                 "sh",
-                "-c",
-                &shell_cmd,
+                "-s",
             ])
-            .stdin(Stdio::null())
+            .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(launcher_err)
             .creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW)
             .spawn()
             .map_err(|e| format!("Failed to spawn WSL shell: {e}"))?;
 
-        let stdout = child.stdout.take().ok_or("Failed to capture WSL stdout")?;
-        let reader = BufReader::new(stdout);
+        let write_result = child
+            .stdin
+            .take()
+            .ok_or_else(|| "Failed to open WSL shell stdin".to_string())
+            .and_then(|mut stdin| {
+                stdin
+                    .write_all(shell_cmd.as_bytes())
+                    .map_err(|e| format!("Failed to write WSL launch command: {e}"))
+            });
+        if let Err(error) = write_result {
+            let _ = child.kill();
+            return Err(error);
+        }
+
+        // The launcher prints Claude's session pid (read from the pid file) once
+        // the detached session is up, then exits.
         let mut pid_str = String::new();
-        for line in reader.lines() {
-            if let Ok(l) = line {
-                pid_str = l.trim().to_string();
-                break;
+        if let Some(stdout) = child.stdout.take() {
+            let mut reader = BufReader::new(stdout);
+            if let Err(e) = reader.read_line(&mut pid_str) {
+                let _ = child.kill();
+                let _ = std::fs::remove_file(&pid_file);
+                return Err(format!("Failed to read WSL PID: {e}"));
             }
         }
+        let pid_str = pid_str.trim();
 
-        let status = child
-            .wait()
-            .map_err(|e| format!("Failed to wait for WSL shell: {e}"))?;
-        if !status.success() {
-            return Err(format!("WSL shell command failed with status: {status}"));
+        let pid: u32 = match pid_str.parse::<u32>() {
+            Ok(pid) => pid,
+            Err(e) => {
+                // No pid printed: the session never came up (e.g. the working
+                // directory could not be entered). Fail loudly.
+                let _ = child.kill();
+                let _ = std::fs::remove_file(&pid_file);
+                return Err(format!("Failed to parse WSL PID '{pid_str}': {e}"));
+            }
+        };
+
+        // `kill -0 0` targets the current process group and can falsely report
+        // success, so never allow an invalid PID into recovery state.
+        if pid == 0 {
+            let _ = child.kill();
+            let _ = std::fs::remove_file(&pid_file);
+            return Err(
+                "WSL spawn produced no process (pid 0) — the working directory \
+                 may not exist inside the distro."
+                    .to_string(),
+            );
         }
 
-        let pid: u32 = pid_str
-            .parse()
-            .map_err(|e| format!("Failed to parse WSL PID '{pid_str}': {e}"))?;
+        // The pid is captured; the file has served its purpose.
+        let _ = std::fs::remove_file(&pid_file);
 
-        log::trace!("Detached Claude CLI spawned inside WSL with PID: {pid}");
+        // Claude runs in its own session (setsid) and no longer needs wsl.exe.
+        // The launcher exits on its own after printing the pid; dropping the
+        // Child just releases Jean's handles.
+        drop(child);
+
+        log::debug!("Detached Claude CLI running in WSL with pid {pid}");
         Ok(pid)
     } else {
         // Native Windows mode
@@ -448,6 +615,9 @@ pub fn spawn_detached_claude(
             .map_err(|e| format!("Failed to spawn Claude CLI: {e}"))?;
 
         let pid = child.id();
+        if pid == 0 {
+            return Err("Claude CLI spawn returned an invalid pid (0)".to_string());
+        }
 
         let input_data =
             std::fs::read(input_file).map_err(|e| format!("Failed to read input file: {e}"))?;
@@ -528,5 +698,81 @@ mod tests {
 
         // Non-existent PID should not be alive
         assert!(!is_process_alive(999999));
+
+        // pid 0 must never read as alive. In WSL mode this maps to `kill -0 0`,
+        // which targets the process group and always succeeds — a failed spawn
+        // (pid 0) would otherwise look alive forever and wedge the tailer.
+        assert!(!is_process_alive(0));
+    }
+
+    #[test]
+    fn test_wslify_path_args_translates_path_flag_values() {
+        let args = vec![
+            "--print".to_string(),
+            "--add-dir".to_string(),
+            r"C:\Users\foo\proj".to_string(),
+            "--append-system-prompt-file".to_string(),
+            r"\\wsl.localhost\Ubuntu-22.04\home\u\ctx.md".to_string(),
+            "--model".to_string(),
+            "claude-opus-4-8[1m]".to_string(),
+            "--settings".to_string(),
+            r"C:\Users\foo\.claude\settings.json".to_string(),
+        ];
+        let out = wslify_path_args(&args);
+        assert_eq!(out[2], "/mnt/c/Users/foo/proj");
+        assert_eq!(out[4], "/home/u/ctx.md");
+        // A non-path flag's value must be left untouched.
+        assert_eq!(out[6], "claude-opus-4-8[1m]");
+        assert_eq!(out[8], "/mnt/c/Users/foo/.claude/settings.json");
+    }
+
+    #[test]
+    fn test_wslify_path_args_leaves_non_windows_values() {
+        // Path flag whose value is already a unix path (or not a Windows path).
+        let args = vec!["--add-dir".to_string(), "/home/u/x".to_string()];
+        assert_eq!(wslify_path_args(&args), args);
+    }
+
+    #[test]
+    fn test_wslify_path_args_leaves_inline_settings_json_unchanged() {
+        let args = vec![
+            "--settings".to_string(),
+            r#"{"permissions":{"allow":["Read"]}}"#.to_string(),
+        ];
+
+        assert_eq!(wslify_path_args(&args), args);
+    }
+
+    #[test]
+    fn test_wsl_claude_script_detaches_with_setsid() {
+        let script = build_wsl_claude_script(
+            "/usr/bin/claude",
+            &["--print".to_string(), "hello world".to_string()],
+            "/mnt/c/tmp/input.jsonl",
+            "/mnt/c/tmp/output.jsonl",
+            "/mnt/c/tmp/output.pid",
+            &[("JEAN_MCP_TOKEN", "secret")],
+        );
+
+        // New session so Claude survives wsl.exe exiting, detached from stdin.
+        assert!(script.starts_with("setsid sh -c "));
+        assert!(script.contains("</dev/null &"));
+        // Inner command records the pid then becomes Claude via exec. (Inner
+        // single quotes are re-escaped by the outer `sh -c '...'` wrap, so match
+        // on the unquoted fragments that survive escaping.)
+        assert!(script.contains("echo $$ >"));
+        assert!(script.contains("exec env JEAN_MCP_TOKEN="));
+        assert!(script.contains("secret"));
+        assert!(script.contains("/usr/bin/claude"));
+        assert!(script.contains("--print"));
+        assert!(script.contains("hello world"));
+        assert!(script.contains("input.jsonl"));
+        assert!(script.contains("output.jsonl"));
+        assert!(script.contains("2>&1"));
+        // Launcher waits for the pid file (outer, unescaped), then prints it.
+        assert!(script.contains("while [ ! -s '/mnt/c/tmp/output.pid' ]"));
+        assert!(script.contains("cat '/mnt/c/tmp/output.pid'"));
+        // Never rely on `$!` of setsid (a short-lived forking parent).
+        assert!(!script.contains("echo $!"));
     }
 }

--- a/jean-core/src/platform/process.rs
+++ b/jean-core/src/platform/process.rs
@@ -206,6 +206,12 @@ pub fn raise_fd_limit() {}
 /// - Windows: Uses OpenProcess + GetExitCodeProcess
 #[cfg(unix)]
 pub fn is_process_alive(pid: u32) -> bool {
+    // pid 0 is never a real spawned child: kill(0, 0) targets the caller's
+    // process group and would report "alive" forever. Treat as dead so a bad
+    // spawn (pid 0) can't wedge callers into an infinite liveness wait.
+    if pid == 0 {
+        return false;
+    }
     // kill with signal 0 checks if process exists without actually sending a signal
     let result = unsafe { libc::kill(pid as i32, 0) };
     if result == 0 {
@@ -219,17 +225,7 @@ pub fn is_process_alive(pid: u32) -> bool {
 }
 
 #[cfg(windows)]
-pub fn is_process_alive(pid: u32) -> bool {
-    // When WSL is enabled, PIDs are WSL-internal — check via wsl.exe
-    let wsl = super::wsl::get_wsl_config();
-    if wsl.enabled {
-        return silent_command("wsl.exe")
-            .args(["-d", &wsl.distro, "--", "kill", "-0", &pid.to_string()])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false);
-    }
-
+fn windows_process_alive(pid: u32) -> bool {
     use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
     use windows_sys::Win32::System::Threading::{
         GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
@@ -247,6 +243,27 @@ pub fn is_process_alive(pid: u32) -> bool {
 
         result != 0 && exit_code == STILL_ACTIVE as u32
     }
+}
+
+#[cfg(windows)]
+pub fn is_process_alive(pid: u32) -> bool {
+    // pid 0 is never a real spawned child. In WSL mode `kill -0 0` targets the
+    // process group and always succeeds, which would report a failed spawn
+    // (pid 0) as "alive" forever and wedge the tailer until its startup timeout.
+    if pid == 0 {
+        return false;
+    }
+    // When WSL is enabled, PIDs are WSL-internal — check via wsl.exe
+    let wsl = super::wsl::get_wsl_config();
+    if wsl.enabled {
+        return silent_command("wsl.exe")
+            .args(["-d", &wsl.distro, "--", "kill", "-0", &pid.to_string()])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+    }
+
+    windows_process_alive(pid)
 }
 
 /// Kill a single process

--- a/jean-core/src/platform/wsl.rs
+++ b/jean-core/src/platform/wsl.rs
@@ -102,6 +102,18 @@ pub fn win_to_wsl_path(path: &str) -> String {
     // Normalize backslashes
     let normalized = path.replace('\\', "/");
 
+    // Strip Windows extended-length / verbatim prefixes. Path canonicalization
+    // (e.g. std::fs) can hand back `\\?\UNC\wsl.localhost\..` or `\\?\C:\..`,
+    // which would otherwise fall through untouched and produce an unresolved
+    // `--cd` (chdir fails -> pid 0 -> silent hang).
+    let normalized = if let Some(rest) = normalized.strip_prefix("//?/UNC/") {
+        format!("//{rest}")
+    } else if let Some(rest) = normalized.strip_prefix("//?/") {
+        rest.to_string()
+    } else {
+        normalized
+    };
+
     // Handle \\wsl.localhost\Distro\... or \\wsl$\Distro\...
     for prefix in &["//wsl.localhost/", "//wsl$/"] {
         if let Some(rest) = normalized.strip_prefix(prefix) {
@@ -739,6 +751,32 @@ mod tests {
     #[test]
     fn test_win_to_wsl_path_unc_wsl_dollar() {
         assert_eq!(win_to_wsl_path(r"\\wsl$\Ubuntu\home\user"), "/home/user");
+    }
+
+    #[test]
+    fn test_win_to_wsl_path_unc_localhost_dotted_distro() {
+        // Distro names with dots/dashes (e.g. Ubuntu-22.04) must still be skipped.
+        assert_eq!(
+            win_to_wsl_path(r"\\wsl.localhost\Ubuntu-22.04\home\firice\repos\idnexus"),
+            "/home/firice/repos/idnexus"
+        );
+    }
+
+    #[test]
+    fn test_win_to_wsl_path_verbatim_unc() {
+        // Extended-length UNC form from path canonicalization.
+        assert_eq!(
+            win_to_wsl_path(r"\\?\UNC\wsl.localhost\Ubuntu-22.04\home\firice\repos\idnexus"),
+            "/home/firice/repos/idnexus"
+        );
+    }
+
+    #[test]
+    fn test_win_to_wsl_path_verbatim_drive() {
+        assert_eq!(
+            win_to_wsl_path(r"\\?\C:\Users\foo\project"),
+            "/mnt/c/Users/foo/project"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Starting a Claude session from Jean on Windows with WSL mode enabled would hang for 120s and then die silently. No output, no error in the chat — just a spinner until the startup timeout, and a `wsl.exe` left pinned for the whole run.

Two independent bugs stacked on top of each other, which is why it looked like a hang instead of a failure.

### 1. The Linux child was killed the moment `wsl.exe` exited

Jean launched Claude with `wsl.exe -- sh -c "... nohup claude ... & echo $!"`. That backgrounded child stays in the launcher's session. When the launcher finishes and `wsl.exe` tears the session down, the child gets SIGHUP'd and dies — instantly, before it ever writes a byte to the output file.

Windows *does* have a handoff for this: when `wsl.exe` exits before the Linux process finishes, `wslhost.exe` [takes over the lifetime of the Linux process](https://github.com/microsoft/WSL/blob/master/doc/docs/technical-documentation/wslhost.exe.md). The catch neither doc spells out is that adoption only saves a process that is *still alive* when `wsl.exe` leaves. A plain backgrounded child sharing the launcher's session is reaped at teardown — before adoption ever applies. `nohup` doesn't help either; it covers the `nohup`'d command, not the session teardown that kills it.

### 2. pid 0 reads as "alive" forever

The spawn path took whatever `echo $!` printed and trusted it. If the session never came up — a `--cd` into a directory that doesn't exist inside the distro, or a pid mangled by Windows→WSL argument rewriting — that value came back as `0`.

`is_process_alive(0)` in WSL mode shells out to `kill -0 0`. Signal 0 with pid 0 targets **the caller's process group**, not "process zero" — so it always succeeds. A dead spawn reported alive, forever. The tailer then sat on an empty output file waiting for a process that never existed, until the 120s startup timeout, and even then exited quietly with no `chat:error`.

A third contributor fed bug 2: `win_to_wsl_path` didn't strip Windows verbatim prefixes. A canonicalized cwd comes back as `\\?\C:\..` or `\\?\UNC\wsl.localhost\..`, fell through untranslated, and produced a `--cd` that couldn't resolve inside the distro — chdir fails → pid 0 → silent hang.

## Fix

**Launch Claude in its own session.** The launcher now runs `setsid sh -c '...' </dev/null &`, giving Claude a new session with no controlling terminal. It survives the launcher's teardown, `wslhost.exe` adopts it, and `wsl.exe` returns immediately instead of being pinned for the entire run. Verified on WSL2: the child stays alive with its own SID after the launcher is gone.

**Report Claude's real pid.** The inner session does `echo $$ > pidfile; exec claude ...`, so the pid Jean records is Claude's own stable Linux pid. Reading `$!` of `setsid` would give the short-lived forking parent — a pid that is dead or zero by the time anyone checks it. The outer launcher waits (≤2s) for the pid file to land, prints it, and exits. The pid file is deleted right after it's read; only the run path ever touches disk — the MCP token stays in Claude's argv/env.

**Feed the script over stdin.** `sh -s` with the program written to stdin, instead of `sh -c "<program>"` as an argv element, so Windows→WSL argument rewriting can't mangle it.

**Make pid 0 impossible to mistake for a live process:**
- `is_process_alive(0)` returns `false` on both Unix and Windows, before the `kill -0` / `OpenProcess` call.
- Every detached spawn branch (Unix, WSL, native Windows) rejects pid 0 with a real error instead of handing it to recovery state.

**Fail loudly on startup timeout.** If Claude produced no output before the timeout, Jean now emits a `chat:error` with the CLI's stderr when there is any, or an actionable message pointing at the Claude CLI install / distro config when there isn't — and terminates the process tree so nothing is left running behind a dead session.

**Path translation fixes:**
- `win_to_wsl_path` strips `\\?\` and `\\?\UNC\` prefixes, so a canonicalized cwd resolves inside the distro.
- Path-valued flags (`--add-dir`, `--append-system-prompt-file`, `--settings`) get their Windows values translated to WSL paths. Only values that actually *look* like Windows paths (`C:\..`, `\\..`) are touched, so inline JSON for `--settings` and non-path values like `--model` pass through untouched. `--append-system-prompt-file` was the worst of these — a Windows path there aborts the entire run.

## Changed files

| File | What |
|---|---|
| `jean-core/src/chat/detached.rs` | `setsid` launcher, pid-file capture, stdin-fed script, pid 0 rejection, path-flag translation |
| `jean-core/src/chat/claude.rs` | Terminal `chat:error` + process-tree kill on startup timeout |
| `jean-core/src/platform/process.rs` | `is_process_alive(0) == false` on Unix and Windows |
| `jean-core/src/platform/wsl.rs` | Strip `\\?\` / `\\?\UNC\` verbatim prefixes |

## Testing

- WSL2 (Ubuntu), Windows host: session starts, streams, and completes; `wsl.exe` exits immediately after spawn while Claude keeps running with its own SID.
- Unit tests added for `wslify_path_args` (path flags translated, non-path values and inline `--settings` JSON untouched), `startup_failure_message` (uses CLI stderr when present, actionable fallback when not, silent on user cancel / completed runs), `is_process_alive(0)`, and the new `win_to_wsl_path` prefix cases.
- Non-WSL paths unchanged: Unix and native Windows spawn only gained the pid 0 guard.

Main changes from current body: separated the two bugs with why each one bites (session teardown vs kill -0 0 targeting the process group), added the wslhost.exe adoption nuance that explains why nohup alone was never enough, folded the verbatim-prefix bug in as a cause of pid 0 instead of a loose bullet, and expanded the "additional improvements" one-liner into concrete items with rationale.