### PR TITLE
fix(sessions): sync unread state across clients on mark-read

### DIFF
--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -2284,6 +2284,9 @@ pub async fn set_active_session(
 /// Update the last_opened_at timestamp on a session's metadata.
 /// View-only: never mutates waiting/review state — explicit user actions
 /// (approve/reject/answer) are the only path out of waiting.
+///
+/// Emits `cache:invalidate` for sessions so native + web clients refresh
+/// unread/finished-session state (e.g. web marks read → native bell clears).
 pub async fn set_session_last_opened(app: AppHandle, session_id: String) -> Result<(), String> {
     log::trace!("Setting last_opened_at for session: {session_id}");
 
@@ -2294,12 +2297,17 @@ pub async fn set_session_last_opened(app: AppHandle, session_id: String) -> Resu
             .as_secs();
         metadata.last_opened_at = Some(now);
         save_metadata(&app, &metadata)?;
+        // Broadcast so other clients (native ↔ web) drop stale last_opened_at.
+        emit_sessions_cache_invalidation(&app);
     }
 
     Ok(())
 }
 
 /// Bulk-update last_opened_at for multiple sessions in a single call.
+///
+/// Emits a single `cache:invalidate` after updates so multi-client unread
+/// counts stay in sync (mark all read from web or native).
 pub async fn set_sessions_last_opened_bulk(
     app: AppHandle,
     session_ids: Vec<String>,
@@ -2314,11 +2322,17 @@ pub async fn set_sessions_last_opened_bulk(
         .unwrap_or_default()
         .as_secs();
 
+    let mut updated = false;
     for session_id in &session_ids {
         if let Ok(Some(mut metadata)) = load_metadata(&app, session_id) {
             metadata.last_opened_at = Some(now);
             save_metadata(&app, &metadata)?;
+            updated = true;
         }
+    }
+
+    if updated {
+        emit_sessions_cache_invalidation(&app);
     }
 
     Ok(())

--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -462,6 +462,17 @@ fn emit_sessions_cache_invalidation(app: &AppHandle) {
     }
 }
 
+fn finish_bulk_update<T, E>(
+    updated: bool,
+    result: Result<T, E>,
+    invalidate: impl FnOnce(),
+) -> Result<T, E> {
+    if updated {
+        invalidate();
+    }
+    result
+}
+
 // ============================================================================
 // Session Management Commands
 // ============================================================================
@@ -2323,19 +2334,19 @@ pub async fn set_sessions_last_opened_bulk(
         .as_secs();
 
     let mut updated = false;
+    let mut result = Ok(());
     for session_id in &session_ids {
         if let Ok(Some(mut metadata)) = load_metadata(&app, session_id) {
             metadata.last_opened_at = Some(now);
-            save_metadata(&app, &metadata)?;
+            if let Err(error) = save_metadata(&app, &metadata) {
+                result = Err(error);
+                break;
+            }
             updated = true;
         }
     }
 
-    if updated {
-        emit_sessions_cache_invalidation(&app);
-    }
-
-    Ok(())
+    finish_bulk_update(updated, result, || emit_sessions_cache_invalidation(&app))
 }
 
 // ============================================================================
@@ -10098,6 +10109,15 @@ my-disabled: /usr/bin/disabled (STDIO) - disabled";
         let remaining = vec![s2, s3];
         let selected = find_neighbor_non_archived_session_id(&remaining, 0);
         assert_eq!(selected.as_deref(), Some("s3"));
+    }
+
+    #[test]
+    fn bulk_update_invalidates_before_returning_partial_failure() {
+        let mut invalidated = false;
+        let result = finish_bulk_update(true, Err("save failed"), || invalidated = true);
+
+        assert!(invalidated);
+        assert_eq!(result, Err("save failed"));
     }
 
     #[test]

--- a/src/hooks/session_last_opened_sync.test.ts
+++ b/src/hooks/session_last_opened_sync.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Structure regression for multi-client unread sync (#512).
+ * `set_session_last_opened` must broadcast cache:invalidate so native + web
+ * clients refresh finished/unread state after one client marks a session read.
+ */
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('set_session_last_opened multi-client sync', () => {
+  const source = readFileSync(
+    `${process.cwd()}/jean-core/src/chat/commands.rs`,
+    'utf8'
+  )
+
+  it('emits sessions cache invalidation after single mark-opened', () => {
+    const singleFn = source.match(
+      /pub async fn set_session_last_opened[\s\S]*?^pub async fn set_sessions_last_opened_bulk/m
+    )
+    expect(singleFn?.[0]).toBeTruthy()
+    expect(singleFn?.[0]).toContain('emit_sessions_cache_invalidation(&app)')
+  })
+
+  it('emits sessions cache invalidation after bulk mark-opened', () => {
+    const bulkFn = source.match(
+      /pub async fn set_sessions_last_opened_bulk[\s\S]*?^\/\/ =+[\s\S]*?Chat Commands/m
+    )
+    expect(bulkFn?.[0]).toBeTruthy()
+    expect(bulkFn?.[0]).toContain('emit_sessions_cache_invalidation(&app)')
+  })
+})

--- a/src/hooks/useMainWindowEventListeners.test.tsx
+++ b/src/hooks/useMainWindowEventListeners.test.tsx
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useChatStore } from '@/store/chat-store'
 import { useTerminalStore } from '@/store/terminal-store'
 import { useUIStore } from '@/store/ui-store'
+import { QueryClient } from '@tanstack/react-query'
 import {
   addTerminalTabForShortcut,
+  applyCacheInvalidationKeys,
   blurFocusedTerminalForShortcut,
   closeActiveTerminalTabForShortcut,
   findKeybindingAction,
@@ -13,6 +15,8 @@ import {
   shouldLetPlanDialogHandleAction,
   switchActiveTerminalTabByIndexForShortcut,
 } from './useMainWindowEventListeners'
+import { chatQueryKeys } from '@/services/chat'
+import { projectsQueryKeys } from '@/services/projects'
 import { DEFAULT_KEYBINDINGS } from '@/types/keybindings'
 
 const { mockInvoke, mockListen, mockDisposeTerminal } = vi.hoisted(() => ({
@@ -425,5 +429,52 @@ describe('dialog overlay keybinding passthrough', () => {
         useUIStore.getState()
       )
     ).toBe(false)
+  })
+})
+
+describe('applyCacheInvalidationKeys', () => {
+  it('invalidates chat queries and all-sessions for sessions keys', () => {
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    applyCacheInvalidationKeys(queryClient, ['sessions'])
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: chatQueryKeys.all,
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['all-sessions'],
+    })
+  })
+
+  it('invalidates projects queries for projects keys', () => {
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    applyCacheInvalidationKeys(queryClient, ['projects'])
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: projectsQueryKeys.all,
+    })
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: ['all-sessions'],
+    })
+  })
+
+  it('invalidates both chat and all-sessions when sessions is among multiple keys', () => {
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    applyCacheInvalidationKeys(queryClient, ['preferences', 'sessions'])
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['preferences'],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: chatQueryKeys.all,
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['all-sessions'],
+    })
   })
 })

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -50,6 +50,55 @@ export function findKeybindingAction(
   return null
 }
 
+/**
+ * Apply backend `cache:invalidate` keys to the React Query client.
+ * Shared by the debounced multi-client sync listener.
+ *
+ * `sessions` also invalidates `['all-sessions']` (finished/unread bell) which
+ * is intentionally outside `chatQueryKeys.all` (`['chat']`).
+ */
+export function applyCacheInvalidationKeys(
+  queryClient: QueryClient,
+  keys: Iterable<string>
+): void {
+  for (const key of keys) {
+    switch (key) {
+      case 'sessions':
+        queryClient.invalidateQueries({
+          queryKey: chatQueryKeys.all,
+        })
+        // UnreadBell / useUnreadCount read from this separate key.
+        queryClient.invalidateQueries({
+          queryKey: ['all-sessions'],
+        })
+        break
+      case 'projects':
+        queryClient.invalidateQueries({
+          queryKey: projectsQueryKeys.all,
+        })
+        break
+      case 'preferences':
+        queryClient.invalidateQueries({
+          queryKey: ['preferences'],
+        })
+        break
+      case 'ui-state':
+        queryClient.invalidateQueries({
+          queryKey: ['ui-state'],
+        })
+        break
+      case 'contexts':
+        queryClient.invalidateQueries({
+          queryKey: ['contexts'],
+        })
+        queryClient.invalidateQueries({
+          queryKey: ['saved-contexts'],
+        })
+        break
+    }
+  }
+}
+
 export function shouldAllowKeybindingThroughOpenOverlay(
   action: KeybindingAction | null,
   uiState: ReturnType<typeof useUIStore.getState>
@@ -963,38 +1012,7 @@ export function useMainWindowEventListeners() {
 
           const flushInvalidations = () => {
             flushTimer = null
-            for (const key of pendingKeys) {
-              switch (key) {
-                case 'sessions':
-                  queryClient.invalidateQueries({
-                    queryKey: chatQueryKeys.all,
-                  })
-                  break
-                case 'projects':
-                  queryClient.invalidateQueries({
-                    queryKey: projectsQueryKeys.all,
-                  })
-                  break
-                case 'preferences':
-                  queryClient.invalidateQueries({
-                    queryKey: ['preferences'],
-                  })
-                  break
-                case 'ui-state':
-                  queryClient.invalidateQueries({
-                    queryKey: ['ui-state'],
-                  })
-                  break
-                case 'contexts':
-                  queryClient.invalidateQueries({
-                    queryKey: ['contexts'],
-                  })
-                  queryClient.invalidateQueries({
-                    queryKey: ['saved-contexts'],
-                  })
-                  break
-              }
-            }
+            applyCacheInvalidationKeys(queryClient, pendingKeys)
             pendingKeys.clear()
           }
 


### PR DESCRIPTION
## Summary

- Broadcast `cache:invalidate` when marking sessions as opened (single and bulk) so native and web clients refresh unread/finished state together
- Invalidate the separate `all-sessions` query (unread bell / counts) whenever sessions cache is invalidated
- Add regression tests for multi-client mark-read sync and cache invalidation key handling

fixes #512

---

Fixes #512