### PR TITLE
feat: Add agent prompt copy button

### DIFF
--- a/src/components/chat/MessageItem.test.tsx
+++ b/src/components/chat/MessageItem.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@/test/test-utils'
+import { render, screen, waitFor } from '@/test/test-utils'
 import { MessageItem } from './MessageItem'
 import type {
   ChatMessage,
@@ -7,6 +7,23 @@ import type {
   QuestionAnswer,
   Question,
 } from '@/types/chat'
+
+const mocks = vi.hoisted(() => ({
+  copyToClipboard: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+vi.mock('@/lib/clipboard', () => ({
+  copyToClipboard: mocks.copyToClipboard,
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: mocks.toastSuccess,
+    error: mocks.toastError,
+  },
+}))
 
 describe('MessageItem', () => {
   const noopQuestionAnswer = (
@@ -381,6 +398,60 @@ describe('MessageItem', () => {
     render(<MessageItem {...baseProps} durationMs={23_000} />)
 
     expect(screen.getByText('23s')).toBeVisible()
+  })
+
+  it('copies an assistant response to the clipboard', async () => {
+    mocks.copyToClipboard.mockResolvedValue(undefined)
+
+    render(
+      <MessageItem
+        {...baseProps}
+        message={{
+          ...baseMessage,
+          content: 'This is the assistant response.',
+          tool_calls: [],
+          content_blocks: [],
+        }}
+      />
+    )
+
+    screen.getByRole('button', { name: 'Copy response to clipboard' }).click()
+
+    await waitFor(() => {
+      expect(mocks.copyToClipboard).toHaveBeenCalledWith(
+        'This is the assistant response.'
+      )
+      expect(mocks.toastSuccess).toHaveBeenCalledWith(
+        'Response copied to clipboard'
+      )
+    })
+  })
+
+  it('copies text from content blocks when the persisted response is empty', async () => {
+    mocks.copyToClipboard.mockResolvedValue(undefined)
+
+    render(
+      <MessageItem
+        {...baseProps}
+        message={{
+          ...baseMessage,
+          content: '',
+          tool_calls: [],
+          content_blocks: [
+            { type: 'text', text: 'First response block.' },
+            { type: 'text', text: 'Second response block.' },
+          ],
+        }}
+      />
+    )
+
+    screen.getByRole('button', { name: 'Copy response to clipboard' }).click()
+
+    await waitFor(() => {
+      expect(mocks.copyToClipboard).toHaveBeenCalledWith(
+        'First response block.\nSecond response block.'
+      )
+    })
   })
 
   it('copies steered prompts rendered in full native messages', () => {

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -1,7 +1,9 @@
 import { memo, useCallback } from 'react'
 import { Copy } from 'lucide-react'
+import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { normalizePath } from '@/lib/path-utils'
+import { copyToClipboard } from '@/lib/clipboard'
 import { Markdown } from '@/components/ui/markdown'
 import type {
   ChatMessage,
@@ -208,6 +210,14 @@ export const MessageItem = memo(function MessageItem({
     message.role === 'user' ? extractSkillPaths(message.content) : []
   const displayContent =
     message.role === 'user' ? stripAllMarkers(message.content) : message.content
+  const assistantResponse =
+    message.role === 'assistant'
+      ? message.content.trim() ||
+        (message.content_blocks ?? [])
+          .flatMap(block => (block.type === 'text' ? [block.text] : []))
+          .join('\n')
+          .trim()
+      : ''
   // Show content if it's not empty
   const showContent = displayContent.trim()
 
@@ -269,6 +279,14 @@ export const MessageItem = memo(function MessageItem({
   const handleCopyToInput = useCallback(() => {
     onCopyToInput?.(message)
   }, [onCopyToInput, message])
+
+  const handleCopyAssistantResponse = useCallback(() => {
+    if (!assistantResponse) return
+
+    void copyToClipboard(assistantResponse)
+      .then(() => toast.success('Response copied to clipboard'))
+      .catch(() => toast.error('Failed to copy response'))
+  }, [assistantResponse])
 
   const handleCopySteeredText = useCallback(
     (text: string) => {
@@ -883,8 +901,25 @@ export const MessageItem = memo(function MessageItem({
           </div>
         </div>
       ) : (
-        <div className="text-foreground/90 w-full min-w-0 break-words">
+        <div className="group relative text-foreground/90 w-full min-w-0 break-words">
           {messageBoxContent}
+          {assistantResponse && (
+            <div className="mt-1 flex justify-end">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Copy response to clipboard"
+                    onClick={handleCopyAssistantResponse}
+                    className="shrink-0 rounded p-1 text-muted-foreground/0 transition-colors [@media(pointer:coarse)]:text-muted-foreground/60 hover:bg-muted/50 hover:text-muted-foreground focus-visible:text-muted-foreground group-hover:text-muted-foreground/50"
+                  >
+                    <Copy className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Copy response</TooltipContent>
+              </Tooltip>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Adds a copy-to-clipboard button at the bottom-right of completed agent responses in the chat message view.

Fixes #527 