### PR TITLE
feat: Add ungrouped tool activity view 

### DIFF
--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -379,6 +379,8 @@ pub struct AppPreferences {
     pub coderabbit_cli_source: String, // CodeRabbit CLI source: "jean" (managed) or "path" (system PATH)
     #[serde(default)]
     pub expand_tool_calls_by_default: bool, // Expand all tool call collapsibles by default (default: false)
+    #[serde(default = "default_group_tool_calls_and_thinking")]
+    pub group_tool_calls_and_thinking: bool, // Combine consecutive thinking and tool calls into one activity block
     #[serde(default)]
     pub window_vibrancy: bool, // macOS window vibrancy effect (high GPU cost, default false)
     #[serde(default = "default_terminal_background")]
@@ -591,6 +593,10 @@ fn default_compact_chat_view_enabled() -> bool {
     true // Enabled by default
 }
 
+fn default_group_tool_calls_and_thinking() -> bool {
+    true // Enabled by default
+}
+
 fn default_auto_recaps_enabled() -> bool {
     true // Enabled by default
 }
@@ -794,6 +800,19 @@ mod tests {
 
         assert!(prefs.parallel_execution_prompt_enabled);
         assert!(prefs.codex_multi_agent_enabled);
+    }
+
+    #[test]
+    fn tool_call_and_thinking_grouping_defaults_on_for_existing_preferences() {
+        let mut value = serde_json::to_value(AppPreferences::default()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("group_tool_calls_and_thinking");
+
+        let prefs: AppPreferences = serde_json::from_value(value).unwrap();
+
+        assert!(prefs.group_tool_calls_and_thinking);
     }
 
     #[test]
@@ -2404,6 +2423,7 @@ impl Default for AppPreferences {
             commandcode_cli_source: default_cli_source(),
             coderabbit_cli_source: default_cli_source(),
             expand_tool_calls_by_default: false,
+            group_tool_calls_and_thinking: default_group_tool_calls_and_thinking(),
             window_vibrancy: false,
             terminal_background: default_terminal_background(),
             terminal_background_custom: None,

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -57,6 +57,7 @@ import {
   normalizeQuestionMultipleField,
 } from '@/types/chat'
 import { MessageSettingsBadges } from '@/components/chat/MessageSettingsBadges'
+import { usePreferences } from '@/services/preferences'
 import type { ApprovalModelOverride } from './ApprovalModelSubmenu'
 
 interface MessageItemProps {
@@ -192,6 +193,9 @@ export const MessageItem = memo(function MessageItem({
   hideCancelledIndicator,
   durationMs,
 }: MessageItemProps) {
+  const { data: preferences } = usePreferences()
+  const groupToolCallsAndThinking =
+    preferences?.group_tool_calls_and_thinking ?? true
   // Only show Approve button for the last message with ExitPlanMode
   const isLatestPlanRequest = messageIndex === lastPlanMessageIndex
 
@@ -396,7 +400,8 @@ export const MessageItem = memo(function MessageItem({
               try {
                 timeline = buildTimeline(
                   message.content_blocks,
-                  message.tool_calls ?? []
+                  message.tool_calls ?? [],
+                  groupToolCallsAndThinking
                 )
               } catch (e) {
                 logger.error('Failed to build timeline for message', {

--- a/src/components/chat/ShellCommand.tsx
+++ b/src/components/chat/ShellCommand.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react'
+import { useTheme } from '@/hooks/use-theme'
+
+interface Token {
+  content: string
+  color?: string
+}
+
+type TokenLines = Token[][]
+
+/**
+ * Small, on-demand syntax-highlighted shell command. The Shiki bundle is only
+ * requested after a tool call is expanded.
+ */
+export function ShellCommand({ command }: { command: string }) {
+  const [lines, setLines] = useState<TokenLines | null>(null)
+  const { theme } = useTheme()
+
+  useEffect(() => {
+    let cancelled = false
+    const isDark =
+      theme === 'dark' ||
+      (theme === 'system' &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches)
+
+    import('@/lib/bash-highlighting')
+      .then(({ highlightBash }) => highlightBash(command, isDark))
+      .then(result => {
+        if (!cancelled) setLines(result.tokens)
+      })
+      .catch(() => {
+        if (!cancelled) setLines([])
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [command, theme])
+
+  if (!lines || lines.length === 0) {
+    return <code className="font-mono text-foreground/80">$ {command}</code>
+  }
+
+  return (
+    <code className="font-mono text-foreground/80">
+      {lines.map((line, lineIndex) => (
+        <span key={lineIndex}>
+          {lineIndex === 0 && <span className="text-muted-foreground/60">$ </span>}
+          {line.map((token, tokenIndex) => (
+            <span key={tokenIndex} style={{ color: token.color }}>
+              {token.content}
+            </span>
+          ))}
+          {lineIndex < lines.length - 1 && '\n'}
+        </span>
+      ))}
+    </code>
+  )
+}

--- a/src/components/chat/StreamingMessage.tsx
+++ b/src/components/chat/StreamingMessage.tsx
@@ -34,6 +34,7 @@ import { ThinkingBlock } from './ThinkingBlock'
 import { SteeredPromptGroup } from './SteeredPromptGroup'
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary'
 import { logger } from '@/lib/logger'
+import { usePreferences } from '@/services/preferences'
 
 function WorkingVisualRow() {
   return (
@@ -101,6 +102,9 @@ export const StreamingMessage = memo(function StreamingMessage({
   areQuestionsSkipped,
   onCopySteeredText,
 }: StreamingMessageProps) {
+  const { data: preferences } = usePreferences()
+  const groupToolCallsAndThinking =
+    preferences?.group_tool_calls_and_thinking ?? true
   const resolvedPlan = useMemo(
     () =>
       resolvePlanContent({
@@ -126,7 +130,11 @@ export const StreamingMessage = memo(function StreamingMessage({
     if (contentBlocks.length === 0) return null
     let timeline: TimelineItem[]
     try {
-      timeline = buildTimeline(contentBlocks, toolCalls)
+      timeline = buildTimeline(
+        contentBlocks,
+        toolCalls,
+        groupToolCallsAndThinking
+      )
     } catch (e) {
       logger.error('Failed to build streaming timeline', {
         sessionId,
@@ -162,7 +170,7 @@ export const StreamingMessage = memo(function StreamingMessage({
       textBlockIndexByText,
       incompleteIndices,
     }
-  }, [contentBlocks, toolCalls, sessionId])
+  }, [contentBlocks, toolCalls, sessionId, groupToolCallsAndThinking])
 
   return (
     <div className="text-foreground/90">

--- a/src/components/chat/ThinkingBlock.tsx
+++ b/src/components/chat/ThinkingBlock.tsx
@@ -23,7 +23,7 @@ export const ThinkingBlock = memo(function ThinkingBlock({
   isStreaming = false,
 }: ThinkingBlockProps) {
   return (
-    <details className="group border border-border/50 rounded-md bg-muted/30">
+    <details className="group min-w-0">
       <summary
         className={cn(
           TOOL_CALL_ROW_CLASS,
@@ -32,10 +32,10 @@ export const ThinkingBlock = memo(function ThinkingBlock({
       >
         <Brain className={cn('h-3.5 w-3.5 shrink-0 text-purple-500')} />
         <span>Thinking...</span>
-        <ChevronRight className="ml-auto h-3.5 w-3.5 shrink-0 transition-transform duration-200 group-open:rotate-90" />
+        <ChevronRight className="h-3.5 w-3.5 shrink-0 transition-transform duration-200 group-open:rotate-90" />
       </summary>
-      <div className="border-t border-border/50 px-3 py-2">
-        <div className="pl-4 border-l-2 border-purple-500/30 text-sm text-muted-foreground">
+      <div className="ml-5 border-l border-purple-500/30 pl-3 py-1.5">
+        <div className="text-sm text-muted-foreground">
           <Markdown streaming={isStreaming} variant="tool-call">
             {thinking}
           </Markdown>

--- a/src/components/chat/ToolCallInline.test.tsx
+++ b/src/components/chat/ToolCallInline.test.tsx
@@ -106,7 +106,13 @@ describe('ToolCallInline', () => {
     )
 
     expect(screen.getByText('Read 20 lines')).toBeInTheDocument()
-    expect(screen.getByText('package.json')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        (_, element) =>
+          element?.tagName === 'CODE' && element.textContent === 'package.json'
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByText('package.json')).toHaveClass('text-amber-400')
     expect(screen.queryByText(/unhandled tool/i)).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button'))
@@ -197,7 +203,12 @@ describe('ToolCallInline', () => {
       )
 
       expect(screen.getByText(tool.label)).toBeInTheDocument()
-      expect(screen.getByText(tool.detail)).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.tagName === 'CODE' && element.textContent === tool.detail
+        )
+      ).toBeInTheDocument()
       expect(screen.queryByText(/unhandled tool/i)).not.toBeInTheDocument()
       unmount()
     }
@@ -224,7 +235,7 @@ describe('ToolCallInline', () => {
 
     fireEvent.click(screen.getByRole('button'))
 
-    expect(screen.getByText('chat-store.ts')).toBeInTheDocument()
+    expect(screen.getAllByText('chat-store.ts')).toHaveLength(2)
     expect(screen.getByText('update')).toBeInTheDocument()
     expect(inlineFileDiffProps.at(-1)).toMatchObject({
       patch: '@@ -1 +1 @@\n-old\n+new',
@@ -251,7 +262,12 @@ describe('ToolCallInline', () => {
 
     fireEvent.click(screen.getByRole('button'))
 
-    expect(screen.getAllByText('legacy.ts')).toHaveLength(2)
+    expect(
+      screen.getByText(
+        (_, element) =>
+          element?.tagName === 'CODE' && element.textContent === 'legacy.ts'
+      )
+    ).toBeInTheDocument()
     expect(container.querySelector('diffs-container')).not.toBeNull()
     expect(screen.queryByText('Output:')).not.toBeInTheDocument()
   })
@@ -318,7 +334,9 @@ describe('normalizeToolCallForDisplay', () => {
     )
 
     expect(screen.getByText('Grep')).toBeInTheDocument()
-    expect(screen.getByText('"needle" in /tmp')).toBeInTheDocument()
+    expect(
+      screen.getByText((_, element) => element?.textContent === '"needle" in /tmp')
+    ).toBeInTheDocument()
     expect(screen.queryByText(/unhandled tool/i)).not.toBeInTheDocument()
   })
 })

--- a/src/components/chat/ToolCallInline.tsx
+++ b/src/components/chat/ToolCallInline.tsx
@@ -41,6 +41,7 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { InlineFileDiff } from './InlineFileDiff'
+import { ShellCommand } from './ShellCommand'
 
 function shouldRenderRawOutput(toolCall: ToolCall): boolean {
   return (
@@ -50,17 +51,103 @@ function shouldRenderRawOutput(toolCall: ToolCall): boolean {
   )
 }
 
-// Single source of truth for tool call row layout. Bump min-h-9/px-2.5 here, all rows update.
-// min-h ensures consistent baseline regardless of inline-content height (pill vs no-pill).
+// Single source of truth for tool call row layout. Tool activity stays visually
+// lightweight until the user expands its details.
 export const TOOL_CALL_ROW_CLASS =
-  'flex min-h-9 w-full items-center gap-1.5 px-2.5 py-1.5 text-xs text-muted-foreground hover:bg-muted/50 select-none min-w-0'
+  'flex min-h-8 w-full items-center gap-1.5 rounded-sm px-1.5 py-1 text-xs text-muted-foreground hover:bg-muted/50 select-none min-w-0'
 
 export const TOOL_CALL_SUB_ROW_CLASS =
   'flex min-h-7 w-full items-center gap-1.5 px-2 py-1 text-xs text-muted-foreground/80 hover:bg-muted/30 select-none min-w-0'
 
 // Detail pill — sits AFTER label, snug to content (no flex-1 stretch).
 export const TOOL_CALL_DETAIL_PILL_CLASS =
-  'min-w-0 max-w-[55%] sm:max-w-full truncate rounded px-1 text-[0.6875rem] font-sans leading-none'
+  'min-w-0 max-w-[55%] sm:max-w-full truncate rounded-sm bg-muted/50 px-1.5 py-0.5 text-[0.6875rem] font-mono leading-none text-muted-foreground/80'
+
+function getFileExtensionColor(extension: string): string {
+  switch (extension.toLowerCase()) {
+    case '.ts':
+    case '.tsx':
+    case '.js':
+    case '.jsx':
+      return 'text-sky-400'
+    case '.rs':
+      return 'text-orange-400'
+    case '.json':
+    case '.yaml':
+    case '.yml':
+    case '.toml':
+      return 'text-amber-400'
+    case '.md':
+    case '.mdx':
+      return 'text-violet-400'
+    case '.css':
+    case '.scss':
+      return 'text-pink-400'
+    case '.html':
+    case '.svg':
+      return 'text-emerald-400'
+    default:
+      return 'text-foreground/90'
+  }
+}
+
+function FileName({ filePath }: { filePath: string }) {
+  const filename = getFilename(filePath)
+  const extensionIndex = filename.lastIndexOf('.')
+  const hasExtension = extensionIndex > 0
+  const extension = hasExtension ? filename.slice(extensionIndex) : ''
+
+  return (
+    <span
+      className={cn('truncate font-medium', getFileExtensionColor(extension))}
+    >
+      {filename}
+    </span>
+  )
+}
+
+function FilePath({ filePath }: { filePath: string }) {
+  const filename = getFilename(filePath)
+  const directory = filePath.slice(0, -filename.length)
+
+  return (
+    <span className="font-mono">
+      <span className="text-muted-foreground/60">{directory}</span>
+      <FileName filePath={filePath} />
+    </span>
+  )
+}
+
+function PathDetail({ path }: { path: string }) {
+  const lastSlash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+  const directory = lastSlash >= 0 ? path.slice(0, lastSlash + 1) : ''
+  const name = lastSlash >= 0 ? path.slice(lastSlash + 1) : path
+
+  return (
+    <>
+      <span className="text-muted-foreground/60">{directory}</span>
+      <span className="font-medium text-emerald-400">{name}</span>
+    </>
+  )
+}
+
+function CommandDetail({ command }: { command: string }) {
+  const [executable, ...arguments_] = command.split(/(\s+)/)
+
+  return (
+    <>
+      <span className="font-medium text-sky-400">{executable}</span>
+      {arguments_.map((part, index) => (
+        <span
+          key={index}
+          className={part.startsWith('-') ? 'text-violet-400' : undefined}
+        >
+          {part}
+        </span>
+      ))}
+    </>
+  )
+}
 
 interface ToolCallInlineProps {
   toolCall: ToolCall
@@ -88,7 +175,7 @@ export function ToolCallInline({
   const [isOpen, setIsOpen] = useState(
     preferences?.expand_tool_calls_by_default ?? false
   )
-  const { icon, label, detail, filePath, expandedContent } =
+  const { icon, label, detail, filePath, expandedContent, shellCommand } =
     getToolDisplay(toolCall)
 
   const handleFileClick = (e: React.MouseEvent) => {
@@ -104,12 +191,7 @@ export function ToolCallInline({
       onOpenChange={setIsOpen}
       className={cn('min-w-0', className)}
     >
-      <div
-        className={cn(
-          'rounded-md border border-border/50 bg-muted/30 min-w-0',
-          isOpen && 'bg-muted/50'
-        )}
-      >
+      <div className="min-w-0">
         <CollapsibleTrigger className={TOOL_CALL_ROW_CLASS}>
           {icon}
           <span className="font-medium shrink-0 flex-none whitespace-nowrap">
@@ -129,27 +211,38 @@ export function ToolCallInline({
                 'inline-flex items-center gap-1 hover:bg-primary/20 hover:text-primary transition-colors cursor-pointer'
               )}
             >
-              <span className="truncate">{detail}</span>
+              <FileName filePath={filePath} />
               <ExternalLink className="h-3 w-3 shrink-0 opacity-60" />
             </code>
           ) : detail ? (
-            <code className={TOOL_CALL_DETAIL_PILL_CLASS}>{detail}</code>
+            <code className={TOOL_CALL_DETAIL_PILL_CLASS}>
+              {filePath ? <FileName filePath={filePath} /> : detail}
+            </code>
           ) : null}
           {isStreaming && isIncomplete ? (
             <Loader2 className="ml-auto h-3 w-3 shrink-0 animate-spin text-muted-foreground/50" />
           ) : (
             <ChevronRight
               className={cn(
-                'ml-auto h-3.5 w-3.5 shrink-0 transition-transform duration-200',
+                'ml-0.5 h-3.5 w-3.5 shrink-0 transition-transform duration-200',
                 isOpen && 'rotate-90'
               )}
             />
           )}
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="border-t border-border/50 px-3 py-2">
+          <div className="ml-5 border-l border-border/40 pl-3 py-1.5">
             <div className="whitespace-pre-wrap text-xs text-muted-foreground">
-              {expandedContent}
+              {shellCommand ? (
+                <>
+                  {expandedContent && (
+                    <div className="mb-2">{expandedContent}</div>
+                  )}
+                  <ShellCommand command={shellCommand} />
+                </>
+              ) : (
+                expandedContent
+              )}
             </div>
             {shouldRenderRawOutput(toolCall) && (
               <>
@@ -457,7 +550,7 @@ function SubToolItem({ toolCall, onFileClick }: SubToolItemProps) {
   const [isOpen, setIsOpen] = useState(
     preferences?.expand_tool_calls_by_default ?? false
   )
-  const { icon, label, detail, filePath, expandedContent } =
+  const { icon, label, detail, filePath, expandedContent, shellCommand } =
     getToolDisplay(toolCall)
 
   const handleFileClick = (e: React.MouseEvent) => {
@@ -491,12 +584,12 @@ function SubToolItem({ toolCall, onFileClick }: SubToolItemProps) {
               }
               className="inline-flex min-w-0 max-w-[55%] sm:max-w-full items-center gap-0.5 truncate rounded px-0.5 text-[0.625rem] font-sans leading-none hover:bg-primary/20 hover:text-primary transition-colors cursor-pointer"
             >
-              <span className="truncate">{detail}</span>
+              <FileName filePath={filePath} />
               <ExternalLink className="h-2.5 w-2.5 shrink-0 opacity-60" />
             </code>
           ) : detail ? (
             <code className="min-w-0 max-w-[55%] sm:max-w-full truncate rounded px-0.5 text-[0.625rem] font-sans leading-none">
-              {detail}
+              {filePath ? <FileName filePath={filePath} /> : detail}
             </code>
           ) : null}
           <ChevronRight
@@ -509,7 +602,16 @@ function SubToolItem({ toolCall, onFileClick }: SubToolItemProps) {
         <CollapsibleContent>
           <div className="border-t border-border/30 px-2 py-1.5">
             <div className="whitespace-pre-wrap text-[0.625rem] text-muted-foreground/70">
-              {expandedContent}
+              {shellCommand ? (
+                <>
+                  {expandedContent && (
+                    <div className="mb-1">{expandedContent}</div>
+                  )}
+                  <ShellCommand command={shellCommand} />
+                </>
+              ) : (
+                expandedContent
+              )}
             </div>
             {shouldRenderRawOutput(toolCall) && (
               <>
@@ -535,6 +637,8 @@ interface ToolDisplay {
   detail?: React.ReactNode
   /** Full file path for file-related tools (Read, Edit, Write) */
   filePath?: string
+  /** Shell command rendered with on-demand syntax highlighting when expanded. */
+  shellCommand?: string
   expandedContent: React.ReactNode
 }
 
@@ -844,8 +948,13 @@ function getToolDisplay(toolCall: ToolCall): ToolDisplay {
         label: lineInfo ? `Read ${lineInfo}` : 'Read',
         detail: filename,
         filePath,
-        expandedContent: filePath
-          ? `Path: ${filePath}${offset ? `\nOffset: ${offset}` : ''}${limit ? `\nLimit: ${limit}` : ''}`
+        expandedContent: filePath ? (
+          <>
+            Path: <FilePath filePath={filePath} />
+            {offset ? `\nOffset: ${offset}` : ''}
+            {limit ? `\nLimit: ${limit}` : ''}
+          </>
+        )
           : 'No file path specified',
       }
     }
@@ -881,8 +990,13 @@ function getToolDisplay(toolCall: ToolCall): ToolDisplay {
         label: 'Write',
         detail: filename,
         filePath,
-        expandedContent: filePath
-          ? `Path: ${filePath}\n\nContent:\n${content ?? '(empty)'}`
+        expandedContent: filePath ? (
+          <>
+            Path: <FilePath filePath={filePath} />
+            {'\n\nContent:\n'}
+            {content ?? '(empty)'}
+          </>
+        )
           : 'No file path specified',
       }
     }
@@ -898,10 +1012,9 @@ function getToolDisplay(toolCall: ToolCall): ToolDisplay {
       return {
         icon: <Terminal className="h-4 w-4 shrink-0" />,
         label: 'Bash',
-        detail: truncatedCommand,
-        expandedContent: description
-          ? `${description}\n\n$ ${command}`
-          : `$ ${command ?? '(no command)'}`,
+        detail: truncatedCommand ? <CommandDetail command={truncatedCommand} /> : undefined,
+        shellCommand: command ?? '(no command)',
+        expandedContent: description ?? '',
       }
     }
 
@@ -913,7 +1026,17 @@ function getToolDisplay(toolCall: ToolCall): ToolDisplay {
         icon: <Search className="h-4 w-4 shrink-0" />,
         label: 'Grep',
         detail: pattern
-          ? `"${pattern}"${path ? ` in ${path}` : ''}`
+          ? (
+              <>
+                <span className="text-amber-400">&quot;{pattern}&quot;</span>
+                {path && (
+                  <>
+                    <span className="text-muted-foreground/60"> in </span>
+                    <PathDetail path={path} />
+                  </>
+                )}
+              </>
+            )
           : undefined,
         expandedContent: `Pattern: ${pattern ?? '(none)'}\nPath: ${path ?? '(cwd)'}\n${glob ? `Glob: ${glob}` : ''}`,
       }

--- a/src/components/chat/tool-call-utils.test.ts
+++ b/src/components/chat/tool-call-utils.test.ts
@@ -370,4 +370,26 @@ describe('buildTimeline with fragmented text deltas', () => {
     expect(timeline[0]).toMatchObject({ text: 'intro-start' })
     expect(timeline[2]).toMatchObject({ text: 'mid-summary' })
   })
+
+  it('keeps consecutive thinking and tool calls separate when grouping is disabled', () => {
+    const tools: ToolCall[] = [
+      { id: 'read-1', name: 'Read', input: {}, output: 'ok' },
+      { id: 'bash-1', name: 'Bash', input: {}, output: 'ok' },
+    ]
+    const blocks: ContentBlock[] = [
+      { type: 'thinking', thinking: 'Inspecting the repository.' },
+      { type: 'tool_use', tool_call_id: 'read-1' },
+      { type: 'thinking', thinking: 'Checking the result.' },
+      { type: 'tool_use', tool_call_id: 'bash-1' },
+    ]
+
+    const timeline = buildTimeline(blocks, tools, false)
+
+    expect(timeline.map(item => item.type)).toEqual([
+      'thinking',
+      'standalone',
+      'thinking',
+      'standalone',
+    ])
+  })
 })

--- a/src/components/chat/tool-call-utils.ts
+++ b/src/components/chat/tool-call-utils.ts
@@ -251,7 +251,8 @@ export function coalesceContentBlocks(blocks: ContentBlock[]): ContentBlock[] {
 
 export function buildTimeline(
   contentBlocks: ContentBlock[],
-  toolCalls: ToolCall[]
+  toolCalls: ToolCall[],
+  groupStackables = true
 ): TimelineItem[] {
   const normalizedBlocks = coalesceContentBlocks(contentBlocks)
   const result: TimelineItem[] = []
@@ -473,8 +474,10 @@ export function buildTimeline(
     }
   }
 
-  // Merge consecutive stackable items (thinking + standalone tools) into groups
-  return mergeConsecutiveStackables(result)
+  // Merge consecutive stackable items (thinking + standalone tools) into groups.
+  // Keeping this optional lets the chat preference show the same activity as
+  // individual, chronological rows without changing the stored message data.
+  return groupStackables ? mergeConsecutiveStackables(result) : result
 }
 
 /**

--- a/src/components/preferences/panes/AppearancePane.tsx
+++ b/src/components/preferences/panes/AppearancePane.tsx
@@ -353,6 +353,21 @@ export const AppearancePane: React.FC = () => {
             </Select>
           </InlineField>
 
+          <InlineField
+            label="Group tool calls and thinking"
+            description="Combine consecutive thinking and tool calls into one collapsible activity block."
+          >
+            <Switch
+              checked={preferences?.group_tool_calls_and_thinking ?? true}
+              onCheckedChange={checked => {
+                patchPreferences.mutate({
+                  group_tool_calls_and_thinking: checked,
+                })
+              }}
+              disabled={patchPreferences.isPending}
+            />
+          </InlineField>
+
           {isClientMacOS && (
             <InlineField
               label="Window transparency"

--- a/src/lib/bash-highlighting.ts
+++ b/src/lib/bash-highlighting.ts
@@ -1,0 +1,25 @@
+import {
+  createBundledHighlighter,
+  createSingletonShorthands,
+} from '@shikijs/core'
+import { createJavaScriptRegexEngine } from '@shikijs/engine-javascript'
+
+const createHighlighter = createBundledHighlighter({
+  langs: {
+    bash: () => import('@shikijs/langs/bash'),
+  },
+  themes: {
+    'vitesse-black': () => import('@shikijs/themes/vitesse-black'),
+    'vitesse-light': () => import('@shikijs/themes/vitesse-light'),
+  },
+  engine: () => createJavaScriptRegexEngine(),
+})
+
+const { codeToTokens } = createSingletonShorthands(createHighlighter)
+
+export async function highlightBash(command: string, isDark: boolean) {
+  return codeToTokens(command, {
+    lang: 'bash',
+    theme: isDark ? 'vitesse-black' : 'vitesse-light',
+  })
+}

--- a/src/services/preferences.test.ts
+++ b/src/services/preferences.test.ts
@@ -103,6 +103,10 @@ describe('model option helpers', () => {
     expect(defaultPreferences.compact_chat_view_enabled).toBe(true)
   })
 
+  it('groups tool calls and thinking by default', () => {
+    expect(defaultPreferences.group_tool_calls_and_thinking).toBe(true)
+  })
+
   it('syncs desktop and mobile zoom by default', () => {
     expect(defaultPreferences.zoom_level).toBe(ZOOM_LEVEL_DEFAULT)
     expect(defaultPreferences.mobile_zoom_level).toBe(ZOOM_LEVEL_DEFAULT)

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1264,6 +1264,7 @@ export interface AppPreferences {
   wsl_distro: string // WSL distro name, e.g. "Ubuntu"
   coderabbit_cli_source?: 'jean' | 'path' // CodeRabbit CLI source: 'jean' (managed) or 'path' (system PATH)
   expand_tool_calls_by_default: boolean // Expand all tool call collapsibles by default
+  group_tool_calls_and_thinking?: boolean // Combine consecutive thinking and tool calls into one activity block
   window_vibrancy: boolean // macOS window vibrancy effect (high GPU cost, default false)
   terminal_background: TerminalBackgroundMode // Override the terminal background independently of the app theme
   terminal_background_custom: string | null // Hex color used when terminal_background === 'custom'
@@ -2187,6 +2188,7 @@ export const defaultPreferences: AppPreferences = {
   wsl_distro: '', // Default: empty
   coderabbit_cli_source: 'jean', // Default: Jean-managed
   expand_tool_calls_by_default: false, // Default: collapsed
+  group_tool_calls_and_thinking: true, // Default: grouped
   window_vibrancy: false, // Default: disabled (high GPU cost)
   terminal_background: 'auto',
   terminal_background_custom: null,


### PR DESCRIPTION
Adds a new setting (Group tool calls and thinking) under Apperance that changes how tools and thinking blocks are rendered. 

Currently (and the new setting when enabled) they are shown combined and grouped like this: 
<img width="1267" height="105" alt="image" src="https://github.com/user-attachments/assets/e3ad18c4-59d2-4572-9c90-7cc284f5035b" />


Disabling this setting de-combines tool calls and thinking blocks so that they are shown as the agent process them, creating a nicer look to the chat that feels more verbose and interactive. This is how that looks: 
<img width="881" height="438" alt="image" src="https://github.com/user-attachments/assets/0a739037-f152-4add-a391-ffac9079d3b3" />

*Note: The "Expand tool calls by default" option does not ungroup them as well, it only expands the inner group.*

I have taken the liberty to also use the included Shiki highlighter so that tool calls to files can look a bit more pretty than just blank - however I have not tuned with the colors much so a later PR to fine tune the colors might be needed. 

This PR does not alter how thinking blocks are presented (currently always shows "Thinking"), something for another PR to touch on.

---

Tested on Windows client and macOS, web & native.