### PR TITLE
feat: Show active terminal badge

### DIFF
--- a/src/components/chat/ChatToolbar.test.tsx
+++ b/src/components/chat/ChatToolbar.test.tsx
@@ -4,13 +4,21 @@ import { render, screen } from '@/test/test-utils'
 import { ChatToolbar } from './ChatToolbar'
 import type { ChatToolbarProps } from './toolbar/types'
 
-vi.mock('@/store/terminal-store', () => ({
-  useTerminalStore: {
-    getState: () => ({
-      toggleModalTerminal: vi.fn(),
-    }),
-  },
-}))
+vi.mock('@/store/terminal-store', () => {
+  const state = {
+    terminals: {},
+    runningTerminals: new Set<string>(),
+    failedTerminals: new Set<string>(),
+    toggleModalTerminal: vi.fn(),
+  }
+  return {
+    isPanelTerminal: () => true,
+    useTerminalStore: Object.assign(
+      (selector: (value: typeof state) => unknown) => selector(state),
+      { getState: () => state }
+    ),
+  }
+})
 
 beforeEach(() => {
   vi.stubGlobal(

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -20,7 +20,6 @@ import {
   Pencil,
   RefreshCw,
   Tag,
-  Terminal,
   Globe,
   Play,
   Plus,
@@ -44,7 +43,7 @@ import { FailedRunsBadge } from '@/components/shared/FailedRunsBadge'
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area'
 import { CloseWorktreeDialog } from './CloseWorktreeDialog'
 import { useChatStore } from '@/store/chat-store'
-import { isPanelTerminal, useTerminalStore } from '@/store/terminal-store'
+import { useTerminalStore } from '@/store/terminal-store'
 import { useBrowserStore } from '@/store/browser-store'
 import { useUIStore } from '@/store/ui-store'
 import {
@@ -78,6 +77,8 @@ import { copyToClipboard } from '@/lib/clipboard'
 import { toast } from 'sonner'
 import { ChatWindow } from './ChatWindow'
 import { ModalTerminalDrawer } from './ModalTerminalDrawer'
+import { TerminalActivityIcon } from './TerminalActivityIcon'
+import { useWorktreeTerminalStatus } from '@/hooks/useWorktreeTerminalStatus'
 import { ModalBrowserDrawer } from '@/components/browser/ModalBrowserDrawer'
 import { OpenInButton } from '@/components/open-in/OpenInButton'
 import { ScriptsButton } from '@/components/open-in/ScriptsButton'
@@ -264,18 +265,8 @@ export function SessionChatModal({
   const hasBottomBrowser =
     isBrowserModalOpen && browserModalDockMode === 'bottom'
   const hasBottomDock = hasBottomTerminal || hasBottomBrowser
-  const hasRunningTerminal = useTerminalStore(state => {
-    const terminals = state.terminals[worktreeId] ?? []
-    return terminals.some(
-      t => isPanelTerminal(t) && state.runningTerminals.has(t.id)
-    )
-  })
-  const hasFailedTerminal = useTerminalStore(state => {
-    const terminals = state.terminals[worktreeId] ?? []
-    return terminals.some(
-      t => isPanelTerminal(t) && !!t.command && state.failedTerminals.has(t.id)
-    )
-  })
+  const { hasActiveTerminal, hasRunningTerminal, hasFailedTerminal } =
+    useWorktreeTerminalStatus(worktreeId)
   const terminalShortcut = formatShortcutDisplay(
     preferences?.keybindings?.toggle_terminal ??
       DEFAULT_KEYBINDINGS.toggle_terminal
@@ -1124,18 +1115,25 @@ export function SessionChatModal({
                         variant="ghost"
                         size="sm"
                         className="h-7 px-2 text-xs"
-                        aria-label="Toggle terminal"
+                        aria-label={
+                          hasActiveTerminal
+                            ? 'Toggle terminal (active)'
+                            : 'Toggle terminal'
+                        }
                         onClick={() => {
                           useTerminalStore
                             .getState()
                             .toggleModalTerminal(worktreeId)
                         }}
                       >
-                        <Terminal className="h-3 w-3" />
+                        <TerminalActivityIcon
+                          active={hasActiveTerminal}
+                          className="h-3 w-3"
+                        />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      Terminal{' '}
+                      {hasActiveTerminal ? 'Terminal active' : 'Terminal'}{' '}
                       <kbd className="ml-1 text-[0.625rem] opacity-60">
                         {terminalShortcut}
                       </kbd>

--- a/src/components/chat/TerminalActivityIcon.test.tsx
+++ b/src/components/chat/TerminalActivityIcon.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@/test/test-utils'
+import { describe, expect, it } from 'vitest'
+import { TerminalActivityIcon } from './TerminalActivityIcon'
+
+describe('TerminalActivityIcon', () => {
+  it('does not render a badge for an inactive terminal', () => {
+    render(<TerminalActivityIcon active={false} className="h-4 w-4" />)
+
+    expect(screen.queryByTestId('terminal-active-badge')).toBeNull()
+  })
+
+  it('renders a live-PTY badge for an active terminal', () => {
+    render(<TerminalActivityIcon active className="h-4 w-4" />)
+
+    expect(screen.getByTestId('terminal-active-badge')).toHaveClass(
+      'bg-emerald-500'
+    )
+  })
+})

--- a/src/components/chat/TerminalActivityIcon.tsx
+++ b/src/components/chat/TerminalActivityIcon.tsx
@@ -1,0 +1,28 @@
+import { Terminal } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface TerminalActivityIconProps {
+  active: boolean
+  className?: string
+}
+
+/** Terminal glyph with a live-PTY badge for compact session controls. */
+export function TerminalActivityIcon({
+  active,
+  className,
+}: TerminalActivityIconProps) {
+  return (
+    <span className="relative inline-flex shrink-0" aria-hidden="true">
+      <Terminal className={className} />
+      {active && (
+        <span
+          data-testid="terminal-active-badge"
+          className={cn(
+            'absolute -right-0.5 -top-0.5 size-1.5 rounded-full',
+            'bg-emerald-500 ring-1 ring-background'
+          )}
+        />
+      )}
+    </span>
+  )
+}

--- a/src/components/chat/toolbar/MobileSettingsMenu.test.tsx
+++ b/src/components/chat/toolbar/MobileSettingsMenu.test.tsx
@@ -4,8 +4,14 @@ import { Zap } from 'lucide-react'
 import { fireEvent, render, screen, within } from '@/test/test-utils'
 import { MobileSettingsMenu } from './MobileSettingsMenu'
 import * as platform from '@/lib/platform'
+import { useTerminalStore } from '@/store/terminal-store'
 
 beforeEach(() => {
+  useTerminalStore.setState({
+    terminals: {},
+    runningTerminals: new Set(),
+    failedTerminals: new Set(),
+  })
   vi.stubGlobal(
     'matchMedia',
     vi.fn().mockImplementation(() => ({
@@ -61,6 +67,23 @@ const baseProps = {
 }
 
 describe('MobileSettingsMenu', () => {
+  it('badges the terminal menu item while a panel PTY is active', async () => {
+    const user = userEvent.setup()
+    const terminalId = useTerminalStore.getState().addTerminal('worktree-1')
+    useTerminalStore.getState().setTerminalRunning(terminalId, true)
+
+    render(<MobileSettingsMenu {...baseProps} worktreeId="worktree-1" />)
+
+    await user.click(screen.getByRole('button', { name: /settings/i }))
+    const terminalItem = screen
+      .getByText('Terminal')
+      .closest('[role="menuitem"]')
+    expect(terminalItem).toHaveTextContent('Terminal active')
+    expect(
+      terminalItem?.querySelector('[data-testid="terminal-active-badge"]')
+    ).not.toBeNull()
+  })
+
   it('aligns the mobile Effort label with the other setting labels', async () => {
     const user = userEvent.setup()
     const originalInnerWidth = window.innerWidth

--- a/src/components/chat/toolbar/MobileSettingsMenu.tsx
+++ b/src/components/chat/toolbar/MobileSettingsMenu.tsx
@@ -19,7 +19,6 @@ import {
   ShieldAlert,
   Sparkles,
   Star,
-  Terminal,
 } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
@@ -84,6 +83,8 @@ import { BackendLabel } from '@/components/ui/backend-label'
 import { useChatStore } from '@/store/chat-store'
 import { useProjectsStore } from '@/store/projects-store'
 import { useTerminalStore } from '@/store/terminal-store'
+import { useWorktreeTerminalStatus } from '@/hooks/useWorktreeTerminalStatus'
+import { TerminalActivityIcon } from '@/components/chat/TerminalActivityIcon'
 import { useUIStore } from '@/store/ui-store'
 import {
   useProjects,
@@ -271,6 +272,7 @@ export function MobileSettingsMenu({
   const [mcpSheetOpen, setMcpSheetOpen] = useState(false)
   const [scriptsSheetOpen, setScriptsSheetOpen] = useState(false)
   const [resumeCommand, setResumeCommand] = useState<string | null>(null)
+  const { hasActiveTerminal } = useWorktreeTerminalStatus(worktreeId ?? '')
   const providerDisplayName = getProviderDisplayName(selectedProvider)
   const { data: worktree } = useWorktree(worktreeId ?? null)
   const { data: projects } = useProjects()
@@ -707,8 +709,12 @@ export function MobileSettingsMenu({
           )}
           {worktreeId && (
             <DropdownMenuItem onSelect={handleToggleTerminal}>
-              <Terminal className="h-4 w-4" />
+              <TerminalActivityIcon
+                active={hasActiveTerminal}
+                className="h-4 w-4"
+              />
               Terminal
+              {hasActiveTerminal && <span className="sr-only"> active</span>}
             </DropdownMenuItem>
           )}
           {resumeCommand && (

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -641,10 +641,6 @@ function WorktreeSectionHeader({
               <span className="text-[9px]">⌘{shortcutNumber}</span>
             </kbd>
           )}
-          <TerminalStatusIndicator
-            worktreeId={worktree.id}
-            iconSize="h-3 w-3"
-          />
           <span className="flex min-w-0 flex-1 flex-col gap-1 font-medium sm:flex-row sm:items-center sm:gap-1.5">
             <span className="flex min-w-0 items-center gap-1.5">
               <span className="min-w-0 flex-1 truncate">
@@ -821,6 +817,11 @@ function WorktreeSectionHeader({
                 {lastActivity}
               </span>
             )}
+            <TerminalStatusIndicator
+              worktreeId={worktree.id}
+              iconSize="h-3 w-3"
+              variant="summary"
+            />
             {onRowClick && (
               <span className="ml-auto hidden text-[11px] opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 sm:inline-flex">
                 Press Enter to open

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -626,9 +626,6 @@ export function WorktreeItem({
             className="h-2 w-2"
           />
 
-          {/* Terminal running/failed indicator */}
-          <TerminalStatusIndicator worktreeId={worktree.id} />
-
           {/* Workspace name - editable on double-click */}
           {isEditing ? (
             <input
@@ -676,6 +673,9 @@ export function WorktreeItem({
               })()}
             </span>
           )}
+
+          {/* Worktree-level terminal activity */}
+          <TerminalStatusIndicator worktreeId={worktree.id} />
 
           {/* Pull badge - shown when behind remote */}
           {behindCount > 0 && (

--- a/src/hooks/useWorktreeTerminalStatus.test.tsx
+++ b/src/hooks/useWorktreeTerminalStatus.test.tsx
@@ -38,7 +38,9 @@ describe('useWorktreeTerminalStatus', () => {
     })
 
     await waitFor(() => expect(result.current.hasActiveTerminal).toBe(true))
+    expect(result.current.activeTerminalCount).toBe(1)
     expect(result.current.hasRunningTerminal).toBe(false)
+    expect(result.current.tooltipLines).toContain('Shell')
   })
 
   it('reports a Jean-launched script as active and running', async () => {
@@ -104,9 +106,49 @@ describe('useWorktreeTerminalStatus', () => {
       <TerminalStatusIndicator worktreeId="worktree-1" />
     )
 
-    expect(container.querySelector('svg.lucide-play')).toHaveClass(
+    expect(screen.getByLabelText('1 active terminal')).toBeInTheDocument()
+    expect(container.querySelector('svg.lucide-terminal')).toHaveClass(
       'text-amber-500'
     )
     expect(screen.queryByText('bun run dev')).toBeNull()
+  })
+
+  it('shows a compact count when multiple worktree terminals are active', () => {
+    const firstId = useTerminalStore.getState().addTerminal('worktree-1')
+    const secondId = useTerminalStore.getState().addTerminal('worktree-1')
+    useTerminalStore.getState().setTerminalRunning(firstId, true)
+    useTerminalStore.getState().setTerminalRunning(secondId, true)
+
+    render(<TerminalStatusIndicator worktreeId="worktree-1" />)
+
+    expect(screen.getByLabelText('2 active terminals')).toHaveTextContent('2')
+  })
+
+  it('renders a readable terminal summary for the worktree viewer', () => {
+    const terminalId = useTerminalStore.getState().addTerminal('worktree-1')
+    useTerminalStore.getState().setTerminalRunning(terminalId, true)
+
+    render(
+      <TerminalStatusIndicator worktreeId="worktree-1" variant="summary" />
+    )
+
+    expect(screen.getByText('1 terminal running')).toBeInTheDocument()
+  })
+
+  it('includes failures alongside running terminals in the worktree summary', () => {
+    const runningId = useTerminalStore.getState().addTerminal('worktree-1')
+    const failedId = useTerminalStore
+      .getState()
+      .addTerminal('worktree-1', 'bun run dev')
+    useTerminalStore.getState().setTerminalRunning(runningId, true)
+    useTerminalStore.getState().setTerminalFailed(failedId, true)
+
+    render(
+      <TerminalStatusIndicator worktreeId="worktree-1" variant="summary" />
+    )
+
+    expect(
+      screen.getByText('1 terminal running · 1 failed')
+    ).toBeInTheDocument()
   })
 })

--- a/src/hooks/useWorktreeTerminalStatus.test.tsx
+++ b/src/hooks/useWorktreeTerminalStatus.test.tsx
@@ -1,0 +1,112 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { render, screen } from '@/test/test-utils'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { PropsWithChildren } from 'react'
+import { useTerminalStore } from '@/store/terminal-store'
+import {
+  TerminalStatusIndicator,
+  useWorktreeTerminalStatus,
+} from './useWorktreeTerminalStatus'
+
+function wrapper({ children }: PropsWithChildren) {
+  return (
+    <QueryClientProvider client={new QueryClient()}>
+      {children}
+    </QueryClientProvider>
+  )
+}
+
+describe('useWorktreeTerminalStatus', () => {
+  beforeEach(() => {
+    useTerminalStore.setState({
+      terminals: {},
+      runningTerminals: new Set(),
+      failedTerminals: new Set(),
+    })
+  })
+
+  it('reports an active generic panel shell without classifying it as a script', async () => {
+    const terminalId = useTerminalStore.getState().addTerminal('worktree-1')
+    const { result } = renderHook(
+      () => useWorktreeTerminalStatus('worktree-1'),
+      { wrapper }
+    )
+
+    act(() => {
+      useTerminalStore.getState().setTerminalRunning(terminalId, true)
+    })
+
+    await waitFor(() => expect(result.current.hasActiveTerminal).toBe(true))
+    expect(result.current.hasRunningTerminal).toBe(false)
+  })
+
+  it('reports a Jean-launched script as active and running', async () => {
+    const terminalId = useTerminalStore
+      .getState()
+      .addTerminal('worktree-1', 'bun run dev')
+    const { result } = renderHook(
+      () => useWorktreeTerminalStatus('worktree-1'),
+      { wrapper }
+    )
+
+    act(() => {
+      useTerminalStore.getState().setTerminalRunning(terminalId, true)
+    })
+
+    await waitFor(() => expect(result.current.hasActiveTerminal).toBe(true))
+    expect(result.current.hasRunningTerminal).toBe(true)
+    expect(result.current.tooltipLines).toContain('bun run dev')
+  })
+
+  it('does not count a full-screen session terminal as panel activity', () => {
+    const terminalId = useTerminalStore
+      .getState()
+      .addTerminal('worktree-1', 'codex', 'Codex', {
+        kind: 'session',
+        activate: false,
+        openPanel: false,
+      })
+    useTerminalStore.getState().setTerminalRunning(terminalId, true)
+
+    const { result } = renderHook(
+      () => useWorktreeTerminalStatus('worktree-1'),
+      { wrapper }
+    )
+
+    expect(result.current.hasActiveTerminal).toBe(false)
+    expect(result.current.hasRunningTerminal).toBe(false)
+  })
+
+  it('reports failed run commands for sidebar and canvas indicators', () => {
+    const terminalId = useTerminalStore
+      .getState()
+      .addTerminal('worktree-1', 'bun run dev')
+    useTerminalStore.getState().setTerminalFailed(terminalId, true)
+
+    const { result } = renderHook(
+      () => useWorktreeTerminalStatus('worktree-1'),
+      { wrapper }
+    )
+
+    expect(result.current.hasActiveTerminal).toBe(false)
+    expect(result.current.hasFailedTerminal).toBe(true)
+    expect(result.current.tooltipLines).toContain('bun run dev (crashed)')
+  })
+
+  it('renders the shared sidepanel/canvas script indicator', () => {
+    const terminalId = useTerminalStore
+      .getState()
+      .addTerminal('worktree-1', 'bun run dev')
+    useTerminalStore.getState().setTerminalRunning(terminalId, true)
+
+    const { container } = render(
+      <TerminalStatusIndicator worktreeId="worktree-1" />
+    )
+
+    expect(container.querySelector('svg.lucide-play')).toHaveClass(
+      'text-amber-500'
+    )
+    expect(screen.queryByText('bun run dev')).toBeNull()
+  })
+})

--- a/src/hooks/useWorktreeTerminalStatus.tsx
+++ b/src/hooks/useWorktreeTerminalStatus.tsx
@@ -15,6 +15,12 @@ import {
  * Tracks running/failed run-script terminals and discovered listening ports.
  */
 export function useWorktreeTerminalStatus(worktreeId: string) {
+  const hasActiveTerminal = useTerminalStore(state => {
+    const terminals = state.terminals[worktreeId] ?? []
+    return terminals.some(
+      t => isPanelTerminal(t) && state.runningTerminals.has(t.id)
+    )
+  })
   const hasRunningTerminal = useTerminalStore(state => {
     const terminals = state.terminals[worktreeId] ?? []
     return terminals.some(
@@ -58,6 +64,7 @@ export function useWorktreeTerminalStatus(worktreeId: string) {
   }, [showTerminalIndicator, worktreeId, listeningPorts])
 
   return {
+    hasActiveTerminal,
     hasRunningTerminal,
     hasFailedTerminal,
     showTerminalIndicator,

--- a/src/hooks/useWorktreeTerminalStatus.tsx
+++ b/src/hooks/useWorktreeTerminalStatus.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Play } from 'lucide-react'
+import { Terminal } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { isPanelTerminal, useTerminalStore } from '@/store/terminal-store'
 import { useTerminalListeningPorts } from '@/services/projects'
@@ -15,11 +15,11 @@ import {
  * Tracks running/failed run-script terminals and discovered listening ports.
  */
 export function useWorktreeTerminalStatus(worktreeId: string) {
-  const hasActiveTerminal = useTerminalStore(state => {
+  const activeTerminalCount = useTerminalStore(state => {
     const terminals = state.terminals[worktreeId] ?? []
-    return terminals.some(
+    return terminals.filter(
       t => isPanelTerminal(t) && state.runningTerminals.has(t.id)
-    )
+    ).length
   })
   const hasRunningTerminal = useTerminalStore(state => {
     const terminals = state.terminals[worktreeId] ?? []
@@ -33,11 +33,19 @@ export function useWorktreeTerminalStatus(worktreeId: string) {
       t => isPanelTerminal(t) && !!t.command && state.failedTerminals.has(t.id)
     )
   })
-  const showTerminalIndicator = hasRunningTerminal || hasFailedTerminal
+  const failedTerminalCount = useTerminalStore(state => {
+    const terminals = state.terminals[worktreeId] ?? []
+    return terminals.filter(
+      t => isPanelTerminal(t) && !!t.command && state.failedTerminals.has(t.id)
+    ).length
+  })
+  const hasActiveTerminal = activeTerminalCount > 0
+  const showTerminalIndicator = hasActiveTerminal || hasFailedTerminal
 
-  // Poll for listening ports only when terminals are running
+  // Poll while any PTY is active so manually started dev servers can also
+  // surface their listening ports in the worktree tooltip.
   const { data: listeningPorts = [] } =
-    useTerminalListeningPorts(hasRunningTerminal)
+    useTerminalListeningPorts(hasActiveTerminal)
 
   // Build tooltip lines on demand via getState() — no subscription needed
   // for tooltip content (stale-by-one-render is fine for hover-only UI)
@@ -49,58 +57,95 @@ export function useWorktreeTerminalStatus(worktreeId: string) {
     const lines: string[] = []
     for (const t of worktreeTerminals) {
       if (!isPanelTerminal(t)) continue
-      if (!t.command) continue
       if (runningTerminals.has(t.id)) {
         const ports = (listeningPorts as TerminalPortInfo[])
           .filter(p => p.terminalId === t.id)
           .map(p => `:${p.port}`)
         const portSuffix = ports.length > 0 ? ` (${ports.join(', ')})` : ''
-        lines.push(`${t.command}${portSuffix}`)
-      } else if (failedTerminals.has(t.id)) {
+        lines.push(`${t.command ?? t.label}${portSuffix}`)
+      } else if (t.command && failedTerminals.has(t.id)) {
         lines.push(`${t.command} (crashed)`)
       }
     }
     return lines
-  }, [showTerminalIndicator, worktreeId, listeningPorts])
+  }, [
+    showTerminalIndicator,
+    worktreeId,
+    listeningPorts,
+    activeTerminalCount,
+    failedTerminalCount,
+  ])
 
   return {
     hasActiveTerminal,
+    activeTerminalCount,
     hasRunningTerminal,
     hasFailedTerminal,
+    failedTerminalCount,
     showTerminalIndicator,
     tooltipLines,
   }
 }
 
 /**
- * Terminal status indicator with tooltip showing running/failed status and listening ports.
- * Running: yellow square-spinner (original style). Failed: red square.
- * Returns null when no run-script terminals are active or failed.
+ * Compact worktree-level terminal status for the sidebar and canvas.
+ * Green: active shell. Amber: active known script. Red: failed script.
  */
 export function TerminalStatusIndicator({
   worktreeId,
   iconSize = 'h-2.5 w-2.5',
+  variant = 'compact',
 }: {
   worktreeId: string
   iconSize?: string
+  variant?: 'compact' | 'summary'
 }) {
-  const { hasFailedTerminal, showTerminalIndicator, tooltipLines } =
-    useWorktreeTerminalStatus(worktreeId)
+  const {
+    activeTerminalCount,
+    hasRunningTerminal,
+    hasFailedTerminal,
+    failedTerminalCount,
+    showTerminalIndicator,
+    tooltipLines,
+  } = useWorktreeTerminalStatus(worktreeId)
 
   if (!showTerminalIndicator || !tooltipLines) return null
+
+  const statusColor = hasFailedTerminal
+    ? 'text-red-500'
+    : hasRunningTerminal
+      ? 'text-amber-500 dark:text-yellow-400'
+      : 'text-emerald-500'
+  const ariaLabel =
+    activeTerminalCount > 0
+      ? `${activeTerminalCount} active terminal${activeTerminalCount === 1 ? '' : 's'}${failedTerminalCount > 0 ? `, ${failedTerminalCount} failed` : ''}`
+      : `${failedTerminalCount} failed terminal${failedTerminalCount === 1 ? '' : 's'}`
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Play
+        <span
           className={cn(
-            'shrink-0 fill-none',
-            iconSize,
-            hasFailedTerminal
-              ? 'text-red-500'
-              : 'text-amber-500 dark:text-yellow-400 animate-icon-glow'
+            'inline-flex shrink-0 items-center text-muted-foreground',
+            variant === 'summary' ? 'gap-1 rounded px-2 py-0.5' : 'h-4 gap-0.5'
           )}
-        />
+          aria-label={ariaLabel}
+        >
+          <Terminal className={cn('shrink-0', iconSize, statusColor)} />
+          {variant === 'summary' ? (
+            <span>
+              {activeTerminalCount > 0
+                ? `${activeTerminalCount} terminal${activeTerminalCount === 1 ? '' : 's'} running${failedTerminalCount > 0 ? ` · ${failedTerminalCount} failed` : ''}`
+                : `${failedTerminalCount} terminal${failedTerminalCount === 1 ? '' : 's'} failed`}
+            </span>
+          ) : (
+            activeTerminalCount > 1 && (
+              <span className="text-[9px] leading-none tabular-nums">
+                {activeTerminalCount}
+              </span>
+            )
+          )}
+        </span>
       </TooltipTrigger>
       <TooltipContent>
         <div className="flex flex-col gap-0.5">


### PR DESCRIPTION
Adds a small badge on the terminal button when a terminal is open, as otherwise you have no other indicator that a terminal is still running in a worktree. 

<img width="154" height="65" alt="image" src="https://github.com/user-attachments/assets/b12de673-ce02-4488-8614-81e7d769af1b" />
<img width="171" height="65" alt="image" src="https://github.com/user-attachments/assets/ee288a99-7d61-4e6e-ab1e-c65a7210c1ba" />

Also adds an indicator on the worktree sidebar + worktree browser
<img width="1032" height="347" alt="image" src="https://github.com/user-attachments/assets/da4c67f9-2c61-4ec7-88de-d43b23de229e" />


---

The related terminal-store test was also updated: `MobileSettingsMenu` now accesses it through the reactive `useTerminalStore(selector)` hook. The mock still supports `getState()`, preserving existing test behavior while covering the new activity indicator.