### PR TITLE
fix(opencode): refresh model list in picker

### DIFF
--- a/jean-core/src/http_server/dispatch.rs
+++ b/jean-core/src/http_server/dispatch.rs
@@ -2539,6 +2539,10 @@ pub async fn dispatch_command(
             let result = crate::opencode_cli::list_opencode_models(app.clone()).await?;
             to_value(result)
         }
+        "refresh_opencode_models" => {
+            let result = crate::opencode_cli::refresh_opencode_models(app.clone()).await?;
+            to_value(result)
+        }
         "check_gh_cli_installed" => {
             let result = crate::gh_cli::check_gh_cli_installed(app.clone()).await?;
             to_value(result)

--- a/jean-core/src/opencode_cli/commands.rs
+++ b/jean-core/src/opencode_cli/commands.rs
@@ -78,8 +78,27 @@ enum ArchiveFormat {
 
 /// List available OpenCode models by refreshing from the OpenCode CLI cache source.
 pub async fn list_opencode_models(app: AppHandle) -> Result<Vec<String>, String> {
+    let binary_str = checked_opencode_binary(&app)?;
+
+    match run_opencode_models_command(&binary_str, true) {
+        Ok(models) => Ok(models),
+        Err(refresh_error) => run_opencode_models_command(&binary_str, false).map_err(|cached_error| {
+            format!(
+                "OpenCode models refresh failed: {refresh_error}; cached model listing failed: {cached_error}"
+            )
+        }),
+    }
+}
+
+/// Force-refresh available OpenCode models without falling back to cached output.
+pub async fn refresh_opencode_models(app: AppHandle) -> Result<Vec<String>, String> {
+    let binary_str = checked_opencode_binary(&app)?;
+    run_opencode_models_command(&binary_str, true)
+}
+
+fn checked_opencode_binary(app: &AppHandle) -> Result<String, String> {
     let wsl = crate::platform::get_wsl_config();
-    let binary_path = resolve_cli_binary(&app);
+    let binary_path = resolve_cli_binary(app);
     let binary_str = binary_path.to_string_lossy().to_string();
     if !wsl.enabled && !binary_path.exists() {
         return Err(format!(
@@ -98,14 +117,7 @@ pub async fn list_opencode_models(app: AppHandle) -> Result<Vec<String>, String>
         }
     }
 
-    match run_opencode_models_command(&binary_str, true) {
-        Ok(models) => Ok(models),
-        Err(refresh_error) => run_opencode_models_command(&binary_str, false).map_err(|cached_error| {
-            format!(
-                "OpenCode models refresh failed: {refresh_error}; cached model listing failed: {cached_error}"
-            )
-        }),
-    }
+    Ok(binary_str)
 }
 
 fn opencode_models_args(refresh: bool) -> Vec<&'static str> {

--- a/src/components/chat/toolbar/BackendModelPickerContent.test.tsx
+++ b/src/components/chat/toolbar/BackendModelPickerContent.test.tsx
@@ -20,9 +20,15 @@ vi.stubGlobal('ResizeObserver', ResizeObserverMock)
 HTMLCanvasElement.prototype.getContext = vi.fn(() => null)
 Element.prototype.scrollIntoView = vi.fn()
 
+const refreshOpencodeModelsMutateAsync = vi.fn()
+
 vi.mock('@/services/opencode-cli', () => ({
   useAvailableOpencodeModels: () => ({
     data: ['openai/gpt-5.4', 'groq/compound-mini'],
+  }),
+  useRefreshOpencodeModels: () => ({
+    mutateAsync: refreshOpencodeModelsMutateAsync,
+    isPending: false,
   }),
 }))
 
@@ -60,6 +66,8 @@ beforeEach(() => {
   mockFastModeModels = []
   mockCursorModels = [{ id: 'auto', label: 'Auto' }]
   patchPreferencesMutate.mockClear()
+  refreshOpencodeModelsMutateAsync.mockReset()
+  refreshOpencodeModelsMutateAsync.mockResolvedValue(['openai/gpt-5.4'])
   vi.stubGlobal(
     'matchMedia',
     vi.fn().mockImplementation(() => ({
@@ -99,6 +107,52 @@ describe('BackendModelPickerContent', () => {
     expect(
       screen.getByRole('button', { name: /refresh model list/i })
     ).toBeInTheDocument()
+  })
+
+  it('shows a manual refresh button for OpenCode CLI model lists', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <BackendModelPickerContent
+        open
+        selectedBackend="opencode"
+        selectedModel="openai/gpt-5.4"
+        selectedProvider={null}
+        installedBackends={['claude', 'codex', 'opencode']}
+        customCliProfiles={[]}
+        onModelChange={vi.fn()}
+        onBackendModelChange={vi.fn()}
+        onRequestClose={vi.fn()}
+      />
+    )
+
+    const refreshButton = screen.getByRole('button', {
+      name: /refresh model list/i,
+    })
+    expect(refreshButton).toBeInTheDocument()
+
+    await user.click(refreshButton)
+    expect(refreshOpencodeModelsMutateAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not show a refresh button for Cursor model lists', () => {
+    render(
+      <BackendModelPickerContent
+        open
+        selectedBackend="cursor"
+        selectedModel="cursor/auto"
+        selectedProvider={null}
+        installedBackends={['cursor']}
+        customCliProfiles={[]}
+        onModelChange={vi.fn()}
+        onBackendModelChange={vi.fn()}
+        onRequestClose={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.queryByRole('button', { name: /refresh model list/i })
+    ).not.toBeInTheDocument()
   })
   it('keeps Claude 1M variants plus standard models', () => {
     render(

--- a/src/components/chat/toolbar/BackendModelPickerContent.tsx
+++ b/src/components/chat/toolbar/BackendModelPickerContent.tsx
@@ -16,7 +16,10 @@ import { Kbd } from '@/components/ui/kbd'
 import { toast } from 'sonner'
 import type { CliBackend, CustomCliProfile } from '@/types/preferences'
 import { usePatchPreferences, usePreferences } from '@/services/preferences'
-import { useAvailableOpencodeModels } from '@/services/opencode-cli'
+import {
+  useAvailableOpencodeModels,
+  useRefreshOpencodeModels,
+} from '@/services/opencode-cli'
 import { useAvailableCursorModels } from '@/services/cursor-cli'
 import { useAvailablePiModels } from '@/services/pi-cli'
 import { useAvailableCommandCodeModels } from '@/services/commandcode-cli'
@@ -95,6 +98,7 @@ export function BackendModelPickerContent({
   const { data: prefs } = usePreferences()
   const { data: modelCatalog } = useModelCatalog()
   const refreshModelCatalog = useRefreshModelCatalog()
+  const refreshOpencodeModels = useRefreshOpencodeModels()
   const patchPreferences = usePatchPreferences()
   const favoriteModels = useMemo(
     () => prefs?.favorite_models ?? [],
@@ -382,16 +386,20 @@ export function BackendModelPickerContent({
     [isLocked, selectedBackend]
   )
 
-  const handleRefreshModelCatalog = useCallback(async () => {
+  const handleRefreshModels = useCallback(async () => {
     const toastId = toast.loading('Refreshing model list...')
 
     try {
-      await refreshModelCatalog.mutateAsync()
+      if (activeBackend === 'opencode') {
+        await refreshOpencodeModels.mutateAsync()
+      } else {
+        await refreshModelCatalog.mutateAsync()
+      }
       toast.success('Model list refreshed', { id: toastId })
     } catch (error) {
       toast.error(`Failed to refresh model list: ${error}`, { id: toastId })
     }
-  }, [refreshModelCatalog])
+  }, [activeBackend, refreshModelCatalog, refreshOpencodeModels])
 
   const handleUseHighlightedFastMode = useCallback(() => {
     if (!highlightedOption) return false
@@ -464,8 +472,15 @@ export function BackendModelPickerContent({
     searchPlaceholder ??
     `Search ${getBackendPlainLabel(activeBackend)} models...`
 
-  const canRefreshModelCatalog =
-    activeBackend === 'claude' || activeBackend === 'codex'
+  // Claude/Codex use the CDN model catalog; OpenCode refreshes via CLI.
+  const canRefreshModels =
+    activeBackend === 'claude' ||
+    activeBackend === 'codex' ||
+    activeBackend === 'opencode'
+  const isRefreshingModels =
+    activeBackend === 'opencode'
+      ? refreshOpencodeModels.isPending
+      : refreshModelCatalog.isPending
 
   const sidebar = showSidebar ? (
     <SidebarBackends
@@ -504,22 +519,22 @@ export function BackendModelPickerContent({
               placeholder={placeholder}
               className="h-9 text-base md:text-sm"
             />
-            {canRefreshModelCatalog && (
+            {canRefreshModels && (
               <button
                 type="button"
                 aria-label="Refresh model list"
                 className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-input text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
-                disabled={refreshModelCatalog.isPending}
+                disabled={isRefreshingModels}
                 onClick={event => {
                   event.preventDefault()
                   event.stopPropagation()
-                  void handleRefreshModelCatalog()
+                  void handleRefreshModels()
                 }}
               >
                 <RefreshCw
                   className={cn(
                     'h-4 w-4',
-                    refreshModelCatalog.isPending && 'animate-spin'
+                    isRefreshingModels && 'animate-spin'
                   )}
                 />
               </button>

--- a/src/components/chat/toolbar/DesktopBackendModelPicker.test.tsx
+++ b/src/components/chat/toolbar/DesktopBackendModelPicker.test.tsx
@@ -46,6 +46,10 @@ vi.mock('@/services/opencode-cli', () => ({
     data: modelMocks.opencodeModels,
     isError: modelMocks.opencodeModelsError,
   }),
+  useRefreshOpencodeModels: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
 }))
 
 vi.mock('@/services/cursor-cli', () => ({

--- a/src/components/chat/toolbar/MobileBackendModelPickerSheet.test.tsx
+++ b/src/components/chat/toolbar/MobileBackendModelPickerSheet.test.tsx
@@ -4,6 +4,10 @@ import { MobileBackendModelPickerSheet } from './MobileBackendModelPickerSheet'
 
 vi.mock('@/services/opencode-cli', () => ({
   useAvailableOpencodeModels: () => ({ data: [] }),
+  useRefreshOpencodeModels: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
 }))
 vi.mock('@/services/cursor-cli', () => ({
   useAvailableCursorModels: () => ({ data: [] }),

--- a/src/services/opencode-cli.test.ts
+++ b/src/services/opencode-cli.test.ts
@@ -1,0 +1,44 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useRefreshOpencodeModels } from './opencode-cli'
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }))
+
+vi.mock('@/lib/transport', () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+  listen: vi.fn(),
+}))
+
+vi.mock('@/lib/environment', () => ({
+  hasBackendTransport: () => true,
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}))
+
+describe('OpenCode model refresh', () => {
+  beforeEach(() => {
+    invokeMock.mockReset()
+  })
+
+  it('uses the strict refresh command so refresh failures are propagated', async () => {
+    invokeMock.mockRejectedValue(new Error('refresh failed'))
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    })
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children)
+
+    const { result } = renderHook(() => useRefreshOpencodeModels(), { wrapper })
+
+    await expect(
+      act(async () => await result.current.mutateAsync())
+    ).rejects.toThrow('refresh failed')
+    expect(invokeMock).toHaveBeenCalledWith('refresh_opencode_models')
+  })
+})

--- a/src/services/opencode-cli.ts
+++ b/src/services/opencode-cli.ts
@@ -166,6 +166,29 @@ export function useAvailableOpencodeModels(options?: { enabled?: boolean }) {
   })
 }
 
+/**
+ * Force-refresh OpenCode models from the CLI (`opencode models --refresh`).
+ * Updates the shared models query cache on success.
+ */
+export function useRefreshOpencodeModels() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (): Promise<string[]> => {
+      if (!isTauri()) return []
+      try {
+        return await invoke<string[]>('refresh_opencode_models')
+      } catch (error) {
+        logger.error('Failed to refresh OpenCode models', { error })
+        throw error
+      }
+    },
+    onSuccess: models => {
+      queryClient.setQueryData(opencodeCliQueryKeys.models(), models)
+    },
+  })
+}
+
 export function useInstallOpencodeCli() {
   const queryClient = useQueryClient()
   return useMutation({


### PR DESCRIPTION
## Summary

- Fixes the OpenCode model picker so users can manually refresh the model list, matching Claude/Codex behavior
- Adds a `refresh_opencode_models` command that force-refreshes via `opencode models --refresh` without falling back to stale cache
- Wires the refresh button for the OpenCode backend and updates the shared models query cache on success

## Related

fixes #525

---

Fixes #525