### PR TITLE
fix(worktrees): keep pending rows during slow create

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,9 @@ import { isNativeApp } from '@/lib/environment'
 import { setServerPlatform } from '@/lib/platform'
 import { projectsQueryKeys } from '@/services/projects'
 import { chatQueryKeys } from '@/services/chat'
+import { mergeWorktreesPreservingOptimistic } from '@/lib/worktree-list-cache'
 import type { Session, WorktreeSessions } from '@/types/chat'
+import type { Worktree } from '@/types/projects'
 import { initializeCommandSystem } from './lib/commands'
 import { logger } from './lib/logger'
 import { toast } from 'sonner'
@@ -282,14 +284,20 @@ function App() {
       if (data.projects) {
         queryClient.setQueryData(projectsQueryKeys.list(), data.projects)
       }
-      // Seed worktrees for each project
+      // Seed worktrees for each project (preserve in-flight pending/deleting)
       if (data.worktreesByProject) {
         for (const [projectId, worktrees] of Object.entries(
           data.worktreesByProject
         )) {
+          const previous = queryClient.getQueryData<Worktree[]>(
+            projectsQueryKeys.worktrees(projectId)
+          )
           queryClient.setQueryData(
             projectsQueryKeys.worktrees(projectId),
-            worktrees
+            mergeWorktreesPreservingOptimistic(
+              worktrees as Worktree[],
+              previous
+            )
           )
         }
       }

--- a/src/lib/worktree-list-cache.test.ts
+++ b/src/lib/worktree-list-cache.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import {
+  mergeWorktreesPreservingOptimistic,
+  removePendingWorktree,
+} from './worktree-list-cache'
+import type { Worktree } from '@/types/projects'
+
+function makeWorktree(
+  overrides: Partial<Worktree> & Pick<Worktree, 'id'>
+): Worktree {
+  return {
+    project_id: 'proj-1',
+    name: overrides.name ?? overrides.id,
+    path: `/tmp/${overrides.id}`,
+    branch: overrides.branch ?? overrides.id,
+    created_at: 1,
+    order: 0,
+    session_type: 'worktree',
+    ...overrides,
+  }
+}
+
+describe('mergeWorktreesPreservingOptimistic', () => {
+  it('returns server list when there is no previous cache', () => {
+    const server = [makeWorktree({ id: 'a' })]
+    expect(mergeWorktreesPreservingOptimistic(server, undefined)).toEqual(
+      server
+    )
+    expect(mergeWorktreesPreservingOptimistic(server, [])).toEqual(server)
+  })
+
+  it('preserves pending worktrees missing from the server response', () => {
+    const pending = makeWorktree({ id: 'pending-1', status: 'pending' })
+    const ready = makeWorktree({ id: 'ready-1', status: 'ready' })
+    const server = [ready]
+
+    const merged = mergeWorktreesPreservingOptimistic(server, [pending, ready])
+
+    expect(merged.map(w => w.id)).toEqual(['pending-1', 'ready-1'])
+    expect(merged[0]?.status).toBe('pending')
+  })
+
+  it('drops pending once the server includes the same id', () => {
+    const pending = makeWorktree({ id: 'wt-1', status: 'pending', name: 'old' })
+    const serverReady = makeWorktree({
+      id: 'wt-1',
+      name: 'new-name',
+      branch: 'new-name',
+    })
+
+    const merged = mergeWorktreesPreservingOptimistic([serverReady], [pending])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0]?.id).toBe('wt-1')
+    expect(merged[0]?.name).toBe('new-name')
+    expect(merged[0]?.status).toBeUndefined()
+  })
+
+  it('clears deleting status on server-backed rows', () => {
+    const deleting = makeWorktree({ id: 'wt-1', status: 'deleting' })
+    const server = [makeWorktree({ id: 'wt-1', name: 'from-server' })]
+
+    const merged = mergeWorktreesPreservingOptimistic(server, [deleting])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0]?.status).toBeUndefined()
+    expect(merged[0]?.name).toBe('from-server')
+  })
+
+  it('does not keep non-optimistic rows that disappeared from the server', () => {
+    const previous = [
+      makeWorktree({ id: 'gone', status: 'ready' }),
+      makeWorktree({ id: 'pending', status: 'pending' }),
+    ]
+    const server = [makeWorktree({ id: 'kept' })]
+
+    const merged = mergeWorktreesPreservingOptimistic(server, previous)
+
+    expect(merged.map(w => w.id)).toEqual(['pending', 'kept'])
+  })
+})
+
+describe('removePendingWorktree', () => {
+  it('removes only the exhausted pending row', () => {
+    const exhausted = makeWorktree({ id: 'exhausted', status: 'pending' })
+    const otherPending = makeWorktree({ id: 'other', status: 'pending' })
+    const ready = makeWorktree({ id: 'ready', status: 'ready' })
+
+    expect(
+      removePendingWorktree([exhausted, otherPending, ready], 'exhausted')
+    ).toEqual([otherPending, ready])
+  })
+
+  it('does not remove a server-reconciled row', () => {
+    const ready = makeWorktree({ id: 'ready', status: 'ready' })
+
+    expect(removePendingWorktree([ready], 'ready')).toEqual([ready])
+  })
+})

--- a/src/lib/worktree-list-cache.ts
+++ b/src/lib/worktree-list-cache.ts
@@ -1,0 +1,38 @@
+import type { Worktree } from '@/types/projects'
+
+/**
+ * Merge a server `list_worktrees` response with client-only optimistic entries.
+ *
+ * Pending worktrees are not persisted until git creation finishes, so any
+ * refetch that replaces the query cache would otherwise remove them from the
+ * sidebar while the "Setting up worktree..." toast is still visible (#528).
+ *
+ * Server-backed rows remain authoritative so a missed optimistic-state event
+ * cannot leave them stuck in a transient status.
+ */
+export function mergeWorktreesPreservingOptimistic(
+  serverWorktrees: Worktree[],
+  previous: Worktree[] | undefined
+): Worktree[] {
+  if (!previous?.length) return serverWorktrees
+
+  const serverIds = new Set(serverWorktrees.map(w => w.id))
+
+  const pendingOnly = previous.filter(
+    w => w.status === 'pending' && !serverIds.has(w.id)
+  )
+
+  if (pendingOnly.length === 0) return serverWorktrees
+
+  // Keep creating rows visible (sidebar/canvas show pending first).
+  return [...pendingOnly, ...serverWorktrees]
+}
+
+export function removePendingWorktree(
+  worktrees: Worktree[] | undefined,
+  worktreeId: string
+): Worktree[] {
+  return (worktrees ?? []).filter(
+    worktree => worktree.id !== worktreeId || worktree.status !== 'pending'
+  )
+}

--- a/src/services/projects.ts
+++ b/src/services/projects.ts
@@ -35,6 +35,10 @@ import { hasBackend, hasBackendTransport } from '@/lib/environment'
 import { openExternal, preOpenWindow } from '@/lib/platform'
 import { shouldSuppressAutoFixConflictNotification } from './worktree-conflict-events'
 import { preserveQueryCacheOnError } from '@/lib/query-error'
+import {
+  mergeWorktreesPreservingOptimistic,
+  removePendingWorktree,
+} from '@/lib/worktree-list-cache'
 
 // Check if a backend is available (Tauri IPC or WebSocket)
 // Kept as `isTauri` for backward compatibility across the codebase
@@ -84,6 +88,8 @@ export function useProjects() {
  * Hook to list worktrees for a specific project
  */
 export function useWorktrees(projectId: string | null) {
+  const queryClient = useQueryClient()
+
   return useQuery({
     queryKey: projectsQueryKeys.worktrees(projectId ?? ''),
     queryFn: async (): Promise<Worktree[]> => {
@@ -96,10 +102,17 @@ export function useWorktrees(projectId: string | null) {
         const worktrees = await invoke<Worktree[]>('list_worktrees', {
           projectId,
         })
+        // Pending creations are client-only until git finishes; keep them when
+        // something else invalidates this query mid-create (issue #528).
+        const previous = queryClient.getQueryData<Worktree[]>(
+          projectsQueryKeys.worktrees(projectId)
+        )
+        const merged = mergeWorktreesPreservingOptimistic(worktrees, previous)
         logger.info('Worktrees loaded successfully', {
           count: worktrees.length,
+          pendingPreserved: merged.length - worktrees.length,
         })
-        return worktrees
+        return merged
       } catch (error) {
         logger.error('Failed to load worktrees', { error, projectId })
         return preserveQueryCacheOnError(error)
@@ -912,6 +925,9 @@ export function useWorktreeEvents() {
 
     // Track pending worktree timeouts for recovery if events are missed
     const pendingTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+    const pendingTimeoutAttempts = new Map<string, number>()
+    const PENDING_TIMEOUT_MS = 120_000 // 2m — large repos / auto-pull often exceed 1m
+    const PENDING_TIMEOUT_MAX_ATTEMPTS = 10 // ~20m total recovery window
 
     const clearPendingTimeout = (worktreeId: string) => {
       const timeout = pendingTimeouts.get(worktreeId)
@@ -919,24 +935,59 @@ export function useWorktreeEvents() {
         clearTimeout(timeout)
         pendingTimeouts.delete(worktreeId)
       }
+      pendingTimeoutAttempts.delete(worktreeId)
     }
 
     const startPendingTimeout = (worktreeId: string, projectId: string) => {
-      clearPendingTimeout(worktreeId)
+      // Clear only the timer; keep attempt count across reschedules
+      const existing = pendingTimeouts.get(worktreeId)
+      if (existing) {
+        clearTimeout(existing)
+        pendingTimeouts.delete(worktreeId)
+      }
+      // Long creations (large repos, auto-pull, PR checkout) can take minutes.
+      // Refetch for recovery, and reschedule while still pending so a missed
+      // worktree:created event can still be recovered later without wiping UI.
       const timeoutId = setTimeout(() => {
         pendingTimeouts.delete(worktreeId)
+        const attempt = (pendingTimeoutAttempts.get(worktreeId) ?? 0) + 1
+        pendingTimeoutAttempts.set(worktreeId, attempt)
         logger.warn('Pending worktree timed out, forcing refetch', {
           worktreeId,
           projectId,
+          attempt,
         })
-        // Force refetch to get actual state from backend
-        queryClient.invalidateQueries({
-          queryKey: projectsQueryKeys.worktrees(projectId),
-        })
+        // Force refetch to get actual state from backend. useWorktrees merges
+        // optimistic pending rows so this no longer wipes the sidebar (#528).
+        void queryClient
+          .invalidateQueries({
+            queryKey: projectsQueryKeys.worktrees(projectId),
+          })
+          .then(() => {
+            const stillPending = queryClient
+              .getQueryData<Worktree[]>(projectsQueryKeys.worktrees(projectId))
+              ?.some(w => w.id === worktreeId && w.status === 'pending')
+            if (stillPending && attempt < PENDING_TIMEOUT_MAX_ATTEMPTS) {
+              startPendingTimeout(worktreeId, projectId)
+            } else if (stillPending) {
+              pendingTimeoutAttempts.delete(worktreeId)
+              queryClient.setQueryData<Worktree[]>(
+                projectsQueryKeys.worktrees(projectId),
+                old => removePendingWorktree(old, worktreeId)
+              )
+              toast.dismiss(`worktree-creating-${worktreeId}`)
+              toast.error('Worktree creation could not be confirmed', {
+                description:
+                  'The pending worktree was removed after repeated recovery attempts.',
+              })
+            } else if (!stillPending) {
+              pendingTimeoutAttempts.delete(worktreeId)
+            }
+          })
         queryClient.invalidateQueries({
           queryKey: [...projectsQueryKeys.all, 'worktree', worktreeId],
         })
-      }, 60_000) // 60s timeout
+      }, PENDING_TIMEOUT_MS)
       pendingTimeouts.set(worktreeId, timeoutId)
     }
 


### PR DESCRIPTION
## Summary

- Fixes pending worktrees disappearing from the sidebar during slow creation (large repos, auto-pull, etc.) while the setup toast was still visible.
- Merges server worktree lists with client-only optimistic `pending` rows so mid-create refetches and recovery invalidations no longer wipe the UI.
- Extends pending recovery timeout/reschedule behavior and only removes an exhausted pending row after repeated failed recovery attempts.

fixes #528

---

Fixes #528