### PR TITLE
fix(projects): preserve session selection on project row tap

### DIFF
--- a/src/components/projects/ProjectTreeItem.test.tsx
+++ b/src/components/projects/ProjectTreeItem.test.tsx
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@/test/test-utils'
+import {
+  ProjectTreeItem,
+  resolveProjectRowClickAction,
+} from './ProjectTreeItem'
+import type { Project, Worktree } from '@/types/projects'
+import { useProjectsStore } from '@/store/projects-store'
+import { useChatStore } from '@/store/chat-store'
+
+const mocks = vi.hoisted(() => ({
+  worktrees: [] as Worktree[],
+  updateSettingsMutate: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}))
+
+vi.mock('@/hooks/useRemotePicker', () => ({
+  useRemotePicker: () => (run: (remote?: string) => void) => run(),
+}))
+
+vi.mock('@/services/projects', () => ({
+  useWorktrees: () => ({ data: mocks.worktrees }),
+  useAppDataDir: () => ({ data: '' }),
+  useUpdateProjectSettings: () => ({
+    mutate: mocks.updateSettingsMutate,
+    isPending: false,
+  }),
+}))
+
+vi.mock('@/services/git-status', () => ({
+  useFetchWorktreesStatus: () => undefined,
+  useGitStatus: () => ({ data: null }),
+  gitPush: vi.fn(),
+  fetchWorktreesStatus: vi.fn(),
+  performGitPull: vi.fn(),
+}))
+
+vi.mock('@/components/shared/NewIssuesBadge', () => ({
+  NewIssuesBadge: () => null,
+}))
+vi.mock('@/components/shared/OpenPRsBadge', () => ({
+  OpenPRsBadge: () => null,
+}))
+vi.mock('@/components/shared/FailedRunsBadge', () => ({
+  FailedRunsBadge: () => null,
+}))
+vi.mock('@/components/shared/SecurityAlertsBadge', () => ({
+  SecurityAlertsBadge: () => null,
+}))
+
+vi.mock('./WorktreeList', () => ({
+  WorktreeList: () => <div data-testid="worktree-list" />,
+}))
+
+vi.mock('./ProjectContextMenu', () => ({
+  ProjectContextMenu: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}))
+
+const project: Project = {
+  id: 'project-1',
+  name: 'jean',
+  path: '/tmp/jean',
+  default_branch: 'main',
+  added_at: 0,
+  order: 0,
+}
+
+const worktree: Worktree = {
+  id: 'wt-1',
+  project_id: 'project-1',
+  name: 'feature',
+  path: '/tmp/jean-feature',
+  branch: 'feature',
+  created_at: 0,
+  order: 0,
+  status: 'ready',
+  session_type: 'worktree',
+}
+
+describe('resolveProjectRowClickAction', () => {
+  it('toggles expand when the project has worktrees', () => {
+    expect(resolveProjectRowClickAction(true)).toBe('toggle-expand')
+  })
+
+  it('opens canvas when the project has no worktrees', () => {
+    expect(resolveProjectRowClickAction(false)).toBe('open-canvas')
+  })
+})
+
+describe('ProjectTreeItem', () => {
+  beforeEach(() => {
+    mocks.worktrees = [worktree]
+    mocks.updateSettingsMutate.mockReset()
+    useProjectsStore.setState({
+      selectedProjectId: 'project-1',
+      selectedWorktreeId: 'wt-1',
+      expandedProjectIds: new Set(['project-1']),
+      expandedWorktreeIds: new Set(),
+      expandedFolderIds: new Set(),
+      projectAccessTimestamps: {},
+      projectCanvasSettings: {},
+      githubDashboardFavoriteProjectIds: [],
+      addProjectDialogOpen: false,
+      addProjectParentFolderId: null,
+      projectSettingsDialogOpen: false,
+      projectSettingsProjectId: null,
+      projectSettingsInitialPane: null,
+      gitInitModalOpen: false,
+      gitInitModalPath: null,
+      cloneModalOpen: false,
+      jeanConfigWizardOpen: false,
+      jeanConfigWizardProjectId: null,
+      editingFolderId: null,
+    })
+    useChatStore.setState({
+      activeWorktreeId: 'wt-1',
+      activeWorktreePath: '/tmp/jean-feature',
+    })
+  })
+
+  it('toggles expand without clearing the selected worktree/session', async () => {
+    const user = userEvent.setup()
+    render(<ProjectTreeItem project={project} />)
+
+    await user.click(screen.getByTestId('project-row-project-1'))
+
+    const projectsState = useProjectsStore.getState()
+    expect(projectsState.selectedWorktreeId).toBe('wt-1')
+    expect(projectsState.expandedProjectIds.has('project-1')).toBe(false)
+    expect(useChatStore.getState().activeWorktreeId).toBe('wt-1')
+    expect(useChatStore.getState().activeWorktreePath).toBe('/tmp/jean-feature')
+  })
+
+  it('opens project canvas when the project has no worktrees', async () => {
+    mocks.worktrees = []
+    const user = userEvent.setup()
+    render(<ProjectTreeItem project={project} />)
+
+    await user.click(screen.getByTestId('project-row-project-1'))
+
+    expect(useProjectsStore.getState().selectedProjectId).toBe('project-1')
+    expect(useProjectsStore.getState().selectedWorktreeId).toBeNull()
+    expect(useChatStore.getState().activeWorktreeId).toBeNull()
+    expect(useChatStore.getState().activeWorktreePath).toBeNull()
+  })
+
+  it('starts inline rename on double-click and renames on Enter', async () => {
+    const user = userEvent.setup()
+    render(<ProjectTreeItem project={project} />)
+
+    await user.dblClick(screen.getByTestId('project-row-project-1'))
+
+    const input = screen.getByRole('textbox', { name: 'Project name' })
+    expect(input).toHaveValue('jean')
+
+    await user.clear(input)
+    await user.type(input, 'jean-app{Enter}')
+
+    expect(mocks.updateSettingsMutate).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      name: 'jean-app',
+    })
+  })
+})

--- a/src/components/projects/ProjectTreeItem.tsx
+++ b/src/components/projects/ProjectTreeItem.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   ArrowDown,
   ArrowUp,
@@ -16,7 +16,11 @@ import { useChatStore } from '@/store/chat-store'
 import { useUIStore } from '@/store/ui-store'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useRemotePicker } from '@/hooks/useRemotePicker'
-import { useWorktrees, useAppDataDir } from '@/services/projects'
+import {
+  useAppDataDir,
+  useUpdateProjectSettings,
+  useWorktrees,
+} from '@/services/projects'
 import {
   useFetchWorktreesStatus,
   useGitStatus,
@@ -38,6 +42,17 @@ import { ProjectContextMenu } from './ProjectContextMenu'
 
 interface ProjectTreeItemProps {
   project: Project
+}
+
+/**
+ * Resolve the primary action for a project-row click.
+ * Projects with worktrees expand/collapse only — never clear session selection.
+ * Empty projects still open the project canvas.
+ */
+export function resolveProjectRowClickAction(hasWorktrees: boolean):
+  | 'toggle-expand'
+  | 'open-canvas' {
+  return hasWorktrees ? 'toggle-expand' : 'open-canvas'
 }
 
 export function ProjectTreeItem({ project }: ProjectTreeItemProps) {
@@ -102,15 +117,93 @@ export function ProjectTreeItem({ project }: ProjectTreeItemProps) {
   const isSelected = selectedProjectId === project.id && !activeWorktreeId
   const showStatusBadges = !isMobile && (isExpanded || isSelected)
 
+  // Inline rename (double-click), matching folder/worktree patterns
+  const [isEditing, setIsEditing] = useState(false)
+  const [editName, setEditName] = useState(project.name)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const editStartTimeRef = useRef<number>(0)
+  const updateSettings = useUpdateProjectSettings()
+
+  useEffect(() => {
+    if (isEditing) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setEditName(project.name)
+      editStartTimeRef.current = Date.now()
+    }
+  }, [isEditing, project.name])
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [isEditing])
+
   const handleClick = useCallback(() => {
+    if (isEditing) return
+
+    const action = resolveProjectRowClickAction(hasWorktrees)
+    if (action === 'toggle-expand') {
+      // Expand/collapse only — preserve selected worktree/session highlight
+      toggleProjectExpanded(project.id)
+      return
+    }
+
+    // Empty project: open project canvas
     selectProject(project.id)
-    // Clear active worktree so ChatWindow shows project canvas view
     clearActiveWorktree()
-    // Close sidebar on mobile after navigation
     if (isMobile) {
       useUIStore.getState().setLeftSidebarVisible(false)
     }
-  }, [isMobile, project.id, selectProject, clearActiveWorktree])
+  }, [
+    isEditing,
+    hasWorktrees,
+    toggleProjectExpanded,
+    project.id,
+    selectProject,
+    clearActiveWorktree,
+    isMobile,
+  ])
+
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      if (isEditing) return
+      setEditName(project.name)
+      setIsEditing(true)
+    },
+    [isEditing, project.name]
+  )
+
+  const handleSubmitRename = useCallback(
+    (fromBlur = false) => {
+      // Ignore blur events within 300ms of edit start (prevents re-render blur issues)
+      if (fromBlur && Date.now() - editStartTimeRef.current < 300) {
+        inputRef.current?.focus()
+        return
+      }
+
+      const trimmedName = editName.trim()
+      if (trimmedName && trimmedName !== project.name) {
+        updateSettings.mutate({ projectId: project.id, name: trimmedName })
+      }
+      setIsEditing(false)
+    },
+    [editName, project.id, project.name, updateSettings]
+  )
+
+  const handleRenameKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      e.stopPropagation()
+      if (e.key === 'Enter') {
+        handleSubmitRename(false)
+      } else if (e.key === 'Escape') {
+        setEditName(project.name)
+        setIsEditing(false)
+      }
+    },
+    [handleSubmitRename, project.name]
+  )
 
   const handleChevronClick = useCallback(
     (e: React.MouseEvent) => {
@@ -175,6 +268,8 @@ export function ProjectTreeItem({ project }: ProjectTreeItemProps) {
               : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
           )}
           onClick={handleClick}
+          onDoubleClick={handleDoubleClick}
+          data-testid={`project-row-${project.id}`}
         >
           {/* Avatar */}
           {avatarUrl ? (
@@ -193,27 +288,44 @@ export function ProjectTreeItem({ project }: ProjectTreeItemProps) {
           )}
 
           {/* Name + Chevron */}
-          <span className="flex flex-1 items-center gap-0.5 truncate text-sm">
-            <span className="truncate">{project.name}</span>
-            {hasWorktrees && (
-              <button
-                className={cn(
-                  'flex size-4 shrink-0 items-center justify-center rounded transition-opacity hover:bg-accent-foreground/10',
-                  isMobile
-                    ? 'opacity-70'
-                    : 'opacity-0 group-hover:opacity-50 hover:!opacity-100'
-                )}
-                onClick={handleChevronClick}
-              >
-                <ChevronDown
+          {isEditing ? (
+            <input
+              ref={inputRef}
+              type="text"
+              aria-label="Project name"
+              value={editName}
+              onChange={e => setEditName(e.target.value)}
+              onBlur={() => handleSubmitRename(true)}
+              onKeyDown={handleRenameKeyDown}
+              className="flex-1 bg-transparent text-base outline-none ring-1 ring-primary/50 rounded px-1 md:text-sm"
+              onClick={e => e.stopPropagation()}
+              autoFocus
+            />
+          ) : (
+            <span className="flex flex-1 items-center gap-0.5 truncate text-sm">
+              <span className="truncate">{project.name}</span>
+              {hasWorktrees && (
+                <button
+                  type="button"
+                  aria-label={isExpanded ? 'Collapse project' : 'Expand project'}
                   className={cn(
-                    'size-3 transition-transform',
-                    isExpanded && 'rotate-180'
+                    'flex size-4 shrink-0 items-center justify-center rounded transition-opacity hover:bg-accent-foreground/10',
+                    isMobile
+                      ? 'opacity-70'
+                      : 'opacity-0 group-hover:opacity-50 hover:!opacity-100'
                   )}
-                />
-              </button>
-            )}
-          </span>
+                  onClick={handleChevronClick}
+                >
+                  <ChevronDown
+                    className={cn(
+                      'size-3 transition-transform',
+                      isExpanded && 'rotate-180'
+                    )}
+                  />
+                </button>
+              )}
+            </span>
+          )}
 
           {/* Base branch pull/push indicators (when no base session) */}
           {baseBranchBehindCount > 0 && (


### PR DESCRIPTION
## Summary
- Fixes project-row clicks clearing the selected session/worktree highlight when the project already has worktrees
- Single-click on a project with worktrees now only expands/collapses; empty projects still open the project canvas
- Adds double-click inline rename for project names (Enter to save, Escape to cancel)
- Adds coverage for expand-without-deselect, empty-project canvas open, and rename flow

fixes #515

---

Fixes #515