### PR TITLE
fix(chat): restore auto session naming after NDJSON

### DIFF
--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -79,6 +79,26 @@ static BACKEND_QUEUE_DRAINING: Lazy<Mutex<HashSet<String>>> =
 /// `send_chat_message` entry and held for the whole call.
 static ACTIVE_SENDS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
+/// Whether a session has no prior user messages for auto-naming purposes.
+///
+/// After the NDJSON migration, `Session.messages` is always empty (messages are
+/// loaded on demand from run logs). Prefer `message_count` / `total_runs` from
+/// metadata, falling back to in-memory messages for tests / legacy paths.
+pub(crate) fn session_has_no_prior_user_messages(session: &Session) -> bool {
+    if let Some(count) = session.message_count {
+        return count == 0;
+    }
+    if session.total_runs > 0 {
+        return false;
+    }
+    session
+        .messages
+        .iter()
+        .filter(|m| m.role == MessageRole::User)
+        .count()
+        == 0
+}
+
 fn should_auto_name_branch(worktree: Option<&Worktree>) -> bool {
     worktree
         .map(|worktree| {
@@ -2447,105 +2467,106 @@ pub async fn send_chat_message(
         sessions.sessions.iter().map(|s| &s.id).collect::<Vec<_>>()
     );
 
-    // Check if we should trigger automatic naming (session and/or branch)
-    // Branch naming: first user message ever AND not already attempted
-    // Session naming: first user message in THIS session AND not already attempted
+    // Check if we should trigger automatic naming (session and/or branch).
+    // Branch naming: first user message ever AND not already attempted.
+    // Session naming: first user message in THIS session AND not already attempted.
+    //
+    // IMPORTANT: `Session.messages` is always empty after the NDJSON migration
+    // (messages load on demand from run logs). Use message_count / total_runs
+    // instead of scanning `messages`.
     let is_first_worktree_message = !sessions.branch_naming_completed
         && sessions
             .sessions
             .iter()
-            .flat_map(|s| &s.messages)
-            .filter(|m| m.role == MessageRole::User)
-            .count()
-            == 0;
+            .all(session_has_no_prior_user_messages);
 
     let session_for_naming = sessions.find_session(&session_id).cloned();
     let is_first_session_message = session_for_naming
         .as_ref()
-        .map(|sess| {
-            !sess.session_naming_completed
-                && sess
-                    .messages
-                    .iter()
-                    .filter(|m| m.role == MessageRole::User)
-                    .count()
-                    == 0
-        })
+        .map(|sess| !sess.session_naming_completed && session_has_no_prior_user_messages(sess))
         .unwrap_or(false);
 
     // Spawn unified naming task if either condition is met
     if is_first_worktree_message || is_first_session_message {
-        if let Ok(prefs) = crate::load_preferences(app.clone()).await {
-            // Preserve branches selected by the user, base sessions, and PR worktrees.
-            let worktree_record = load_projects_data(&app)
-                .ok()
-                .and_then(|data| data.find_worktree(&worktree_id).cloned());
-            let generate_branch = is_first_worktree_message
-                && prefs.auto_branch_naming
-                && should_auto_name_branch(worktree_record.as_ref());
-            let generate_session = is_first_session_message && prefs.auto_session_naming;
+        match crate::load_preferences(app.clone()).await {
+            Ok(prefs) => {
+                // Preserve branches selected by the user, base sessions, and PR worktrees.
+                let worktree_record = load_projects_data(&app)
+                    .ok()
+                    .and_then(|data| data.find_worktree(&worktree_id).cloned());
+                let generate_branch = is_first_worktree_message
+                    && prefs.auto_branch_naming
+                    && should_auto_name_branch(worktree_record.as_ref());
+                let generate_session = is_first_session_message && prefs.auto_session_naming;
 
-            if generate_branch || generate_session {
-                log::trace!(
-                    "Spawning naming task (session: {generate_session}, branch: {generate_branch})"
+                if generate_branch || generate_session {
+                    log::info!(
+                        "[Naming] Spawning naming task session={session_id} worktree={worktree_id} (session: {generate_session}, branch: {generate_branch})"
+                    );
+
+                    // Get existing worktree names to avoid duplicates (only needed for branch naming)
+                    let existing_names = if generate_branch {
+                        load_projects_data(&app)
+                            .map(|data| data.worktrees.iter().map(|w| w.name.clone()).collect())
+                            .unwrap_or_default()
+                    } else {
+                        Vec::new()
+                    };
+
+                    let custom_session_prompt = if generate_session {
+                        prefs.magic_prompts.session_naming.clone()
+                    } else {
+                        None
+                    };
+
+                    let request = NamingRequest {
+                        session_id: session_id.clone(),
+                        worktree_id: worktree_id.clone(),
+                        worktree_path: PathBuf::from(&worktree_path),
+                        first_message: message.clone(),
+                        model: prefs.magic_prompt_models.session_naming_model.clone(),
+                        existing_branch_names: existing_names,
+                        generate_session_name: generate_session,
+                        generate_branch_name: generate_branch,
+                        custom_session_prompt,
+                        // Keep provider semantics consistent with manual regeneration:
+                        // session_naming_provider = None means Anthropic (no custom profile),
+                        // not fallback to global default_provider.
+                        custom_profile_name: prefs
+                            .magic_prompt_providers
+                            .session_naming_provider
+                            .clone(),
+                        backend_override: prefs.magic_prompt_backends.session_naming_backend.clone(),
+                        reasoning_effort: prefs.magic_prompt_efforts.session_naming_effort.clone(),
+                    };
+
+                    // Spawn in background - does not block chat
+                    spawn_naming_task(app.clone(), request);
+                }
+
+                // Mark as completed only after prefs loaded successfully so a
+                // transient prefs failure does not permanently skip auto-naming.
+                with_sessions_mut(&app, &worktree_path, &worktree_id, |sessions| {
+                    if is_first_worktree_message {
+                        sessions.branch_naming_completed = true;
+                    }
+                    if is_first_session_message {
+                        if let Some(session) = sessions.find_session_mut(&session_id) {
+                            session.session_naming_completed = true;
+                        }
+                    }
+                    Ok(())
+                })?;
+
+                // Reload sessions to get fresh state after save
+                sessions = load_sessions(&app, &worktree_path, &worktree_id)?;
+            }
+            Err(e) => {
+                log::warn!(
+                    "[Naming] Skipping auto-naming for session={session_id}: failed to load preferences: {e}"
                 );
-
-                // Get existing worktree names to avoid duplicates (only needed for branch naming)
-                let existing_names = if generate_branch {
-                    load_projects_data(&app)
-                        .map(|data| data.worktrees.iter().map(|w| w.name.clone()).collect())
-                        .unwrap_or_default()
-                } else {
-                    Vec::new()
-                };
-
-                let custom_session_prompt = if generate_session {
-                    prefs.magic_prompts.session_naming.clone()
-                } else {
-                    None
-                };
-
-                let request = NamingRequest {
-                    session_id: session_id.clone(),
-                    worktree_id: worktree_id.clone(),
-                    worktree_path: PathBuf::from(&worktree_path),
-                    first_message: message.clone(),
-                    model: prefs.magic_prompt_models.session_naming_model.clone(),
-                    existing_branch_names: existing_names,
-                    generate_session_name: generate_session,
-                    generate_branch_name: generate_branch,
-                    custom_session_prompt,
-                    // Keep provider semantics consistent with manual regeneration:
-                    // session_naming_provider = None means Anthropic (no custom profile),
-                    // not fallback to global default_provider.
-                    custom_profile_name: prefs
-                        .magic_prompt_providers
-                        .session_naming_provider
-                        .clone(),
-                    backend_override: prefs.magic_prompt_backends.session_naming_backend.clone(),
-                    reasoning_effort: prefs.magic_prompt_efforts.session_naming_effort.clone(),
-                };
-
-                // Spawn in background - does not block chat
-                spawn_naming_task(app.clone(), request);
             }
         }
-
-        // Mark as completed to prevent re-triggering (atomic update)
-        with_sessions_mut(&app, &worktree_path, &worktree_id, |sessions| {
-            if is_first_worktree_message {
-                sessions.branch_naming_completed = true;
-            }
-            if is_first_session_message {
-                if let Some(session) = sessions.find_session_mut(&session_id) {
-                    session.session_naming_completed = true;
-                }
-            }
-            Ok(())
-        })?;
-
-        // Reload sessions to get fresh state after save
-        sessions = load_sessions(&app, &worktree_path, &worktree_id)?;
     }
 
     // Notify all clients that a message is being sent (for real-time sync).
@@ -9311,6 +9332,44 @@ mod tests {
         let worktree = naming_test_worktree("random-workspace", Some("main"));
 
         assert!(should_auto_name_branch(Some(&worktree)));
+    }
+
+    #[test]
+    fn session_has_no_prior_user_messages_uses_message_count() {
+        let mut session = Session::new("Session 1".to_string(), 0, Backend::Claude);
+        session.message_count = Some(0);
+        session.messages = vec![]; // NDJSON path: messages always empty
+        assert!(session_has_no_prior_user_messages(&session));
+
+        session.message_count = Some(2);
+        assert!(!session_has_no_prior_user_messages(&session));
+    }
+
+    #[test]
+    fn session_has_no_prior_user_messages_falls_back_to_total_runs() {
+        let mut session = Session::new("Session 1".to_string(), 0, Backend::Claude);
+        session.message_count = None;
+        session.total_runs = 0;
+        assert!(session_has_no_prior_user_messages(&session));
+
+        session.total_runs = 1;
+        assert!(!session_has_no_prior_user_messages(&session));
+    }
+
+    #[test]
+    fn session_has_no_prior_user_messages_falls_back_to_in_memory_messages() {
+        let mut session = Session::new("Session 1".to_string(), 0, Backend::Claude);
+        session.message_count = None;
+        session.total_runs = 0;
+        session.messages = vec![ChatMessage {
+            id: "m1".to_string(),
+            session_id: session.id.clone(),
+            role: MessageRole::User,
+            content: "hello".to_string(),
+            timestamp: 0,
+            ..Default::default()
+        }];
+        assert!(!session_has_no_prior_user_messages(&session));
     }
 
     #[test]

--- a/jean-core/src/chat/naming.rs
+++ b/jean-core/src/chat/naming.rs
@@ -250,9 +250,13 @@ fn get_cli_model_alias(model: &str) -> &'static str {
     }
 }
 
-/// Extract text content from stream-json output
+/// Extract text content from stream-json output.
+///
+/// Also accepts StructuredOutput tool_use blocks (from --json-schema) so naming
+/// keeps working if Claude returns JSON via the tool-call path instead of text.
 fn extract_text_from_stream_json(output: &str) -> Result<String, String> {
     let mut text_content = String::new();
+    let mut structured_json: Option<String> = None;
 
     for line in output.lines() {
         let line = line.trim();
@@ -269,9 +273,16 @@ fn extract_text_from_stream_json(output: &str) -> Result<String, String> {
             if let Some(message) = parsed.get("message") {
                 if let Some(content) = message.get("content").and_then(|c| c.as_array()) {
                     for block in content {
-                        if block.get("type").and_then(|t| t.as_str()) == Some("text") {
+                        let block_type = block.get("type").and_then(|t| t.as_str());
+                        if block_type == Some("text") {
                             if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
                                 text_content.push_str(text);
+                            }
+                        } else if block_type == Some("tool_use")
+                            && block.get("name").and_then(|n| n.as_str()) == Some("StructuredOutput")
+                        {
+                            if let Some(input) = block.get("input") {
+                                structured_json = Some(input.to_string());
                             }
                         }
                     }
@@ -286,6 +297,10 @@ fn extract_text_from_stream_json(output: &str) -> Result<String, String> {
                 }
             }
         }
+    }
+
+    if let Some(json) = structured_json {
+        return Ok(json);
     }
 
     if text_content.is_empty() {
@@ -1111,12 +1126,19 @@ fn execute_naming(app: &AppHandle, request: &NamingRequest) {
             match validate_session_name(session_name) {
                 Ok(validated_name) => match apply_session_name(app, request, &validated_name) {
                     Ok(result) => {
-                        log::trace!(
-                            "Session renamed from '{}' to '{}'",
+                        log::info!(
+                            "[Naming] Session renamed from '{}' to '{}' (session={})",
                             result.old_name,
-                            result.new_name
+                            result.new_name,
+                            result.session_id
                         );
                         let _ = app.emit_all("session-renamed", &result);
+                        // Also broadcast cache invalidation so web + native clients
+                        // refresh session lists even if they miss session-renamed.
+                        let _ = app.emit_all(
+                            "cache:invalidate",
+                            &serde_json::json!({ "keys": ["sessions"] }),
+                        );
                     }
                     Err(error) => {
                         log::warn!("Session naming storage failed: {}", error.error);
@@ -1145,12 +1167,17 @@ fn execute_naming(app: &AppHandle, request: &NamingRequest) {
             match validate_branch_name(branch_name) {
                 Ok(validated_name) => match apply_branch_name(app, request, &validated_name) {
                     Ok(result) => {
-                        log::trace!(
-                            "Branch renamed from '{}' to '{}'",
+                        log::info!(
+                            "[Naming] Branch renamed from '{}' to '{}' (worktree={})",
                             result.old_branch,
-                            result.new_branch
+                            result.new_branch,
+                            result.worktree_id
                         );
                         let _ = app.emit_all("branch-renamed", &result);
+                        let _ = app.emit_all(
+                            "cache:invalidate",
+                            &serde_json::json!({ "keys": ["projects"] }),
+                        );
                     }
                     Err(error) => {
                         log::warn!("Branch naming failed: {}", error.error);
@@ -1199,6 +1226,22 @@ pub fn spawn_naming_task(app: AppHandle, request: NamingRequest) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extract_text_prefers_structured_output_tool_call() {
+        let output = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"I'll name it"},{"type":"tool_use","id":"toolu_1","name":"StructuredOutput","input":{"session_name":"Fix auto naming","branch_name":"fix-auto-naming"}}]}}"#;
+        let text = extract_text_from_stream_json(output).unwrap();
+        let parsed: NamingOutput = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed.session_name.as_deref(), Some("Fix auto naming"));
+        assert_eq!(parsed.branch_name.as_deref(), Some("fix-auto-naming"));
+    }
+
+    #[test]
+    fn extract_text_falls_back_to_assistant_text() {
+        let output = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"{\"session_name\":\"Plain text name\"}"}]}}"#;
+        let text = extract_text_from_stream_json(output).unwrap();
+        assert!(text.contains("Plain text name"));
+    }
 
     #[test]
     fn parses_commandcode_naming_output_with_surrounding_text() {

--- a/jean-core/src/http_server/mod.rs
+++ b/jean-core/src/http_server/mod.rs
@@ -295,17 +295,17 @@ pub trait EmitExt {
 
 impl EmitExt for AppHandle {
     fn emit_all<S: Serialize + Clone>(&self, event: &str, payload: &S) -> Result<(), String> {
-        // Send to Tauri frontend (native app)
-        self.emit(event, payload.clone())
-            .map_err(|e| format!("Tauri emit failed: {e}"))?;
-
-        // Broadcast to WebSocket clients (if server is running).
-        // Serializes directly from &S → JSON in one pass (no intermediate Value).
+        // Broadcast to WebSocket clients first so web-access clients still receive
+        // events even if the native Tauri emit path fails. (Previously Tauri-first
+        // short-circuited and dropped WS delivery on emit errors — broke session
+        // auto-rename UI updates for browser clients.)
         if let Some(ws) = self.try_state::<WsBroadcaster>() {
             ws.broadcast(event, payload);
         }
 
-        Ok(())
+        // Send to Tauri frontend (native app / event sink)
+        self.emit(event, payload.clone())
+            .map_err(|e| format!("Tauri emit failed: {e}"))
     }
 
     fn emit_all_owned<S: Serialize + Clone>(&self, event: &str, payload: S) -> Result<(), String> {
@@ -316,9 +316,7 @@ impl EmitExt for AppHandle {
 
         // Send to Tauri frontend — consumes payload (Tauri's emit requires Clone internally).
         self.emit(event, payload)
-            .map_err(|e| format!("Tauri emit failed: {e}"))?;
-
-        Ok(())
+            .map_err(|e| format!("Tauri emit failed: {e}"))
     }
 }
 

--- a/src/hooks/useMainWindowEventListeners.test.tsx
+++ b/src/hooks/useMainWindowEventListeners.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient } from '@tanstack/react-query'
 import {
   addTerminalTabForShortcut,
   applyCacheInvalidationKeys,
+  applySessionRenamedToCaches,
   blurFocusedTerminalForShortcut,
   closeActiveTerminalTabForShortcut,
   findKeybindingAction,
@@ -18,6 +19,11 @@ import {
 import { chatQueryKeys } from '@/services/chat'
 import { projectsQueryKeys } from '@/services/projects'
 import { DEFAULT_KEYBINDINGS } from '@/types/keybindings'
+import type {
+  AllSessionsResponse,
+  Session,
+  WorktreeSessions,
+} from '@/types/chat'
 
 const { mockInvoke, mockListen, mockDisposeTerminal } = vi.hoisted(() => ({
   mockInvoke: vi.fn().mockResolvedValue(undefined),
@@ -429,6 +435,76 @@ describe('dialog overlay keybinding passthrough', () => {
         useUIStore.getState()
       )
     ).toBe(false)
+  })
+})
+
+describe('applySessionRenamedToCaches', () => {
+  const worktreeId = 'wt-1'
+  const sessionId = 'sess-1'
+
+  function seedSessionCaches(queryClient: QueryClient) {
+    const sessions: WorktreeSessions = {
+      worktree_id: worktreeId,
+      sessions: [
+        {
+          id: sessionId,
+          name: 'Session 1',
+          order: 0,
+          created_at: 0,
+          updated_at: 0,
+          messages: [],
+        } as Session,
+      ],
+      active_session_id: sessionId,
+      version: 2,
+    }
+    queryClient.setQueryData(chatQueryKeys.sessions(worktreeId), sessions)
+    queryClient.setQueryData(
+      [...chatQueryKeys.sessions(worktreeId), 'with-counts'],
+      sessions
+    )
+    queryClient.setQueryData(chatQueryKeys.session(sessionId), sessions.sessions[0])
+    queryClient.setQueryData<AllSessionsResponse>(['all-sessions'], {
+      entries: [
+        {
+          project_id: 'p1',
+          project_name: 'Project',
+          worktree_id: worktreeId,
+          worktree_name: 'main',
+          worktree_path: '/tmp/wt',
+          sessions: sessions.sessions,
+        },
+      ],
+    })
+  }
+
+  it('updates base sessions, with-counts, session detail, and all-sessions caches', () => {
+    const queryClient = new QueryClient()
+    seedSessionCaches(queryClient)
+
+    applySessionRenamedToCaches(
+      queryClient,
+      worktreeId,
+      sessionId,
+      'Fix auto naming'
+    )
+
+    const base = queryClient.getQueryData<WorktreeSessions>(
+      chatQueryKeys.sessions(worktreeId)
+    )
+    const withCounts = queryClient.getQueryData<WorktreeSessions>([
+      ...chatQueryKeys.sessions(worktreeId),
+      'with-counts',
+    ])
+    const detail = queryClient.getQueryData<Session>(
+      chatQueryKeys.session(sessionId)
+    )
+    const all = queryClient.getQueryData<AllSessionsResponse>(['all-sessions'])
+
+    expect(base?.sessions[0]?.name).toBe('Fix auto naming')
+    expect(withCounts?.sessions[0]?.name).toBe('Fix auto naming')
+    expect(detail?.name).toBe('Fix auto naming')
+    expect(all?.entries[0]?.sessions[0]?.name).toBe('Fix auto naming')
   })
 })
 

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -10,7 +10,12 @@ import { isPanelTerminal, useTerminalStore } from '@/store/terminal-store'
 import { useBrowserStore } from '@/store/browser-store'
 import { projectsQueryKeys } from '@/services/projects'
 import { chatQueryKeys } from '@/services/chat'
-import type { QueuedMessage } from '@/types/chat'
+import type {
+  AllSessionsResponse,
+  QueuedMessage,
+  Session,
+  WorktreeSessions,
+} from '@/types/chat'
 import { disposeTerminal, startHeadless } from '@/lib/terminal-instances'
 import { toast } from 'sonner'
 import { useCommandContext } from './use-command-context'
@@ -97,6 +102,62 @@ export function applyCacheInvalidationKeys(
         break
     }
   }
+}
+
+/**
+ * Optimistically apply a session rename across all React Query caches that
+ * display session names (tab bar, ProjectCanvas with-counts, all-sessions bell).
+ * Used by the `session-renamed` event so web clients update immediately without
+ * waiting for a refetch race against concurrent chat:done cache writes.
+ */
+export function applySessionRenamedToCaches(
+  queryClient: QueryClient,
+  worktreeId: string,
+  sessionId: string,
+  newName: string
+): void {
+  const patchWorktreeSessions = (
+    old: WorktreeSessions | undefined
+  ): WorktreeSessions | undefined => {
+    if (!old) return old
+    let changed = false
+    const sessions = old.sessions.map(session => {
+      if (session.id !== sessionId || session.name === newName) return session
+      changed = true
+      return { ...session, name: newName }
+    })
+    return changed ? { ...old, sessions } : old
+  }
+
+  queryClient.setQueryData<WorktreeSessions>(
+    chatQueryKeys.sessions(worktreeId),
+    patchWorktreeSessions
+  )
+  // ProjectCanvasView uses the with-counts variant — update it directly so the
+  // dashboard list renames even before the invalidate refetch completes.
+  queryClient.setQueryData<WorktreeSessions>(
+    [...chatQueryKeys.sessions(worktreeId), 'with-counts'],
+    patchWorktreeSessions
+  )
+  queryClient.setQueryData<Session>(chatQueryKeys.session(sessionId), old => {
+    if (!old || old.name === newName) return old
+    return { ...old, name: newName }
+  })
+  queryClient.setQueryData<AllSessionsResponse>(['all-sessions'], old => {
+    if (!old) return old
+    let changed = false
+    const entries = old.entries.map(entry => {
+      let entryChanged = false
+      const sessions = entry.sessions.map(session => {
+        if (session.id !== sessionId || session.name === newName) return session
+        entryChanged = true
+        changed = true
+        return { ...session, name: newName }
+      })
+      return entryChanged ? { ...entry, sessions } : entry
+    })
+    return changed ? { ...old, entries } : old
+  })
 }
 
 export function shouldAllowKeybindingThroughOpenOverlay(
@@ -962,9 +1023,20 @@ export function useMainWindowEventListeners() {
             oldName: event.payload.old_name,
             newName: event.payload.new_name,
           })
-          // Invalidate sessions query to refresh the session name in the UI
+          // Optimistically patch all caches first so the UI renames immediately
+          // (especially important for web clients and ProjectCanvas with-counts).
+          applySessionRenamedToCaches(
+            queryClient,
+            event.payload.worktree_id,
+            event.payload.session_id,
+            event.payload.new_name
+          )
+          // Then invalidate so disk is the eventual source of truth.
           queryClient.invalidateQueries({
             queryKey: chatQueryKeys.sessions(event.payload.worktree_id),
+          })
+          queryClient.invalidateQueries({
+            queryKey: ['all-sessions'],
           })
         }),
 


### PR DESCRIPTION
## Summary

- Fixes auto-generation of session (and branch) names that stopped working after the NDJSON migration, especially on web clients
- Detects first-message naming using `message_count` / `total_runs` instead of the always-empty in-memory `Session.messages`
- Avoids permanently skipping naming when preferences fail to load, and patches session rename events into UI caches so names update immediately

fixes #508

---

Fixes #508