### PR TITLE
fix(ui): prevent cascade close on held shortcuts

### DIFF
--- a/src/components/chat/SessionChatModal.removal-behavior.test.ts
+++ b/src/components/chat/SessionChatModal.removal-behavior.test.ts
@@ -39,6 +39,27 @@ describe('SessionChatModal removal behavior', () => {
     )
   })
 
+  it('confirms non-empty session tab close even when other tabs remain (issue #56)', () => {
+    const source = readSource('src/components/chat/SessionChatModal.tsx')
+    const start = source.indexOf('const removeSessionTab = useCallback(')
+    const end = source.indexOf('\n  const handleTabAuxClick', start)
+    const removeSessionTab =
+      start === -1 || end === -1 ? '' : source.slice(start, end)
+
+    expect(removeSessionTab).toContain('needsConfirm')
+    expect(removeSessionTab).toContain(
+      'preferences?.confirm_session_close !== false && !sessionIsEmpty'
+    )
+    // Confirm gate wraps the action for every non-empty tab (not only last).
+    expect(removeSessionTab).toMatch(
+      /if \(needsConfirm\) \{\s*pendingCloseAction\.current = action/
+    )
+    // Neighbor select happens inside the deferred action, not as a bypass.
+    expect(removeSessionTab).toMatch(
+      /const action = \(\) => \{[\s\S]*activeSessions\.length > 1[\s\S]*handleDeleteSession/
+    )
+  })
+
   it('waits for last-session removal success before leaving the modal', () => {
     const source = readSource('src/components/chat/SessionChatModal.tsx')
     const start = source.indexOf('const removeSessionTab = useCallback(')

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -536,21 +536,26 @@ export function SessionChatModal({
   const removeSessionTab = useCallback(
     (session: Session) => {
       const activeSessions = sessions.filter(s => !s.archived_at)
-      if (activeSessions.length <= 1) {
-        // The mutation navigates after success, provided navigation is unchanged.
-        const action = () => {
-          handleDeleteSession(session.id)
+      const sessionIsEmpty = !session.message_count
+      // Confirm any non-empty session when preference is on (default). Only
+      // confirming the last tab allowed held/cascade closes to wipe chats
+      // without a prompt (issue #56). Empty sessions close immediately.
+      const needsConfirm =
+        preferences?.confirm_session_close !== false && !sessionIsEmpty
+
+      const action = () => {
+        if (activeSessions.length > 1) {
+          selectVisualNeighbor(session.id)
         }
-        const sessionIsEmpty = !session.message_count
-        if (preferences?.confirm_session_close !== false && !sessionIsEmpty) {
-          pendingCloseAction.current = action
-          setCloseConfirmOpen(true)
-        } else {
-          action()
-        }
-      } else {
-        selectVisualNeighbor(session.id)
+        // The mutation navigates after success when this was the last session.
         handleDeleteSession(session.id)
+      }
+
+      if (needsConfirm) {
+        pendingCloseAction.current = action
+        setCloseConfirmOpen(true)
+      } else {
+        action()
       }
     },
     [

--- a/src/components/chat/TerminalView.tsx
+++ b/src/components/chat/TerminalView.tsx
@@ -14,6 +14,16 @@ import {
   disposeTerminal,
   disposePanelWorktreeTerminals,
 } from '@/lib/terminal-instances'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Kbd } from '@/components/ui/kbd'
 import { formatShortcutDisplay } from '@/types/keybindings'
 import { cn } from '@/lib/utils'
@@ -200,6 +210,10 @@ export function TerminalView({
   const [draggedTerminalId, setDraggedTerminalId] = useState<string | null>(
     null
   )
+  // Pending close when the tab still has a live PTY (issue #56: no silent kill).
+  const [pendingClose, setPendingClose] = useState<
+    { type: 'one'; terminalId: string } | { type: 'all' } | null
+  >(null)
 
   // Auto-create a default shell when this worktree has no panel terminals AND
   // UI state hydration has finished. Waiting on `uiStateInitialized` is
@@ -224,9 +238,8 @@ export function TerminalView({
     addTerminal(worktreeId)
   }, [worktreeId, addTerminal])
 
-  const handleCloseTerminal = useCallback(
-    async (e: React.MouseEvent, terminalId: string) => {
-      e.stopPropagation()
+  const closeTerminalById = useCallback(
+    async (terminalId: string) => {
       // Stop the PTY process
       try {
         await invoke('stop_terminal', { terminalId })
@@ -247,6 +260,20 @@ export function TerminalView({
       }
     },
     [worktreeId, removeTerminal, setTerminalPanelOpen, setTerminalVisible]
+  )
+
+  const handleCloseTerminal = useCallback(
+    (e: React.MouseEvent, terminalId: string) => {
+      e.stopPropagation()
+      // Running PTYs need an explicit confirm so a held/mis-clicked close
+      // cannot silently kill work in progress (issue #56).
+      if (useTerminalStore.getState().runningTerminals.has(terminalId)) {
+        setPendingClose({ type: 'one', terminalId })
+        return
+      }
+      void closeTerminalById(terminalId)
+    },
+    [closeTerminalById]
   )
 
   const handleSelectTerminal = useCallback(
@@ -299,47 +326,123 @@ export function TerminalView({
   }, [setTerminalVisible])
 
   const handleCloseAll = useCallback(() => {
+    const panelTerminals = (
+      useTerminalStore.getState().terminals[worktreeId] ?? []
+    ).filter(isPanelTerminal)
+    const hasRunning = panelTerminals.some(t =>
+      useTerminalStore.getState().runningTerminals.has(t.id)
+    )
+    if (hasRunning) {
+      setPendingClose({ type: 'all' })
+      return
+    }
     // Dispose side/drawer terminal tabs only; session terminals are independent.
     disposePanelWorktreeTerminals(worktreeId)
   }, [worktreeId])
 
+  const confirmPendingClose = useCallback(() => {
+    if (!pendingClose) return
+    if (pendingClose.type === 'all') {
+      disposePanelWorktreeTerminals(worktreeId)
+    } else {
+      void closeTerminalById(pendingClose.terminalId)
+    }
+    setPendingClose(null)
+  }, [pendingClose, worktreeId, closeTerminalById])
+
+  // Keyboard close path (Ctrl/Cmd+W) dispatches this when the active tab is
+  // still running so we can show the same confirm dialog as the tab X button.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ worktreeId: string; terminalId: string }>)
+        .detail
+      if (!detail || detail.worktreeId !== worktreeId) return
+      setPendingClose({ type: 'one', terminalId: detail.terminalId })
+    }
+    window.addEventListener('confirm-close-terminal', handler)
+    return () => window.removeEventListener('confirm-close-terminal', handler)
+  }, [worktreeId])
+
+  const closeConfirmDialog = (
+    <AlertDialog
+      open={pendingClose !== null}
+      onOpenChange={open => {
+        if (!open) setPendingClose(null)
+      }}
+    >
+      <AlertDialogContent
+        onEscapeKeyDown={e => e.stopPropagation()}
+        onKeyDown={e => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            e.stopPropagation()
+            confirmPendingClose()
+          }
+        }}
+      >
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {pendingClose?.type === 'all'
+              ? 'Close all terminals?'
+              : 'Close running terminal?'}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {pendingClose?.type === 'all'
+              ? 'One or more terminals still have a running process. Closing them will terminate those processes.'
+              : 'This terminal still has a running process. Closing it will terminate that process.'}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={confirmPendingClose}>
+            Close
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+
   // When collapsed, show collapsed bar but keep terminals mounted (hidden) to preserve state
   if (isCollapsed) {
     return (
-      <div className="flex h-full flex-col bg-background">
-        {/* Collapsed bar */}
-        <button
-          type="button"
-          onClick={onExpand}
-          className="flex h-full w-full items-center gap-2 px-3 text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-        >
-          <Terminal className="h-3.5 w-3.5" />
-          <span>Terminal</span>
-          {hasRunningPanelTerminal && (
-            <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
-          )}
-          <div className="flex-1" />
-          <ChevronUp className="h-3.5 w-3.5" />
-        </button>
-        {/* Keep terminals mounted but hidden to preserve state */}
-        <div className="hidden">
-          {terminals.map(terminal => (
-            <TerminalTabContent
-              key={terminal.id}
-              terminal={terminal}
-              worktreeId={worktreeId}
-              worktreePath={worktreePath}
-              isActive={terminal.id === activeTerminalId}
-              isCollapsed
-              isWorktreeActive={isWorktreeActive}
-            />
-          ))}
+      <>
+        <div className="flex h-full flex-col bg-background">
+          {/* Collapsed bar */}
+          <button
+            type="button"
+            onClick={onExpand}
+            className="flex h-full w-full items-center gap-2 px-3 text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          >
+            <Terminal className="h-3.5 w-3.5" />
+            <span>Terminal</span>
+            {hasRunningPanelTerminal && (
+              <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+            )}
+            <div className="flex-1" />
+            <ChevronUp className="h-3.5 w-3.5" />
+          </button>
+          {/* Keep terminals mounted but hidden to preserve state */}
+          <div className="hidden">
+            {terminals.map(terminal => (
+              <TerminalTabContent
+                key={terminal.id}
+                terminal={terminal}
+                worktreeId={worktreeId}
+                worktreePath={worktreePath}
+                isActive={terminal.id === activeTerminalId}
+                isCollapsed
+                isWorktreeActive={isWorktreeActive}
+              />
+            ))}
+          </div>
         </div>
-      </div>
+        {closeConfirmDialog}
+      </>
     )
   }
 
   return (
+    <>
     <div className="flex h-full flex-col bg-background">
       {/* Tab bar - fixed height for consistency */}
       <div
@@ -468,5 +571,7 @@ export function TerminalView({
         ))}
       </div>
     </div>
+    {closeConfirmDialog}
+    </>
   )
 }

--- a/src/components/projects/worktree-close-decision.test.ts
+++ b/src/components/projects/worktree-close-decision.test.ts
@@ -59,14 +59,14 @@ describe('decideSessionMiddleClose', () => {
     ).toBe('delete')
   })
 
-  it('deletes without confirming when other sessions remain (non-empty)', () => {
+  it('confirms non-empty sessions even when other sessions remain (issue #56)', () => {
     expect(
       decideSessionMiddleClose({
         activeSessionCount: 3,
         sessionIsEmpty: false,
         confirmSessionClose: true,
       })
-    ).toBe('delete')
+    ).toBe('confirm')
   })
 
   it('deletes without confirming when other sessions remain (empty)', () => {
@@ -79,7 +79,7 @@ describe('decideSessionMiddleClose', () => {
     ).toBe('delete')
   })
 
-  it('treats an empty worktree (count 0) as the last session', () => {
+  it('confirms a non-empty session even when count is 0 (stale/empty list edge)', () => {
     expect(
       decideSessionMiddleClose({
         activeSessionCount: 0,
@@ -87,5 +87,15 @@ describe('decideSessionMiddleClose', () => {
         confirmSessionClose: true,
       })
     ).toBe('confirm')
+  })
+
+  it('deletes a non-empty non-last session when confirmation is disabled', () => {
+    expect(
+      decideSessionMiddleClose({
+        activeSessionCount: 3,
+        sessionIsEmpty: false,
+        confirmSessionClose: false,
+      })
+    ).toBe('delete')
   })
 })

--- a/src/components/projects/worktree-close-decision.ts
+++ b/src/components/projects/worktree-close-decision.ts
@@ -22,18 +22,22 @@ export function decideWorktreeMiddleClose(
 export type SessionCloseDecision = 'confirm' | 'delete'
 
 /**
- * A middle-click on a conversation row deletes it, mirroring the session-tab
- * middle-click: confirm only when removing the last (non-empty) session of the
- * worktree and confirmation is enabled.
+ * Decide whether closing a session (tab X, middle-click, etc.) should prompt.
+ *
+ * When `confirm_session_close` is enabled (default), any non-empty session
+ * confirms before remove — not only the last tab. Confirming only the last tab
+ * let a held close shortcut cascade-delete chats with no recovery prompt
+ * (GitHub issue #56). Empty sessions still close immediately.
+ *
+ * `activeSessionCount` is retained for call-site compatibility / future UX.
  */
 export function decideSessionMiddleClose(params: {
   activeSessionCount: number
   sessionIsEmpty: boolean
   confirmSessionClose: boolean | undefined
 }): SessionCloseDecision {
-  const { activeSessionCount, sessionIsEmpty, confirmSessionClose } = params
-  const isLastSession = activeSessionCount <= 1
-  if (isLastSession && confirmSessionClose !== false && !sessionIsEmpty) {
+  const { sessionIsEmpty, confirmSessionClose } = params
+  if (confirmSessionClose !== false && !sessionIsEmpty) {
     return 'confirm'
   }
   return 'delete'

--- a/src/hooks/useMainWindowEventListeners.test.tsx
+++ b/src/hooks/useMainWindowEventListeners.test.tsx
@@ -5,6 +5,7 @@ import { useUIStore } from '@/store/ui-store'
 import { QueryClient } from '@tanstack/react-query'
 import {
   addTerminalTabForShortcut,
+  allowsKeybindingRepeat,
   applyCacheInvalidationKeys,
   blurFocusedTerminalForShortcut,
   closeActiveTerminalTabForShortcut,
@@ -284,6 +285,7 @@ describe('useMainWindowEventListeners terminal shortcuts', () => {
       activeTerminalIds: { 'modal-worktree': 'term-1' },
       modalTerminalOpen: { 'modal-worktree': true },
       terminalVisible: true,
+      runningTerminals: new Set(),
     })
 
     expect(closeActiveTerminalTabForShortcut()).toBe(true)
@@ -296,6 +298,64 @@ describe('useMainWindowEventListeners terminal shortcuts', () => {
     expect(
       useTerminalStore.getState().modalTerminalOpen['modal-worktree']
     ).toBe(false)
+  })
+
+  it('asks for confirmation instead of killing a running terminal via shortcut (issue #56)', () => {
+    focusTerminal()
+
+    useUIStore.setState({
+      sessionChatModalOpen: true,
+      sessionChatModalWorktreeId: 'modal-worktree',
+    })
+    useTerminalStore.setState({
+      terminals: {
+        'modal-worktree': [
+          {
+            id: 'term-running',
+            worktreeId: 'modal-worktree',
+            command: 'bun run dev',
+            label: 'dev',
+          },
+        ],
+      },
+      activeTerminalIds: { 'modal-worktree': 'term-running' },
+      modalTerminalOpen: { 'modal-worktree': true },
+      terminalVisible: true,
+      runningTerminals: new Set(['term-running']),
+    })
+
+    const confirmListener = vi.fn()
+    window.addEventListener('confirm-close-terminal', confirmListener)
+
+    expect(closeActiveTerminalTabForShortcut()).toBe(true)
+
+    expect(confirmListener).toHaveBeenCalledTimes(1)
+    const event = confirmListener.mock.calls[0]?.[0] as CustomEvent | undefined
+    expect(event?.detail).toEqual({
+      worktreeId: 'modal-worktree',
+      terminalId: 'term-running',
+    })
+    expect(mockInvoke).not.toHaveBeenCalledWith('stop_terminal', {
+      terminalId: 'term-running',
+    })
+    expect(mockDisposeTerminal).not.toHaveBeenCalled()
+    expect(useTerminalStore.getState().terminals['modal-worktree']).toHaveLength(
+      1
+    )
+
+    window.removeEventListener('confirm-close-terminal', confirmListener)
+  })
+
+  it('allows key-repeat only for scroll/navigation actions (issue #56)', () => {
+    expect(allowsKeybindingRepeat('scroll_chat_up')).toBe(true)
+    expect(allowsKeybindingRepeat('scroll_chat_down_small')).toBe(true)
+    expect(allowsKeybindingRepeat('next_session')).toBe(true)
+    expect(allowsKeybindingRepeat('previous_session')).toBe(true)
+
+    expect(allowsKeybindingRepeat('close_session_or_worktree')).toBe(false)
+    expect(allowsKeybindingRepeat('new_session')).toBe(false)
+    expect(allowsKeybindingRepeat('cancel_prompt')).toBe(false)
+    expect(allowsKeybindingRepeat('approve_plan')).toBe(false)
   })
 
   it('switches the active terminal tab by index for the modal worktree', () => {

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -51,6 +51,27 @@ export function findKeybindingAction(
 }
 
 /**
+ * Keybindings that intentionally re-fire while a key is held (OS key-repeat).
+ * Everything else is one-shot: a held Ctrl+W must not cascade-close terminals
+ * or sessions (GitHub issue #56).
+ */
+const KEYBINDING_ACTIONS_ALLOWING_REPEAT = new Set<KeybindingAction>([
+  'scroll_chat_up',
+  'scroll_chat_down',
+  'scroll_chat_up_medium',
+  'scroll_chat_down_medium',
+  'scroll_chat_up_small',
+  'scroll_chat_down_small',
+  'next_session',
+  'previous_session',
+])
+
+/** Whether OS key-repeat should re-execute this keybinding action. */
+export function allowsKeybindingRepeat(action: KeybindingAction): boolean {
+  return KEYBINDING_ACTIONS_ALLOWING_REPEAT.has(action)
+}
+
+/**
  * Apply backend `cache:invalidate` keys to the React Query client.
  * Shared by the debounced multi-client sync listener.
  *
@@ -170,6 +191,17 @@ export function closeActiveTerminalTabForShortcut(): boolean {
   const activeTerminalId = terminalStore.activeTerminalIds[worktreeId]
 
   if (!activeTerminalId) return true
+
+  // Running PTYs need an explicit confirm (issue #56). TerminalView listens
+  // for this event and opens the same dialog as the tab close button.
+  if (terminalStore.runningTerminals.has(activeTerminalId)) {
+    window.dispatchEvent(
+      new CustomEvent('confirm-close-terminal', {
+        detail: { worktreeId, terminalId: activeTerminalId },
+      })
+    )
+    return true
+  }
 
   invoke('stop_terminal', { terminalId: activeTerminalId }).catch(() => {
     /* noop */
@@ -657,6 +689,15 @@ export function useMainWindowEventListeners() {
 
       const keybindings = keybindingsRef.current
       const matchedAction = findKeybindingAction(shortcut, keybindings)
+
+      // OS key-repeat must not re-fire one-shot actions (issue #56: holding
+      // Ctrl/Cmd+W cascade-closed every terminal/session under the cursor).
+      // Consume the event so the browser does not handle the repeated shortcut.
+      if (e.repeat && matchedAction && !allowsKeybindingRepeat(matchedAction)) {
+        e.preventDefault()
+        e.stopPropagation()
+        return
+      }
 
       // Cancel prompt should work even when modals are open
       if (matchedAction === 'cancel_prompt') {


### PR DESCRIPTION
## Summary

- Block OS key-repeat for one-shot close actions so holding Ctrl/Cmd+W no longer cascade-closes terminals and sessions
- Require confirmation before closing non-empty session tabs (not only the last tab)
- Prompt before closing terminals that still have a running process, including close-all and keyboard close paths

fixes #56

---

Fixes #56