### PR TITLE
fix(preferences): scope AI Language save loading state

### DIFF
--- a/src/components/preferences/panes/AiLanguageField.test.tsx
+++ b/src/components/preferences/panes/AiLanguageField.test.tsx
@@ -1,0 +1,148 @@
+import { createElement } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppPreferences } from '@/types/preferences'
+import { defaultPreferences } from '@/types/preferences'
+import { AiLanguageField, isAiLanguageSavePending } from './AiLanguageField'
+
+const mutateMock = vi.fn()
+const isPendingRef = { current: false }
+const variablesRef = {
+  current: undefined as Partial<AppPreferences> | undefined,
+}
+
+vi.mock('@/services/preferences', () => ({
+  usePatchPreferences: () => ({
+    mutate: mutateMock,
+    get isPending() {
+      return isPendingRef.current
+    },
+    get variables() {
+      return variablesRef.current
+    },
+  }),
+}))
+
+function renderField(preferences: AppPreferences = defaultPreferences) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(AiLanguageField, { preferences })
+    )
+  )
+}
+
+describe('isAiLanguageSavePending (#505)', () => {
+  it('is false while a model-default (or other) patch is pending', () => {
+    expect(
+      isAiLanguageSavePending(true, {
+        selected_model: 'claude-sonnet-4-6[1m]',
+      })
+    ).toBe(false)
+    expect(isAiLanguageSavePending(true, { thinking_level: 'high' })).toBe(
+      false
+    )
+    expect(isAiLanguageSavePending(false, { ai_language: 'French' })).toBe(
+      false
+    )
+    expect(isAiLanguageSavePending(true, undefined)).toBe(false)
+    expect(isAiLanguageSavePending(true, null)).toBe(false)
+  })
+
+  it('is true only while an ai_language patch is pending', () => {
+    expect(isAiLanguageSavePending(true, { ai_language: 'French' })).toBe(true)
+    expect(isAiLanguageSavePending(true, { ai_language: '' })).toBe(true)
+  })
+})
+
+describe('AiLanguageField (#505)', () => {
+  beforeEach(() => {
+    mutateMock.mockReset()
+    isPendingRef.current = false
+    variablesRef.current = undefined
+  })
+
+  it('does not show a loading spinner while a model-default patch is pending', async () => {
+    const user = userEvent.setup()
+    const { rerender } = renderField()
+
+    const input = screen.getByPlaceholderText('Default')
+    await user.clear(input)
+    await user.type(input, 'French')
+
+    const save = screen.getByRole('button', { name: /save/i })
+    await waitFor(() => expect(save).not.toBeDisabled())
+
+    // Concurrent model default edit — previously shared isPending spun this button
+    isPendingRef.current = true
+    variablesRef.current = { selected_model: 'claude-sonnet-4-6[1m]' }
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    rerender(
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(AiLanguageField, { preferences: defaultPreferences })
+      )
+    )
+
+    expect(screen.getByRole('button', { name: /save/i })).not.toBeDisabled()
+    expect(document.querySelector('.animate-spin')).toBeNull()
+  })
+
+  it('shows a loading spinner only while an ai_language patch is pending', async () => {
+    const user = userEvent.setup()
+    const { rerender } = renderField()
+
+    const input = screen.getByPlaceholderText('Default')
+    await user.clear(input)
+    await user.type(input, 'French')
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save/i })).not.toBeDisabled()
+    })
+
+    isPendingRef.current = true
+    variablesRef.current = { ai_language: 'French' }
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    rerender(
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(AiLanguageField, { preferences: defaultPreferences })
+      )
+    )
+
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()
+    expect(document.querySelector('.animate-spin')).not.toBeNull()
+  })
+
+  it('patches ai_language on save', async () => {
+    const user = userEvent.setup()
+    renderField()
+
+    const input = screen.getByPlaceholderText('Default')
+    await user.clear(input)
+    await user.type(input, '日本語')
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(mutateMock).toHaveBeenCalledWith({ ai_language: '日本語' })
+  })
+})

--- a/src/components/preferences/panes/AiLanguageField.tsx
+++ b/src/components/preferences/panes/AiLanguageField.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useState, type FC } from 'react'
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { usePatchPreferences } from '@/services/preferences'
+import type { AppPreferences } from '@/types/preferences'
+
+const InlineField: FC<{
+  label: string
+  description?: React.ReactNode
+  children: React.ReactNode
+}> = ({ label, description, children }) => (
+  <div className="settings-inline-field flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+    <div className="space-y-0.5 sm:w-56 sm:shrink-0 lg:w-72">
+      <Label className="text-sm text-foreground">{label}</Label>
+      {description && (
+        <div className="text-xs text-muted-foreground break-words">
+          {description}
+        </div>
+      )}
+    </div>
+    {children}
+  </div>
+)
+
+/** True only while this field's own ai_language patch is in flight. */
+export function isAiLanguageSavePending(
+  isPending: boolean,
+  variables: Partial<AppPreferences> | undefined | null
+): boolean {
+  return (
+    isPending && variables != null && Object.hasOwn(variables, 'ai_language')
+  )
+}
+
+// Own mutation instance so model-default patches (and other GeneralPane saves)
+// do not put this Save button into a shared isPending loading state (#505).
+export const AiLanguageField: FC<{
+  preferences: AppPreferences | undefined
+}> = ({ preferences }) => {
+  const patchPreferences = usePatchPreferences()
+  const [localValue, setLocalValue] = useState(preferences?.ai_language ?? '')
+
+  const hasChanges = localValue !== (preferences?.ai_language ?? '')
+  const isSaving = isAiLanguageSavePending(
+    patchPreferences.isPending,
+    patchPreferences.variables
+  )
+
+  const handleSave = useCallback(() => {
+    if (!preferences) return
+    patchPreferences.mutate({ ai_language: localValue })
+  }, [preferences, patchPreferences, localValue])
+
+  return (
+    <InlineField
+      label="AI Language"
+      description="Language for AI responses (e.g. French, 日本語)"
+    >
+      <div className="flex items-center gap-2">
+        <Input
+          className="w-full sm:w-40"
+          placeholder="Default"
+          value={localValue}
+          onChange={e => setLocalValue(e.target.value)}
+        />
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={!hasChanges || isSaving}
+        >
+          {isSaving && <Loader2 className="h-4 w-4 animate-spin" />}
+          Save
+        </Button>
+      </div>
+    </InlineField>
+  )
+}

--- a/src/components/preferences/panes/GeneralPane.structure.test.ts
+++ b/src/components/preferences/panes/GeneralPane.structure.test.ts
@@ -107,6 +107,36 @@ describe('GeneralPane settings structure', () => {
     expect(executionOverrides).not.toContain('? codexReasoningOptions')
   })
 
+  // Regression #505: shared patchPreferences.isPending made the AI Language
+  // Save button spin when model defaults (or any other General field) saved.
+  it('scopes AI Language save loading to its own preferences mutation', () => {
+    const generalSource = readFileSync(
+      'src/components/preferences/panes/GeneralPane.tsx',
+      'utf8'
+    )
+    const fieldSource = readFileSync(
+      'src/components/preferences/panes/AiLanguageField.tsx',
+      'utf8'
+    )
+
+    // Field lives in its own module with an independent mutation instance
+    expect(generalSource).toContain(
+      "import { AiLanguageField } from './AiLanguageField'"
+    )
+    expect(generalSource).toContain(
+      '<AiLanguageField preferences={preferences} />'
+    )
+    expect(generalSource).not.toMatch(
+      /<AiLanguageField[\s\S]*?patchPreferences=/
+    )
+    expect(fieldSource).toContain('usePatchPreferences()')
+    expect(fieldSource).toContain('isAiLanguageSavePending')
+    expect(fieldSource).toContain('disabled={!hasChanges || isSaving}')
+    expect(fieldSource).not.toContain(
+      'disabled={!hasChanges || patchPreferences.isPending}'
+    )
+  })
+
   it('renders the app version and build commit at the bottom of general settings', () => {
     const source = readFileSync(
       'src/components/preferences/panes/GeneralPane.tsx',

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -203,6 +203,7 @@ import {
 } from '@/services/git-status'
 import { getPathUpdateAction } from '@/lib/cli-update'
 import { BackendPaneHeader, SettingsSection } from '../SettingsSection'
+import { AiLanguageField } from './AiLanguageField'
 import {
   resolveDefaultModelForBackend,
   resolvePiDefaultModel,
@@ -1120,8 +1121,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
   const selectedCursorModelLabel =
     cursorModelOptions.find(option => option.value === selectedCursorModel)
       ?.label ?? formatCursorModelLabel(selectedCursorModel)
-  const selectedGrokModel =
-    preferences?.selected_grok_model ?? 'grok/grok-4.5'
+  const selectedGrokModel = preferences?.selected_grok_model ?? 'grok/grok-4.5'
   const grokModelOptions: { value: GrokModel; label: string }[] = (
     availableGrokModels?.length
       ? availableGrokModels.map(model => ({
@@ -4356,10 +4356,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
               </div>
             </InlineField>
 
-            <AiLanguageField
-              preferences={preferences}
-              patchPreferences={patchPreferences}
-            />
+            <AiLanguageField preferences={preferences} />
 
             <InlineField
               label="Allow web tools in plan mode"
@@ -5032,46 +5029,6 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
         </AlertDialogContent>
       </AlertDialog>
     </div>
-  )
-}
-
-const AiLanguageField: FC<{
-  preferences: AppPreferences | undefined
-  patchPreferences: ReturnType<typeof usePatchPreferences>
-}> = ({ preferences, patchPreferences }) => {
-  const [localValue, setLocalValue] = useState(preferences?.ai_language ?? '')
-
-  const hasChanges = localValue !== (preferences?.ai_language ?? '')
-
-  const handleSave = useCallback(() => {
-    if (!preferences) return
-    patchPreferences.mutate({ ai_language: localValue })
-  }, [preferences, patchPreferences, localValue])
-
-  return (
-    <InlineField
-      label="AI Language"
-      description="Language for AI responses (e.g. French, 日本語)"
-    >
-      <div className="flex items-center gap-2">
-        <Input
-          className="w-full sm:w-40"
-          placeholder="Default"
-          value={localValue}
-          onChange={e => setLocalValue(e.target.value)}
-        />
-        <Button
-          size="sm"
-          onClick={handleSave}
-          disabled={!hasChanges || patchPreferences.isPending}
-        >
-          {patchPreferences.isPending && (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          )}
-          Save
-        </Button>
-      </div>
-    </InlineField>
   )
 }
 


### PR DESCRIPTION
## Summary

- Fixes the AI Language Save button showing a spinner/disabled state when editing model defaults (or other General settings) on Jean web
- Moves AI Language into its own preferences field with an independent mutation so loading only applies to `ai_language` patches
- Adds regression tests covering the shared-pending bug and save behavior

fixes #505

---

Fixes #505