### PR TITLE
fix(chat): recover send after cancel mid-run

### DIFF
--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -1,7 +1,8 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -76,8 +77,13 @@ static BACKEND_QUEUE_DRAINING: Lazy<Mutex<HashSet<String>>> =
 /// process/turn is registered, leaving a window where two concurrent sends
 /// (frontend queue processor vs backend queue drain vs another client) both
 /// pass the check and spawn duplicate runs. This claim is taken atomically at
-/// `send_chat_message` entry and held for the whole call.
-static ACTIVE_SENDS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+/// `send_chat_message` entry and held for the whole call — unless cancel
+/// releases it early so a follow-up send is not stuck (#329).
+///
+/// Values are generation tokens so an early cancel release cannot be clobbered
+/// by a later `Drop` from the cancelled claim after a new claim was acquired.
+static ACTIVE_SENDS: Lazy<Mutex<HashMap<String, u64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static SEND_CLAIM_GENERATION: AtomicU64 = AtomicU64::new(1);
 
 fn should_auto_name_branch(worktree: Option<&Worktree>) -> bool {
     worktree
@@ -92,33 +98,56 @@ fn should_auto_name_branch(worktree: Option<&Worktree>) -> bool {
 }
 
 /// RAII claim on a session's send slot — released on drop (any return path).
-struct SendClaim(String);
+struct SendClaim {
+    session_id: String,
+    generation: u64,
+}
 
 impl SendClaim {
     fn try_acquire(session_id: &str) -> Option<Self> {
         let mut active = ACTIVE_SENDS.lock().unwrap();
-        if active.insert(session_id.to_string()) {
-            Some(Self(session_id.to_string()))
-        } else {
-            None
+        if active.contains_key(session_id) {
+            return None;
         }
+        let generation = SEND_CLAIM_GENERATION.fetch_add(1, Ordering::Relaxed);
+        active.insert(session_id.to_string(), generation);
+        Some(Self {
+            session_id: session_id.to_string(),
+            generation,
+        })
     }
 }
 
 impl Drop for SendClaim {
     fn drop(&mut self) {
-        ACTIVE_SENDS.lock().unwrap().remove(&self.0);
+        let mut active = ACTIVE_SENDS.lock().unwrap();
+        // Only clear if we still own the slot — cancel may have released early
+        // and a newer send may already hold a different generation.
+        if active.get(&self.session_id) == Some(&self.generation) {
+            active.remove(&self.session_id);
+        }
     }
 }
 
+/// Release the in-flight send claim for a session after cancel so a follow-up
+/// prompt is not rejected with "Session already has an active request" while
+/// the cancelled worker finishes teardown (#329).
+fn release_active_send(session_id: &str) {
+    if ACTIVE_SENDS.lock().unwrap().remove(session_id).is_some() {
+        log::info!("[SendChat] released active send claim after cancel session={session_id}");
+    }
+}
+
+fn has_active_send(session_id: &str) -> bool {
+    ACTIVE_SENDS.lock().unwrap().contains_key(session_id)
+}
+
 fn should_forward_cancel_request(session_id: &str) -> bool {
-    ACTIVE_SENDS.lock().unwrap().contains(session_id)
-        || super::registry::is_session_actively_managed(session_id)
+    has_active_send(session_id) || super::registry::is_session_actively_managed(session_id)
 }
 
 fn clear_stale_pending_cancel_before_send(session_id: &str) {
-    let has_active_send = ACTIVE_SENDS.lock().unwrap().contains(session_id);
-    if !has_active_send
+    if !has_active_send(session_id)
         && !super::registry::is_session_actively_managed(session_id)
         && super::registry::clear_pending_cancel(session_id)
     {
@@ -4426,12 +4455,18 @@ pub async fn send_chat_message(
         let _ = tx.send(result);
     });
 
-    let (_pid, unified_response) = match rx.await {
+    let (pid, unified_response) = match rx.await {
         Ok(Ok(result)) => result,
         Ok(Err(e)) => {
-            // Thread completed with an error — clean up all registrations.
+            // Thread completed with an error — clean up registrations owned by
+            // this send. Prefer ownership-aware cleanup so a follow-up send that
+            // started after cancel is not clobbered (#329).
             log::info!("[SendChat] EXIT session={session_id} reason=thread_error error={e}");
-            super::registry::cleanup_session_registrations(&session_id);
+            super::registry::cleanup_owned_session_registrations(
+                &session_id,
+                None,
+                opencode_cancel_flag.as_ref(),
+            );
             if let Some(ref flag) = opencode_cancel_flag {
                 if !flag.load(std::sync::atomic::Ordering::SeqCst) {
                     // Mark run as crashed so it doesn't stay in Running forever
@@ -4503,7 +4538,11 @@ pub async fn send_chat_message(
         }
         Err(_) => {
             log::info!("[SendChat] EXIT session={session_id} reason=thread_panic");
-            super::registry::cleanup_session_registrations(&session_id);
+            super::registry::cleanup_owned_session_registrations(
+                &session_id,
+                None,
+                opencode_cancel_flag.as_ref(),
+            );
             // Check if CLI completed despite thread panic (#209)
             let partial_sid = run_log::extract_session_id_from_jsonl(&app, &session_id, &run_id);
             if run_log::jsonl_has_result_line(&app, &session_id, &run_id) {
@@ -4547,8 +4586,14 @@ pub async fn send_chat_message(
         }
     };
 
-    // Clear any stale pending cancel entry and unregister OpenCode cancel flag now that we have a result.
-    super::registry::cleanup_session_registrations(&session_id);
+    // Clear registry state owned by this send. After cancel, a newer send may
+    // already own ACTIVE_SENDS / CANCEL_FLAGS / PROCESS_REGISTRY for this session,
+    // so only remove entries that still match this run (#329).
+    super::registry::cleanup_owned_session_registrations(
+        &session_id,
+        Some(pid),
+        opencode_cancel_flag.as_ref(),
+    );
 
     // PID is now persisted via pid_callback immediately after spawn (before tailing).
     // No need to set_pid here — it was already saved for crash recovery.
@@ -5343,7 +5388,13 @@ pub async fn cancel_chat_message(
         super::registry::cleanup_session_registrations(&session_id);
         return Ok(false);
     }
-    cancel_process(&app, &session_id, &worktree_id)
+    let cancelled = cancel_process(&app, &session_id, &worktree_id)?;
+    if cancelled {
+        // Free the send slot immediately so a follow-up prompt is not rejected
+        // while the cancelled worker finishes teardown (issue #329).
+        release_active_send(&session_id);
+    }
+    Ok(cancelled)
 }
 
 /// Check if any sessions have running Claude processes
@@ -9618,6 +9669,27 @@ mod tests {
             SendClaim::try_acquire("pre-register-session").expect("send claim should acquire");
 
         assert!(should_forward_cancel_request("pre-register-session"));
+    }
+
+    #[test]
+    fn release_active_send_allows_new_claim_without_drop_clobber() {
+        // Regression for #329: cancel releases the claim while the cancelled
+        // send is still alive; Drop of the old claim must not free the new one.
+        let old = SendClaim::try_acquire("race-session").expect("first claim");
+        assert!(SendClaim::try_acquire("race-session").is_none());
+
+        release_active_send("race-session");
+        let new = SendClaim::try_acquire("race-session").expect("claim after cancel release");
+        assert!(has_active_send("race-session"));
+
+        drop(old);
+        assert!(
+            has_active_send("race-session"),
+            "old claim Drop must not remove newer generation"
+        );
+
+        drop(new);
+        assert!(!has_active_send("race-session"));
     }
 
     #[test]

--- a/jean-core/src/chat/opencode.rs
+++ b/jean-core/src/chat/opencode.rs
@@ -547,7 +547,11 @@ fn is_shared_sse_connected(working_dir: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn wait_for_shared_sse_connection(timeout: Duration, working_dir: &str) -> bool {
+fn wait_for_shared_sse_connection(
+    timeout: Duration,
+    working_dir: &str,
+    cancelled: Option<&Arc<AtomicBool>>,
+) -> bool {
     log::info!(
         "OpenCode shared SSE: waiting for connection dir={} timeout_ms={}",
         working_dir,
@@ -555,6 +559,14 @@ fn wait_for_shared_sse_connection(timeout: Duration, working_dir: &str) -> bool 
     );
     let wait_start = Instant::now();
     while wait_start.elapsed() < timeout {
+        if cancelled.is_some_and(|flag| flag.load(Ordering::SeqCst)) {
+            log::info!(
+                "OpenCode shared SSE: wait aborted by cancel dir={} wait_ms={}",
+                working_dir,
+                wait_start.elapsed().as_millis()
+            );
+            return false;
+        }
         if is_shared_sse_connected(working_dir) {
             log::info!(
                 "OpenCode shared SSE: connection ready dir={} wait_ms={}",
@@ -2269,7 +2281,11 @@ pub fn execute_opencode_http(
         steered.clone(),
     );
 
-    let sse_connected = wait_for_shared_sse_connection(Duration::from_secs(3), &working_dir_string);
+    let sse_connected = wait_for_shared_sse_connection(
+        Duration::from_secs(3),
+        &working_dir_string,
+        Some(cancelled),
+    );
 
     if sse_connected {
         log::info!("OpenCode: shared SSE streaming active, events will stream in real-time");

--- a/jean-core/src/chat/registry.rs
+++ b/jean-core/src/chat/registry.rs
@@ -357,6 +357,63 @@ pub fn cleanup_session_registrations(session_id: &str) {
     }
 }
 
+/// Ownership-aware cleanup used when a cancelled send may already have released
+/// its claim and a newer send may own registry state for the same session (#329).
+///
+/// - `pid`: remove process entry only when it still matches this run (`None` =
+///   remove any process entry; `Some(0)` skips process cleanup — OpenCode sentinel)
+/// - `cancel_flag`: remove OpenCode cancel entry only when the Arc still matches
+pub fn cleanup_owned_session_registrations(
+    session_id: &str,
+    pid: Option<u32>,
+    cancel_flag: Option<&Arc<AtomicBool>>,
+) {
+    let removed_pid = match pid {
+        Some(0) => None, // OpenCode / no process
+        Some(expected) => {
+            let mut registry = lock_recover(&PROCESS_REGISTRY, "PROCESS_REGISTRY");
+            match registry.get(session_id).copied() {
+                Some(current) if current == expected => registry.remove(session_id),
+                _ => None,
+            }
+        }
+        None => lock_recover(&PROCESS_REGISTRY, "PROCESS_REGISTRY").remove(session_id),
+    };
+    if removed_pid.is_some() {
+        lock_recover(&DETACHED_SESSIONS, "DETACHED_SESSIONS").remove(session_id);
+    }
+
+    let removed_flag = match cancel_flag {
+        Some(flag) => {
+            let mut flags = lock_recover(&CANCEL_FLAGS, "CANCEL_FLAGS");
+            match flags.get(session_id) {
+                Some(entry) if Arc::ptr_eq(&entry.flag, flag) => flags.remove(session_id).is_some(),
+                _ => false,
+            }
+        }
+        None => lock_recover(&CANCEL_FLAGS, "CANCEL_FLAGS")
+            .remove(session_id)
+            .is_some(),
+    };
+
+    // Only clear pre-registration cancel when nothing else is actively managed.
+    // A newer send may already be mid-registration.
+    let removed_pending = if !is_session_actively_managed(session_id) {
+        lock_recover(&PENDING_CANCELS, "PENDING_CANCELS").remove(session_id)
+    } else {
+        false
+    };
+
+    // Codex turns are unregistered by the Codex path itself; do not remove a
+    // turn that may belong to a newer concurrent send after cancel-release.
+
+    if removed_pid.is_some() || removed_pending || removed_flag {
+        log::info!(
+            "[Registry] cleaned owned state for session={session_id} pid={removed_pid:?} pending={removed_pending} cancel_flag={removed_flag}"
+        );
+    }
+}
+
 /// Clear only a queued pre-registration cancel for an otherwise idle session.
 /// Used before starting a fresh send so stale pending cancel state from a
 /// previous idle-cancel race cannot poison the next run.
@@ -531,6 +588,72 @@ mod tests {
     }
 
     #[test]
+    fn opencode_cancel_flag_free_allows_immediate_resend() {
+        // Regression for #329: after cancel, CANCEL_FLAGS must not keep the
+        // session "actively managed" while the HTTP worker unwinds.
+        let _guard = lock_recover(&TEST_LOCK, "TEST_LOCK");
+        clear_registries();
+
+        let flag = Arc::new(AtomicBool::new(false));
+        assert!(register_cancel_flag(
+            "opencode-session".to_string(),
+            flag.clone()
+        ));
+        assert!(is_session_actively_managed("opencode-session"));
+
+        // Mirror cancel_process OpenCode path: signal + free registry slot.
+        flag.store(true, Ordering::SeqCst);
+        lock_recover(&CANCEL_FLAGS, "CANCEL_FLAGS").remove("opencode-session");
+
+        assert!(flag.load(Ordering::SeqCst), "worker still sees cancel");
+        assert!(
+            !is_session_actively_managed("opencode-session"),
+            "session must accept a new send immediately after cancel"
+        );
+
+        // A new run can register a fresh cancel flag right away.
+        let new_flag = Arc::new(AtomicBool::new(false));
+        assert!(register_cancel_flag(
+            "opencode-session".to_string(),
+            new_flag.clone()
+        ));
+        assert!(is_session_actively_managed("opencode-session"));
+
+        // Owned cleanup for the OLD flag must not clobber the new registration.
+        cleanup_owned_session_registrations("opencode-session", Some(0), Some(&flag));
+        assert!(is_session_actively_managed("opencode-session"));
+        assert!(!new_flag.load(Ordering::SeqCst));
+
+        // Owned cleanup for the NEW flag clears it.
+        cleanup_owned_session_registrations("opencode-session", Some(0), Some(&new_flag));
+        assert!(!is_session_actively_managed("opencode-session"));
+
+        clear_registries();
+    }
+
+    #[test]
+    fn cleanup_owned_process_only_removes_matching_pid() {
+        let _guard = lock_recover(&TEST_LOCK, "TEST_LOCK");
+        clear_registries();
+
+        assert!(register_process("session".to_string(), 111));
+        // Old cancelled run tries to clean pid 111 after a new run registered 222.
+        assert!(register_process("session".to_string(), 222));
+
+        cleanup_owned_session_registrations("session", Some(111), None);
+        assert!(is_session_actively_managed("session"));
+        assert_eq!(
+            lock_recover(&PROCESS_REGISTRY, "PROCESS_REGISTRY").get("session"),
+            Some(&222)
+        );
+
+        cleanup_owned_session_registrations("session", Some(222), None);
+        assert!(!is_session_actively_managed("session"));
+
+        clear_registries();
+    }
+
+    #[test]
     fn clear_pending_cancel_leaves_active_registrations_intact() {
         let _guard = lock_recover(&TEST_LOCK, "TEST_LOCK");
         clear_registries();
@@ -660,6 +783,18 @@ pub fn cancel_process(
             abort_opencode_session(oc_sid, entry.working_dir.clone());
         }
 
+        // Free actively-managed state immediately so a follow-up send is not
+        // rejected while the cancelled HTTP worker unwinds (#329 / #375).
+        // The Arc flag remains alive in the worker, which observes cancel and exits.
+        let removed = lock_recover(&CANCEL_FLAGS, "CANCEL_FLAGS")
+            .remove(session_id)
+            .is_some();
+        if removed {
+            log::info!(
+                "[Registry] freed OpenCode cancel flag after cancel session={session_id}"
+            );
+        }
+
         // Mark run as cancelled immediately (before HTTP call returns)
         if let Err(e) = run_log::mark_running_run_cancelled(app, session_id) {
             log::warn!("Failed to mark run as cancelled in manifest: {e}");
@@ -776,6 +911,9 @@ pub fn cancel_process_if_running(
         if let Some(oc_sid) = entry.opencode_session_id {
             abort_opencode_session(oc_sid, entry.working_dir.clone());
         }
+
+        // Free actively-managed state immediately (same as cancel_process).
+        lock_recover(&CANCEL_FLAGS, "CANCEL_FLAGS").remove(session_id);
 
         if let Err(e) = run_log::mark_running_run_cancelled(app, session_id) {
             log::warn!("Failed to mark run as cancelled in manifest: {e}");

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -1947,21 +1947,26 @@ export function useSendMessage() {
       }
 
       // Benign race: another queue consumer (backend drain / another client)
-      // started a run for this session first. A run IS active, so keep the
-      // sending state and skip the error banner/toast. The losing message is
-      // requeued: the queue processor's per-call onError handles queued
-      // messages; for direct submits we restore the input draft so the typed
-      // text isn't lost.
+      // started a run for this session first. Queued messages are requeued by
+      // the queue processor's per-call onError. Direct submits restore the
+      // draft so typed text isn't lost.
+      //
+      // After cancel, a brief residual race can still produce this error while
+      // the cancelled worker tears down (#329). Do NOT leave sending sticky —
+      // that makes the session look unrecoverable until the user cancels again.
       if (isDuplicateSendError(error)) {
         logger.warn('Duplicate send rejected — another run is active', {
           sessionId,
           fromQueue: variables.fromQueue ?? false,
         })
         if (!variables.fromQueue) {
-          const { inputDrafts, setInputDraft } = useChatStore.getState()
+          const { inputDrafts, setInputDraft, removeSendingSession, clearExecutingMode } =
+            useChatStore.getState()
           if (!inputDrafts[sessionId]?.trim()) {
             setInputDraft(sessionId, variables.message)
           }
+          removeSendingSession(sessionId)
+          clearExecutingMode(sessionId)
         }
         // Drop the optimistic user message by refetching authoritative state
         queryClient.invalidateQueries({


### PR DESCRIPTION
## Summary

- Free the in-flight send claim immediately on cancel so a follow-up message is not stuck with `Session already has an active request`
- Use generation-scoped send claims and ownership-aware registry cleanup so a cancelled run cannot clobber a newer send
- Make OpenCode cancel interrupt SSE wait/teardown paths so cancel actually unblocks the session
- Clear sticky frontend sending state on residual duplicate-send races after cancel

fixes #329

---

Fixes #329