### PR TITLE
fix(cli): detect PATH backends and Claude auth (#387)

### DIFF
--- a/jean-core/src/auto_fix/scheduler.rs
+++ b/jean-core/src/auto_fix/scheduler.rs
@@ -215,6 +215,11 @@ pub fn is_backend_quota_or_auth_error(error: &str) -> bool {
         || lower.contains("token expired")
         || lower.contains("not authenticated")
         || lower.contains("authrequired")
+        // Claude CLI headless auth prompts (issue #387)
+        || lower.contains("not logged in")
+        || lower.contains("please run /login")
+        || lower.contains("session expired")
+        || (lower.contains("isn't available in this environment") && lower.contains("login"))
 }
 
 pub fn start_auto_fix_scheduler(app: AppHandle) {
@@ -1182,6 +1187,12 @@ mod tests {
         ));
         assert!(is_backend_quota_or_auth_error(
             "Claude usage limit reached for this plan"
+        ));
+        assert!(is_backend_quota_or_auth_error(
+            "Not logged in · Please run /login"
+        ));
+        assert!(is_backend_quota_or_auth_error(
+            "/login isn't available in this environment."
         ));
         assert!(!is_backend_quota_or_auth_error(
             "worktree path already exists"

--- a/jean-core/src/claude_cli/config.rs
+++ b/jean-core/src/claude_cli/config.rs
@@ -52,13 +52,62 @@ pub fn get_wsl_cli_binary_path(distro: &str) -> Result<String, String> {
     ))
 }
 
+/// Whether the Jean-managed Claude binary is present and executable.
+pub fn jean_managed_installed(app: &AppHandle) -> bool {
+    let wsl = get_wsl_config();
+    if wsl.enabled {
+        return get_wsl_cli_binary_path(&wsl.distro)
+            .map(|path| crate::platform::wsl_file_executable(&wsl.distro, &path))
+            .unwrap_or(false);
+    }
+    get_cli_binary_path(app)
+        .map(|path| path.exists())
+        .unwrap_or(false)
+}
+
+/// Find Claude on the system PATH (excluding the Jean-managed binary).
+pub fn find_system_binary(app: &AppHandle) -> Option<PathBuf> {
+    let wsl = get_wsl_config();
+    if wsl.enabled {
+        return crate::platform::wsl_which(
+            &wsl.distro,
+            "claude",
+            get_wsl_cli_binary_path(&wsl.distro).ok().as_deref(),
+        )
+        .map(PathBuf::from);
+    }
+
+    let jean_managed = get_cli_binary_path(app)
+        .ok()
+        .and_then(|path| std::fs::canonicalize(path).ok());
+    crate::platform::find_cli_in_host_path("claude", jean_managed.as_deref())
+}
+
+/// True when Jean-managed Claude is missing but a system PATH install exists.
+/// Used to auto-select `claude_cli_source = "path"` so Homebrew installs work
+/// without requiring a manual Settings toggle (issue #387).
+pub fn should_auto_use_system(app: &AppHandle) -> bool {
+    !jean_managed_installed(app) && find_system_binary(app).is_some()
+}
+
+fn jean_managed_path(app: &AppHandle) -> PathBuf {
+    let wsl = get_wsl_config();
+    if wsl.enabled {
+        return get_wsl_cli_binary_path(&wsl.distro)
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(CLI_BINARY_NAME_UNIX));
+    }
+    get_cli_binary_path(app).unwrap_or_else(|_| PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME))
+}
+
 /// Resolve Claude binary path based on the user's preference.
 ///
-/// If `claude_cli_source` preference is `"path"`, look up `claude` in system PATH.
-/// Otherwise (default `"jean"`), use the Jean-managed binary.
+/// If `claude_cli_source` is `"path"`, look up `claude` in system PATH.
+/// If `"jean"` (default) and the Jean-managed binary exists, use it.
+/// Otherwise fall back to a system PATH install when present so Homebrew
+/// (and similar) CLIs work without an explicit source switch.
 pub fn resolve_cli_binary(app: &AppHandle) -> PathBuf {
-    // Read preference from disk to avoid needing managed state
-    let use_path = match crate::get_preferences_path(app) {
+    let prefer_path = match crate::get_preferences_path(app) {
         Ok(prefs_path) => {
             if let Ok(contents) = std::fs::read_to_string(&prefs_path) {
                 if let Ok(prefs) = serde_json::from_str::<crate::AppPreferences>(&contents) {
@@ -73,37 +122,29 @@ pub fn resolve_cli_binary(app: &AppHandle) -> PathBuf {
         Err(_) => false,
     };
 
-    if use_path {
-        let wsl = get_wsl_config();
-        if wsl.enabled {
-            // In WSL mode, resolve the absolute Unix path so the session
-            // spawn path can exec it directly. `wsl_which` uses a login
-            // shell so PATH additions from ~/.profile / ~/.bashrc apply
-            // (nvm, bun, volta, npm-global, etc.).
-            if let Some(unix_path) = crate::platform::wsl_which(
-                &wsl.distro,
-                "claude",
-                get_wsl_cli_binary_path(&wsl.distro).ok().as_deref(),
-            ) {
-                return PathBuf::from(unix_path);
-            }
-        } else if let Some(path) = crate::platform::find_cli_in_host_path("claude", None) {
+    if prefer_path {
+        if let Some(path) = find_system_binary(app) {
             return path;
         }
-        // Fallback: if PATH lookup fails, still return Jean-managed path
-        log::warn!("claude_cli_source is 'path' but could not find claude in PATH, falling back to Jean-managed binary");
+        log::warn!(
+            "claude_cli_source is 'path' but could not find claude in PATH, falling back to Jean-managed binary"
+        );
+        return jean_managed_path(app);
     }
 
-    // In WSL mode, the Jean-managed install lives inside the distro — return
-    // the Linux absolute path so the runtime can exec it via `wsl.exe`.
-    let wsl = get_wsl_config();
-    if wsl.enabled {
-        return get_wsl_cli_binary_path(&wsl.distro)
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from(CLI_BINARY_NAME_UNIX));
+    if jean_managed_installed(app) {
+        return jean_managed_path(app);
     }
 
-    get_cli_binary_path(app).unwrap_or_else(|_| PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME))
+    if let Some(path) = find_system_binary(app) {
+        log::info!(
+            "Jean-managed Claude CLI not installed; using system PATH binary at {}",
+            path.display()
+        );
+        return path;
+    }
+
+    jean_managed_path(app)
 }
 
 /// Ensure the CLI directory exists, creating it if necessary

--- a/jean-core/src/codex_cli/config.rs
+++ b/jean-core/src/codex_cli/config.rs
@@ -44,12 +44,59 @@ pub fn get_cli_binary_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(get_cli_dir(app)?.join(CLI_BINARY_NAME))
 }
 
+/// Whether the Jean-managed Codex binary is present and executable.
+pub fn jean_managed_installed(app: &AppHandle) -> bool {
+    let wsl = get_wsl_config();
+    if wsl.enabled {
+        return get_wsl_cli_binary_path(&wsl.distro)
+            .map(|path| crate::platform::wsl_file_executable(&wsl.distro, &path))
+            .unwrap_or(false);
+    }
+    get_cli_binary_path(app)
+        .map(|path| path.exists())
+        .unwrap_or(false)
+}
+
+/// Find Codex on the system PATH (excluding the Jean-managed binary).
+pub fn find_system_binary(app: &AppHandle) -> Option<PathBuf> {
+    let wsl = get_wsl_config();
+    if wsl.enabled {
+        return crate::platform::wsl_which(
+            &wsl.distro,
+            "codex",
+            get_wsl_cli_binary_path(&wsl.distro).ok().as_deref(),
+        )
+        .map(PathBuf::from);
+    }
+
+    let jean_managed = get_cli_binary_path(app)
+        .ok()
+        .and_then(|path| std::fs::canonicalize(path).ok());
+    crate::platform::find_cli_in_host_path("codex", jean_managed.as_deref())
+}
+
+/// True when Jean-managed Codex is missing but a system PATH install exists.
+pub fn should_auto_use_system(app: &AppHandle) -> bool {
+    !jean_managed_installed(app) && find_system_binary(app).is_some()
+}
+
+fn jean_managed_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let wsl = get_wsl_config();
+    if wsl.enabled {
+        return get_wsl_cli_binary_path(&wsl.distro).map(PathBuf::from);
+    }
+    get_cli_binary_path(app)
+        .or_else(|_| Ok(PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME)))
+}
+
 /// Resolve Codex binary path based on the user's preference.
 ///
-/// If `codex_cli_source` preference is `"path"`, look up `codex` in system PATH.
-/// Otherwise (default `"jean"`), use the Jean-managed binary.
+/// If `codex_cli_source` is `"path"`, look up `codex` in system PATH.
+/// If `"jean"` (default) and the Jean-managed binary exists, use it.
+/// Otherwise fall back to a system PATH install when present so Homebrew
+/// installs work without an explicit source switch (issue #387).
 pub fn resolve_cli_binary(app: &AppHandle) -> Result<PathBuf, String> {
-    let use_path = match crate::get_preferences_path(app) {
+    let prefer_path = match crate::get_preferences_path(app) {
         Ok(prefs_path) => {
             if let Ok(contents) = std::fs::read_to_string(&prefs_path) {
                 if let Ok(prefs) = serde_json::from_str::<crate::AppPreferences>(&contents) {
@@ -79,35 +126,32 @@ pub fn resolve_cli_binary(app: &AppHandle) -> Result<PathBuf, String> {
         }
     };
 
-    if use_path {
-        let wsl = get_wsl_config();
-        if wsl.enabled {
-            // Resolve absolute Unix path so downstream session/status probes
-            // don't depend on a non-login-shell PATH.
-            let jean_managed = get_wsl_cli_binary_path(&wsl.distro).ok();
-            if let Some(unix_path) =
-                crate::platform::wsl_which(&wsl.distro, "codex", jean_managed.as_deref())
-            {
-                log::debug!(
-                    "resolve_cli_binary: found codex in WSL distro {} at {unix_path}",
-                    wsl.distro
-                );
-                return Ok(PathBuf::from(unix_path));
-            }
-        } else if let Some(path) = crate::platform::find_cli_in_host_path("codex", None) {
+    if prefer_path {
+        if let Some(path) = find_system_binary(app) {
             log::debug!("resolve_cli_binary: resolved to PATH binary: {path:?}");
             return Ok(path);
         }
-        log::warn!("codex_cli_source is 'path' but could not find codex in PATH, falling back to Jean-managed binary");
+        log::warn!(
+            "codex_cli_source is 'path' but could not find codex in PATH, falling back to Jean-managed binary"
+        );
+        return jean_managed_path(app);
     }
 
-    let wsl = get_wsl_config();
-    if wsl.enabled {
-        return get_wsl_cli_binary_path(&wsl.distro).map(PathBuf::from);
+    if jean_managed_installed(app) {
+        let path = jean_managed_path(app)?;
+        log::debug!("resolve_cli_binary: using jean-managed binary: {path:?}");
+        return Ok(path);
     }
 
-    let fallback = get_cli_binary_path(app)
-        .unwrap_or_else(|_| PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME));
+    if let Some(path) = find_system_binary(app) {
+        log::info!(
+            "Jean-managed Codex CLI not installed; using system PATH binary at {}",
+            path.display()
+        );
+        return Ok(path);
+    }
+
+    let fallback = jean_managed_path(app)?;
     log::debug!("resolve_cli_binary: using jean-managed binary: {fallback:?}");
     Ok(fallback)
 }

--- a/jean-core/src/codex_cli/mod.rs
+++ b/jean-core/src/codex_cli/mod.rs
@@ -7,4 +7,4 @@ mod config;
 pub mod mcp;
 
 pub use commands::*;
-pub use config::{get_cli_binary_path, resolve_cli_binary};
+pub use config::{get_cli_binary_path, resolve_cli_binary, should_auto_use_system};

--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -645,6 +645,49 @@ fn maybe_auto_select_system_coderabbit(
     false
 }
 
+/// When Jean-managed Claude/Codex/OpenCode is missing but a system PATH install
+/// exists, switch the preference to `"path"` so Settings UI, auth, and status
+/// checks agree with the binary actually used (issue #387).
+///
+/// Runtime `resolve_cli_binary` also falls back to PATH when Jean-managed is
+/// missing; this persists the source so the UI does not show a misleading
+/// "Jean" selection.
+fn maybe_auto_select_system_cli_sources(
+    app: &AppHandle,
+    preferences: &mut AppPreferences,
+) -> bool {
+    let mut changed = false;
+
+    if preferences.claude_cli_source == "jean" && claude_cli::should_auto_use_system(app) {
+        log::info!("Auto-selecting Claude CLI source=path (Jean-managed missing, system found)");
+        preferences.claude_cli_source = "path".to_string();
+        changed = true;
+    }
+    if preferences.codex_cli_source == "jean" && codex_cli::should_auto_use_system(app) {
+        log::info!("Auto-selecting Codex CLI source=path (Jean-managed missing, system found)");
+        preferences.codex_cli_source = "path".to_string();
+        changed = true;
+    }
+    if preferences.opencode_cli_source == "jean" && opencode_cli::should_auto_use_system(app) {
+        log::info!("Auto-selecting OpenCode CLI source=path (Jean-managed missing, system found)");
+        preferences.opencode_cli_source = "path".to_string();
+        changed = true;
+    }
+
+    changed
+}
+
+/// Apply all PATH auto-selection migrations. Returns true if any preference changed.
+fn maybe_auto_select_system_cli_preferences(
+    app: &AppHandle,
+    preferences: &mut AppPreferences,
+    raw_preferences: Option<&Value>,
+) -> bool {
+    let mut changed = maybe_auto_select_system_coderabbit(app, preferences, raw_preferences);
+    changed |= maybe_auto_select_system_cli_sources(app, preferences);
+    changed
+}
+
 fn normalize_parallel_execution_preferences(preferences: &mut AppPreferences) -> bool {
     if preferences.parallel_execution_prompt_enabled && !preferences.codex_multi_agent_enabled {
         preferences.codex_multi_agent_enabled = true;
@@ -2711,7 +2754,7 @@ pub fn load_preferences_sync(app: &AppHandle) -> Result<AppPreferences, String> 
     let prefs_path = get_preferences_path(app)?;
     if !prefs_path.exists() {
         let mut preferences = AppPreferences::default();
-        maybe_auto_select_system_coderabbit(app, &mut preferences, None);
+        maybe_auto_select_system_cli_preferences(app, &mut preferences, None);
         return Ok(preferences);
     }
     let contents = std::fs::read_to_string(&prefs_path)
@@ -2722,7 +2765,7 @@ pub fn load_preferences_sync(app: &AppHandle) -> Result<AppPreferences, String> 
         .map_err(|e| format!("Failed to parse preferences: {e}"))?;
     migrate_final_review_preferences(&mut preferences, &raw_preferences);
     normalize_parallel_execution_preferences(&mut preferences);
-    maybe_auto_select_system_coderabbit(app, &mut preferences, Some(&raw_preferences));
+    maybe_auto_select_system_cli_preferences(app, &mut preferences, Some(&raw_preferences));
     Ok(preferences)
 }
 
@@ -2733,10 +2776,10 @@ async fn load_preferences(app: AppHandle) -> Result<AppPreferences, String> {
     if !prefs_path.exists() {
         log::trace!("Preferences file not found, using defaults");
         let mut preferences = AppPreferences::default();
-        if maybe_auto_select_system_coderabbit(&app, &mut preferences, None) {
+        if maybe_auto_select_system_cli_preferences(&app, &mut preferences, None) {
             if let Ok(json) = serde_json::to_string_pretty(&preferences) {
                 let _ = std::fs::write(&prefs_path, json);
-                log::trace!("Saved preferences after CodeRabbit PATH auto-detection");
+                log::trace!("Saved preferences after CLI PATH auto-detection");
             }
         }
         return Ok(preferences);
@@ -2777,7 +2820,7 @@ async fn load_preferences(app: AppHandle) -> Result<AppPreferences, String> {
         preferences.branch_naming_model = default_branch_naming_model();
         needs_resave = true;
     }
-    if maybe_auto_select_system_coderabbit(&app, &mut preferences, Some(&raw_preferences)) {
+    if maybe_auto_select_system_cli_preferences(&app, &mut preferences, Some(&raw_preferences)) {
         needs_resave = true;
     }
     if preferences.session_naming_model == "haiku" {

--- a/jean-core/src/opencode_cli/config.rs
+++ b/jean-core/src/opencode_cli/config.rs
@@ -42,12 +42,61 @@ pub fn get_cli_binary_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(get_cli_dir(app)?.join(CLI_BINARY_NAME))
 }
 
+/// Whether the Jean-managed OpenCode binary is present and executable.
+pub fn jean_managed_installed(app: &AppHandle) -> bool {
+    let wsl = get_wsl_config();
+    if wsl.enabled {
+        return get_wsl_cli_binary_path(&wsl.distro)
+            .map(|path| crate::platform::wsl_file_executable(&wsl.distro, &path))
+            .unwrap_or(false);
+    }
+    get_cli_binary_path(app)
+        .map(|path| path.exists())
+        .unwrap_or(false)
+}
+
+/// Find OpenCode on the system PATH (excluding the Jean-managed binary).
+pub fn find_system_binary(app: &AppHandle) -> Option<PathBuf> {
+    let wsl = get_wsl_config();
+    if wsl.enabled {
+        return crate::platform::wsl_which(
+            &wsl.distro,
+            "opencode",
+            get_wsl_cli_binary_path(&wsl.distro).ok().as_deref(),
+        )
+        .map(PathBuf::from);
+    }
+
+    let jean_managed = get_cli_binary_path(app)
+        .ok()
+        .and_then(|path| std::fs::canonicalize(path).ok());
+    crate::platform::find_cli_in_host_path("opencode", jean_managed.as_deref())
+}
+
+/// True when Jean-managed OpenCode is missing but a system PATH install exists.
+pub fn should_auto_use_system(app: &AppHandle) -> bool {
+    !jean_managed_installed(app) && find_system_binary(app).is_some()
+}
+
+fn jean_managed_path(app: &AppHandle) -> PathBuf {
+    let wsl = get_wsl_config();
+    if wsl.enabled {
+        return get_wsl_cli_binary_path(&wsl.distro)
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(CLI_BINARY_NAME_UNIX));
+    }
+    get_cli_binary_path(app).unwrap_or_else(|_| PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME))
+}
+
 /// Resolve OpenCode binary path based on the user's preference.
 ///
-/// If `opencode_cli_source` preference is `"path"`, look up `opencode` in system PATH.
-/// Otherwise (default `"jean"`), use the Jean-managed binary.
+/// If `opencode_cli_source` is `"path"`, look up `opencode` in system PATH.
+/// If `"jean"` (default) and the Jean-managed binary exists, use it.
+/// Otherwise fall back to a system PATH install when present so installs under
+/// `~/.opencode/bin` (and similar) work without an explicit source switch
+/// (issue #387).
 pub fn resolve_cli_binary(app: &AppHandle) -> PathBuf {
-    let use_path = match crate::get_preferences_path(app) {
+    let prefer_path = match crate::get_preferences_path(app) {
         Ok(prefs_path) => {
             if let Ok(contents) = std::fs::read_to_string(&prefs_path) {
                 if let Ok(prefs) = serde_json::from_str::<crate::AppPreferences>(&contents) {
@@ -62,30 +111,29 @@ pub fn resolve_cli_binary(app: &AppHandle) -> PathBuf {
         Err(_) => false,
     };
 
-    if use_path {
-        let wsl = get_wsl_config();
-        if wsl.enabled {
-            if let Some(unix_path) = crate::platform::wsl_which(
-                &wsl.distro,
-                "opencode",
-                get_wsl_cli_binary_path(&wsl.distro).ok().as_deref(),
-            ) {
-                return PathBuf::from(unix_path);
-            }
-        } else if let Some(path) = crate::platform::find_cli_in_host_path("opencode", None) {
+    if prefer_path {
+        if let Some(path) = find_system_binary(app) {
             return path;
         }
-        log::warn!("opencode_cli_source is 'path' but could not find opencode in PATH, falling back to Jean-managed binary");
+        log::warn!(
+            "opencode_cli_source is 'path' but could not find opencode in PATH, falling back to Jean-managed binary"
+        );
+        return jean_managed_path(app);
     }
 
-    let wsl = get_wsl_config();
-    if wsl.enabled {
-        return get_wsl_cli_binary_path(&wsl.distro)
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from(CLI_BINARY_NAME_UNIX));
+    if jean_managed_installed(app) {
+        return jean_managed_path(app);
     }
 
-    get_cli_binary_path(app).unwrap_or_else(|_| PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME))
+    if let Some(path) = find_system_binary(app) {
+        log::info!(
+            "Jean-managed OpenCode CLI not installed; using system PATH binary at {}",
+            path.display()
+        );
+        return path;
+    }
+
+    jean_managed_path(app)
 }
 
 /// Ensure the CLI directory exists.

--- a/jean-core/src/opencode_cli/mod.rs
+++ b/jean-core/src/opencode_cli/mod.rs
@@ -7,4 +7,4 @@ mod config;
 pub mod mcp;
 
 pub use commands::*;
-pub use config::resolve_cli_binary;
+pub use config::{resolve_cli_binary, should_auto_use_system};

--- a/src/components/chat/hooks/useMessageSending.ts
+++ b/src/components/chat/hooks/useMessageSending.ts
@@ -29,6 +29,10 @@ import type {
 } from '@/types/chat'
 import type { QueryClient } from '@tanstack/react-query'
 import { GIT_ALLOWED_TOOLS } from './useMessageHandlers'
+import {
+  isLoginSlashCommand,
+  openBackendLoginModal,
+} from '@/lib/cli-auth'
 
 interface UseMessageSendingParams {
   activeSessionId: string | null | undefined
@@ -301,6 +305,28 @@ export function useMessageSending({
         toast.error(
           'Session not found. Please refresh or create a new session.'
         )
+        return
+      }
+
+      // Intercept /login — interactive CLI login is not available inside Jean
+      // headless chat (issue #387). Open CliLoginModal instead.
+      if (
+        isLoginSlashCommand(textMessage) &&
+        images.length === 0 &&
+        files.length === 0 &&
+        textFiles.length === 0 &&
+        skills.length === 0
+      ) {
+        clearInputDraft(activeSessionId)
+        clearChatInputState()
+        const backend = selectedBackendRef.current
+        void openBackendLoginModal(backend).then(opened => {
+          if (opened) {
+            toast.message(
+              `Opening ${backend} login… Interactive /login is not available in Jean chat.`
+            )
+          }
+        })
         return
       }
 

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -69,6 +69,10 @@ import {
   hasMeaningfulAssistantPayload,
   shouldHydrateCompletedSessionFromBackend,
 } from '@/components/chat/hooks/completion-hydration'
+import {
+  handleCliAuthError,
+  isCliAuthError,
+} from '@/lib/cli-auth'
 
 interface UseStreamingEventsParams {
   queryClient: QueryClient
@@ -1560,8 +1564,19 @@ export default function useStreamingEvents({
           .catch(() => undefined)
       }
 
+      // Auth failures from headless CLIs (e.g. Claude "Please run /login")
+      // are not actionable inside chat — rewrite and offer Jean's Login modal.
+      let displayError = error
+      if (isCliAuthError(error)) {
+        const session = queryClient.getQueryData<Session>(
+          chatQueryKeys.session(session_id)
+        )
+        const backend = (session?.backend as CliBackend | undefined) ?? 'claude'
+        displayError = handleCliAuthError(error, backend)
+      }
+
       // Set error state for inline display
-      setError(session_id, error)
+      setError(session_id, displayError)
 
       // Check if CLI produced streaming content BEFORE clearing state.
       // If content was streamed, the CLI ran — don't remove the user message

--- a/src/lib/cli-auth.test.ts
+++ b/src/lib/cli-auth.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isCliAuthError,
+  isLoginSlashCommand,
+  loginArgsForBackend,
+  rewriteCliAuthErrorMessage,
+} from './cli-auth'
+
+describe('isCliAuthError', () => {
+  it('detects Claude not-logged-in guidance', () => {
+    expect(isCliAuthError('Not logged in · Please run /login')).toBe(true)
+  })
+
+  it('detects headless /login unavailable message', () => {
+    expect(
+      isCliAuthError("/login isn't available in this environment.")
+    ).toBe(true)
+  })
+
+  it('detects codex re-auth prompts', () => {
+    expect(
+      isCliAuthError('Codex token expired. Run `codex` to log in again.')
+    ).toBe(true)
+  })
+
+  it('ignores unrelated errors', () => {
+    expect(isCliAuthError('worktree path already exists')).toBe(false)
+    expect(isCliAuthError('network timeout')).toBe(false)
+  })
+})
+
+describe('rewriteCliAuthErrorMessage', () => {
+  it('does not recommend interactive /login in chat', () => {
+    const msg = rewriteCliAuthErrorMessage(
+      'Not logged in · Please run /login',
+      'claude'
+    )
+    expect(msg.toLowerCase()).toContain('not authenticated')
+    expect(msg.toLowerCase()).toContain('settings')
+    expect(msg).toMatch(/not available in Jean chat/i)
+  })
+})
+
+describe('isLoginSlashCommand', () => {
+  it('matches bare /login only', () => {
+    expect(isLoginSlashCommand('/login')).toBe(true)
+    expect(isLoginSlashCommand('  /login  ')).toBe(true)
+    expect(isLoginSlashCommand('/login please')).toBe(false)
+    expect(isLoginSlashCommand('please /login')).toBe(false)
+  })
+})
+
+describe('loginArgsForBackend', () => {
+  it('uses auth login for modern Claude', () => {
+    expect(loginArgsForBackend('claude', true)).toEqual(['auth', 'login'])
+    expect(loginArgsForBackend('claude', false)).toEqual(['login'])
+  })
+
+  it('uses expected args for codex and opencode', () => {
+    expect(loginArgsForBackend('codex')).toEqual(['login'])
+    expect(loginArgsForBackend('opencode')).toEqual(['auth', 'login'])
+  })
+})

--- a/src/lib/cli-auth.ts
+++ b/src/lib/cli-auth.ts
@@ -1,0 +1,180 @@
+/**
+ * CLI authentication helpers for chat UX (issue #387).
+ *
+ * Claude (and other backends) emit messages like "Not logged in · Please run /login"
+ * that do not work inside Jean's headless chat. Jean owns interactive login via
+ * CliLoginModal — these helpers detect auth failures and open that flow instead.
+ */
+
+import { toast } from 'sonner'
+import { invoke } from '@/lib/transport'
+import { useUIStore } from '@/store/ui-store'
+import type { CliBackend } from '@/types/preferences'
+import { getBackendPlainLabel } from '@/components/ui/backend-label'
+
+/** True when a backend error indicates the user needs to re-authenticate. */
+export function isCliAuthError(error: string): boolean {
+  const lower = error.toLowerCase()
+  if (
+    lower.includes('not logged in') ||
+    lower.includes('please run /login') ||
+    lower.includes('not authenticated') ||
+    lower.includes('authentication required') ||
+    lower.includes('auth required') ||
+    lower.includes('login required') ||
+    lower.includes('please log in') ||
+    lower.includes('please login') ||
+    lower.includes('unauthorized') ||
+    lower.includes('token expired') ||
+    lower.includes('session expired') ||
+    lower.includes('to authenticate') ||
+    lower.includes('to log in again') ||
+    lower.includes('to login again') ||
+    lower.includes('run `claude`') ||
+    lower.includes('run `codex`') ||
+    lower.includes('run `opencode`')
+  ) {
+    return true
+  }
+  // Claude headless: "/login isn't available in this environment"
+  if (lower.includes("isn't available in this environment") && lower.includes('login')) {
+    return true
+  }
+  return false
+}
+
+/** Jean-facing message — never recommend interactive /login inside chat. */
+export function rewriteCliAuthErrorMessage(
+  _error: string,
+  backend: CliBackend | string
+): string {
+  const label = getBackendPlainLabel(backend as CliBackend) || String(backend)
+  return (
+    `${label} is not authenticated. ` +
+    `Use Settings → ${label} → Login (interactive /login is not available in Jean chat).`
+  )
+}
+
+/** Login CLI args for the given backend. */
+export function loginArgsForBackend(
+  backend: CliBackend,
+  supportsAuthCommand = true
+): string[] {
+  switch (backend) {
+    case 'claude':
+      return supportsAuthCommand ? ['auth', 'login'] : ['login']
+    case 'codex':
+      return ['login']
+    case 'opencode':
+      return ['auth', 'login']
+    case 'cursor':
+      return ['login']
+    case 'pi':
+      return []
+    case 'commandcode':
+      return ['login']
+    case 'grok':
+      return ['login']
+    case 'kimi':
+      return ['login']
+    default:
+      return ['login']
+  }
+}
+
+const STATUS_COMMANDS: Partial<
+  Record<CliBackend, { command: string; pathField?: string }>
+> = {
+  claude: { command: 'check_claude_cli_installed' },
+  codex: { command: 'check_codex_cli_installed' },
+  opencode: { command: 'check_opencode_cli_installed' },
+  cursor: { command: 'check_cursor_cli_installed' },
+  pi: { command: 'check_pi_cli_installed' },
+  commandcode: { command: 'check_commandcode_cli_installed' },
+  grok: { command: 'check_grok_cli_installed' },
+  kimi: { command: 'check_kimi_cli_installed' },
+}
+
+/**
+ * Resolve the binary path for a backend and open the CLI login modal.
+ * Returns false if the backend is not installed / path is unknown.
+ */
+export async function openBackendLoginModal(
+  backend: CliBackend
+): Promise<boolean> {
+  const statusCmd = STATUS_COMMANDS[backend]
+  if (!statusCmd) {
+    toast.error(`Login is not supported for ${backend}`)
+    return false
+  }
+
+  try {
+    const status = await invoke<{
+      installed?: boolean
+      path?: string | null
+      supports_auth_command?: boolean
+    }>(statusCmd.command)
+
+    const path = status?.path
+    if (!path) {
+      toast.error(
+        `${getBackendPlainLabel(backend)} is not installed. Install it in Settings first.`
+      )
+      return false
+    }
+
+    const args = loginArgsForBackend(backend, status.supports_auth_command ?? true)
+    const loginType =
+      backend === 'claude' ||
+      backend === 'codex' ||
+      backend === 'opencode' ||
+      backend === 'cursor' ||
+      backend === 'pi' ||
+      backend === 'commandcode' ||
+      backend === 'grok' ||
+      backend === 'kimi'
+        ? backend
+        : null
+    if (!loginType) {
+      toast.error(`Login is not supported for ${backend}`)
+      return false
+    }
+    useUIStore.getState().openCliLoginModal(loginType, path, args, 'login')
+    return true
+  } catch (err) {
+    toast.error(`Failed to start login: ${err}`)
+    return false
+  }
+}
+
+/**
+ * Show a toast for an auth error with a Login action that opens CliLoginModal.
+ * Also returns the rewritten user-facing error string for inline display.
+ */
+export function handleCliAuthError(
+  error: string,
+  backend: CliBackend | string | null | undefined
+): string {
+  const resolvedBackend = (backend ?? 'claude') as CliBackend
+  const rewritten = rewriteCliAuthErrorMessage(error, resolvedBackend)
+  const label = getBackendPlainLabel(resolvedBackend) || String(resolvedBackend)
+
+  toast.error(rewritten, {
+    id: `cli-auth-${resolvedBackend}`,
+    duration: 15_000,
+    action: {
+      label: 'Login',
+      onClick: () => {
+        void openBackendLoginModal(resolvedBackend)
+      },
+    },
+    description: `Or open Settings → ${label} → Login`,
+  })
+
+  return rewritten
+}
+
+/** True when the user message is only the interactive /login slash command. */
+export function isLoginSlashCommand(message: string): boolean {
+  return /^\/login\s*$/i.test(message.trim())
+}

--- a/src/lib/cli-update.test.ts
+++ b/src/lib/cli-update.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { getPathUpdateAction, resolveCliPathUpdateAction } from './cli-update'
+
+describe('getPathUpdateAction', () => {
+  it('prefers self-update over homebrew for Claude', () => {
+    expect(
+      getPathUpdateAction(
+        '/opt/homebrew/bin/claude',
+        'homebrew',
+        'claude-code',
+        ['update']
+      )
+    ).toEqual(['/opt/homebrew/bin/claude', ['update']])
+  })
+
+  it('uses brew upgrade when no self-update exists', () => {
+    expect(
+      getPathUpdateAction('/opt/homebrew/bin/codex', 'homebrew', 'codex', null)
+    ).toEqual(['brew', ['upgrade', 'codex']])
+  })
+
+  it('uses npm global install when package manager is npm', () => {
+    expect(
+      getPathUpdateAction(
+        '/usr/local/bin/codex',
+        'npm',
+        'codex',
+        null,
+        '@openai/codex',
+        '0.1.0'
+      )
+    ).toEqual(['npm', ['install', '-g', '@openai/codex@0.1.0']])
+  })
+})
+
+describe('resolveCliPathUpdateAction', () => {
+  it('resolves Claude path update via self-update even when homebrew detected', () => {
+    expect(
+      resolveCliPathUpdateAction(
+        'claude',
+        '/opt/homebrew/bin/claude',
+        'homebrew',
+        '2.1.150'
+      )
+    ).toEqual(['/opt/homebrew/bin/claude', ['update']])
+  })
+})

--- a/src/lib/cli-update.ts
+++ b/src/lib/cli-update.ts
@@ -54,7 +54,12 @@ export const CLI_DISPLAY_NAMES: Record<CliType, string> = {
 }
 
 /** Get [command, args] for updating a PATH-mode CLI, respecting package manager.
- *  Returns null when the CLI has no self-update command and no known package manager. */
+ *  Returns null when the CLI has no self-update command and no known package manager.
+ *
+ *  Prefer self-update (`claude update`, `opencode upgrade`, …) over Homebrew when
+ *  available. Brew package names often mismatch install method (formula vs cask
+ *  `claude-code`), which produced "Cask 'claude-code' is not installed" (issue #387).
+ */
 export function getPathUpdateAction(
   cliPath: string | null | undefined,
   packageManager: string | null | undefined,
@@ -63,11 +68,11 @@ export function getPathUpdateAction(
   npmPkg?: string,
   targetVersion?: string
 ): [string, string[]] | null {
-  if (packageManager === 'homebrew') {
-    return ['brew', ['upgrade', brewPkg]]
-  }
   if (selfUpdateArgs) {
     return [cliPath ?? brewPkg, selfUpdateArgs]
+  }
+  if (packageManager === 'homebrew') {
+    return ['brew', ['upgrade', brewPkg]]
   }
   if (packageManager === 'bun' && npmPkg && targetVersion) {
     return ['bun', ['install', '-g', `${npmPkg}@${targetVersion}`]]


### PR DESCRIPTION
## Summary

- Auto-detect Homebrew/system PATH installs for Claude and Codex when the Jean-managed binary is missing, so backends no longer stay locked despite working terminal CLIs.
- Prefer each CLI’s self-update command over `brew upgrade` to avoid false failures like `Cask 'claude-code' is not installed`.
- Treat Claude headless auth messages (`Not logged in`, `Please run /login`, `/login isn't available in this environment`) as auth/quota errors so Jean can surface a real login path instead of a dead end.

fixes #387

---

Fixes #387