### PR TITLE
fix(server): route native open over headless HTTP/WSL

### DIFF
--- a/docs/developer/server-architecture.md
+++ b/docs/developer/server-architecture.md
@@ -15,9 +15,16 @@ those events to browser clients and retains the existing replay behavior. The
 shared dispatcher remains the protocol compatibility boundary for browser
 commands.
 
-Native window, embedded browser, clipboard, picker, notification, menu, and
-Finder/editor operations stay desktop-only. Server calls to native-only command
-paths return an explicit error instead of initializing a graphical toolkit.
+Native window, embedded browser, clipboard, picker, notification, and menu
+operations stay desktop-only. Finder/editor/terminal open commands are gated:
+
+- allowed automatically under WSL (Windows host tools via `explorer.exe` / CLI)
+- allowed with `--allow-native-open` / `JEAN_ALLOW_NATIVE_OPEN=1`
+- allowed when the desktop app hosts Web Access
+- otherwise return an explicit "desktop app" error over HTTP
+
+Server paths never initialize a graphical toolkit; they only spawn existing host
+tools when the gate above permits it.
 
 ## Required server gates
 

--- a/docs/headless-server.md
+++ b/docs/headless-server.md
@@ -157,9 +157,19 @@ bun run install:local:server
 | `--token <token>`         | `JEAN_TOKEN`                   | saved/generated token                  |
 | `--no-token`              | `JEAN_NO_TOKEN=1`              | off                                    |
 | `--allow-unsafe-no-token` | `JEAN_ALLOW_UNSAFE_NO_TOKEN=1` | off                                    |
+| `--allow-native-open`     | `JEAN_ALLOW_NATIVE_OPEN=1`     | off (auto-on under WSL)                |
 | n/a                       | `JEAN_ALLOWED_ORIGINS`         | same-origin only                       |
 
 By default a token is required (using `--token`, `JEAN_TOKEN`, or an auto-generated one); pass `--no-token` to disable it. `--token` and `--no-token` are mutually exclusive. Jean rejects `--no-token` with `--host 0.0.0.0` or `--host ::` unless `--allow-unsafe-no-token` is also set.
+
+### Native open actions (editor / file manager / terminal)
+
+HTTP/WebSocket clients can trigger **Open in editor**, **Open worktrees folder**, and related actions only when native open is allowed:
+
+- **Auto-enabled under WSL** — headless Jean inside WSL routes folders through `explorer.exe` and editors through the Linux CLI binaries on PATH (same as #490 / #522).
+- **Opt-in elsewhere** — pass `--allow-native-open` or set `JEAN_ALLOW_NATIVE_OPEN=1` for a local headless server that should open host apps.
+- **Desktop Web Access** — automatically allowed when the desktop app hosts the HTTP server.
+- **Remote/VPS headless** — left off by default so a browser client cannot spawn GUI tools on the server.
 
 ## Health checks
 

--- a/jean-core/src/http_server/dispatch.rs
+++ b/jean-core/src/http_server/dispatch.rs
@@ -87,6 +87,21 @@ fn parse_open_worktree_in_editor_args(args: &Value) -> Result<OpenWorktreeInEdit
     })
 }
 
+#[derive(Debug, PartialEq)]
+struct OpenWorktreeInTerminalArgs {
+    worktree_path: String,
+    terminal: Option<String>,
+}
+
+fn parse_open_worktree_in_terminal_args(
+    args: &Value,
+) -> Result<OpenWorktreeInTerminalArgs, String> {
+    Ok(OpenWorktreeInTerminalArgs {
+        worktree_path: field(args, "worktreePath", "worktree_path")?,
+        terminal: from_field_opt(args, "terminal")?,
+    })
+}
+
 /// Dispatch a command by name to the corresponding Rust handler.
 /// This mirrors Tauri's invoke system but routes through WebSocket.
 ///
@@ -1739,16 +1754,29 @@ pub async fn dispatch_command(
             to_value(result)
         }
         "open_worktree_in_finder" => {
-            Err("Opening a file manager is only available in the desktop app".to_string())
+            crate::platform::ensure_native_open_allowed("a file manager")?;
+            let parsed = parse_worktree_path_args(&args)?;
+            crate::projects::open_worktree_in_finder(parsed.worktree_path).await?;
+            Ok(Value::Null)
         }
         "open_project_worktrees_folder" => {
-            Err("Opening a file manager is only available in the desktop app".to_string())
+            crate::platform::ensure_native_open_allowed("a file manager")?;
+            let project_id: String = field(&args, "projectId", "project_id")?;
+            crate::projects::open_project_worktrees_folder(app.clone(), project_id).await?;
+            Ok(Value::Null)
         }
         "open_worktree_in_terminal" => {
-            Err("Opening a terminal is only available in the desktop app".to_string())
+            crate::platform::ensure_native_open_allowed("a terminal")?;
+            let parsed = parse_open_worktree_in_terminal_args(&args)?;
+            crate::projects::open_worktree_in_terminal(parsed.worktree_path, parsed.terminal)
+                .await?;
+            Ok(Value::Null)
         }
         "open_worktree_in_editor" => {
-            Err("Opening an editor is only available in the desktop app".to_string())
+            crate::platform::ensure_native_open_allowed("an editor")?;
+            let parsed = parse_open_worktree_in_editor_args(&args)?;
+            crate::projects::open_worktree_in_editor(parsed.worktree_path, parsed.editor).await?;
+            Ok(Value::Null)
         }
         "open_pull_request" => {
             let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
@@ -3068,7 +3096,9 @@ pub async fn dispatch_command(
             Err("Opening a browser is only available in the desktop app".to_string())
         }
         "open_log_directory" => {
-            Err("Opening a file manager is only available in the desktop app".to_string())
+            crate::platform::ensure_native_open_allowed("a file manager")?;
+            crate::projects::open_log_directory(app.clone()).await?;
+            Ok(Value::Null)
         }
         "remove_git_remote" => {
             let repo_path: String = field(&args, "repoPath", "repo_path")?;
@@ -3478,19 +3508,82 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    #[tokio::test]
-    async fn headless_dispatch_rejects_desktop_only_commands() {
-        let temp = tempfile::tempdir().unwrap();
-        let app = AppHandle::new(temp.path().into(), temp.path().into()).unwrap();
+    #[test]
+    fn headless_dispatch_rejects_native_open_when_not_allowed() {
+        crate::platform::with_native_open_flag_lock(|| {
+            let previous = crate::platform::allow_native_open_enabled();
+            crate::platform::set_allow_native_open(false);
 
-        for (command, args) in [
-            ("open_worktree_in_finder", json!({ "worktreePath": "/tmp" })),
-            ("open_worktree_in_editor", json!({ "worktreePath": "/tmp" })),
-            ("open_file_in_default_app", json!({ "path": "/tmp/file" })),
-        ] {
-            let error = dispatch_command(&app, command, args).await.unwrap_err();
-            assert!(error.contains("desktop app"), "{command}: {error}");
-        }
+            // When not under WSL and without the opt-in flag, native open stays blocked.
+            if crate::platform::is_running_in_wsl() {
+                crate::platform::set_allow_native_open(previous);
+                return;
+            }
+
+            let temp = tempfile::tempdir().unwrap();
+            let app = AppHandle::new(temp.path().into(), temp.path().into()).unwrap();
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            for (command, args) in [
+                ("open_worktree_in_finder", json!({ "worktreePath": "/tmp" })),
+                ("open_worktree_in_editor", json!({ "worktreePath": "/tmp" })),
+                ("open_worktree_in_terminal", json!({ "worktreePath": "/tmp" })),
+                ("open_file_in_default_app", json!({ "path": "/tmp/file" })),
+            ] {
+                let error = runtime
+                    .block_on(dispatch_command(&app, command, args))
+                    .unwrap_err();
+                assert!(error.contains("desktop app"), "{command}: {error}");
+            }
+
+            crate::platform::set_allow_native_open(previous);
+        });
+    }
+
+    #[test]
+    fn headless_dispatch_routes_native_open_when_allowed() {
+        crate::platform::with_native_open_flag_lock(|| {
+            let previous = crate::platform::allow_native_open_enabled();
+            crate::platform::set_allow_native_open(true);
+
+            let temp = tempfile::tempdir().unwrap();
+            let app = AppHandle::new(temp.path().into(), temp.path().into()).unwrap();
+            let worktree = temp.path().join("wt");
+            std::fs::create_dir_all(&worktree).unwrap();
+            let worktree_path = worktree.to_string_lossy().to_string();
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            // Should not short-circuit with the desktop-app error. Spawn may still fail
+            // on headless CI (missing GUI tools); either success or a non-desktop error is OK.
+            for (command, args) in [
+                (
+                    "open_worktree_in_finder",
+                    json!({ "worktreePath": worktree_path }),
+                ),
+                (
+                    "open_worktree_in_editor",
+                    json!({ "worktreePath": worktree_path, "editor": "code" }),
+                ),
+            ] {
+                match runtime.block_on(dispatch_command(&app, command, args)) {
+                    Ok(_) => {}
+                    Err(error) => {
+                        assert!(
+                            !error.contains("desktop app"),
+                            "{command} should not be blocked as desktop-only when native open is allowed: {error}"
+                        );
+                    }
+                }
+            }
+
+            crate::platform::set_allow_native_open(previous);
+        });
     }
 
     #[test]
@@ -3647,6 +3740,31 @@ mod tests {
             OpenWorktreeInEditorArgs {
                 worktree_path: "/tmp/b".to_string(),
                 editor: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_open_worktree_in_terminal_args_accepts_web_transport_fields() {
+        assert_eq!(
+            parse_open_worktree_in_terminal_args(&json!({
+                "worktreePath": "/tmp/a",
+                "terminal": "ghostty"
+            }))
+            .unwrap(),
+            OpenWorktreeInTerminalArgs {
+                worktree_path: "/tmp/a".to_string(),
+                terminal: Some("ghostty".to_string()),
+            }
+        );
+        assert_eq!(
+            parse_open_worktree_in_terminal_args(&json!({
+                "worktree_path": "/tmp/b"
+            }))
+            .unwrap(),
+            OpenWorktreeInTerminalArgs {
+                worktree_path: "/tmp/b".to_string(),
+                terminal: None,
             }
         );
     }

--- a/jean-core/src/http_server/server.rs
+++ b/jean-core/src/http_server/server.rs
@@ -532,6 +532,7 @@ async fn init_handler(
     response["webBuildId"] = Value::String(build_info.web_build_id.clone());
     response["appVersion"] = Value::String(build_info.app_version.clone());
     response["serverPlatform"] = Value::String(crate::server_platform_name().to_string());
+    response["nativeOpenAllowed"] = Value::Bool(crate::platform::native_open_allowed());
 
     let projects = match projects_result {
         Ok(projects) => projects,

--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -862,6 +862,7 @@ mod tests {
         assert_eq!(args.port, Some(4567));
         assert_eq!(args.token.as_deref(), Some("secret"));
         assert!(!args.no_token);
+        assert!(!args.allow_native_open);
     }
 
     #[test]
@@ -890,6 +891,30 @@ mod tests {
         assert_eq!(args.host.as_deref(), Some("100.64.0.1"));
         assert_eq!(args.port, Some(5678));
         assert_eq!(args.token.as_deref(), Some("cli-secret"));
+    }
+
+    #[test]
+    fn parse_cli_args_reads_allow_native_open_from_env_and_flag() {
+        let from_env = parse_cli_args_from(
+            ["jean", "--headless"],
+            [("JEAN_ALLOW_NATIVE_OPEN", "1")],
+        )
+        .unwrap();
+        assert!(from_env.allow_native_open);
+
+        let from_flag = parse_cli_args_from(
+            ["jean", "--headless", "--allow-native-open"],
+            std::iter::empty::<(&str, &str)>(),
+        )
+        .unwrap();
+        assert!(from_flag.allow_native_open);
+
+        let off = parse_cli_args_from(
+            ["jean", "--headless"],
+            std::iter::empty::<(&str, &str)>(),
+        )
+        .unwrap();
+        assert!(!off.allow_native_open);
     }
 
     #[test]
@@ -3210,6 +3235,9 @@ pub async fn start_http_server(
     use std::sync::Arc;
     use tokio::sync::Mutex;
 
+    // Desktop-hosted Web Access can open local Finder/editor/terminal for clients.
+    platform::set_allow_native_open(true);
+
     let prefs = load_preferences(app.clone()).await?;
     let actual_port = port.unwrap_or(prefs.http_server_port);
     let bind_host = resolve_http_server_bind_host(&prefs);
@@ -3594,6 +3622,8 @@ struct CliArgs {
     token: Option<String>,
     no_token: bool,
     allow_unsafe_no_token: bool,
+    /// Allow HTTP clients to open local file managers / editors / terminals.
+    allow_native_open: bool,
 }
 
 /// CLI overrides for HTTP server configuration.
@@ -3620,12 +3650,14 @@ fn print_cli_help() {
     println!("  --no-token          Disable token authentication");
     println!("  --allow-unsafe-no-token");
     println!("                      Allow --no-token with a wildcard bind host");
+    println!("  --allow-native-open Allow Open in editor/finder/terminal over HTTP");
+    println!("                      (auto-enabled under WSL; off by default otherwise)");
     println!("  --help              Show this help message");
     println!("  --version           Show version");
     println!();
     println!("Environment:");
     println!("  JEAN_HEADLESS=1 JEAN_HOST JEAN_PORT JEAN_TOKEN JEAN_NO_TOKEN=1");
-    println!("  JEAN_ALLOW_UNSAFE_NO_TOKEN=1");
+    println!("  JEAN_ALLOW_UNSAFE_NO_TOKEN=1 JEAN_ALLOW_NATIVE_OPEN=1");
 }
 
 fn parse_cli_args() -> CliArgs {
@@ -3677,6 +3709,8 @@ where
     let mut no_token = env_truthy(env.get("JEAN_NO_TOKEN").map(String::as_str));
     let mut allow_unsafe_no_token =
         env_truthy(env.get("JEAN_ALLOW_UNSAFE_NO_TOKEN").map(String::as_str));
+    let mut allow_native_open =
+        env_truthy(env.get("JEAN_ALLOW_NATIVE_OPEN").map(String::as_str));
     let mut host = env
         .get("JEAN_HOST")
         .map(|h| h.trim().to_string())
@@ -3735,6 +3769,9 @@ where
             "--allow-unsafe-no-token" => {
                 allow_unsafe_no_token = true;
             }
+            "--allow-native-open" => {
+                allow_native_open = true;
+            }
             _ => {} // ignore unknown flags (Tauri/OS may pass their own)
         }
     }
@@ -3743,9 +3780,15 @@ where
         return Err("--token and --no-token are mutually exclusive".to_string());
     }
 
-    if !headless && (host.is_some() || port.is_some() || token.is_some() || no_token) {
+    if !headless
+        && (host.is_some()
+            || port.is_some()
+            || token.is_some()
+            || no_token
+            || allow_native_open)
+    {
         eprintln!(
-            "Warning: --host, --port, --token, --no-token are only effective with --headless"
+            "Warning: --host, --port, --token, --no-token, --allow-native-open are only effective with --headless"
         );
     }
 
@@ -3756,6 +3799,7 @@ where
         token,
         no_token,
         allow_unsafe_no_token,
+        allow_native_open,
     })
 }
 
@@ -3926,6 +3970,8 @@ pub async fn run_server() -> Result<(), String> {
     #[cfg(target_os = "linux")]
     platform::fix_headless_path();
     let cli = parse_cli_args();
+    // WSL headless auto-allows native open; explicit flag covers non-WSL local servers.
+    platform::set_allow_native_open(cli.allow_native_open);
     let context = RuntimeContext::from_environment()?;
     initialize_runtime(&context)?;
 

--- a/jean-core/src/platform/mod.rs
+++ b/jean-core/src/platform/mod.rs
@@ -9,3 +9,87 @@ pub use cli_detect::*;
 pub use process::*;
 pub use shell::*;
 pub use wsl::*;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Explicit opt-in for native open actions over the HTTP/WebSocket transport.
+/// Set via `--allow-native-open` / `JEAN_ALLOW_NATIVE_OPEN=1`, or automatically
+/// when the desktop app hosts Web Access (GUI-capable process).
+static ALLOW_NATIVE_OPEN: AtomicBool = AtomicBool::new(false);
+
+/// Enable or disable the explicit native-open opt-in for headless/web transport.
+pub fn set_allow_native_open(enabled: bool) {
+    ALLOW_NATIVE_OPEN.store(enabled, Ordering::Relaxed);
+}
+
+/// True when native open was explicitly enabled (CLI/env or desktop host).
+pub fn allow_native_open_enabled() -> bool {
+    ALLOW_NATIVE_OPEN.load(Ordering::Relaxed)
+}
+
+/// Whether HTTP dispatch may spawn local file managers / editors / terminals.
+///
+/// Allowed when:
+/// - the process is the desktop app hosting Web Access (`set_allow_native_open(true)`), or
+/// - the operator passed `--allow-native-open` / `JEAN_ALLOW_NATIVE_OPEN=1`, or
+/// - Jean is running under WSL (can launch Windows host tools like `explorer.exe`)
+pub fn native_open_allowed() -> bool {
+    allow_native_open_enabled() || is_running_in_wsl()
+}
+
+/// Reject native open commands unless [`native_open_allowed`].
+pub fn ensure_native_open_allowed(action: &str) -> Result<(), String> {
+    if native_open_allowed() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Opening {action} is only available in the desktop app, under WSL, or with --allow-native-open"
+        ))
+    }
+}
+
+/// Serialize tests that mutate the process-wide native-open flag.
+#[cfg(test)]
+pub fn with_native_open_flag_lock<T>(f: impl FnOnce() -> T) -> T {
+    use std::sync::{Mutex, OnceLock};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let lock = LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    f()
+}
+
+#[cfg(test)]
+mod native_open_tests {
+    use super::*;
+
+    #[test]
+    fn native_open_respects_explicit_flag() {
+        with_native_open_flag_lock(|| {
+            let previous = allow_native_open_enabled();
+            set_allow_native_open(false);
+            // Without the flag, permission depends only on WSL detection.
+            let without_flag = native_open_allowed();
+            assert_eq!(without_flag, is_running_in_wsl());
+
+            set_allow_native_open(true);
+            assert!(native_open_allowed());
+            assert!(ensure_native_open_allowed("an editor").is_ok());
+
+            set_allow_native_open(previous);
+        });
+    }
+
+    #[test]
+    fn ensure_native_open_mentions_desktop_app_when_blocked() {
+        with_native_open_flag_lock(|| {
+            let previous = allow_native_open_enabled();
+            set_allow_native_open(false);
+            if !is_running_in_wsl() {
+                let err = ensure_native_open_allowed("a file manager").unwrap_err();
+                assert!(err.contains("desktop app"), "{err}");
+                assert!(err.contains("allow-native-open"), "{err}");
+            }
+            set_allow_native_open(previous);
+        });
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import {
   usesWebSocketBackend,
   type InitialData,
 } from '@/lib/transport'
-import { isNativeApp } from '@/lib/environment'
+import { isNativeApp, setNativeOpenAllowed } from '@/lib/environment'
 import { setServerPlatform } from '@/lib/platform'
 import { projectsQueryKeys } from '@/services/projects'
 import { chatQueryKeys } from '@/services/chat'
@@ -275,6 +275,13 @@ function App() {
 
       if (data.serverPlatform) {
         setServerPlatform(data.serverPlatform)
+      }
+      if (typeof data.nativeOpenAllowed === 'boolean') {
+        setNativeOpenAllowed(data.nativeOpenAllowed)
+      }
+      // Force a re-render so non-reactive environment helpers (platform,
+      // canOpenNativeApps) update UI after /api/init.
+      if (data.serverPlatform || typeof data.nativeOpenAllowed === 'boolean') {
         setPlatformVersion(version => version + 1)
       }
 

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -20,7 +20,7 @@ import {
 import { useQueries, useQueryClient } from '@tanstack/react-query'
 import { invoke } from '@/lib/transport'
 import { cn } from '@/lib/utils'
-import { isLocalBackend } from '@/lib/environment'
+import { canOpenNativeApps } from '@/lib/environment'
 import { dismissibleToast } from '@/lib/dismissible-toast'
 import {
   Search,
@@ -875,7 +875,7 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [activeFilterTab, setActiveFilterTab] = useState<CanvasFilterTab>('all')
   const isMobile = useIsMobile()
-  const canOpenLocally = isLocalBackend()
+  const canOpenLocally = canOpenNativeApps()
   const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false)
   const showWorktreeLabelContextMenu = shouldShowWorktreeLabelContextMenu({
     isMobile,

--- a/src/components/open-in/OpenInButton.tsx
+++ b/src/components/open-in/OpenInButton.tsx
@@ -28,7 +28,7 @@ import {
 } from '@/services/projects'
 import { usePreferences } from '@/services/preferences'
 import { getOpenInDefaultLabel } from '@/types/preferences'
-import { isLocalBackend } from '@/lib/environment'
+import { canOpenNativeApps } from '@/lib/environment'
 import { useUIStore } from '@/store/ui-store'
 
 interface OpenInButtonProps {
@@ -88,7 +88,7 @@ export function OpenInButton({
     preferences?.terminal
   )
 
-  if (!isLocalBackend()) return null
+  if (!canOpenNativeApps()) return null
 
   return (
     <div

--- a/src/components/open-in/OpenInModal.test.tsx
+++ b/src/components/open-in/OpenInModal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@/test/test-utils'
 import { OpenInModal } from './OpenInModal'
 
 const localBackendState = vi.hoisted(() => ({ value: true }))
+const nativeOpenAllowedState = vi.hoisted(() => ({ value: false }))
 
 const mocks = vi.hoisted(() => ({
   setOpenInModalOpen: vi.fn(),
@@ -78,6 +79,9 @@ vi.mock('@/services/preferences', () => ({
 vi.mock('@/lib/environment', () => ({
   isLocalBackend: () => localBackendState.value,
   isNativeApp: () => localBackendState.value,
+  canOpenNativeApps: () =>
+    localBackendState.value || nativeOpenAllowedState.value,
+  isNativeOpenAllowed: () => nativeOpenAllowedState.value,
 }))
 
 vi.mock('@/lib/platform', () => ({
@@ -159,10 +163,12 @@ describe('OpenInModal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localBackendState.value = true
+    nativeOpenAllowedState.value = false
   })
 
-  it('hides Finder/editor/terminal in browser/headless mode', async () => {
+  it('hides Finder/editor/terminal in browser/headless mode without native open', async () => {
     localBackendState.value = false
+    nativeOpenAllowedState.value = false
 
     render(<OpenInModal />)
 
@@ -172,9 +178,22 @@ describe('OpenInModal', () => {
     expect(screen.queryByText('Ghostty')).not.toBeInTheDocument()
   })
 
-  it('hides Finder/editor/terminal on remote connections', async () => {
-    // Native shell with a remote Jean backend: local apps target the wrong machine.
+  it('shows Finder/editor/terminal when the backend allows native open', async () => {
+    // Browser or remote client against a WSL/--allow-native-open headless server.
     localBackendState.value = false
+    nativeOpenAllowedState.value = true
+
+    render(<OpenInModal />)
+
+    expect(await screen.findByText('Zed')).toBeInTheDocument()
+    expect(screen.getByText('Finder')).toBeInTheDocument()
+    expect(screen.getByText('Ghostty')).toBeInTheDocument()
+  })
+
+  it('hides Finder/editor/terminal on remote connections without native open', async () => {
+    // Native shell with a remote Jean backend that does not allow native open.
+    localBackendState.value = false
+    nativeOpenAllowedState.value = false
 
     render(<OpenInModal />)
 

--- a/src/components/open-in/OpenInModal.tsx
+++ b/src/components/open-in/OpenInModal.tsx
@@ -41,7 +41,7 @@ import { getEditorLabel, getTerminalLabel } from '@/types/preferences'
 import { notify } from '@/lib/notifications'
 import { openExternal } from '@/lib/platform'
 import { cn } from '@/lib/utils'
-import { isLocalBackend } from '@/lib/environment'
+import { canOpenNativeApps } from '@/lib/environment'
 import { resolvePortUrl } from '@/components/browser/default-tab-url'
 
 interface ModalOption {
@@ -102,9 +102,10 @@ export function OpenInModal() {
     selectedWorktreeId
   )
 
-  // Local editor/terminal/finder only work against the desktop machine's FS.
-  // Remote connections and browser/web access should only show URL-based options.
-  const canOpenLocally = isLocalBackend()
+  // Editor/terminal/finder open against the Jean backend host (local desktop,
+  // WSL headless, or --allow-native-open). Pure remote VPS without that flag
+  // only gets URL-based options.
+  const canOpenLocally = canOpenNativeApps()
 
   const targetPath = useMemo(() => {
     if (worktree?.path) return worktree.path

--- a/src/components/projects/WorktreeContextMenu.tsx
+++ b/src/components/projects/WorktreeContextMenu.tsx
@@ -28,7 +28,7 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import { getEditorLabel, getTerminalLabel } from '@/types/preferences'
-import { isLocalBackend } from '@/lib/environment'
+import { canOpenNativeApps } from '@/lib/environment'
 import { getFileManagerName } from '@/lib/platform'
 import type { useWorktreeMenuActions } from './useWorktreeMenuActions'
 
@@ -88,23 +88,23 @@ export function WorktreeContextMenu({
           </ContextMenuSub>
         )}
 
-        {isLocalBackend() && <ContextMenuSeparator />}
+        {canOpenNativeApps() && <ContextMenuSeparator />}
 
-        {isLocalBackend() && (
+        {canOpenNativeApps() && (
           <ContextMenuItem onClick={handleOpenInEditor}>
             <Code className="mr-2 h-4 w-4" />
             Open in {getEditorLabel(preferences?.editor)}
           </ContextMenuItem>
         )}
 
-        {isLocalBackend() && (
+        {canOpenNativeApps() && (
           <ContextMenuItem onClick={handleOpenInFinder}>
             <FolderOpen className="mr-2 h-4 w-4" />
             Open in {getFileManagerName()}
           </ContextMenuItem>
         )}
 
-        {isLocalBackend() && (
+        {canOpenNativeApps() && (
           <ContextMenuItem onClick={handleOpenInTerminal}>
             <Terminal className="mr-2 h-4 w-4" />
             Open in {getTerminalLabel(preferences?.terminal)}

--- a/src/components/projects/WorktreeDropdownMenu.test.tsx
+++ b/src/components/projects/WorktreeDropdownMenu.test.tsx
@@ -8,6 +8,7 @@ import type * as EnvironmentModule from '@/lib/environment'
 const envMocks = vi.hoisted(() => ({
   isNativeApp: false,
   isLocalBackend: false,
+  canOpenNativeApps: false,
   isMobile: true,
 }))
 
@@ -21,6 +22,7 @@ vi.mock('@/lib/environment', async importOriginal => ({
   ...(await importOriginal<typeof EnvironmentModule>()),
   isNativeApp: () => envMocks.isNativeApp,
   isLocalBackend: () => envMocks.isLocalBackend,
+  canOpenNativeApps: () => envMocks.canOpenNativeApps,
 }))
 
 vi.mock('@/hooks/use-mobile', () => ({
@@ -72,6 +74,7 @@ describe('WorktreeDropdownMenu', () => {
   beforeEach(() => {
     envMocks.isNativeApp = false
     envMocks.isLocalBackend = false
+    envMocks.canOpenNativeApps = false
     envMocks.isMobile = true
     actionMocks.runScripts = ['bun run dev']
     actionMocks.handleRun.mockClear()
@@ -95,10 +98,11 @@ describe('WorktreeDropdownMenu', () => {
     expect(actionMocks.handleRun).not.toHaveBeenCalled()
   })
 
-  it('hides open-in editor/terminal/finder on remote connections', async () => {
+  it('hides open-in editor/terminal/finder on remote connections without native open', async () => {
     const user = userEvent.setup()
     envMocks.isNativeApp = true
     envMocks.isLocalBackend = false
+    envMocks.canOpenNativeApps = false
     envMocks.isMobile = false
 
     render(
@@ -112,5 +116,26 @@ describe('WorktreeDropdownMenu', () => {
     await user.click(screen.getByRole('button'))
 
     expect(screen.queryByRole('menuitem', { name: /open in/i })).toBeNull()
+  })
+
+  it('shows open-in editor/terminal/finder when the remote backend allows native open', async () => {
+    const user = userEvent.setup()
+    envMocks.isNativeApp = true
+    envMocks.isLocalBackend = false
+    envMocks.canOpenNativeApps = true
+    envMocks.isMobile = false
+
+    render(
+      <WorktreeDropdownMenu
+        worktree={worktree}
+        projectId="project-1"
+        projectPath="/tmp/project"
+      />
+    )
+
+    await user.click(screen.getByRole('button'))
+
+    const openItems = screen.getAllByRole('menuitem', { name: /open in/i })
+    expect(openItems.length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/src/components/projects/WorktreeDropdownMenu.tsx
+++ b/src/components/projects/WorktreeDropdownMenu.tsx
@@ -49,7 +49,7 @@ import {
   useRepositoryAdvisories,
   useWorkflowRuns,
 } from '@/services/github'
-import { isLocalBackend } from '@/lib/environment'
+import { canOpenNativeApps } from '@/lib/environment'
 import { useProjectsStore } from '@/store/projects-store'
 import { useUIStore } from '@/store/ui-store'
 import { useIsMobile } from '@/hooks/use-mobile'
@@ -286,23 +286,23 @@ export function WorktreeDropdownMenu({
             </DropdownMenuItem>
           )}
 
-          {isLocalBackend() && <DropdownMenuSeparator />}
+          {canOpenNativeApps() && <DropdownMenuSeparator />}
 
-          {isLocalBackend() && (
+          {canOpenNativeApps() && (
             <DropdownMenuItem onClick={handleOpenInEditor}>
               <Code className="mr-2 h-4 w-4" />
               Open in {getEditorLabel(preferences?.editor)}
             </DropdownMenuItem>
           )}
 
-          {isLocalBackend() && (
+          {canOpenNativeApps() && (
             <DropdownMenuItem onClick={handleOpenInFinder}>
               <FolderOpen className="mr-2 h-4 w-4" />
               Open in Finder
             </DropdownMenuItem>
           )}
 
-          {isLocalBackend() && (
+          {canOpenNativeApps() && (
             <DropdownMenuItem onClick={handleOpenInTerminal}>
               <Terminal className="mr-2 h-4 w-4" />
               Open in {getTerminalLabel(preferences?.terminal)}

--- a/src/lib/environment.ts
+++ b/src/lib/environment.ts
@@ -10,8 +10,9 @@ import { getActiveRemoteConnection } from './remote-connections'
  *
  * Service queries should guard with hasBackendTransport(); mutations that
  * must run immediately should guard with hasBackend().
- * UI should use isNativeApp() for local shell features and isLocalBackend()
- * for backend-side desktop features (Finder, external editors, etc.).
+ * UI should use isNativeApp() for local shell features, isLocalBackend() for
+ * "this machine's desktop shell", and canOpenNativeApps() for Finder/editor/
+ * terminal open actions (local desktop, WSL headless, or --allow-native-open).
  */
 
 /** Running inside the native Tauri desktop app with usable IPC.
@@ -25,6 +26,23 @@ export const isNativeApp = (): boolean =>
 /** Whether backend operations target this desktop app's local Jean core. */
 export const isLocalBackend = (): boolean =>
   isNativeApp() && getActiveRemoteConnection() === null
+
+/**
+ * Whether the connected Jean backend can open host apps (editor/finder/terminal).
+ * Set from `/api/init` (`nativeOpenAllowed`) for web/remote clients. Local
+ * desktop shells always can.
+ */
+let _nativeOpenAllowed = false
+
+export const setNativeOpenAllowed = (allowed: boolean): void => {
+  _nativeOpenAllowed = allowed
+}
+
+export const isNativeOpenAllowed = (): boolean => _nativeOpenAllowed
+
+/** Show Open in editor/finder/terminal when the backend host can launch them. */
+export const canOpenNativeApps = (): boolean =>
+  isLocalBackend() || _nativeOpenAllowed
 
 /** A backend is available (either Tauri IPC, WebSocket connection, or E2E mock). */
 export const hasBackend = (): boolean => {

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -306,6 +306,8 @@ export interface InitialData {
   uiState?: unknown
   appDataDir?: string
   serverPlatform?: 'mac' | 'windows' | 'linux'
+  /** Server can launch host editor/finder/terminal (WSL or --allow-native-open). */
+  nativeOpenAllowed?: boolean
   webBuildId?: string
   appVersion?: string
 }


### PR DESCRIPTION
## Summary

- Route Open in editor / file manager / terminal over the HTTP transport instead of always returning “only available in the desktop app”.
- Auto-allow native open under WSL; elsewhere require `--allow-native-open` / `JEAN_ALLOW_NATIVE_OPEN=1` so remote headless stays safe.
- Surface `nativeOpenAllowed` from `/api/init` so web/remote UI shows those actions when the backend can launch host tools.
- Document the gate and keep browser open actions desktop-only.

fixes #522

---

Fixes #522