### PR TITLE
fix(markdown): preserve ordered list numbering with nested bullets

### DIFF
--- a/src/components/ui/markdown.test.tsx
+++ b/src/components/ui/markdown.test.tsx
@@ -15,6 +15,61 @@ describe('Markdown', () => {
     expect(orderedLists[1]?.getAttribute('start')).toBe('2')
   })
 
+  it('continues top-level numbering when 2nd-level bullets interrupt the list (issue #200)', () => {
+    // LLMs often emit unindented sub-bullets and restart every parent at "1."
+    const md = `1. **Define architecture**
+- Pick default backend
+- Decide on fallbacks
+
+1. **Centralize resolution**
+- Create helper
+- Replace call sites
+
+1. **Make migrations**
+- Apply to all
+- Ensure consistency`
+
+    const { container } = render(<Markdown>{md}</Markdown>)
+
+    const orderedLists = Array.from(container.querySelectorAll('ol'))
+    // One continuous ordered list — browser markers are 1, 2, 3
+    expect(orderedLists).toHaveLength(1)
+
+    const topLevelItems = Array.from(orderedLists[0]?.children ?? []).filter(
+      el => el.tagName === 'LI'
+    )
+    expect(topLevelItems).toHaveLength(3)
+
+    // Each top-level item nests its bullet children
+    for (const li of topLevelItems) {
+      const nestedUl = li.querySelector(':scope > ul')
+      expect(nestedUl).not.toBeNull()
+      expect(nestedUl?.querySelectorAll(':scope > li').length).toBe(2)
+    }
+
+    expect(container.textContent).toContain('Define architecture')
+    expect(container.textContent).toContain('Centralize resolution')
+    expect(container.textContent).toContain('Make migrations')
+  })
+
+  it('keeps properly indented nested lists as a single ordered list', () => {
+    const md = `1. First
+   - a
+   - b
+2. Second
+   - c
+3. Third`
+
+    const { container } = render(<Markdown>{md}</Markdown>)
+    const orderedLists = Array.from(container.querySelectorAll('ol'))
+
+    expect(orderedLists).toHaveLength(1)
+    const topLevelItems = Array.from(orderedLists[0]?.children ?? []).filter(
+      el => el.tagName === 'LI'
+    )
+    expect(topLevelItems).toHaveLength(3)
+  })
+
   it('keeps list marker gutters inside the markdown box', () => {
     const { container } = render(
       <div className="overflow-x-hidden">

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -17,6 +17,7 @@ import ReactMarkdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import remarkGfm from 'remark-gfm'
 import remend from 'remend'
+import { remarkFixInterruptedLists } from '@/lib/remark-fix-interrupted-lists'
 import { Copy, Check, Table, ListChecks } from 'lucide-react'
 import { toast } from 'sonner'
 import { copyToClipboard } from '@/lib/clipboard'
@@ -555,7 +556,9 @@ const compactComponents: Components = {
 }
 
 // Module-level plugin arrays keep references stable across renders.
-const remarkPlugins = [remarkGfm]
+// remarkFixInterruptedLists runs after GFM so task lists are already parsed,
+// then nests orphan sibling ULs under the preceding OL item (issue #200).
+const remarkPlugins = [remarkGfm, remarkFixInterruptedLists]
 // rehype-raw re-parses the full accumulated text as HTML on every render —
 // the dominant per-frame cost while streaming — so streaming mode skips it
 // and only completed (non-streaming) renders apply it.

--- a/src/lib/remark-fix-interrupted-lists.test.ts
+++ b/src/lib/remark-fix-interrupted-lists.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import {
+  fixInterruptedOrderedLists,
+  type MdastNode,
+  type MdastParent,
+} from './remark-fix-interrupted-lists'
+
+function textParagraph(value: string): MdastNode {
+  return {
+    type: 'paragraph',
+    children: [{ type: 'text', value }],
+  }
+}
+
+function listItem(...children: MdastNode[]): MdastNode {
+  return {
+    type: 'listItem',
+    spread: false,
+    checked: null,
+    children,
+  }
+}
+
+function orderedList(items: MdastNode[], start: number | null = 1): MdastNode {
+  return {
+    type: 'list',
+    ordered: true,
+    start,
+    spread: false,
+    children: items,
+  }
+}
+
+function unorderedList(items: MdastNode[]): MdastNode {
+  return {
+    type: 'list',
+    ordered: false,
+    start: null,
+    spread: false,
+    children: items,
+  }
+}
+
+describe('fixInterruptedOrderedLists', () => {
+  it('merges ordered lists interrupted by sibling unordered lists (issue #200)', () => {
+    const tree: MdastParent = {
+      type: 'root',
+      children: [
+        orderedList([listItem(textParagraph('Define architecture'))]),
+        unorderedList([
+          listItem(textParagraph('Pick default backend')),
+          listItem(textParagraph('Decide on fallbacks')),
+        ]),
+        orderedList([listItem(textParagraph('Centralize resolution'))]),
+        unorderedList([
+          listItem(textParagraph('Create helper')),
+          listItem(textParagraph('Replace call sites')),
+        ]),
+        orderedList([listItem(textParagraph('Make migrations'))]),
+        unorderedList([
+          listItem(textParagraph('Apply to all')),
+          listItem(textParagraph('Ensure consistency')),
+        ]),
+      ],
+    }
+
+    fixInterruptedOrderedLists(tree)
+
+    expect(tree.children).toHaveLength(1)
+    const ol = tree.children[0] as MdastParent
+    expect(ol.type).toBe('list')
+    expect(ol.ordered).toBe(true)
+    expect(ol.children).toHaveLength(3)
+
+    for (const item of ol.children) {
+      const li = item as MdastParent
+      expect(li.type).toBe('listItem')
+      const nested = li.children[li.children.length - 1] as MdastParent
+      expect(nested.type).toBe('list')
+      expect(nested.ordered).toBe(false)
+      expect(nested.children.length).toBe(2)
+    }
+  })
+
+  it('merges when sequential numbers are used after interruption', () => {
+    const tree: MdastParent = {
+      type: 'root',
+      children: [
+        orderedList([listItem(textParagraph('First'))], 1),
+        unorderedList([
+          listItem(textParagraph('a')),
+          listItem(textParagraph('b')),
+        ]),
+        orderedList([listItem(textParagraph('Second'))], 2),
+        unorderedList([listItem(textParagraph('c'))]),
+        orderedList([listItem(textParagraph('Third'))], 3),
+      ],
+    }
+
+    fixInterruptedOrderedLists(tree)
+
+    expect(tree.children).toHaveLength(1)
+    const ol = tree.children[0] as MdastParent
+    expect(ol.children).toHaveLength(3)
+  })
+
+  it('leaves a single ordered list with already-nested bullets unchanged', () => {
+    const nestedUl = unorderedList([
+      listItem(textParagraph('a')),
+      listItem(textParagraph('b')),
+    ])
+    const tree: MdastParent = {
+      type: 'root',
+      children: [
+        orderedList([
+          listItem(textParagraph('First'), nestedUl),
+          listItem(
+            textParagraph('Second'),
+            unorderedList([listItem(textParagraph('c'))])
+          ),
+          listItem(textParagraph('Third')),
+        ]),
+      ],
+    }
+
+    const before = JSON.stringify(tree)
+    fixInterruptedOrderedLists(tree)
+    expect(JSON.stringify(tree)).toBe(before)
+  })
+
+  it('does not merge when a non-list node separates ordered lists', () => {
+    const tree: MdastParent = {
+      type: 'root',
+      children: [
+        orderedList([listItem(textParagraph('First'))]),
+        textParagraph('Interlude'),
+        orderedList([listItem(textParagraph('Second'))], 2),
+      ],
+    }
+
+    fixInterruptedOrderedLists(tree)
+
+    expect(tree.children).toHaveLength(3)
+    expect((tree.children[0] as MdastParent).ordered).toBe(true)
+    expect(tree.children[1]?.type).toBe('paragraph')
+    expect((tree.children[2] as MdastParent).start).toBe(2)
+  })
+
+  it('does not steal a following ul when the last item already has a nested list', () => {
+    const tree: MdastParent = {
+      type: 'root',
+      children: [
+        orderedList([
+          listItem(
+            textParagraph('A'),
+            unorderedList([listItem(textParagraph('nested'))])
+          ),
+        ]),
+        unorderedList([listItem(textParagraph('sibling bullets'))]),
+        orderedList([listItem(textParagraph('B'))]),
+      ],
+    }
+
+    fixInterruptedOrderedLists(tree)
+
+    expect(tree.children).toHaveLength(3)
+  })
+
+  it('nests a trailing unordered list under the last ordered item', () => {
+    const tree: MdastParent = {
+      type: 'root',
+      children: [
+        orderedList([listItem(textParagraph('Only parent'))]),
+        unorderedList([
+          listItem(textParagraph('child a')),
+          listItem(textParagraph('child b')),
+        ]),
+      ],
+    }
+
+    fixInterruptedOrderedLists(tree)
+
+    expect(tree.children).toHaveLength(1)
+    const ol = tree.children[0] as MdastParent
+    const li = ol.children[0] as MdastParent
+    const nested = li.children[li.children.length - 1] as MdastParent
+    expect(nested.type).toBe('list')
+    expect(nested.ordered).toBe(false)
+    expect(nested.children).toHaveLength(2)
+  })
+})

--- a/src/lib/remark-fix-interrupted-lists.ts
+++ b/src/lib/remark-fix-interrupted-lists.ts
@@ -1,0 +1,151 @@
+/**
+ * remark plugin: nest interrupting sibling unordered lists under the preceding
+ * ordered-list item and merge the split ordered lists back together.
+ *
+ * LLMs often emit:
+ *
+ *   1. Parent A
+ *   - child
+ *   - child
+ *
+ *   1. Parent B
+ *   - child
+ *
+ * CommonMark treats the unindented `-` lines as a sibling list that ends the
+ * ordered list. Each subsequent `1.` then starts a fresh `<ol>`, so the UI
+ * shows 1, 1, 1 instead of 1, 2, 3 (GitHub issue #200).
+ *
+ * Properly indented nested bullets already parse as one list and are left alone.
+ */
+
+export interface MdastNode {
+  type: string
+  children?: MdastNode[]
+  ordered?: boolean
+  start?: number | null
+  spread?: boolean | null
+  checked?: boolean | null
+  [key: string]: unknown
+}
+
+export interface MdastParent extends MdastNode {
+  children: MdastNode[]
+}
+
+function isList(node: MdastNode | undefined): node is MdastParent {
+  return node?.type === 'list' && Array.isArray(node.children)
+}
+
+function isOrderedList(node: MdastNode | undefined): node is MdastParent {
+  return isList(node) && node.ordered === true
+}
+
+function isUnorderedList(node: MdastNode | undefined): node is MdastParent {
+  return isList(node) && node.ordered !== true
+}
+
+function lastListItem(list: MdastParent): MdastParent | null {
+  const items = list.children
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i]
+    if (item?.type === 'listItem' && Array.isArray(item.children)) {
+      return item as MdastParent
+    }
+  }
+  return null
+}
+
+/**
+ * True when `list` already ends with a nested list — further sibling ULs are
+ * more likely intentional separate lists than orphaned nested content.
+ */
+function lastItemAlreadyHasNestedList(list: MdastParent): boolean {
+  const item = lastListItem(list)
+  if (!item) return false
+  const lastChild = item.children[item.children.length - 1]
+  return isList(lastChild)
+}
+
+/**
+ * Merge ordered lists that were split only by intervening unordered lists.
+ * Mutates the tree in place (remark plugin convention).
+ */
+export function fixInterruptedOrderedLists(tree: MdastParent): void {
+  if (!Array.isArray(tree.children) || tree.children.length < 2) return
+
+  // Recurse into block containers so nested content is handled too.
+  for (const child of tree.children) {
+    if (child && Array.isArray(child.children) && child.type !== 'list') {
+      fixInterruptedOrderedLists(child as MdastParent)
+    }
+  }
+
+  const out: MdastNode[] = []
+  let i = 0
+  const children = tree.children
+
+  while (i < children.length) {
+    const node = children[i]
+    if (!node) {
+      i++
+      continue
+    }
+
+    if (!isOrderedList(node)) {
+      out.push(node)
+      i++
+      continue
+    }
+
+    // Absorb following `ul, ol` pairs (and a trailing `ul`) into this list.
+    let j = i + 1
+    while (j < children.length) {
+      const maybeUl = children[j]
+      if (!isUnorderedList(maybeUl)) break
+
+      const maybeOl = children[j + 1]
+      if (isOrderedList(maybeOl)) {
+        if (lastItemAlreadyHasNestedList(node)) break
+
+        const lastItem = lastListItem(node)
+        if (!lastItem) break
+
+        lastItem.children.push(maybeUl)
+        // Merged items continue the same ordered list; ignore source start
+        // values that all say "1." (the LLM restart pattern).
+        node.children.push(...maybeOl.children)
+        if (node.spread || maybeOl.spread) {
+          node.spread = true
+        }
+        j += 2
+        continue
+      }
+
+      // Trailing unordered list after an ordered list (end of section).
+      if (j === children.length - 1 || !isOrderedList(children[j + 1])) {
+        if (!lastItemAlreadyHasNestedList(node)) {
+          const lastItem = lastListItem(node)
+          if (lastItem) {
+            lastItem.children.push(maybeUl)
+            j += 1
+          }
+        }
+      }
+      break
+    }
+
+    out.push(node)
+    i = j > i ? j : i + 1
+  }
+
+  tree.children = out
+}
+
+/**
+ * remark plugin factory.
+ */
+export function remarkFixInterruptedLists() {
+  return (tree: MdastParent) => {
+    fixInterruptedOrderedLists(tree)
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes ordered markdown lists that restart at `1.` when unindented 2nd-level bullets interrupt the parent list (common LLM output pattern).
- Nests interrupting sibling unordered lists under the preceding ordered item and merges the split ordered lists so browser markers show 1, 2, 3 instead of 1, 1, 1.
- Leaves properly indented nested lists and intentionally separate lists (separated by non-list content) unchanged.
- Adds unit and component tests covering the issue #200 cases and non-regression paths.

fixes #200

---

Fixes #200