### PR TITLE
fix(codex): auto-approve residual yolo command prompts

### DIFF
--- a/jean-core/src/chat/codex.rs
+++ b/jean-core/src/chat/codex.rs
@@ -553,40 +553,56 @@ pub fn build_turn_start_params(
         params["effort"] = serde_json::json!(effort);
     }
 
-    // Sandbox policy — grant read access to add_dirs (pasted files, contexts, etc.)
-    // in ALL modes, and writable roots only in build mode.
-    // Also include git metadata dirs so worktree commits work (issue #280).
+    // Sandbox + approval policy — per-turn overrides apply to this turn and
+    // subsequent turns (Codex app-server schema). Keep these aligned with the
+    // thread-level settings from `build_thread_start_params`.
+    //
+    // Grant writable roots only in build mode (plus git metadata dirs so
+    // worktree commits work — issue #280).
     // In yolo mode, keep true danger-full-access. A per-turn sandboxPolicy
     // overrides the thread-level `sandbox`, so using workspaceWrite here would
     // accidentally re-sandbox yolo turns and break tools such as Playwright on
-    // macOS.
+    // macOS (issue #328 / PR #362).
     let mode = execution_mode.unwrap_or("plan");
-    if mode == "yolo" {
-        params["sandboxPolicy"] = serde_json::json!({
-            "type": "dangerFullAccess",
-        });
-    } else {
-        let is_writable = mode == "build";
-        let writable_roots: Vec<serde_json::Value> = if is_writable {
-            let mut roots = vec![serde_json::json!(working_dir.to_string_lossy())];
+    match mode {
+        "yolo" => {
+            params["approvalPolicy"] = serde_json::json!("never");
+            params["sandboxPolicy"] = serde_json::json!({
+                "type": "dangerFullAccess",
+            });
+        }
+        "build" => {
+            params["approvalPolicy"] = serde_json::json!({
+                "granular": {
+                    "mcp_elicitations": false,
+                    "sandbox_approval": true,
+                    "rules": true,
+                    "request_permissions": true,
+                }
+            });
+            let mut writable_roots = vec![serde_json::json!(working_dir.to_string_lossy())];
             for dir in add_dirs {
-                roots.push(serde_json::json!(dir));
+                writable_roots.push(serde_json::json!(dir));
             }
             for dir in git_writable_roots {
-                roots.push(serde_json::json!(dir));
+                writable_roots.push(serde_json::json!(dir));
             }
-            roots
-        } else {
-            vec![]
-        };
-        params["sandboxPolicy"] = serde_json::json!({
-            "type": if is_writable { "workspaceWrite" } else { "readOnly" },
-            "writableRoots": writable_roots,
-            "readOnlyAccess": { "type": "fullAccess" },
-            "networkAccess": true,
-            "excludeTmpdirEnvVar": false,
-            "excludeSlashTmp": false,
-        });
+            params["sandboxPolicy"] = serde_json::json!({
+                "type": "workspaceWrite",
+                "writableRoots": writable_roots,
+                "networkAccess": true,
+                "excludeTmpdirEnvVar": false,
+                "excludeSlashTmp": false,
+            });
+        }
+        // "plan" or default: read-only, never ask for approvals
+        _ => {
+            params["approvalPolicy"] = serde_json::json!("never");
+            params["sandboxPolicy"] = serde_json::json!({
+                "type": "readOnly",
+                "networkAccess": true,
+            });
+        }
     }
 
     // Override cwd per turn
@@ -657,6 +673,11 @@ pub fn execute_codex_via_server(
 
     let is_plan_mode = execution_mode.unwrap_or("plan") == "plan";
     let is_build_mode = execution_mode.unwrap_or("plan") == "build";
+    let is_yolo_mode = execution_mode.unwrap_or("plan") == "yolo";
+
+    // Mid-turn Approve (yolo) and pure yolo turns both auto-accept residual
+    // command/permission prompts (issue #328).
+    super::registry::set_codex_yolo_auto_approve(session_id, is_yolo_mode);
 
     log::debug!(
         "Codex server turn: session={session_id}, model={model:?}, mode={execution_mode:?}, effort={reasoning_effort:?}, resume={}",
@@ -799,6 +820,7 @@ pub fn execute_codex_via_server(
         output_file,
         is_plan_mode,
         is_build_mode,
+        is_yolo_mode,
         &event_rx,
         None,
         None,
@@ -1191,6 +1213,8 @@ pub fn resume_codex_after_crash(
                 });
                 let is_plan_mode = exec_mode.as_deref() == Some("plan");
                 let is_build_mode = exec_mode.as_deref() == Some("build");
+                let is_yolo_mode = exec_mode.as_deref() == Some("yolo");
+                super::registry::set_codex_yolo_auto_approve(session_id, is_yolo_mode);
 
                 super::increment_tailer_count();
                 let response = process_turn_events(
@@ -1202,6 +1226,7 @@ pub fn resume_codex_after_crash(
                     &output_file,
                     is_plan_mode,
                     is_build_mode,
+                    is_yolo_mode,
                     &event_rx,
                     Some(std::time::Duration::from_secs(15)),
                     codex_turn_id,
@@ -1484,6 +1509,7 @@ fn process_turn_events(
     output_file: &std::path::Path,
     is_plan_mode: bool,
     is_build_mode: bool,
+    is_yolo_mode: bool,
     event_rx: &std::sync::mpsc::Receiver<super::codex_server::ServerEvent>,
     status_poll_interval: Option<std::time::Duration>,
     recovery_turn_id: Option<&str>,
@@ -1731,6 +1757,7 @@ fn process_turn_events(
                     &params,
                     is_build_mode,
                     is_plan_mode,
+                    is_yolo_mode,
                 );
             }
             ServerEvent::ServerDied => {
@@ -2475,6 +2502,34 @@ fn sub_agent_activity_tool(item: &serde_json::Value) -> Option<(&'static str, se
     Some((tool_name, input))
 }
 
+/// Whether Codex command/permission approvals should be auto-accepted for this session.
+///
+/// True when:
+/// - the current turn started in yolo mode, or
+/// - the user chose Approve (yolo) / acceptForSession mid-turn (in-memory flag), or
+/// - session metadata already reflects selected_execution_mode = yolo
+///
+/// Mid-turn mode switches cannot reconfigure the active Codex turn sandbox, so
+/// Jean must auto-accept residual prompts itself (issue #328).
+fn should_auto_approve_codex_commands(
+    app: &tauri::AppHandle,
+    session_id: &str,
+    is_yolo_mode: bool,
+) -> bool {
+    if is_yolo_mode || super::registry::is_codex_yolo_auto_approve(session_id) {
+        return true;
+    }
+
+    match super::storage::load_metadata(app, session_id) {
+        Ok(Some(meta)) if meta.selected_execution_mode.as_deref() == Some("yolo") => {
+            // Cache for subsequent prompts in this turn.
+            super::registry::set_codex_yolo_auto_approve(session_id, true);
+            true
+        }
+        _ => false,
+    }
+}
+
 /// Handle an approval request from the app-server.
 fn handle_approval_request(
     app: &tauri::AppHandle,
@@ -2485,6 +2540,7 @@ fn handle_approval_request(
     params: &serde_json::Value,
     _is_build_mode: bool,
     is_plan_mode: bool,
+    is_yolo_mode: bool,
 ) {
     let emit_connection_error = || {
         let _ = app.emit_all(
@@ -2565,6 +2621,25 @@ fn handle_approval_request(
                 return;
             }
 
+            // Yolo / Approve (yolo): auto-accept residual sandbox/command prompts,
+            // including "command failed; retry without sandbox?" (issue #328).
+            if should_auto_approve_codex_commands(app, session_id, is_yolo_mode) {
+                log::trace!(
+                    "Auto-accepting command approval in yolo mode (rpc_id={rpc_id}): {command}"
+                );
+                if let Err(e) = super::codex_server::send_response(
+                    rpc_id,
+                    // acceptForSession caches similar prompts for the Codex thread
+                    serde_json::json!({"decision": "acceptForSession"}),
+                ) {
+                    log::error!(
+                        "Failed to auto-accept command approval in yolo mode (rpc_id={rpc_id}): {e}"
+                    );
+                    emit_connection_error();
+                }
+                return;
+            }
+
             log::trace!("Command approval requested (rpc_id={rpc_id}): {command}");
 
             let request = CodexCommandApprovalRequest {
@@ -2634,6 +2709,29 @@ fn handle_approval_request(
                 ) {
                     log::error!(
                         "Failed to deny permissions request in plan mode (rpc_id={rpc_id}): {e}"
+                    );
+                    emit_connection_error();
+                }
+                return;
+            }
+
+            if should_auto_approve_codex_commands(app, session_id, is_yolo_mode) {
+                let permissions = params
+                    .get("permissions")
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!({}));
+                log::trace!(
+                    "Auto-granting permissions request in yolo mode (rpc_id={rpc_id})"
+                );
+                if let Err(e) = super::codex_server::send_response(
+                    rpc_id,
+                    serde_json::json!({
+                        "permissions": permissions,
+                        "scope": "session",
+                    }),
+                ) {
+                    log::error!(
+                        "Failed to auto-grant permissions in yolo mode (rpc_id={rpc_id}): {e}"
                     );
                     emit_connection_error();
                 }
@@ -5097,9 +5195,10 @@ mod tests {
         );
         let policy = &params["sandboxPolicy"];
         assert_eq!(policy["type"], "readOnly");
-        assert_eq!(policy["writableRoots"].as_array().unwrap().len(), 0);
-        assert_eq!(policy["readOnlyAccess"]["type"], "fullAccess");
         assert_eq!(policy["networkAccess"], true);
+        assert_eq!(params["approvalPolicy"], "never");
+        assert!(policy.get("writableRoots").is_none());
+        assert!(policy.get("readOnlyAccess").is_none());
     }
 
     #[test]
@@ -5119,7 +5218,11 @@ mod tests {
             policy["writableRoots"],
             serde_json::json!(["/tmp/worktree", "/tmp/context", "/tmp/git"])
         );
-        assert_eq!(policy["readOnlyAccess"]["type"], "fullAccess");
+        assert_eq!(policy["networkAccess"], true);
+        assert!(policy.get("readOnlyAccess").is_none());
+        let approval = &params["approvalPolicy"]["granular"];
+        assert_eq!(approval["sandbox_approval"], true);
+        assert_eq!(approval["mcp_elicitations"], false);
     }
 
     #[test]
@@ -5149,6 +5252,7 @@ mod tests {
         );
 
         assert_eq!(params["sandboxPolicy"]["type"], "dangerFullAccess");
+        assert_eq!(params["approvalPolicy"], "never");
     }
 
     #[test]
@@ -5164,6 +5268,15 @@ mod tests {
         );
 
         assert_eq!(params["sandboxPolicy"]["type"], "dangerFullAccess");
+        assert_eq!(params["approvalPolicy"], "never");
+    }
+
+    #[test]
+    fn codex_yolo_auto_approve_flag_tracks_session() {
+        super::super::registry::set_codex_yolo_auto_approve("sess-328", true);
+        assert!(super::super::registry::is_codex_yolo_auto_approve("sess-328"));
+        super::super::registry::set_codex_yolo_auto_approve("sess-328", false);
+        assert!(!super::super::registry::is_codex_yolo_auto_approve("sess-328"));
     }
 
     #[test]

--- a/jean-core/src/chat/codex_server.rs
+++ b/jean-core/src/chat/codex_server.rs
@@ -868,7 +868,7 @@ fn request_debug_summary(method: &str, params: &Value) -> Option<Value> {
             "approvalPolicy",
             "config",
         ],
-        "turn/start" => &["threadId", "effort", "cwd", "sandboxPolicy"],
+        "turn/start" => &["threadId", "effort", "cwd", "sandboxPolicy", "approvalPolicy"],
         _ => return None,
     };
 

--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -1600,6 +1600,13 @@ pub async fn update_session_state(
                 session.enabled_mcp_servers = v;
             }
             if let Some(v) = selected_execution_mode {
+                // Keep mid-turn Codex auto-approve in sync with Jean's mode
+                // (issue #328). Approve (yolo) sets this immediately so residual
+                // "retry without sandbox?" prompts stop for the active turn.
+                super::registry::set_codex_yolo_auto_approve(
+                    &session_id,
+                    v.as_deref() == Some("yolo"),
+                );
                 session.selected_execution_mode = v;
             }
             if let Some(v) = table_checked_rows {
@@ -8182,18 +8189,31 @@ fn send_codex_response(rpc_id: u64, payload: serde_json::Value) -> Result<(), St
 
 /// Backward-compatible wrapper for legacy frontend callers.
 pub fn approve_codex_command(
-    _session_id: String,
+    session_id: String,
     rpc_id: u64,
     decision: String,
 ) -> Result<(), String> {
+    // Approve (yolo) / acceptForSession: auto-accept residual sandbox/command
+    // prompts for the rest of this session without waiting for the next turn
+    // (issue #328).
+    if decision == "acceptForSession" {
+        super::registry::set_codex_yolo_auto_approve(&session_id, true);
+    }
     send_codex_response(rpc_id, serde_json::json!({ "decision": decision }))
 }
 
 pub fn respond_codex_command_approval(
-    _session_id: String,
+    session_id: String,
     rpc_id: u64,
     response: serde_json::Value,
 ) -> Result<(), String> {
+    let is_accept_for_session = response
+        .get("decision")
+        .and_then(|d| d.as_str())
+        .is_some_and(|d| d == "acceptForSession");
+    if is_accept_for_session {
+        super::registry::set_codex_yolo_auto_approve(&session_id, true);
+    }
     send_codex_response(rpc_id, response)
 }
 

--- a/jean-core/src/chat/registry.rs
+++ b/jean-core/src/chat/registry.rs
@@ -38,6 +38,16 @@ static CANCEL_FLAGS: Lazy<Mutex<HashMap<String, OpenCodeCancelEntry>>> =
 static CODEX_TURN_REGISTRY: Lazy<Mutex<HashMap<String, (String, String)>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
+/// Jean sessions where Codex command/permission approvals should be auto-accepted.
+/// Set when a turn starts in yolo mode or the user chooses Approve (yolo) /
+/// acceptForSession mid-turn. Cleared when the session leaves yolo mode.
+///
+/// This is the mid-turn bridge for issue #328: switching Jean's execution mode
+/// to yolo does not reconfigure the already-started Codex turn, so Jean must
+/// stop surfacing further sandbox/command prompts itself.
+static CODEX_YOLO_AUTO_APPROVE: Lazy<Mutex<HashSet<String>>> =
+    Lazy::new(|| Mutex::new(HashSet::new()));
+
 /// Sessions in PROCESS_REGISTRY whose process is fully detached (survives Jean
 /// quitting). Claude CLI and host-backed Pi/Grok/Kimi runs are detached.
 static DETACHED_SESSIONS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
@@ -338,6 +348,21 @@ pub fn get_codex_turn(session_id: &str) -> Option<(String, String)> {
         .cloned()
 }
 
+/// Enable or disable automatic Codex command/permission approvals for a Jean session.
+pub fn set_codex_yolo_auto_approve(session_id: &str, enabled: bool) {
+    let mut set = lock_recover(&CODEX_YOLO_AUTO_APPROVE, "CODEX_YOLO_AUTO_APPROVE");
+    if enabled {
+        set.insert(session_id.to_string());
+    } else {
+        set.remove(session_id);
+    }
+}
+
+/// Whether Jean should auto-accept Codex command/permission approvals for this session.
+pub fn is_codex_yolo_auto_approve(session_id: &str) -> bool {
+    lock_recover(&CODEX_YOLO_AUTO_APPROVE, "CODEX_YOLO_AUTO_APPROVE").contains(session_id)
+}
+
 /// Remove all registry state for a session after a backend crash or thread panic.
 pub fn cleanup_session_registrations(session_id: &str) {
     let removed_pid = lock_recover(&PROCESS_REGISTRY, "PROCESS_REGISTRY").remove(session_id);
@@ -349,6 +374,7 @@ pub fn cleanup_session_registrations(session_id: &str) {
     let removed_turn = lock_recover(&CODEX_TURN_REGISTRY, "CODEX_TURN_REGISTRY")
         .remove(session_id)
         .is_some();
+    lock_recover(&CODEX_YOLO_AUTO_APPROVE, "CODEX_YOLO_AUTO_APPROVE").remove(session_id);
 
     if removed_pid.is_some() || removed_pending || removed_flag || removed_turn {
         log::warn!(


### PR DESCRIPTION
## Summary

- Align per-turn Codex sandbox and approval policies with execution mode so yolo turns use full access and never ask for approvals
- Auto-accept residual command and permission prompts after Approve (yolo) mid-turn, including “command failed; retry without sandbox?”
- Keep plan mode read-only with no prompts, and build mode workspace-write with sandbox approvals

fixes #328

---

Fixes #328