### PR TITLE
fix(codex): enrich thin plan mode outputs

### DIFF
--- a/jean-core/src/chat/claude.rs
+++ b/jean-core/src/chat/claude.rs
@@ -24,7 +24,7 @@ const DEFAULT_GLOBAL_SYSTEM_PROMPT: &str = "\
 - If something goes sideways, STOP and re-plan immediately - don't keep pushing\n\
 - Use plan mode for verification steps when the current execution mode is plan; in build/yolo, verify directly after implementing.\n\
 - Write detailed specs upfront to reduce ambiguity\n\
-- Make the plan extremely concise. Sacrifice grammar for the sake of concision.\n\
+- Keep plans concise but complete enough for zero-context handoff (YOLO/Build in a new worktree must not require re-scanning the repo). Prefer short wording over thin checklists.\n\
 - When the current execution mode is plan, use the backend's native plan tool/UI call when available (Claude ExitPlanMode, Codex update_plan/CodexPlan, Cursor/OpenCode equivalent), not plain text only.\n\
 - For unresolved questions while planning, prefer the backend-native interactive question UI instead of plain text when available: Claude AskUserQuestion, Codex request_user_input, OpenCode question. If no such interactive question tool is present in your current tool set (headless/`--print` runs may omit Claude AskUserQuestion), do NOT skip the question and do NOT dead-end on a tool search — instead ask inline as a short numbered list of options (1, 2, 3...) and tell the user to reply with a number.\n\
 - For Codex specifically, when the current execution mode is plan: after the user answers native `request_user_input`/open questions, immediately call `update_plan`/emit `CodexPlan` again with the revised plan before any implementation.\n\

--- a/jean-core/src/chat/codex.rs
+++ b/jean-core/src/chat/codex.rs
@@ -123,6 +123,222 @@ fn codex_plan_tool_id(turn_id: Option<&str>, item_id: Option<&str>) -> String {
     "codex-plan".to_string()
 }
 
+/// Resolve a stable CodexPlan tool id, always merging into an existing plan tool
+/// when one already exists so steps/explanation and plan body stay on one tool.
+fn resolve_codex_plan_tool_id(
+    tool_calls: &[ToolCall],
+    turn_id: Option<&str>,
+    item_id: Option<&str>,
+) -> String {
+    let preferred = codex_plan_tool_id(turn_id, item_id);
+    if tool_calls
+        .iter()
+        .any(|tc| tc.name == CODEX_PLAN_TOOL_NAME && tc.id == preferred)
+    {
+        return preferred;
+    }
+
+    // Prefer turn-scoped id when present so later item events can merge.
+    if let Some(existing) = tool_calls.iter().find(|tc| tc.name == CODEX_PLAN_TOOL_NAME) {
+        // If we only have a generic/item id but a turn-scoped tool exists, use it.
+        // If preferred is turn-scoped and only an item-scoped tool exists, migrate
+        // to preferred only when no other plan tool is turn-scoped; otherwise keep
+        // the first so all events collapse into one tool.
+        return existing.id.clone();
+    }
+
+    preferred
+}
+
+fn is_status_only_plan_explanation(text: &str) -> bool {
+    let normalized = text
+        .trim()
+        .trim_end_matches(['.', '!', ' '])
+        .to_ascii_lowercase();
+    if normalized.is_empty() {
+        return true;
+    }
+    if normalized.len() > 80 {
+        return false;
+    }
+    normalized.contains("ready for approval")
+        || normalized.contains("awaiting approval")
+        || (normalized.contains("plan")
+            && (normalized.contains("created")
+                || normalized.contains("ready")
+                || normalized.contains("complete")
+                || normalized.contains("updated")))
+}
+
+fn plan_input_body_len(input: &serde_json::Value) -> usize {
+    input
+        .get("plan")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && !is_status_only_plan_explanation(s))
+        .map(|s| s.len())
+        .unwrap_or(0)
+}
+
+fn plan_input_is_thin(input: &serde_json::Value) -> bool {
+    if plan_input_body_len(input) >= 120 {
+        return false;
+    }
+    let plan = input
+        .get("plan")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .unwrap_or("");
+    if !plan.is_empty() && !is_status_only_plan_explanation(plan) && plan.len() >= 80 {
+        return false;
+    }
+    true
+}
+
+/// Collapse multiple CodexPlan tools (split turn/item ids) into one richest tool.
+fn collapse_codex_plan_tools(
+    tool_calls: &mut Vec<ToolCall>,
+    content_blocks: &mut Vec<ContentBlock>,
+) {
+    let plan_indices: Vec<usize> = tool_calls
+        .iter()
+        .enumerate()
+        .filter(|(_, tc)| tc.name == CODEX_PLAN_TOOL_NAME)
+        .map(|(i, _)| i)
+        .collect();
+    if plan_indices.len() <= 1 {
+        return;
+    }
+
+    let mut best_idx = plan_indices[0];
+    let mut best_score = -1isize;
+    for &idx in &plan_indices {
+        let input = &tool_calls[idx].input;
+        let body = plan_input_body_len(input) as isize;
+        let preview = input
+            .get("plan_preview")
+            .and_then(|v| v.as_str())
+            .map(|s| s.len())
+            .unwrap_or(0) as isize;
+        let steps = input
+            .get("steps")
+            .and_then(|v| v.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0) as isize;
+        let score = body * 10 + preview + steps * 5;
+        if score > best_score {
+            best_score = score;
+            best_idx = idx;
+        }
+    }
+
+    let keep_id = tool_calls[best_idx].id.clone();
+    let mut merged = tool_calls[best_idx].input.clone();
+
+    for &idx in &plan_indices {
+        if idx == best_idx {
+            continue;
+        }
+        let other = &tool_calls[idx].input;
+        let plan_text = other
+            .get("plan")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+        let plan_preview = other
+            .get("plan_preview")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+        let explanation = other
+            .get("explanation")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty() && !is_status_only_plan_explanation(s))
+            .map(|s| s.to_string());
+        let steps = other.get("steps").and_then(|v| v.as_array()).cloned();
+        // Prefer longer body when merging.
+        let existing_body = plan_input_body_len(&merged);
+        let incoming_body = plan_text.as_ref().map(|s| s.len()).unwrap_or(0);
+        let plan_to_merge = if incoming_body > existing_body {
+            plan_text
+        } else {
+            None
+        };
+        merged = merge_codex_plan_input(
+            Some(&merged),
+            plan_to_merge,
+            plan_preview,
+            explanation,
+            steps,
+        );
+    }
+
+    // Keep the best tool, drop the rest.
+    let drop_ids: Vec<String> = plan_indices
+        .iter()
+        .filter(|&&idx| idx != best_idx)
+        .map(|&idx| tool_calls[idx].id.clone())
+        .collect();
+
+    if let Some(tc) = tool_calls.iter_mut().find(|tc| tc.id == keep_id) {
+        tc.input = merged;
+    }
+    tool_calls.retain(|tc| !drop_ids.contains(&tc.id));
+    content_blocks.retain(|block| {
+        !matches!(
+            block,
+            ContentBlock::ToolUse { tool_call_id } if drop_ids.contains(tool_call_id)
+        )
+    });
+    // Ensure the kept plan tool block is present once at the end.
+    move_tool_block_to_end(content_blocks, &keep_id);
+}
+
+/// If CodexPlan only has thin explanation/steps, promote richer assistant text
+/// into the plan body for YOLO/new-worktree handoff.
+fn enrich_thin_codex_plan(
+    tool_calls: &mut Vec<ToolCall>,
+    content_blocks: &mut Vec<ContentBlock>,
+    full_content: &str,
+) {
+    collapse_codex_plan_tools(tool_calls, content_blocks);
+
+    if full_content.trim().is_empty() {
+        return;
+    }
+
+    let Some(tc) = tool_calls.iter().find(|tc| tc.name == CODEX_PLAN_TOOL_NAME) else {
+        return;
+    };
+    if !plan_input_is_thin(&tc.input) {
+        return;
+    }
+
+    let candidate = if let Some((_, plan)) = extract_plain_text_plan_sections(full_content) {
+        plan
+    } else {
+        full_content.trim().to_string()
+    };
+
+    if candidate.len() < 80 || is_status_only_plan_explanation(&candidate) {
+        return;
+    }
+    if candidate.len() <= plan_input_body_len(&tc.input) {
+        return;
+    }
+
+    let tool_id = tc.id.clone();
+    let input = merge_codex_plan_input(Some(&tc.input), Some(candidate.clone()), None, None, None);
+    upsert_codex_plan_tool_call(tool_calls, content_blocks, &tool_id, input);
+    content_blocks.retain(|block| {
+        !matches!(
+            block,
+            ContentBlock::Text { text }
+                if text.trim() == full_content.trim() || text.trim() == candidate.trim()
+        )
+    });
+}
+
 fn push_unique_text(target: &mut String, text: &str) {
     let trimmed = text.trim();
     if trimmed.is_empty() {
@@ -1806,33 +2022,10 @@ fn process_turn_events(
             false
         };
 
-    // Fallback: if we're in plan mode with a CodexPlan tool that has steps but
-    // no plan text, inject full_content so the investigation summary renders
-    // inside PlanDisplay instead of as unformatted text.
-    // Also remove duplicate text blocks whose content matches the plan text.
-    if !cancelled && !error_emitted && is_plan_mode && !full_content.is_empty() {
-        if let Some(tc) = tool_calls.iter().find(|tc| tc.name == CODEX_PLAN_TOOL_NAME) {
-            let has_plan = tc
-                .input
-                .get("plan")
-                .and_then(|v| v.as_str())
-                .is_some_and(|s| !s.is_empty());
-            if !has_plan {
-                let tool_id = tc.id.clone();
-                let input = merge_codex_plan_input(
-                    Some(&tc.input),
-                    Some(full_content.clone()),
-                    None,
-                    None,
-                    None,
-                );
-                upsert_codex_plan_tool_call(&mut tool_calls, &mut content_blocks, &tool_id, input);
-                // Remove text blocks that duplicate the plan content
-                content_blocks.retain(|block| {
-                    !matches!(block, ContentBlock::Text { text } if text.trim() == full_content.trim())
-                });
-            }
-        }
+    // Collapse split CodexPlan tools and promote richer assistant text when the
+    // plan body is only a thin checklist / status explanation.
+    if !cancelled && !error_emitted && is_plan_mode {
+        enrich_thin_codex_plan(&mut tool_calls, &mut content_blocks, &full_content);
     }
 
     // Emit chat:done unless error was emitted
@@ -1939,13 +2132,25 @@ fn notification_to_history_line(method: &str, params: &serde_json::Value) -> Opt
         "item/started" => {
             let item = params.get("item")?;
             let normalized = normalize_item_types(item);
-            let line = serde_json::json!({ "type": "item.started", "item": normalized });
+            let mut line = serde_json::json!({ "type": "item.started", "item": normalized });
+            // Preserve turnId so plan items merge with turn.plan_updated on reload.
+            if let Some(turn_id) = params.get("turnId").cloned() {
+                if let Some(obj) = line.as_object_mut() {
+                    obj.insert("turn_id".to_string(), turn_id);
+                }
+            }
             return Some(serde_json::to_string(&line).ok()?);
         }
         "item/completed" => {
             let item = params.get("item")?;
             let normalized = normalize_item_types(item);
-            let line = serde_json::json!({ "type": "item.completed", "item": normalized });
+            let mut line = serde_json::json!({ "type": "item.completed", "item": normalized });
+            // Preserve turnId so plan items merge with turn.plan_updated on reload.
+            if let Some(turn_id) = params.get("turnId").cloned() {
+                if let Some(obj) = line.as_object_mut() {
+                    obj.insert("turn_id".to_string(), turn_id);
+                }
+            }
             return Some(serde_json::to_string(&line).ok()?);
         }
         "item/fileChange/patchUpdated" => {
@@ -2060,7 +2265,7 @@ fn process_server_notification(
             }
 
             let turn_id = params.get("turnId").and_then(|v| v.as_str());
-            let tool_id = codex_plan_tool_id(turn_id, None);
+            let tool_id = resolve_codex_plan_tool_id(tool_calls, turn_id, None);
             let explanation = params
                 .get("explanation")
                 .and_then(|v| v.as_str())
@@ -2082,7 +2287,7 @@ fn process_server_notification(
 
             let turn_id = params.get("turnId").and_then(|v| v.as_str());
             let item_id = params.get("itemId").and_then(|v| v.as_str());
-            let tool_id = codex_plan_tool_id(turn_id, item_id);
+            let tool_id = resolve_codex_plan_tool_id(tool_calls, turn_id, item_id);
             let delta = params.get("delta").and_then(|v| v.as_str()).unwrap_or("");
             let existing = tool_calls
                 .iter()
@@ -2115,7 +2320,7 @@ fn process_server_notification(
 
                 let turn_id = params.get("turnId").and_then(|v| v.as_str());
                 let item_id = event_item.get("id").and_then(|v| v.as_str());
-                let tool_id = codex_plan_tool_id(turn_id, item_id);
+                let tool_id = resolve_codex_plan_tool_id(tool_calls, turn_id, item_id);
                 let existing = tool_calls
                     .iter()
                     .find(|tc| tc.id == tool_id)
@@ -2158,7 +2363,7 @@ fn process_server_notification(
 
                 let turn_id = params.get("turnId").and_then(|v| v.as_str());
                 let item_id = event_item.get("id").and_then(|v| v.as_str());
-                let tool_id = codex_plan_tool_id(turn_id, item_id);
+                let tool_id = resolve_codex_plan_tool_id(tool_calls, turn_id, item_id);
                 let existing = tool_calls
                     .iter()
                     .find(|tc| tc.id == tool_id)
@@ -3201,7 +3406,8 @@ fn process_codex_event(
                 | "entered_review_mode"
                 | "exited_review_mode" => {}
                 "plan" => {
-                    let tool_id = codex_plan_tool_id(None, Some(item_id));
+                    let tool_id =
+                        resolve_codex_plan_tool_id(tool_calls, None, Some(item_id));
                     let existing = tool_calls
                         .iter()
                         .find(|tc| tc.id == tool_id)
@@ -3306,7 +3512,8 @@ fn process_codex_event(
                     }
                 }
                 "plan" => {
-                    let tool_id = codex_plan_tool_id(None, Some(item_id));
+                    let tool_id =
+                        resolve_codex_plan_tool_id(tool_calls, None, Some(item_id));
                     let existing = tool_calls
                         .iter()
                         .find(|tc| tc.id == tool_id)
@@ -3796,7 +4003,7 @@ pub fn parse_codex_run_to_message(
                     continue;
                 }
                 let turn_id = msg.get("turn_id").and_then(|v| v.as_str());
-                let tool_id = codex_plan_tool_id(turn_id, None);
+                let tool_id = resolve_codex_plan_tool_id(&tool_calls, turn_id, None);
                 let explanation = msg
                     .get("explanation")
                     .and_then(|v| v.as_str())
@@ -3816,7 +4023,7 @@ pub fn parse_codex_run_to_message(
                 }
                 let turn_id = msg.get("turn_id").and_then(|v| v.as_str());
                 let item_id = msg.get("item_id").and_then(|v| v.as_str());
-                let tool_id = codex_plan_tool_id(turn_id, item_id);
+                let tool_id = resolve_codex_plan_tool_id(&tool_calls, turn_id, item_id);
                 let existing = tool_calls
                     .iter()
                     .find(|tc| tc.id == tool_id)
@@ -3842,13 +4049,15 @@ pub fn parse_codex_run_to_message(
                 let item = &normalized_item;
                 let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
                 let item_id = item.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                let turn_id = msg.get("turn_id").and_then(|v| v.as_str());
 
                 match item_type {
                     "plan" => {
                         if !is_plan_mode {
                             continue;
                         }
-                        let tool_id = codex_plan_tool_id(None, Some(item_id));
+                        let tool_id =
+                            resolve_codex_plan_tool_id(&tool_calls, turn_id, Some(item_id));
                         let existing = tool_calls
                             .iter()
                             .find(|tc| tc.id == tool_id)
@@ -4003,13 +4212,15 @@ pub fn parse_codex_run_to_message(
                 let item = &normalized_item;
                 let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
                 let item_id = item.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                let turn_id = msg.get("turn_id").and_then(|v| v.as_str());
 
                 match item_type {
                     "plan" => {
                         if !is_plan_mode {
                             continue;
                         }
-                        let tool_id = codex_plan_tool_id(None, Some(item_id));
+                        let tool_id =
+                            resolve_codex_plan_tool_id(&tool_calls, turn_id, Some(item_id));
                         let existing = tool_calls
                             .iter()
                             .find(|tc| tc.id == tool_id)
@@ -4223,36 +4434,11 @@ pub fn parse_codex_run_to_message(
     }
 
     let has_executed_tools = tool_calls.iter().any(|tc| tc.name != CODEX_PLAN_TOOL_NAME);
-    if is_plan_mode && !has_executed_tools {
-        ensure_plain_text_codex_plan_tool(&mut tool_calls, &mut content_blocks, &content);
-
-        // Fallback: if CodexPlan exists but has no plan text, inject full content
-        if !content.is_empty() {
-            if let Some(tc) = tool_calls.iter().find(|tc| tc.name == CODEX_PLAN_TOOL_NAME) {
-                let has_plan = tc
-                    .input
-                    .get("plan")
-                    .and_then(|v| v.as_str())
-                    .is_some_and(|s| !s.is_empty());
-                if !has_plan {
-                    let tool_id = tc.id.clone();
-                    let input = merge_codex_plan_input(
-                        Some(&tc.input),
-                        Some(content.clone()),
-                        None,
-                        None,
-                        None,
-                    );
-                    if let Some(tc) = tool_calls.iter_mut().find(|t| t.id == tool_id) {
-                        tc.input = input;
-                    }
-                    // Remove text blocks that duplicate the plan content
-                    content_blocks.retain(|block| {
-                        !matches!(block, ContentBlock::Text { text } if text.trim() == content.trim())
-                    });
-                }
-            }
+    if is_plan_mode {
+        if !has_executed_tools {
+            ensure_plain_text_codex_plan_tool(&mut tool_calls, &mut content_blocks, &content);
         }
+        enrich_thin_codex_plan(&mut tool_calls, &mut content_blocks, &content);
     }
 
     Ok(ChatMessage {
@@ -5332,6 +5518,133 @@ mod tests {
         assert_eq!(
             plan_tool.input.get("plan").and_then(|v| v.as_str()),
             Some("Final plan")
+        );
+    }
+
+    #[test]
+    fn parse_plan_run_merges_split_plan_tools_and_enriches_thin_body() {
+        // History without turn_id on plan item used to create a second CodexPlan tool.
+        // Resolve + collapse must keep one tool with the detailed body.
+        let lines = vec![
+            r#"{"type":"turn.plan_updated","turn_id":"turn-1","explanation":"Plan created and ready for approval.","plan":[{"step":"Touch parser","status":"pending"}]}"#.to_string(),
+            r#"{"type":"item.completed","item":{"id":"plan-1","type":"plan","text":"Goal: fix thin Codex plans.\n\n1. Unify tool ids.\n2. Prefer richest plan body.\n3. Require detailed plan prompts.\n4. Cover with unit tests."}}"#.to_string(),
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"Goal: fix thin Codex plans.\n\n1. Unify tool ids.\n2. Prefer richest plan body.\n3. Require detailed plan prompts.\n4. Cover with unit tests."}}"#.to_string(),
+        ];
+        let run = RunEntry {
+            run_id: "run-merge-plan".to_string(),
+            user_message_id: "user-merge-plan".to_string(),
+            user_message: "prompt".to_string(),
+            model: None,
+            execution_mode: Some("plan".to_string()),
+            thinking_level: None,
+            effort_level: None,
+            backend: None,
+            custom_profile_name: None,
+            started_at: 1,
+            ended_at: Some(2),
+            status: RunStatus::Completed,
+            assistant_message_id: Some("assistant-merge-plan".to_string()),
+            cancelled: false,
+            recovered: false,
+            claude_session_id: None,
+            pid: None,
+            usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
+            cursor_chat_id: None,
+            grok_session_id: None,
+            kimi_session_id: None,
+        };
+
+        let message = parse_codex_run_to_message(&lines, &run).expect("message");
+
+        let plan_tools: Vec<_> = message
+            .tool_calls
+            .iter()
+            .filter(|tool| tool.name == CODEX_PLAN_TOOL_NAME)
+            .collect();
+        assert_eq!(plan_tools.len(), 1, "split plan tools should collapse to one");
+        let plan_tool = plan_tools[0];
+        assert_eq!(
+            plan_tool.input.get("plan").and_then(|v| v.as_str()),
+            Some(
+                "Goal: fix thin Codex plans.\n\n1. Unify tool ids.\n2. Prefer richest plan body.\n3. Require detailed plan prompts.\n4. Cover with unit tests."
+            )
+        );
+        assert!(
+            plan_tool
+                .input
+                .get("steps")
+                .and_then(|v| v.as_array())
+                .is_some_and(|steps| !steps.is_empty()),
+            "checklist steps should be preserved on the merged tool"
+        );
+    }
+
+    #[test]
+    fn parse_plan_run_enriches_status_only_plan_from_assistant_text() {
+        let lines = vec![
+            r#"{"type":"turn.plan_updated","turn_id":"turn-1","explanation":"Plan created and ready for approval.","plan":[{"step":"Implement fix","status":"pending"}]}"#.to_string(),
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"Goal: hand off a usable plan.\n\nFiles: jean-core/src/chat/codex.rs, tool-call-utils.ts.\nSteps: unify ids, pick richest body, strengthen prompt, add tests.\nVerify: unit tests + manual YOLO handoff."}}"#.to_string(),
+        ];
+        let run = RunEntry {
+            run_id: "run-enrich-plan".to_string(),
+            user_message_id: "user-enrich-plan".to_string(),
+            user_message: "prompt".to_string(),
+            model: None,
+            execution_mode: Some("plan".to_string()),
+            thinking_level: None,
+            effort_level: None,
+            backend: None,
+            custom_profile_name: None,
+            started_at: 1,
+            ended_at: Some(2),
+            status: RunStatus::Completed,
+            assistant_message_id: Some("assistant-enrich-plan".to_string()),
+            cancelled: false,
+            recovered: false,
+            claude_session_id: None,
+            pid: None,
+            usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
+            cursor_chat_id: None,
+            grok_session_id: None,
+            kimi_session_id: None,
+        };
+
+        let message = parse_codex_run_to_message(&lines, &run).expect("message");
+        let plan_tool = message
+            .tool_calls
+            .iter()
+            .find(|tool| tool.name == CODEX_PLAN_TOOL_NAME)
+            .expect("plan tool");
+        let plan_body = plan_tool
+            .input
+            .get("plan")
+            .and_then(|v| v.as_str())
+            .expect("plan body");
+        assert!(plan_body.contains("hand off a usable plan"));
+        assert!(plan_body.contains("tool-call-utils.ts"));
+        assert!(!plan_body.contains("Plan created and ready for approval"));
+    }
+
+    #[test]
+    fn notification_history_preserves_turn_id_on_item_completed() {
+        let params = serde_json::json!({
+            "item": { "id": "plan-1", "type": "plan", "text": "Detailed plan body" },
+            "threadId": "thread-1",
+            "turnId": "turn-99",
+        });
+        let line = notification_to_history_line("item/completed", &params).expect("history line");
+        let parsed: serde_json::Value = serde_json::from_str(&line).expect("json");
+        assert_eq!(parsed.get("turn_id").and_then(|v| v.as_str()), Some("turn-99"));
+        assert_eq!(
+            parsed
+                .get("item")
+                .and_then(|i| i.get("id"))
+                .and_then(|v| v.as_str()),
+            Some("plan-1")
         );
     }
 

--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -53,8 +53,18 @@ const CODEX_DEFAULT_PLAN_MODE_PROMPT: &str = "\
 - You are in PLAN MODE. Do not implement yet.
 - Inspect the project as needed, then present the plan with the native Codex plan tool (`update_plan` / `CodexPlan`) so Jean can show the approval UI.
 - Every plan-mode response that contains or revises a plan must use `update_plan` / `CodexPlan`; do not provide a plain-text-only plan.
-- If questions block the plan, prefer Codex `request_user_input`; after the user answers, call `update_plan` / `CodexPlan` again with the revised plan.
-- Do not call implementation tools or make file changes until the user approves the plan.";
+- If questions block the plan, prefer Codex `request_user_input`; after the user answers, call `update_plan` / `CodexPlan` again with the **full revised plan**, not only short step titles.
+- Do not call implementation tools or make file changes until the user approves the plan.
+
+### Plan quality (required for YOLO/Build handoff)
+
+Jean may hand this plan to a zero-context agent in a new worktree. Status lines like \"Plan created and ready for approval.\" are not a plan.
+
+- `update_plan` step titles are a short checklist only (a few words each is fine).
+- The authoritative plan body must be detailed enough to implement without re-scanning the repo or re-asking answered questions.
+- Include: goal/outcome, key decisions from the interview, concrete files/areas to touch, ordered implementation steps with enough approach detail, risks/edge cases, and how to verify.
+- Prefer a structured body (headings/bullets). Concise writing is good; incomplete handoff plans are not.
+- After answering questions, re-emit the full detailed body with `update_plan` / plan item text — never end on explanation-only or checklist-only content.";
 const DEFAULT_PARALLEL_EXECUTION_PROMPT: &str = r#"In plan mode, structure plans so subagents can work simultaneously. In build/execute mode, use subagents in parallel for faster implementation.
 
 When launching multiple Task subagents, prefer sending them in a single message rather than sequentially. Group independent work items (e.g., editing separate files, researching unrelated questions) into parallel Task calls. Only sequence Tasks when one depends on another's output.
@@ -9642,6 +9652,10 @@ mod tests {
         assert!(plan_prompt.contains("update_plan"));
         assert!(plan_prompt.contains("CodexPlan"));
         assert!(plan_prompt.contains("approval UI"));
+        assert!(plan_prompt.contains("Plan quality"));
+        assert!(plan_prompt.contains("zero-context"));
+        assert!(plan_prompt.contains("Plan created and ready for approval"));
+        assert!(plan_prompt.contains("full revised plan"));
         assert!(!plan_prompt.contains("## Not Plan Mode"));
 
         let build_prompt = codex_default_global_system_prompt(Some("build"));

--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -779,6 +779,8 @@ mod tests {
         assert!(prompt.contains("Claude AskUserQuestion"));
         assert!(prompt.contains("OpenCode question"));
         assert!(prompt.contains("Use a plain-text Unresolved Questions section only"));
+        assert!(prompt.contains("zero-context handoff"));
+        assert!(!prompt.contains("Make the plan extremely concise"));
         assert!(prompt.contains("Jean Worktree Policy"));
         assert!(prompt.contains("Do NOT create git worktrees manually"));
         assert!(prompt.contains("Jean MCP/tools"));
@@ -1774,7 +1776,7 @@ fn default_global_system_prompt() -> String {
 - If something goes sideways, STOP and re-plan immediately - don't keep pushing
 - Use plan mode for verification steps when the current execution mode is plan; in build/yolo, verify directly after implementing.
 - Write detailed specs upfront to reduce ambiguity
-- Make the plan extremely concise. Sacrifice grammar for the sake of concision.
+- Keep plans concise but complete enough for zero-context handoff (YOLO/Build in a new worktree must not require re-scanning the repo). Prefer short wording over thin checklists.
 - When the current execution mode is plan, use the backend's native plan tool/UI call when available (Claude ExitPlanMode, Codex update_plan/CodexPlan, Cursor/OpenCode equivalent), not plain text only.
 - For unresolved questions while planning, prefer the backend-native interactive question UI instead of plain text when available: Claude AskUserQuestion, Codex request_user_input, OpenCode question.
 - For Codex specifically, when the current execution mode is plan: after the user answers native `request_user_input`/open questions, immediately call `update_plan`/emit `CodexPlan` again with the revised plan before any implementation.

--- a/src/components/chat/tool-call-utils.test.ts
+++ b/src/components/chat/tool-call-utils.test.ts
@@ -151,6 +151,58 @@ describe('resolvePlanContent', () => {
       source: 'steps',
     })
   })
+
+  it('prefers the richest body when multiple CodexPlan tools exist', () => {
+    const toolCalls: ToolCall[] = [
+      {
+        id: 'codex-plan-turn-1',
+        name: 'CodexPlan',
+        input: {
+          explanation: 'Plan created and ready for approval.',
+          steps: [{ step: 'Touch files', status: 'pending' }],
+        },
+      },
+      {
+        id: 'codex-plan-plan-1',
+        name: 'CodexPlan',
+        input: {
+          plan: 'Plan:\n- Rewrite the parser in codex.rs\n- Add merge tests for split plan tools\n- Verify YOLO handoff content',
+        },
+      },
+    ]
+
+    expect(resolvePlanContent({ toolCalls })).toEqual({
+      content:
+        'Plan:\n- Rewrite the parser in codex.rs\n- Add merge tests for split plan tools\n- Verify YOLO handoff content',
+      source: 'plan',
+    })
+  })
+
+  it('does not treat status-only explanation as authoritative plan content when assistant text is richer', () => {
+    const toolCalls: ToolCall[] = [
+      {
+        id: 'plan-1',
+        name: 'CodexPlan',
+        input: {
+          explanation: 'Plan created and ready for approval.',
+          steps: [{ step: 'Do the thing', status: 'pending' }],
+        },
+      },
+    ]
+
+    const detailed =
+      'Goal: rewrite plan extraction.\n\n1. Unify CodexPlan tool ids across live and history paths.\n2. Prefer richest plan body when tools split.\n3. Require handoff-quality plan prompts for Codex.\n4. Cover with unit tests for multi-tool resolution.'
+
+    expect(
+      resolvePlanContent({
+        toolCalls,
+        messageContent: detailed,
+      })
+    ).toEqual({
+      content: detailed,
+      source: 'message_text',
+    })
+  })
 })
 
 describe('isDuplicatePlanTextBlock', () => {

--- a/src/components/chat/tool-call-utils.ts
+++ b/src/components/chat/tool-call-utils.ts
@@ -498,17 +498,125 @@ function normalizePlanText(content: string): string {
   return content.trim().replace(/\r\n/g, '\n')
 }
 
-function getPlanToolInput(toolCalls: ToolCall[]): PlanToolInput | undefined {
-  const planTool = toolCalls.find(isPlanToolCall)
-  return planTool?.input as PlanToolInput | undefined
-}
-
 function getPlanField(input: PlanToolInput | undefined): string | null {
   return isNonEmptyString(input?.plan) ? input.plan : null
 }
 
 function getPlanPreviewField(input: PlanToolInput | undefined): string | null {
   return isNonEmptyString(input?.plan_preview) ? input.plan_preview : null
+}
+
+/** Status-only explanations are not handoff-quality plan bodies. */
+function isStatusOnlyPlanExplanation(text: string): boolean {
+  const normalized = text.trim().toLowerCase().replace(/[.!]+$/g, '')
+  if (!normalized) return true
+  if (normalized.length > 80) return false
+  return (
+    /plan (created|ready|complete|completed|updated)/.test(normalized) ||
+    /ready for approval/.test(normalized) ||
+    /awaiting approval/.test(normalized)
+  )
+}
+
+/**
+ * Prefer the richest Codex/ExitPlanMode tool input when multiple plan tools
+ * exist (e.g. split turn-id vs item-id after history reload).
+ */
+function getPlanToolInput(toolCalls: ToolCall[]): PlanToolInput | undefined {
+  const planTools = toolCalls.filter(isPlanToolCall)
+  if (planTools.length === 0) return undefined
+  if (planTools.length === 1) {
+    return planTools[0]?.input as PlanToolInput | undefined
+  }
+
+  let best: PlanToolInput | undefined
+  let bestScore = -1
+  for (const tool of planTools) {
+    const input = tool.input as PlanToolInput
+    const plan = getPlanField(input)
+    const preview = getPlanPreviewField(input)
+    const steps =
+      input?.steps?.filter(step => isNonEmptyString(step.step)).length ?? 0
+    const explanation = isNonEmptyString(input?.explanation)
+      ? input.explanation.trim()
+      : ''
+    let score = 0
+    if (plan && !looksLikeFormattedSteps(plan)) {
+      score += 1000 + plan.trim().length
+    }
+    if (preview) score += 500 + preview.trim().length
+    if (steps > 0) score += 100 + steps * 10
+    if (explanation && !isStatusOnlyPlanExplanation(explanation)) {
+      score += 50 + explanation.length
+    } else if (explanation) {
+      score += 1
+    }
+    if (score > bestScore) {
+      bestScore = score
+      best = input
+    }
+  }
+  return best
+}
+
+/**
+ * Merge plan fields from all plan tools so a thin explanation tool and a
+ * rich plan-body tool still produce one complete handoff document.
+ */
+function getMergedPlanToolInput(
+  toolCalls: ToolCall[]
+): PlanToolInput | undefined {
+  const planTools = toolCalls.filter(isPlanToolCall)
+  if (planTools.length === 0) return undefined
+  if (planTools.length === 1) {
+    return planTools[0]?.input as PlanToolInput | undefined
+  }
+
+  const merged: PlanToolInput = { source: 'codex' }
+  let bestPlan: string | null = null
+  let bestPreview: string | null = null
+  let bestSteps: PlanToolInput['steps']
+  let bestExplanation: string | null = null
+
+  for (const tool of planTools) {
+    const input = tool.input as PlanToolInput
+    const plan = getPlanField(input)
+    if (
+      plan &&
+      !looksLikeFormattedSteps(plan) &&
+      (!bestPlan || plan.trim().length > bestPlan.trim().length)
+    ) {
+      bestPlan = plan
+    }
+    const preview = getPlanPreviewField(input)
+    if (
+      preview &&
+      (!bestPreview || preview.trim().length > bestPreview.trim().length)
+    ) {
+      bestPreview = preview
+    }
+    const steps = input?.steps?.filter(step => isNonEmptyString(step.step))
+    if (steps && steps.length > (bestSteps?.length ?? 0)) {
+      bestSteps = steps
+    }
+    if (isNonEmptyString(input?.explanation)) {
+      const explanation = input.explanation.trim()
+      if (
+        !isStatusOnlyPlanExplanation(explanation) &&
+        (!bestExplanation || explanation.length > bestExplanation.length)
+      ) {
+        bestExplanation = explanation
+      } else if (!bestExplanation) {
+        bestExplanation = explanation
+      }
+    }
+  }
+
+  if (bestPlan) merged.plan = bestPlan
+  if (bestPreview) merged.plan_preview = bestPreview
+  if (bestSteps) merged.steps = bestSteps
+  if (bestExplanation) merged.explanation = bestExplanation
+  return merged
 }
 
 function formatPlanSteps(input: PlanToolInput | undefined): string | null {
@@ -526,7 +634,12 @@ function formatPlanSteps(input: PlanToolInput | undefined): string | null {
   const explanation = isNonEmptyString(input?.explanation)
     ? input.explanation.trim()
     : null
-  return [explanation, formattedSteps.join('\n')].filter(Boolean).join('\n\n')
+  // Don't promote status-only explanations as plan intro text
+  const intro =
+    explanation && !isStatusOnlyPlanExplanation(explanation)
+      ? explanation
+      : null
+  return [intro, formattedSteps.join('\n')].filter(Boolean).join('\n\n')
 }
 
 export function splitTextAroundPlan(text: string): SplitTextAroundPlanResult {
@@ -605,7 +718,11 @@ export function resolvePlanContent(params: {
   messageContent?: string | null
   contentBlocks?: ContentBlock[]
 }): ResolvedPlanContent {
-  const input = getPlanToolInput(params.toolCalls)
+  // Merge across split CodexPlan tools (turn-id vs item-id) so the richest
+  // body/steps win instead of whichever tool was inserted first.
+  const input =
+    getMergedPlanToolInput(params.toolCalls) ??
+    getPlanToolInput(params.toolCalls)
   const plan = getPlanField(input)
   const planPreview = getPlanPreviewField(input)
 
@@ -624,13 +741,39 @@ export function resolvePlanContent(params: {
     return { content: extractedFromText, source: 'message_text' }
   }
 
+  // Prefer full assistant text over thin checklist/status when no structured
+  // plan body was persisted — YOLO/new-worktree handoff needs the prose.
+  const fullAssistantText = collectPlanTextCandidates(params)
+    .map(text => text.trim())
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length)[0]
   const formattedSteps = formatPlanSteps(input)
+  if (
+    fullAssistantText &&
+    fullAssistantText.length >= 120 &&
+    (!formattedSteps || fullAssistantText.length > formattedSteps.length * 2)
+  ) {
+    return { content: fullAssistantText, source: 'message_text' }
+  }
+
   if (formattedSteps) {
     return { content: formattedSteps, source: 'steps' }
   }
 
+  if (
+    isNonEmptyString(input?.explanation) &&
+    !isStatusOnlyPlanExplanation(input.explanation)
+  ) {
+    return { content: input.explanation, source: 'explanation' }
+  }
+
+  // Last resort: status-only explanation (still better than empty for UI)
   if (isNonEmptyString(input?.explanation)) {
     return { content: input.explanation, source: 'explanation' }
+  }
+
+  if (fullAssistantText) {
+    return { content: fullAssistantText, source: 'message_text' }
   }
 
   return { content: null, source: null }

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -649,7 +649,7 @@ export const DEFAULT_GLOBAL_SYSTEM_PROMPT = `### 1. Planning Guidance
 - If something goes sideways, STOP and re-plan immediately - don't keep pushing
 - Use plan mode for verification steps when the current execution mode is plan; in build/yolo, verify directly after implementing.
 - Write detailed specs upfront to reduce ambiguity
-- Make the plan extremely concise. Sacrifice grammar for the sake of concision.
+- Keep plans concise but complete enough for zero-context handoff (YOLO/Build in a new worktree must not require re-scanning the repo). Prefer short wording over thin checklists.
 - When the current execution mode is plan, use the backend's native plan tool/UI call when available (Claude ExitPlanMode, Codex update_plan/CodexPlan, Cursor/OpenCode equivalent), not plain text only.
 - For unresolved questions while planning, prefer the backend-native interactive question UI instead of plain text when available: Claude AskUserQuestion, Codex request_user_input, OpenCode question. If no such interactive question tool is present in your current tool set (headless/\`--print\` runs may omit Claude AskUserQuestion), do NOT skip the question and do NOT dead-end on a tool search — instead ask inline as a short numbered list of options (1, 2, 3...) and tell the user to reply with a number.
 - For Codex specifically, when the current execution mode is plan: after the user answers native \`request_user_input\`/open questions, immediately call \`update_plan\`/emit \`CodexPlan\` again with the revised plan before any implementation.


### PR DESCRIPTION
## Summary

- Update default planning guidance so plans stay concise but complete enough for zero-context YOLO/Build handoff in a new worktree, instead of ultra-thin checklists.
- Collapse split CodexPlan tool calls into a single richest plan tool so steps, explanation, and plan body stay together.
- When a Codex plan is status-only or too thin, promote richer assistant text into the plan body so approval and new-worktree execution have usable detail.

fixes #510

---

Fixes #510