### PR TITLE
fix(linux): ship GStreamer plugins for AppImage startup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,22 @@ jobs:
         if: startsWith(matrix.platform, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils libfuse2
+          # gstreamer packages are required when bundleMediaFramework is true so
+          # AppImage ships plugins WebKit needs (appsrc/appsink/autoaudiosink).
+          # See: https://github.com/coollabsio/jean/issues/100
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            xdg-utils \
+            libfuse2 \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-libav
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ xcode-select --install
 
 ```bash
 sudo apt update
-sudo apt install libwebkit2gtk-4.1-dev librsvg2-dev patchelf
+sudo apt install libwebkit2gtk-4.1-dev librsvg2-dev patchelf gstreamer1.0-plugins-good
 
 # Ubuntu/Linux Mint: prefer Ayatana AppIndicator (avoids conflicts between old libappindicator3 and Ayatana packages)
 sudo apt install libayatana-appindicator3-dev
@@ -30,7 +30,7 @@ sudo apt install libayatana-appindicator3-dev
 **Linux** (Arch Linux/Manjaro):
 
 ```bash
-sudo pacman -S webkit2gtk-4.1 librsvg patchelf libayatana-appindicator
+sudo pacman -S webkit2gtk-4.1 librsvg patchelf libayatana-appindicator gst-plugins-good
 ```
 
 **Linux Remote Desktop (RDP/xrdp)**: See [Linux Remote Development](#linux-remote-development-rdpxrdp) section below.

--- a/docs/developer/troubleshooting.md
+++ b/docs/developer/troubleshooting.md
@@ -17,10 +17,14 @@ GStreamer element autoaudiosink not found. Please install it
 **Root Cause:**
 The AppImage bundles GLib 2.72 (from the Ubuntu 22.04 build host), but Ubuntu 24.04 has GLib 2.80. When the bundled old GLib is loaded, system GIO modules that require `g_task_set_static_name` (added in GLib 2.76) fail. This cascading failure crashes WebKitWebProcess, resulting in a white/blank screen.
 
-Additionally, the AppImage bundles `libgstreamer` but no GStreamer plugins, so audio element initialization fails.
+Additionally, older AppImages bundled `libgstreamer` without GStreamer plugins, so WebKit could not create `appsrc` / `appsink` / `autoaudiosink` and the renderer process died.
 
-**Fix:**
-This is handled by the custom AppRun script (`scripts/appimage-webkit-fix.sh`) which prefers system libraries when system WebKitGTK is available. If you have an AppImage that doesn't include this fix, you can work around it by extracting and running with system libs:
+**Fix (current releases):**
+1. Custom AppRun (`scripts/appimage-webkit-fix.sh`) prefers system libraries when system WebKitGTK is available, and sets `GST_PLUGIN_PATH` to bundled/system plugin dirs.
+2. AppImage packaging enables `bundleMediaFramework` so required GStreamer plugins ship inside the AppImage.
+3. Jean sets `WEBKIT_DISABLE_COMPOSITING_MODE=1` and `WEBKIT_DISABLE_DMABUF_RENDERER=1` on Linux before creating the webview.
+
+If you have an older AppImage without these fixes, work around by extracting and running with system libs:
 
 ```bash
 # Extract
@@ -33,6 +37,36 @@ GIO_MODULE_DIR=/dev/null LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:squashfs-roo
 Alternatively, install the `.deb` package which uses system libraries directly.
 
 **Related Issues:** [#54](https://github.com/coollabsio/jean/issues/54), [#100](https://github.com/coollabsio/jean/issues/100)
+
+---
+
+### Required Linux Dependencies (dev / .deb / system WebKit path)
+
+WebKitGTK needs GStreamer plugins at runtime. Without them, the WebKit renderer can crash with a blank screen even outside AppImage.
+
+**Debian/Ubuntu/Linux Mint:**
+
+```bash
+sudo apt install gstreamer1.0-plugins-good
+```
+
+**Arch/Manjaro:**
+
+```bash
+sudo pacman -S gst-plugins-good
+```
+
+**Fedora:**
+
+```bash
+sudo dnf install gstreamer1-plugins-good
+```
+
+**Symptoms of missing GStreamer plugins:**
+
+- Blank/gray window with no content
+- `GStreamer element autoaudiosink not found` in terminal
+- `GLib-GObject-CRITICAL: invalid (NULL) pointer instance` errors
 
 ---
 

--- a/scripts/appimage-webkit-fix.sh
+++ b/scripts/appimage-webkit-fix.sh
@@ -16,11 +16,15 @@
 #      GLib-GObject-WARNING: invalid (NULL) pointer instance
 #      g_signal_connect_data: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed
 #
-# Additionally, the AppImage bundles libgstreamer but no GStreamer plugins,
-# so the bundled GStreamer can never find audio elements like autoaudiosink.
+# Additionally, WebKit needs GStreamer element factories (appsrc/appsink/
+# autoaudiosink). Without plugins next to the loaded libgstreamer, the
+# WebKitWebProcess crashes and the window stays blank.
 #
-# Solution: Prefer system libraries when system WebKitGTK is available (covers
-# both GLib and GStreamer), and prevent loading incompatible GIO modules.
+# Solution:
+# - Prefer system libraries when system WebKitGTK is available (covers GLib,
+#   Mesa, and system GStreamer + plugins).
+# - When using the bundled stack, point GST_PLUGIN_* at bundled plugins
+#   (shipped when bundleMediaFramework is enabled) and isolate GIO modules.
 #
 # Related issues:
 # - https://github.com/coollabsio/jean/issues/52
@@ -47,6 +51,47 @@ for hook in "$APPDIR"/apprun-hooks/*.sh; do
     [ -f "$hook" ] && . "$hook"
 done
 
+# Append $1 to colon-list $2 if the directory exists and is not already listed.
+append_gst_dir() {
+    _dir="$1"
+    _var_name="$2"
+    eval "_cur=\${$_var_name}"
+    [ -d "$_dir" ] || return 0
+    case ":${_cur}:" in
+        *":${_dir}:"*) return 0 ;;
+    esac
+    if [ -z "$_cur" ]; then
+        eval "$_var_name=\"\$_dir\""
+    else
+        eval "$_var_name=\"\${_cur}:\$_dir\""
+    fi
+}
+
+# Collect bundled GStreamer plugin directories (Tauri bundleMediaFramework).
+BUNDLED_GST_PATHS=""
+for gst_dir in \
+    "$APPDIR/usr/lib/gstreamer-1.0" \
+    "$APPDIR/usr/lib/$ARCH_TRIPLET/gstreamer-1.0" \
+    "$APPDIR/usr/lib/gstreamer1.0/gstreamer-1.0" \
+    "$APPDIR/usr/lib64/gstreamer-1.0" \
+    "$APPDIR/lib/gstreamer-1.0" \
+    "$APPDIR/lib/$ARCH_TRIPLET/gstreamer-1.0"
+do
+    append_gst_dir "$gst_dir" BUNDLED_GST_PATHS
+done
+
+# Common system plugin locations (used when preferring system libs).
+SYSTEM_GST_PATHS=""
+for gst_dir in \
+    /usr/lib/gstreamer-1.0 \
+    /usr/lib64/gstreamer-1.0 \
+    "/usr/lib/$ARCH_TRIPLET/gstreamer-1.0" \
+    /usr/lib/x86_64-linux-gnu/gstreamer-1.0 \
+    /usr/lib/aarch64-linux-gnu/gstreamer-1.0
+do
+    append_gst_dir "$gst_dir" SYSTEM_GST_PATHS
+done
+
 # If system WebKitGTK 4.1 is available, prefer system libs first but keep bundled libs
 # available as fallback so AppImage-provided libs still resolve when needed.
 # This also ensures the system's GLib is used (avoiding the g_task_set_static_name
@@ -61,6 +106,23 @@ if [ -f /usr/lib/libwebkit2gtk-4.1.so.0 ] \
     # but these were built against the bundled old GLib. With system GLib loaded
     # first, we should use the system's GIO modules instead.
     unset GIO_EXTRA_MODULES
+
+    # Prefer system GStreamer plugins; keep bundled plugins as fallback.
+    if [ -n "$SYSTEM_GST_PATHS" ] || [ -n "$BUNDLED_GST_PATHS" ]; then
+        COMBINED_GST=""
+        if [ -n "$SYSTEM_GST_PATHS" ]; then
+            COMBINED_GST="$SYSTEM_GST_PATHS"
+        fi
+        if [ -n "$BUNDLED_GST_PATHS" ]; then
+            if [ -n "$COMBINED_GST" ]; then
+                COMBINED_GST="$COMBINED_GST:$BUNDLED_GST_PATHS"
+            else
+                COMBINED_GST="$BUNDLED_GST_PATHS"
+            fi
+        fi
+        export GST_PLUGIN_SYSTEM_PATH="$COMBINED_GST"
+        export GST_PLUGIN_PATH="$COMBINED_GST${GST_PLUGIN_PATH:+:$GST_PLUGIN_PATH}"
+    fi
 else
     # Fallback: use bundled libraries (standard AppImage behavior).
     # Prevent loading system GIO modules that may require a newer GLib than
@@ -68,6 +130,13 @@ else
     # from GLib 2.76+ but AppImage ships GLib 2.72).
     export GIO_MODULE_DIR=/dev/null
     export LD_LIBRARY_PATH="$BUNDLED_LIBS"
+
+    # Point GStreamer at bundled plugins (from bundleMediaFramework). Without
+    # this, bundled libgstreamer finds zero element factories and WebKit dies.
+    if [ -n "$BUNDLED_GST_PATHS" ]; then
+        export GST_PLUGIN_SYSTEM_PATH="$BUNDLED_GST_PATHS"
+        export GST_PLUGIN_PATH="$BUNDLED_GST_PATHS${GST_PLUGIN_PATH:+:$GST_PLUGIN_PATH}"
+    fi
 fi
 
 # Preserve any user-supplied LD_LIBRARY_PATH entries at the end.

--- a/scripts/appimage-webkit-fix.test.mjs
+++ b/scripts/appimage-webkit-fix.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const appRunSource = join(repoRoot, 'scripts/appimage-webkit-fix.sh')
+
+function makeFakeAppDir(root) {
+  const appDir = join(root, 'Jean.AppDir')
+  mkdirSync(join(appDir, 'usr/bin'), { recursive: true })
+  mkdirSync(join(appDir, 'usr/lib/gstreamer-1.0'), { recursive: true })
+  mkdirSync(join(appDir, 'apprun-hooks'), { recursive: true })
+
+  // Dummy binary that prints the GStreamer env Jean would inherit.
+  writeFileSync(
+    join(appDir, 'usr/bin/jean'),
+    `#!/usr/bin/env bash
+echo "GST_PLUGIN_PATH=\${GST_PLUGIN_PATH-}"
+echo "GST_PLUGIN_SYSTEM_PATH=\${GST_PLUGIN_SYSTEM_PATH-}"
+echo "LD_LIBRARY_PATH=\${LD_LIBRARY_PATH-}"
+`
+  )
+  chmodSync(join(appDir, 'usr/bin/jean'), 0o755)
+
+  writeFileSync(join(appDir, 'apprun-hooks/linuxdeploy-plugin-gtk.sh'), '#!/bin/true\n')
+  writeFileSync(
+    join(appDir, 'AppRun'),
+    readFileSync(appRunSource, 'utf8')
+  )
+  chmodSync(join(appDir, 'AppRun'), 0o755)
+
+  return appDir
+}
+
+test('appimage-webkit-fix.sh is valid bash', () => {
+  execFileSync('bash', ['-n', appRunSource], { stdio: 'pipe' })
+})
+
+test('bundleMediaFramework is enabled for AppImage packaging', () => {
+  const conf = JSON.parse(
+    readFileSync(join(repoRoot, 'src-tauri/tauri.conf.json'), 'utf8')
+  )
+  assert.equal(conf.bundle?.linux?.appimage?.bundleMediaFramework, true)
+})
+
+test('AppRun points GST_PLUGIN_PATH at bundled plugins when system WebKit is absent', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'jean-appimage-apprun-'))
+  try {
+    const appDir = makeFakeAppDir(tempRoot)
+    // Force the "no system WebKit" branch by running in an empty fake root-like env.
+    // The script checks absolute /usr/lib paths; we cannot hide real system WebKit,
+    // so only assert bundled path appears when the script sets GST vars from AppDir.
+    // If system WebKit exists on the host, GST paths will still include AppDir plugins.
+    const output = execFileSync(join(appDir, 'AppRun'), {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        // Keep path minimal; AppRun rebuilds LD_LIBRARY_PATH itself.
+        LD_LIBRARY_PATH: '',
+        GST_PLUGIN_PATH: '',
+        GST_PLUGIN_SYSTEM_PATH: '',
+      },
+    })
+
+    assert.match(
+      output,
+      /GST_PLUGIN_PATH=.*Jean\.AppDir\/usr\/lib\/gstreamer-1\.0/
+    )
+    assert.match(
+      output,
+      /GST_PLUGIN_SYSTEM_PATH=.*Jean\.AppDir\/usr\/lib\/gstreamer-1\.0/
+    )
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -3,8 +3,10 @@
 #
 # The default AppImage bundles libraries from Ubuntu 22.04 which conflict
 # with newer system libraries on Arch Linux, Fedora 40+, etc. This script:
-# 1. Builds the AppImage normally via Tauri
+# 1. Builds the AppImage normally via Tauri (bundleMediaFramework ships
+#    GStreamer plugins WebKit needs — see issue #100)
 # 2. Replaces AppRun with a custom script that prefers system WebKitGTK
+#    and wires GST_PLUGIN_PATH to bundled/system plugins
 # 3. Repackages the AppImage
 #
 # Usage: bash scripts/build-appimage.sh
@@ -13,6 +15,7 @@
 # - https://github.com/coollabsio/jean/issues/52
 # - https://github.com/coollabsio/jean/issues/55
 # - https://github.com/coollabsio/jean/issues/71
+# - https://github.com/coollabsio/jean/issues/100
 
 set -euo pipefail
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -321,6 +321,64 @@ fn setup_runtime(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
+/// Apply WebKitGTK / GPU workarounds before the webview is created.
+///
+/// Transparent windows + hardware compositing break on many Linux setups
+/// (NVIDIA, GBM/DMABUF, some Wayland compositors). Users can override:
+/// - `WEBKIT_DISABLE_COMPOSITING_MODE=0` to re-enable GPU compositing (risky)
+/// - `WEBKIT_DISABLE_DMABUF_RENDERER=0` similarly
+/// - `JEAN_FORCE_X11=1` to force GDK X11 backend outside AppImage
+///
+/// Related: https://github.com/coollabsio/jean/issues/100
+#[cfg(target_os = "linux")]
+fn apply_linux_webkit_env_fixes() {
+    log::trace!("Setting WebKit compatibility fixes for Linux");
+
+    let is_appimage =
+        std::env::var_os("APPIMAGE").is_some() || std::env::var_os("APPDIR").is_some();
+    if is_appimage {
+        log::trace!("Running inside AppImage");
+    }
+
+    let wayland_display = std::env::var_os("WAYLAND_DISPLAY");
+    let xdg_session_type = std::env::var("XDG_SESSION_TYPE")
+        .unwrap_or_default()
+        .to_lowercase();
+    let is_wayland = wayland_display.is_some() || xdg_session_type == "wayland";
+    let compositor = std::env::var("XDG_CURRENT_DESKTOP").unwrap_or_default();
+    log::trace!(
+        "Display: wayland={is_wayland}, compositor={compositor}, session={xdg_session_type}"
+    );
+
+    if std::env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_none() {
+        // SAFETY: called once at process start before the webview/runtime spawns threads.
+        unsafe {
+            std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        }
+        log::trace!("WEBKIT_DISABLE_COMPOSITING_MODE=1");
+    }
+
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        unsafe {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+        log::trace!("WEBKIT_DISABLE_DMABUF_RENDERER=1");
+    }
+
+    let force_x11 = std::env::var("JEAN_FORCE_X11").unwrap_or_else(|_| "0".to_string()) == "1";
+    if force_x11 && is_appimage {
+        log::trace!(
+            "JEAN_FORCE_X11 requested but ignored in AppImage (AppRun/apprun-hooks control backend)"
+        );
+    }
+    if !is_appimage && force_x11 && std::env::var_os("GDK_BACKEND").is_none() {
+        unsafe {
+            std::env::set_var("GDK_BACKEND", "x11");
+        }
+        log::trace!("GDK_BACKEND=x11 (forced by JEAN_FORCE_X11)");
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Product version must be the desktop package, not jean-core's library version.
@@ -340,6 +398,10 @@ pub fn run() {
 
     #[cfg(target_os = "macos")]
     fix_macos_path();
+
+    // Must run before tauri::Builder creates the WebKitGTK webview.
+    #[cfg(target_os = "linux")]
+    apply_linux_webkit_env_fixes();
 
     let log_targets = vec![
         tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -82,7 +82,7 @@
     },
     "linux": {
       "appimage": {
-        "bundleMediaFramework": false
+        "bundleMediaFramework": true
       }
     }
   },


### PR DESCRIPTION
## Summary

- Enable `bundleMediaFramework` so Linux AppImages include the GStreamer plugins WebKit needs (`appsrc`/`appsink`/`autoaudiosink`)
- Install GStreamer build/runtime packages in the Linux release workflow so plugins are available to bundle
- Update AppImage AppRun to set `GST_PLUGIN_PATH` / `GST_PLUGIN_SYSTEM_PATH` for bundled and system plugin dirs
- Apply Linux WebKit env defaults (`WEBKIT_DISABLE_COMPOSITING_MODE`, `WEBKIT_DISABLE_DMABUF_RENDERER`) before webview creation
- Document required GStreamer deps and blank-window troubleshooting for dev, `.deb`, and AppImage paths

fixes #100

---

Fixes #100