### PR TITLE
fix(canvas): show empty base branch

### DIFF
--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -179,6 +179,7 @@ import {
   getCanvasFilterTabCount,
   isLabelFilterTab,
   matchesCanvasFilterTab,
+  shouldShowCanvasWorktreeSection,
   type CanvasFilterTab,
   type CanvasPredefinedFilterTab,
   type CanvasPredefinedFilterTabItem,
@@ -1219,8 +1220,8 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
 
       latestActivityByWorktreeId.set(worktree.id, latestActivityAt)
 
-      // Only include worktrees that have sessions (after filtering)
-      if (grouped.length > 0) {
+      // Keep the base branch available for starting its first session.
+      if (shouldShowCanvasWorktreeSection(worktree, grouped.length)) {
         readySections.push({ worktree, cards: grouped })
       }
     }

--- a/src/components/dashboard/canvas-worktree-filters.test.ts
+++ b/src/components/dashboard/canvas-worktree-filters.test.ts
@@ -4,6 +4,7 @@ import {
   CANVAS_FILTER_TABS,
   getCanvasFilterTabCount,
   matchesCanvasFilterTab,
+  shouldShowCanvasWorktreeSection,
 } from './canvas-worktree-filters'
 
 function worktree(overrides: Partial<Worktree>): Worktree {
@@ -51,5 +52,18 @@ describe('canvas worktree filters', () => {
     expect(getCanvasFilterTabCount(worktrees, 'all')).toBe(2)
     expect(getCanvasFilterTabCount(worktrees, 'issues')).toBe(1)
     expect(getCanvasFilterTabCount(worktrees, 'auto_fix')).toBe(1)
+  })
+
+  it('shows the base branch even when it has no sessions', () => {
+    const base = worktree({
+      id: 'base',
+      name: 'main',
+      branch: 'main',
+      session_type: 'base',
+    })
+    const regular = worktree({ id: 'regular' })
+
+    expect(shouldShowCanvasWorktreeSection(base, 0)).toBe(true)
+    expect(shouldShowCanvasWorktreeSection(regular, 0)).toBe(false)
   })
 })

--- a/src/components/dashboard/canvas-worktree-filters.ts
+++ b/src/components/dashboard/canvas-worktree-filters.ts
@@ -116,3 +116,10 @@ export function getCanvasFilterTabCount(
   return worktrees.filter(worktree => matchesCanvasFilterTab(worktree, tab))
     .length
 }
+
+export function shouldShowCanvasWorktreeSection(
+  worktree: Worktree,
+  sessionCount: number
+): boolean {
+  return isBaseSession(worktree) || sessionCount > 0
+}


### PR DESCRIPTION
## Summary

- Keep the base branch visible on the project canvas when it has no sessions, allowing users to start its first session.
- Continue hiding other worktrees with no matching sessions.
- Add test coverage for base-branch visibility.