### PR TITLE
fix(markdown): preserve double-digit ordered list markers

### DIFF
--- a/src/components/ui/markdown.test.tsx
+++ b/src/components/ui/markdown.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { render, screen } from '@/test/test-utils'
+import { render } from '@/test/test-utils'
 import { Markdown } from './markdown'
 
 describe('Markdown', () => {
@@ -70,37 +70,48 @@ describe('Markdown', () => {
     expect(topLevelItems).toHaveLength(3)
   })
 
-  it('keeps list marker gutters inside the markdown box', () => {
+  it('keeps unordered-list marker gutters inside the markdown box', () => {
     const { container } = render(
       <div className="overflow-x-hidden">
-        <Markdown>{'1. First\n2. Second\n\n- Bullet'}</Markdown>
+        <Markdown>{'- First\n- Second'}</Markdown>
       </div>
     )
 
-    const orderedList = container.querySelector('ol')
     const unorderedList = container.querySelector('ul')
 
-    expect(orderedList?.className).toContain('pl-6')
-    expect(orderedList?.className).not.toContain('ml-6')
     expect(unorderedList?.className).toContain('pl-6')
     expect(unorderedList?.className).not.toContain('ml-6')
   })
 
-  it('uses a wider ordered-list gutter for tool-call markdown', () => {
+  it('reserves a double-digit marker gutter in every markdown mode', () => {
+    const md = Array.from(
+      { length: 12 },
+      (_, index) => `${index + 1}. Item ${index + 1}`
+    ).join('\n')
+
     const { container } = render(
-      <Markdown variant="tool-call">
-        {
-          '1. First\n2. Second\n3. Third\n4. Fourth\n5. Fifth\n6. Sixth\n7. Seventh\n8. Eighth\n9. Ninth\n10. Tenth\n11. Eleventh'
-        }
-      </Markdown>
+      <div className="overflow-x-hidden">
+        <Markdown>{md}</Markdown>
+        <Markdown compact>{md}</Markdown>
+        <Markdown streaming>{md}</Markdown>
+        <Markdown variant="tool-call">{md}</Markdown>
+        <Markdown streaming variant="tool-call">
+          {md}
+        </Markdown>
+      </div>
     )
 
-    const orderedList = container.querySelector('ol')
+    const orderedLists = Array.from(container.querySelectorAll('ol'))
 
-    expect(orderedList?.className).toContain('pl-8')
-    expect(orderedList?.className).not.toContain('pl-6')
-    expect(screen.getByText('Tenth')).toBeInTheDocument()
-    expect(screen.getByText('Eleventh')).toBeInTheDocument()
+    expect(orderedLists).toHaveLength(5)
+    for (const orderedList of orderedLists) {
+      expect(orderedList.className).toContain('pl-8')
+      expect(orderedList.className).not.toContain('pl-6')
+      expect(orderedList.querySelectorAll(':scope > li')).toHaveLength(12)
+      expect(orderedList).toHaveTextContent('Item 10')
+      expect(orderedList).toHaveTextContent('Item 11')
+      expect(orderedList).toHaveTextContent('Item 12')
+    }
   })
 
   it('auto-completes incomplete markdown while streaming', () => {

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -40,7 +40,7 @@ interface MarkdownProps {
    */
   streaming?: boolean
   className?: string
-  /** Rendering context; tool-call markdown needs a wider ordered-list gutter. */
+  /** Rendering context for tool-call markdown content. */
   variant?: 'chat' | 'tool-call'
   /** Chat message ID — enables per-table checklist persistence when set */
   messageId?: string
@@ -428,7 +428,7 @@ const components: Components = {
   ol: ({ children, className, ...props }) => (
     <ol
       {...props}
-      className={cn('my-4 pl-6 list-decimal list-outside space-y-2', className)}
+      className={cn('my-4 pl-8 list-decimal list-outside space-y-2', className)}
     >
       {children}
     </ol>


### PR DESCRIPTION
## Summary

- widen the shared Markdown ordered-list gutter so double-digit markers remain visible
- preserve outside markers and wrapped-line alignment
- add regression coverage for chat, compact, streaming, tool-call, and streaming tool-call Markdown modes

## Root cause

The Markdown renderer used outside decimal markers with a `pl-6` gutter while chat surfaces clip horizontal overflow. Starting at item 10, the leading digit extended beyond the visible gutter and was clipped.

## Testing

- `bun x vitest run src/components/ui/markdown.test.tsx` — 11 tests passed
- changed-file ESLint, Prettier, and `git diff --check`
- browser smoke test with 12 items in chat and compact-preview surfaces; confirmed complete markers, aligned wrapping, and no horizontal overflow

Closes #542
