### PR TITLE
fix(markdown): show double-digit ordered list markers

### DIFF
--- a/src/components/ui/markdown.test.tsx
+++ b/src/components/ui/markdown.test.tsx
@@ -80,10 +80,34 @@ describe('Markdown', () => {
     const orderedList = container.querySelector('ol')
     const unorderedList = container.querySelector('ul')
 
-    expect(orderedList?.className).toContain('pl-6')
+    // Ordered lists need pl-8 so two-digit markers ("10.") are not clipped by
+    // overflow-x-hidden ancestors (issue #542). Unordered bullets stay pl-6.
+    expect(orderedList?.className).toContain('pl-8')
     expect(orderedList?.className).not.toContain('ml-6')
+    expect(orderedList?.className).not.toMatch(/(?:^|\s)pl-6(?:\s|$)/)
     expect(unorderedList?.className).toContain('pl-6')
     expect(unorderedList?.className).not.toContain('ml-6')
+  })
+
+  it('uses a wide enough ordered-list gutter for double-digit markers (issue #542)', () => {
+    const md = Array.from(
+      { length: 12 },
+      (_, i) => `${i + 1}. Item ${i + 1}`
+    ).join('\n')
+
+    const { container } = render(
+      <div className="overflow-x-hidden">
+        <Markdown>{md}</Markdown>
+      </div>
+    )
+
+    const orderedList = container.querySelector('ol')
+
+    expect(orderedList?.className).toContain('pl-8')
+    expect(orderedList?.className).not.toMatch(/(?:^|\s)pl-6(?:\s|$)/)
+    expect(screen.getByText('Item 10')).toBeInTheDocument()
+    expect(screen.getByText('Item 11')).toBeInTheDocument()
+    expect(screen.getByText('Item 12')).toBeInTheDocument()
   })
 
   it('uses a wider ordered-list gutter for tool-call markdown', () => {
@@ -98,7 +122,7 @@ describe('Markdown', () => {
     const orderedList = container.querySelector('ol')
 
     expect(orderedList?.className).toContain('pl-8')
-    expect(orderedList?.className).not.toContain('pl-6')
+    expect(orderedList?.className).not.toMatch(/(?:^|\s)pl-6(?:\s|$)/)
     expect(screen.getByText('Tenth')).toBeInTheDocument()
     expect(screen.getByText('Eleventh')).toBeInTheDocument()
   })

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -40,7 +40,7 @@ interface MarkdownProps {
    */
   streaming?: boolean
   className?: string
-  /** Rendering context; tool-call markdown needs a wider ordered-list gutter. */
+  /** Rendering context (tool-call keeps the same ordered-list gutter as chat). */
   variant?: 'chat' | 'tool-call'
   /** Chat message ID — enables per-table checklist persistence when set */
   messageId?: string
@@ -425,10 +425,14 @@ const components: Components = {
       {children}
     </ul>
   ),
+  // pl-8 (not pl-6): double-digit markers ("10.") need extra gutter width when
+  // list-outside paints into padding; chat parents use overflow-x-hidden and
+  // otherwise clip the tens digit to ".0", ".1" (issue #542). tool-call keeps
+  // the same width for consistency.
   ol: ({ children, className, ...props }) => (
     <ol
       {...props}
-      className={cn('my-4 pl-6 list-decimal list-outside space-y-2', className)}
+      className={cn('my-4 pl-8 list-decimal list-outside space-y-2', className)}
     >
       {children}
     </ol>


### PR DESCRIPTION
## Summary

- Widen ordered-list gutter padding so markers like `10.` and `11.` are no longer clipped to `.0` / `.1` in chat markdown
- Keep unordered list spacing unchanged; align tool-call ordered lists with the same gutter
- Add/update tests covering lists past 9 and regression checks for the wider gutter

fixes #542

---

Fixes #542