### PR TITLE
fix(docker): install GitHub CLI in server images

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -22,6 +22,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
     openssh-client \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --create-home --shell /bin/bash jean \
     && mkdir -p /home/jean/.cache /home/jean/.config /home/jean/.local/share/com.jean.desktop \

--- a/Dockerfile.server-runtime
+++ b/Dockerfile.server-runtime
@@ -4,6 +4,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
     openssh-client \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --create-home --shell /bin/bash jean \
     && mkdir -p /home/jean/.cache /home/jean/.config /home/jean/.local/share/com.jean.desktop \

--- a/docs/headless-server.md
+++ b/docs/headless-server.md
@@ -225,6 +225,10 @@ browser terminals can find tools installed by shell setup scripts (for example
 - The server Docker image is published by the Server Release workflow as
   `ghcr.io/<owner>/<repo>-server:<tag>`.
 - The image launches `jean-server` directly and contains no GTK/WebKit/Xvfb packages.
+- Runtime packages include `ca-certificates`, `curl`, `git`, `openssh-client`, and
+  the official **GitHub CLI (`gh`)** so onboarding and GitHub integration can run
+  without a separate install step. Prefer the **System PATH** CLI source in
+  onboarding/Settings when using the container image.
 - Bind to `0.0.0.0` inside the container, but keep token auth enabled.
 - Mount Jean's app-data directory as a volume so projects, preferences, and sessions persist.
 - Put TLS/auth in front of the container for internet exposure.

--- a/scripts/server-ci-assets.test.mjs
+++ b/scripts/server-ci-assets.test.mjs
@@ -45,6 +45,29 @@ test('Dockerfile builds and runs jean-server headlessly as non-root user', () =>
   )
 })
 
+/** Shared assertions: server images ship GitHub CLI from the official apt repo. */
+function assertServerImageInstallsGh(dockerfile) {
+  assert.match(dockerfile, /cli\.github\.com\/packages\/githubcli-archive-keyring\.gpg/)
+  assert.match(dockerfile, /cli\.github\.com\/packages stable main/)
+  assert.match(
+    dockerfile,
+    /apt-get update && apt-get install -y --no-install-recommends gh/
+  )
+  // Keep gh install in the same runtime package layer (no extra FROM/RUN stage).
+  assert.match(
+    dockerfile,
+    /openssh-client[\s\S]*githubcli-archive-keyring[\s\S]*apt-get install -y --no-install-recommends gh[\s\S]*useradd/
+  )
+}
+
+test('Dockerfile.server installs GitHub CLI for onboarding and PATH tools', () => {
+  assertServerImageInstallsGh(read('Dockerfile.server'))
+})
+
+test('Dockerfile.server-runtime installs GitHub CLI for onboarding and PATH tools', () => {
+  assertServerImageInstallsGh(read('Dockerfile.server-runtime'))
+})
+
 test('jean-server depends only on the Tauri-free shared core', () => {
   const cargoToml = read('src-tauri/Cargo.toml')
   const coreCargoToml = read('jean-core/Cargo.toml')


### PR DESCRIPTION
The onboarding flow has a required **"Authenticate GitHub CLI"** step that shells out to `gh`, but the server runtime image ships only `ca-certificates`, `curl`, `git` and `openssh-client`. In a container the step fails immediately with:

```
[Process exited with code unknown]
Login process exited unexpectedly — Exit code: unknown
```

which doesn't hint that the binary is missing.

**Repro** — `ghcr.io/coollabsio/jean-server:v0.1.68`, headless (`JEAN_HEADLESS=1`):

```
$ docker exec <container> sh -c 'command -v gh || echo missing'
missing
```

**Change** — install `gh` from the official apt repository in the runtime stage of both server Dockerfiles, inside the existing layer so no extra layer is added. Verified on `debian:bookworm-slim`: `gh version 2.96.0`, `jean` user unchanged.

**Note** — with `gh` present the prompts render and arrow-key selection works, but I still couldn't finish the login from the dialog: after authorizing the device code on github.com there was no way to advance, and `gh` never wrote `~/.config/gh/hosts.yml`. Running `gh auth login --hostname github.com --git-protocol https --web < /dev/null` via `docker exec` worked, and `gh auth setup-git` was needed afterwards or `git push` still prompts. That looks separate from this change — happy to file it as its own issue if useful.
