### PR TITLE
feat(sidebar): add edge hover preview for collapsed sidebar

### DIFF
--- a/docs/developer/architecture-guide.md
+++ b/docs/developer/architecture-guide.md
@@ -259,6 +259,20 @@ MainWindow (Top-level orchestrator)
     └── Toaster (Notifications)
 ```
 
+### Collapsed Sidebar Edge Preview
+
+On desktop pointer devices, `SidebarHoverPreview.tsx` temporarily renders
+`LeftSideBar` above the main content when the pointer rests on the left edge.
+This preview does not update `leftSidebarVisible`, so navigation inside it does
+not pin the sidebar or change persisted UI state. The normal sidebar toggle
+still updates `leftSidebarVisible`, converting the preview into the persistent,
+in-flow sidebar.
+
+The behavior is controlled by the persisted
+`sidebar_hover_open_enabled` preference, which defaults to `true`. Portaled
+sidebar menus and active drag operations hold the preview open until the
+interaction finishes.
+
 ### Canvas View
 
 **ProjectCanvasView** (`src/components/dashboard/ProjectCanvasView.tsx`) shows sessions across all worktrees in a project, grouped by worktree with section headers. Sessions are opened via `SessionChatModal` overlay.

--- a/e2e/fixtures/invoke-handlers.ts
+++ b/e2e/fixtures/invoke-handlers.ts
@@ -58,7 +58,7 @@ export const defaultResponses: Record<string, unknown> = {
     created_at: 0,
     messages: [],
   },
-  list_all_sessions: { worktrees: {} },
+  list_all_sessions: { entries: [] },
   create_session: {
     id: 'session-new',
     name: 'New Session',
@@ -144,8 +144,11 @@ export const defaultResponses: Record<string, unknown> = {
   rename_session: null,
   send_chat_message: null,
   cancel_chat_message: false,
+  list_pending_wakeups: [],
 
   // Misc
+  get_package_scripts: [],
+  get_run_scripts: [],
   save_emergency_data: null,
   load_emergency_data: null,
 }

--- a/e2e/fixtures/mock-data.ts
+++ b/e2e/fixtures/mock-data.ts
@@ -69,7 +69,7 @@ export const mockPreferences = {
   keybindings: {},
   sidebar_width: 240,
   session_sort: 'manual',
-  zoom_level: 1.0,
+  zoom_level: 90,
   auto_pull_base_branch: false,
   auto_investigate: true,
   auto_archive_on_merge: false,

--- a/e2e/fixtures/tauri-mock.ts
+++ b/e2e/fixtures/tauri-mock.ts
@@ -86,7 +86,9 @@ export const test = base.extend<TauriMockFixtures>({
             }
           },
           list_worktrees: args => {
-            const projectId = args?.projectId as string | undefined
+            const projectId = (args?.projectId ?? args?.project_id) as
+              | string
+              | undefined
             return structuredClone(
               worktreeStore
                 .filter(

--- a/e2e/tests/sidebar-hover-preview.spec.ts
+++ b/e2e/tests/sidebar-hover-preview.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '../fixtures/tauri-mock'
+
+test.describe('Collapsed sidebar edge hover', () => {
+  test.beforeEach(async ({ mockPage }) => {
+    await expect(mockPage.getByText('Test Project')).toBeVisible({
+      timeout: 5000,
+    })
+    await expect(
+      mockPage.getByRole('button', { name: 'Show Left Sidebar' })
+    ).toBeVisible()
+  })
+
+  test('opens temporarily without pinning after navigation', async ({
+    mockPage,
+  }) => {
+    await mockPage.getByTestId('sidebar-hover-hotspot').hover()
+    const preview = mockPage.getByTestId('sidebar-hover-preview')
+    await expect(preview).toBeVisible({ timeout: 1500 })
+
+    await preview.getByText('fuzzy-tiger').click()
+    await mockPage.mouse.move(700, 120)
+    await expect(preview).toBeHidden({ timeout: 1500 })
+    await expect(
+      mockPage.getByRole('button', { name: 'Show Left Sidebar' })
+    ).toBeVisible()
+  })
+
+  test('pins the temporary sidebar only through the sidebar toggle', async ({
+    mockPage,
+  }) => {
+    await mockPage.getByTestId('sidebar-hover-hotspot').hover()
+    await expect(mockPage.getByTestId('sidebar-hover-preview')).toBeVisible({
+      timeout: 1500,
+    })
+
+    await mockPage.getByRole('button', { name: 'Show Left Sidebar' }).click()
+    await mockPage.mouse.move(700, 120)
+
+    await expect(mockPage.getByTestId('sidebar-hover-preview')).toBeHidden()
+    await expect(
+      mockPage.getByRole('button', { name: 'Hide Left Sidebar' })
+    ).toBeVisible()
+  })
+})

--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -207,6 +207,8 @@ pub struct AppPreferences {
     pub parallel_execution_prompt_enabled: bool, // Add system prompt to encourage parallel sub-agent execution
     #[serde(default = "default_compact_chat_view_enabled")]
     pub compact_chat_view_enabled: bool, // Collapse intermediate tool calls into single ticker line
+    #[serde(default = "default_sidebar_hover_open_enabled")]
+    pub sidebar_hover_open_enabled: bool, // Temporarily reveal collapsed sidebar from left edge
     #[serde(default = "default_auto_recaps_enabled")]
     pub auto_recaps_enabled: bool, // Ask agents to end multi-step turns with a recap block
     #[serde(default)]
@@ -637,6 +639,10 @@ fn default_compact_chat_view_enabled() -> bool {
     true // Enabled by default
 }
 
+fn default_sidebar_hover_open_enabled() -> bool {
+    true // Enabled by default
+}
+
 fn default_auto_recaps_enabled() -> bool {
     true // Enabled by default
 }
@@ -890,6 +896,26 @@ mod tests {
 
         assert!(prefs.parallel_execution_prompt_enabled);
         assert!(prefs.codex_multi_agent_enabled);
+    }
+
+    #[test]
+    fn sidebar_hover_open_defaults_on() {
+        let prefs = AppPreferences::default();
+
+        assert!(prefs.sidebar_hover_open_enabled);
+    }
+
+    #[test]
+    fn sidebar_hover_open_defaults_on_for_existing_preferences() {
+        let mut value = serde_json::to_value(AppPreferences::default()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("sidebar_hover_open_enabled");
+
+        let prefs: AppPreferences = serde_json::from_value(value).unwrap();
+
+        assert!(prefs.sidebar_hover_open_enabled);
     }
 
     #[test]
@@ -2777,6 +2803,7 @@ impl Default for AppPreferences {
             syntax_theme_light: default_syntax_theme_light(),
             parallel_execution_prompt_enabled: default_parallel_execution_prompt_enabled(),
             compact_chat_view_enabled: default_compact_chat_view_enabled(),
+            sidebar_hover_open_enabled: default_sidebar_hover_open_enabled(),
             auto_recaps_enabled: default_auto_recaps_enabled(),
             magic_prompts: MagicPrompts::default(),
             magic_prompt_models: MagicPromptModels::default(),

--- a/src/components/layout/MainWindow.tsx
+++ b/src/components/layout/MainWindow.tsx
@@ -15,6 +15,7 @@ import { useIsTouchDevice } from '@/hooks/use-touch-device'
 import { useSwipeDown } from '@/hooks/useSwipeDown'
 import { DevModeBanner } from './DevModeBanner'
 import { SidebarWidthProvider } from './SidebarWidthContext'
+import { SidebarHoverPreview } from './SidebarHoverPreview'
 import { MainWindowContent } from './MainWindowContent'
 import { CommandPalette } from '@/components/command-palette/CommandPalette'
 import { BranchConflictDialog } from '@/components/worktree/BranchConflictDialog'
@@ -208,6 +209,7 @@ import {
 } from '@/services/projects'
 import { isNativeApp } from '@/lib/environment'
 import { isLinux, isWindows } from '@/lib/platform'
+import { usePreferences } from '@/services/preferences'
 
 // Left sidebar resize constraints (pixels)
 const MIN_SIDEBAR_WIDTH = 150
@@ -268,6 +270,7 @@ export function MainWindow() {
   const githubDashboardOpen = useUIStore(state => state.githubDashboardOpen)
   const newSessionModeTarget = useUIStore(state => state.newSessionModeTarget)
   const sessionChatModalOpen = useUIStore(state => state.sessionChatModalOpen)
+  const { data: preferences } = usePreferences()
   const activeWorktreePath = useChatStore(state => state.activeWorktreePath)
   const selectedWorktreeId = useProjectsStore(state => state.selectedWorktreeId)
   const addProjectDialogOpen = useProjectsStore(
@@ -328,8 +331,7 @@ export function MainWindow() {
     return {
       worktreeId: worktree.id,
       worktreePath: worktree.path,
-      baseBranch:
-        worktree.base_branch ?? project.default_branch ?? 'main',
+      baseBranch: worktree.base_branch ?? project.default_branch ?? 'main',
       prNumber: worktree.pr_number,
       prUrl: worktree.pr_url,
     }
@@ -563,6 +565,22 @@ export function MainWindow() {
 
       {/* Main Content Area */}
       <div className="flex flex-1 overflow-hidden pt-8">
+        <SidebarHoverPreview
+          enabled={
+            !isMobile &&
+            isInitialized &&
+            !leftSidebarVisible &&
+            (preferences?.sidebar_hover_open_enabled ?? true)
+          }
+          width={leftSidebarSize}
+        >
+          <SidebarWidthProvider value={leftSidebarSize}>
+            <Suspense fallback={null}>
+              <LeftSideBar />
+            </Suspense>
+          </SidebarWidthProvider>
+        </SidebarHoverPreview>
+
         {/* Desktop: in-flow left sidebar (shifts layout). Only after UI state init. */}
         {!isMobile && leftSidebarVisible && isInitialized && (
           <SidebarWidthProvider value={leftSidebarSize}>

--- a/src/components/layout/SidebarHoverPreview.test.tsx
+++ b/src/components/layout/SidebarHoverPreview.test.tsx
@@ -1,0 +1,176 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SidebarHoverPreview } from './SidebarHoverPreview'
+
+describe('SidebarHoverPreview', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('opens after 200ms and closes 300ms after the pointer leaves', () => {
+    render(
+      <SidebarHoverPreview enabled width={250}>
+        <div>Projects</div>
+      </SidebarHoverPreview>
+    )
+
+    const hotspot = screen.getByTestId('sidebar-hover-hotspot')
+    fireEvent.pointerEnter(hotspot, { pointerType: 'mouse' })
+
+    act(() => {
+      vi.advanceTimersByTime(199)
+    })
+    expect(screen.queryByText('Projects')).not.toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(2)
+    })
+    const preview = screen.getByTestId('sidebar-hover-preview')
+    expect(preview).toHaveAttribute('data-open', 'true')
+
+    fireEvent.pointerLeave(preview)
+    act(() => {
+      vi.advanceTimersByTime(299)
+    })
+    expect(preview).toHaveAttribute('data-open', 'true')
+
+    act(() => {
+      vi.advanceTimersByTime(301)
+    })
+    expect(
+      screen.queryByTestId('sidebar-hover-preview')
+    ).not.toBeInTheDocument()
+  })
+
+  it('ignores touch pointers', () => {
+    render(
+      <SidebarHoverPreview enabled width={250}>
+        <div>Projects</div>
+      </SidebarHoverPreview>
+    )
+
+    fireEvent.pointerEnter(screen.getByTestId('sidebar-hover-hotspot'), {
+      pointerType: 'touch',
+    })
+    act(() => {
+      vi.advanceTimersByTime(250)
+    })
+
+    expect(
+      screen.queryByTestId('sidebar-hover-preview')
+    ).not.toBeInTheDocument()
+  })
+
+  it('closes immediately when the preference is disabled', () => {
+    const { rerender } = render(
+      <SidebarHoverPreview enabled width={250}>
+        <div>Projects</div>
+      </SidebarHoverPreview>
+    )
+
+    fireEvent.pointerEnter(screen.getByTestId('sidebar-hover-hotspot'), {
+      pointerType: 'mouse',
+    })
+    act(() => {
+      vi.advanceTimersByTime(201)
+    })
+    expect(screen.getByTestId('sidebar-hover-preview')).toBeInTheDocument()
+
+    rerender(
+      <SidebarHoverPreview enabled={false} width={250}>
+        <div>Projects</div>
+      </SidebarHoverPreview>
+    )
+
+    expect(
+      screen.queryByTestId('sidebar-hover-preview')
+    ).not.toBeInTheDocument()
+  })
+
+  it('closes when a blocking modal opens', async () => {
+    render(
+      <SidebarHoverPreview enabled width={250}>
+        <div>Projects</div>
+      </SidebarHoverPreview>
+    )
+
+    fireEvent.pointerEnter(screen.getByTestId('sidebar-hover-hotspot'), {
+      pointerType: 'mouse',
+    })
+    act(() => {
+      vi.advanceTimersByTime(201)
+    })
+
+    const overlay = document.createElement('div')
+    overlay.setAttribute('data-slot', 'dialog-overlay')
+    overlay.setAttribute('data-state', 'open')
+    act(() => {
+      document.body.append(overlay)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(
+      screen.queryByTestId('sidebar-hover-preview')
+    ).not.toBeInTheDocument()
+    overlay.remove()
+  })
+
+  it('stays open while the pointer is in a portaled menu', async () => {
+    render(
+      <>
+        <SidebarHoverPreview enabled width={250}>
+          <div>Projects</div>
+        </SidebarHoverPreview>
+        <div data-slot="dropdown-menu-content" data-state="open">
+          Menu
+        </div>
+      </>
+    )
+
+    fireEvent.pointerEnter(screen.getByTestId('sidebar-hover-hotspot'), {
+      pointerType: 'mouse',
+    })
+    act(() => {
+      vi.advanceTimersByTime(201)
+    })
+
+    const preview = screen.getByTestId('sidebar-hover-preview')
+    const menu = screen.getByText('Menu')
+    fireEvent.pointerLeave(preview, { relatedTarget: menu })
+    fireEvent.pointerOver(menu)
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(preview).toHaveAttribute('data-open', 'true')
+
+    act(() => {
+      menu.setAttribute('data-state', 'closed')
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(
+      screen.queryByTestId('sidebar-hover-preview')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/layout/SidebarHoverPreview.tsx
+++ b/src/components/layout/SidebarHoverPreview.tsx
@@ -1,0 +1,290 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from 'react'
+import { cn } from '@/lib/utils'
+
+const OPEN_DELAY_MS = 200
+const CLOSE_DELAY_MS = 300
+const TRANSITION_MS = 180
+
+const INTERACTIVE_POPUP_SELECTOR = [
+  '[data-slot="dropdown-menu-content"]',
+  '[data-slot="dropdown-menu-sub-content"]',
+  '[data-slot="context-menu-content"]',
+  '[data-slot="context-menu-sub-content"]',
+  '[data-slot="popover-content"]',
+  '[data-slot="select-content"]',
+].join(',')
+
+const BLOCKING_OVERLAY_SELECTOR = [
+  '[data-slot="dialog-overlay"][data-state="open"]',
+  '[data-slot="alert-dialog-overlay"][data-state="open"]',
+  '[data-slot="sheet-overlay"][data-state="open"]',
+].join(',')
+
+function isPreviewSurface(target: EventTarget | null) {
+  return (
+    target instanceof Element &&
+    Boolean(
+      target.closest(
+        `[data-sidebar-hover-preview], ${INTERACTIVE_POPUP_SELECTOR}`
+      )
+    )
+  )
+}
+
+function findInteractivePopup(target: EventTarget | null) {
+  return target instanceof Element
+    ? target.closest(INTERACTIVE_POPUP_SELECTOR)
+    : null
+}
+
+interface SidebarHoverPreviewProps {
+  enabled: boolean
+  width: number
+  children: ReactNode
+}
+
+export function SidebarHoverPreview({
+  enabled,
+  width,
+  children,
+}: Readonly<SidebarHoverPreviewProps>) {
+  const [mounted, setMounted] = useState(false)
+  const [open, setOpen] = useState(false)
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const unmountTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const animationFrame = useRef<number | null>(null)
+  const pointerInside = useRef(false)
+  const pointerInPopup = useRef(false)
+  const activePopup = useRef<Element | null>(null)
+  const dragging = useRef(false)
+
+  const clearTimer = useCallback(
+    (timer: React.RefObject<ReturnType<typeof setTimeout> | null>) => {
+      if (timer.current !== null) {
+        clearTimeout(timer.current)
+        timer.current = null
+      }
+    },
+    []
+  )
+
+  const cancelClose = useCallback(() => {
+    clearTimer(closeTimer)
+    clearTimer(unmountTimer)
+  }, [clearTimer])
+
+  const closePreview = useCallback(() => {
+    clearTimer(openTimer)
+    clearTimer(closeTimer)
+    setOpen(false)
+    clearTimer(unmountTimer)
+    unmountTimer.current = setTimeout(() => {
+      unmountTimer.current = null
+      setMounted(false)
+    }, TRANSITION_MS)
+  }, [clearTimer])
+
+  const scheduleClose = useCallback(() => {
+    clearTimer(openTimer)
+    if (dragging.current || pointerInside.current || pointerInPopup.current) {
+      return
+    }
+
+    clearTimer(closeTimer)
+    closeTimer.current = setTimeout(() => {
+      closeTimer.current = null
+      if (
+        !dragging.current &&
+        !pointerInside.current &&
+        !pointerInPopup.current
+      ) {
+        closePreview()
+      }
+    }, CLOSE_DELAY_MS)
+  }, [clearTimer, closePreview])
+
+  const handleHotspotEnter = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.pointerType !== 'mouse') return
+
+      pointerInside.current = true
+      cancelClose()
+      clearTimer(openTimer)
+      openTimer.current = setTimeout(() => {
+        openTimer.current = null
+        setMounted(true)
+      }, OPEN_DELAY_MS)
+    },
+    [cancelClose, clearTimer]
+  )
+
+  const handleHotspotLeave = useCallback(() => {
+    pointerInside.current = false
+    if (!mounted) {
+      clearTimer(openTimer)
+      return
+    }
+    scheduleClose()
+  }, [clearTimer, mounted, scheduleClose])
+
+  const handlePreviewEnter = useCallback(() => {
+    pointerInside.current = true
+    cancelClose()
+  }, [cancelClose])
+
+  const handlePreviewLeave = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      pointerInside.current = false
+      if (isPreviewSurface(event.relatedTarget)) {
+        activePopup.current = findInteractivePopup(event.relatedTarget)
+        pointerInPopup.current = activePopup.current !== null
+        cancelClose()
+        return
+      }
+      scheduleClose()
+    },
+    [cancelClose, scheduleClose]
+  )
+
+  useEffect(() => {
+    if (!mounted) return
+
+    animationFrame.current = requestAnimationFrame(() => {
+      animationFrame.current = null
+      setOpen(true)
+    })
+
+    return () => {
+      if (animationFrame.current !== null) {
+        cancelAnimationFrame(animationFrame.current)
+        animationFrame.current = null
+      }
+    }
+  }, [mounted])
+
+  useEffect(() => {
+    if (!mounted) return
+
+    const handlePointerOver = (event: PointerEvent) => {
+      const popup = findInteractivePopup(event.target)
+      if (!popup) return
+      activePopup.current = popup
+      pointerInPopup.current = true
+      cancelClose()
+    }
+    const handleDocumentMutation = () => {
+      if (document.querySelector(BLOCKING_OVERLAY_SELECTOR)) {
+        pointerInside.current = false
+        closePreview()
+        return
+      }
+
+      const popup = activePopup.current
+      if (
+        popup &&
+        popup.isConnected &&
+        popup.getAttribute('data-state') !== 'closed'
+      ) {
+        return
+      }
+      activePopup.current = null
+      pointerInPopup.current = false
+      scheduleClose()
+    }
+    const handleDragStart = () => {
+      dragging.current = true
+      cancelClose()
+    }
+    const handleDragOver = (event: DragEvent) => {
+      pointerInside.current = isPreviewSurface(event.target)
+    }
+    const handleDragEnd = () => {
+      dragging.current = false
+      scheduleClose()
+    }
+
+    document.addEventListener('pointerover', handlePointerOver)
+    document.addEventListener('dragstart', handleDragStart, true)
+    document.addEventListener('dragover', handleDragOver, true)
+    document.addEventListener('dragend', handleDragEnd, true)
+    const documentObserver = new MutationObserver(handleDocumentMutation)
+    documentObserver.observe(document.body, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ['data-state'],
+    })
+
+    return () => {
+      document.removeEventListener('pointerover', handlePointerOver)
+      document.removeEventListener('dragstart', handleDragStart, true)
+      document.removeEventListener('dragover', handleDragOver, true)
+      document.removeEventListener('dragend', handleDragEnd, true)
+      documentObserver.disconnect()
+    }
+  }, [cancelClose, closePreview, mounted, scheduleClose])
+
+  useEffect(() => {
+    if (enabled) return
+
+    pointerInside.current = false
+    pointerInPopup.current = false
+    activePopup.current = null
+    dragging.current = false
+    clearTimer(openTimer)
+    clearTimer(closeTimer)
+    clearTimer(unmountTimer)
+    setOpen(false)
+    setMounted(false)
+  }, [clearTimer, enabled])
+
+  useEffect(
+    () => () => {
+      clearTimer(openTimer)
+      clearTimer(closeTimer)
+      clearTimer(unmountTimer)
+    },
+    [clearTimer]
+  )
+
+  if (!enabled) return null
+
+  return (
+    <>
+      {!mounted && (
+        <div
+          data-testid="sidebar-hover-hotspot"
+          className="fixed top-8 bottom-0 left-0 z-45 w-4"
+          onPointerEnter={handleHotspotEnter}
+          onPointerLeave={handleHotspotLeave}
+        />
+      )}
+      {mounted && (
+        <div
+          data-sidebar-hover-preview
+          data-testid="sidebar-hover-preview"
+          data-open={open}
+          className={cn(
+            'fixed top-8 bottom-2 left-2 z-40 overflow-hidden border rounded-lg bg-sidebar' +
+              ' shadow-xl',
+            'transition-transform duration-180 ease-out motion-reduce:transition-none',
+            open ? 'translate-x-0' : '-translate-x-full'
+          )}
+          style={{ width }}
+          onPointerEnter={handlePreviewEnter}
+          onPointerLeave={handlePreviewLeave}
+        >
+          {children}
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/preferences/panes/AppearancePane.structure.test.ts
+++ b/src/components/preferences/panes/AppearancePane.structure.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('AppearancePane settings structure', () => {
+  it('offers collapsed sidebar edge hover in its own section', () => {
+    const source = readFileSync(
+      'src/components/preferences/panes/AppearancePane.tsx',
+      'utf8'
+    )
+
+    expect(source).toContain('title="Sidebar"')
+    expect(source).toContain('pref-appearance-section-sidebar')
+    expect(source).toContain('sidebar_hover_open_enabled')
+    expect(source).toContain('Open from screen edge')
+  })
+})

--- a/src/components/preferences/panes/AppearancePane.tsx
+++ b/src/components/preferences/panes/AppearancePane.tsx
@@ -359,6 +359,7 @@ export const AppearancePane: React.FC = () => {
               description="Translucent window with desktop blur (uses significant GPU)"
             >
               <Switch
+                aria-label="Window transparency"
                 checked={preferences?.window_vibrancy ?? false}
                 onCheckedChange={handleVibrancyChange}
                 disabled={patchPreferences.isPending || isVibrancyPending}
@@ -548,6 +549,29 @@ export const AppearancePane: React.FC = () => {
               disabled={syncZoomLevels || patchPreferences.isPending}
             />
           </ScalingField>
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Sidebar"
+        anchorId="pref-appearance-section-sidebar"
+      >
+        <div className="space-y-4">
+          <InlineField
+            label="Open from screen edge"
+            description="Temporarily reveal the collapsed sidebar when the pointer rests on the left edge"
+          >
+            <Switch
+              aria-label="Open sidebar from screen edge"
+              checked={preferences?.sidebar_hover_open_enabled ?? true}
+              onCheckedChange={checked =>
+                patchPreferences.mutate({
+                  sidebar_hover_open_enabled: checked,
+                })
+              }
+              disabled={patchPreferences.isPending}
+            />
+          </InlineField>
         </div>
       </SettingsSection>
 

--- a/src/components/preferences/preferences-search.test.ts
+++ b/src/components/preferences/preferences-search.test.ts
@@ -98,4 +98,12 @@ describe('preferences search index', () => {
 
     expect(results.some(entry => entry.id === 'appearance-fonts')).toBe(true)
   })
+
+  it('finds the collapsed sidebar edge setting', () => {
+    setTauriInternals(false)
+
+    expect(searchPreferenceEntries('screen edge')[0]?.id).toBe(
+      'appearance-sidebar'
+    )
+  })
 })

--- a/src/components/preferences/preferences-search.ts
+++ b/src/components/preferences/preferences-search.ts
@@ -588,6 +588,23 @@ const sectionEntries: PreferenceSearchEntry[] = [
     fallbackAnchorId: 'pref-pane-appearance',
   },
   {
+    id: 'appearance-sidebar',
+    pane: 'appearance',
+    paneTitle: 'Appearance',
+    type: 'section',
+    title: 'Sidebar',
+    sectionTitle: 'Appearance',
+    keywords: [
+      'sidebar',
+      'screen edge',
+      'hover',
+      'collapsed sidebar',
+      'open from screen edge',
+    ],
+    anchorId: 'pref-appearance-section-sidebar',
+    fallbackAnchorId: 'pref-pane-appearance',
+  },
+  {
     id: 'appearance-file-viewer',
     pane: 'appearance',
     paneTitle: 'Appearance',

--- a/src/components/titlebar/TitleBar.tsx
+++ b/src/components/titlebar/TitleBar.tsx
@@ -106,6 +106,9 @@ export function TitleBar({
                 onClick={toggleLeftSidebar}
                 variant="ghost"
                 size="icon"
+                aria-label={
+                  leftSidebarVisible ? 'Hide Left Sidebar' : 'Show Left Sidebar'
+                }
                 className="h-6 w-6 rounded-none text-foreground/70 hover:text-foreground"
               >
                 {leftSidebarVisible ? (

--- a/src/services/preferences.test.ts
+++ b/src/services/preferences.test.ts
@@ -1360,7 +1360,9 @@ describe('preferences service', () => {
         )
       )
 
-      const switchEl = await screen.findByRole('switch')
+      const switchEl = await screen.findByRole('switch', {
+        name: 'Window transparency',
+      })
       expect(switchEl).toHaveAttribute('aria-checked', 'false')
 
       await user.click(switchEl)
@@ -1381,6 +1383,37 @@ describe('preferences service', () => {
       expect(switchEl).toHaveAttribute('aria-checked', 'false')
       expect(toast.error).toHaveBeenCalledWith('Failed to save preferences', {
         description: 'Save failed',
+      })
+    })
+
+    it('persists the collapsed sidebar edge hover setting', async () => {
+      const { invoke } = await import('@/lib/transport')
+      vi.mocked(invoke).mockImplementation(async command => {
+        if (command === 'load_preferences') return defaultPreferences
+        if (command === 'patch_preferences') return undefined
+        throw new Error(`Unexpected command ${command}`)
+      })
+
+      const user = userEvent.setup()
+      render(
+        createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          createElement(AppearancePane)
+        )
+      )
+
+      const switchEl = await screen.findByRole('switch', {
+        name: 'Open sidebar from screen edge',
+      })
+      expect(switchEl).toHaveAttribute('aria-checked', 'true')
+
+      await user.click(switchEl)
+
+      await waitFor(() => {
+        expect(invoke).toHaveBeenCalledWith('patch_preferences', {
+          patch: { sidebar_hover_open_enabled: false },
+        })
       })
     })
   })

--- a/src/types/preferences.test.ts
+++ b/src/types/preferences.test.ts
@@ -37,6 +37,10 @@ describe('magic prompt preference resolvers', () => {
     expect(defaultPreferences.web_access_sounds_enabled).toBe(true)
   })
 
+  it('opens the collapsed sidebar from the screen edge by default', () => {
+    expect(defaultPreferences.sidebar_hover_open_enabled).toBe(true)
+  })
+
   it('uses Jean-managed Command Code CLI by default', () => {
     expect(defaultPreferences.commandcode_cli_source).toBe('jean')
   })

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1350,6 +1350,7 @@ export interface AppPreferences {
   syntax_theme_light: SyntaxTheme // Syntax highlighting theme for light mode
   parallel_execution_prompt_enabled: boolean // Add system prompt to encourage parallel sub-agent execution
   compact_chat_view_enabled: boolean // Collapse intermediate tool calls/replies into a single ticker line, only showing the latest activity
+  sidebar_hover_open_enabled?: boolean // Temporarily reveal the collapsed desktop sidebar from the left screen edge
   auto_recaps_enabled?: boolean // Ask agents to end multi-step/tool turns with a recap
   magic_prompts: MagicPrompts // Customizable prompts for AI-powered features
   magic_prompt_models: MagicPromptModels // Per-prompt model overrides
@@ -2373,6 +2374,7 @@ export const defaultPreferences: AppPreferences = {
   syntax_theme_light: 'github-light',
   parallel_execution_prompt_enabled: true, // Default: enabled
   compact_chat_view_enabled: true, // Default: enabled
+  sidebar_hover_open_enabled: true, // Default: enabled
   auto_recaps_enabled: true, // Default: enabled
   magic_prompts: DEFAULT_MAGIC_PROMPTS,
   magic_prompt_models: DEFAULT_MAGIC_PROMPT_MODELS,


### PR DESCRIPTION
## Summary

- add an edge-hover preview when the desktop sidebar is collapsed
- let users pin the preview with the existing sidebar toggle
- add an Appearance preference to enable or disable the behavior
- persist the preference across existing and new installations
- update E2E fixtures and add component, preference, and Playwright coverage
- document the sidebar preview behavior

## Why

A collapsed sidebar currently requires an explicit toggle before users can reach projects and worktrees. The edge-hover preview makes that navigation temporarily available without changing the pinned layout.

## User impact

On desktop, moving the pointer to the left screen edge temporarily reveals a collapsed sidebar. Moving away closes it, while the existing sidebar toggle pins it open. The behavior is enabled by default and can be disabled in Settings → Appearance.

## Validation

Passed locally:

- `bun install --frozen-lockfile`
- `bun run typecheck`
- changed-file ESLint checks
- changed-file Prettier checks
- `bun run rust:clippy`
- `bun run rust:test`
- 55 focused Vitest tests
- 2 sidebar hover Playwright tests

`bun run check:all` does not currently complete on the fetched `upstream/main`: ESLint reports pre-existing errors in unchanged `useMessageSending.test.tsx` and `QuickActionsTab.test.tsx`. Independent full-suite checks also expose pre-existing rustfmt drift with the local Rust 1.97 toolchain and 9 Vitest failures in unchanged test files. The focused tests and all checks covering this change pass.

## Manual verification

1. Collapse the desktop sidebar.
2. Move the pointer to the left edge and verify that the sidebar preview opens.
3. Move away and verify that the preview closes without changing the pinned layout.
4. Open the preview and use the sidebar toggle to pin it.
5. Disable **Open sidebar from screen edge** under Settings → Appearance and verify that hovering no longer opens it.
