### PR TITLE
fix(chat): show bash tool call output

### DIFF
--- a/src/components/chat/ToolCallInline.test.tsx
+++ b/src/components/chat/ToolCallInline.test.tsx
@@ -144,14 +144,38 @@ describe('ToolCallInline', () => {
     expect(screen.queryByText(/unhandled tool/i)).not.toBeInTheDocument()
   })
 
-  it('renders meaningful success output from a non-Codex tool', () => {
+  it('renders bash/shell stdout in the expanded tool body (issue #572)', () => {
+    render(
+      <ToolCallInline
+        toolCall={{
+          id: 'tool-bash-with-output',
+          name: 'Bash',
+          input: { command: 'cd /tmp; ls -la' },
+          output: 'exit: 0\ntotal 8\ndrwxr-xr-x 2 root root 4096 Jul 1 12:00 .\n',
+        }}
+      />
+    )
+
+    // Collapsed row still shows the command
+    expect(screen.getByText('Bash')).toBeInTheDocument()
+    expect(screen.getByText('cd /tmp; ls -la')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button'))
+
+    // Expanded body must surface the actual command return, not only `$ command`
+    expect(screen.getByText('Output:')).toBeInTheDocument()
+    expect(screen.getByText(/total 8/)).toBeInTheDocument()
+    expect(screen.getByText(/\$ cd \/tmp; ls -la/)).toBeInTheDocument()
+  })
+
+  it('renders shell_command stdout the same way as Bash', () => {
     render(
       <ToolCallInline
         toolCall={{
           id: 'tool-commandcode-shell-success',
           name: 'shell_command',
           input: { command: 'deploy' },
-          output: 'success',
+          output: 'deployed revision abc123\n',
         }}
       />
     )
@@ -159,7 +183,7 @@ describe('ToolCallInline', () => {
     fireEvent.click(screen.getByRole('button'))
 
     expect(screen.getByText('Output:')).toBeInTheDocument()
-    expect(screen.getByText(/^success$/)).toBeInTheDocument()
+    expect(screen.getByText(/deployed revision abc123/)).toBeInTheDocument()
   })
 
   it('renders additional Command Code snake_case tools without the unhandled fallback', () => {

--- a/src/components/chat/ToolCallInline.test.tsx
+++ b/src/components/chat/ToolCallInline.test.tsx
@@ -151,7 +151,8 @@ describe('ToolCallInline', () => {
           id: 'tool-bash-with-output',
           name: 'Bash',
           input: { command: 'cd /tmp; ls -la' },
-          output: 'exit: 0\ntotal 8\ndrwxr-xr-x 2 root root 4096 Jul 1 12:00 .\n',
+          output:
+            'exit: 0\ntotal 8\ndrwxr-xr-x 2 root root 4096 Jul 1 12:00 .\n',
         }}
       />
     )
@@ -184,6 +185,36 @@ describe('ToolCallInline', () => {
 
     expect(screen.getByText('Output:')).toBeInTheDocument()
     expect(screen.getByText(/deployed revision abc123/)).toBeInTheDocument()
+  })
+
+  it.each([
+    'Bash',
+    'shell_command',
+    'run_terminal_command',
+    'Shell',
+    'shell',
+    'execute',
+  ])('renders %s without a variant through the Bash renderer', name => {
+    const output = `stdout from ${name}`
+    const { unmount } = render(
+      <ToolCallInline
+        toolCall={{
+          id: `tool-${name}`,
+          name,
+          input: { command: 'printf hello' },
+          output,
+        }}
+      />
+    )
+
+    expect(screen.getByText('Bash')).toBeInTheDocument()
+    expect(screen.getByText('printf hello')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText(output)).toBeInTheDocument()
+    expect(screen.getAllByText('Output:')).toHaveLength(1)
+    unmount()
   })
 
   it('renders additional Command Code snake_case tools without the unhandled fallback', () => {

--- a/src/components/chat/ToolCallInline.tsx
+++ b/src/components/chat/ToolCallInline.tsx
@@ -58,31 +58,18 @@ function isPlaceholderToolOutput(output: string | undefined | null): boolean {
 function shouldRenderRawOutput(toolCall: ToolCall): boolean {
   if (!toolCall.output?.trim()) return false
   if (isPlaceholderToolOutput(toolCall.output)) return false
+  const input = (toolCall.input ?? {}) as Record<string, unknown>
+  const normalizedName = normalizeToolCallForDisplay(toolCall.name, input).name
   // These tools already surface output (results/path/etc.) in expandedContent.
   if (
-    toolCall.name === 'FileChange' ||
-    toolCall.name === 'Monitor' ||
-    toolCall.name === 'CodexWebSearch' ||
-    toolCall.name === 'CodexImageView' ||
-    toolCall.name === 'CodexImageGeneration' ||
-    toolCall.name === 'CodexContextCompaction' ||
+    normalizedName === 'FileChange' ||
+    normalizedName === 'Monitor' ||
+    normalizedName === 'CodexWebSearch' ||
+    normalizedName === 'CodexImageView' ||
+    normalizedName === 'CodexImageGeneration' ||
+    normalizedName === 'CodexContextCompaction' ||
     // Bash/shell expandedContent includes stdout when present (issue #572).
-    toolCall.name === 'Bash' ||
-    toolCall.name === 'shell_command' ||
-    toolCall.name === 'run_terminal_command'
-  ) {
-    return false
-  }
-  // Grok/Cursor may keep a generic name until normalized; if the input looks
-  // like a shell command, expandedContent for Bash handles the output.
-  const input = (toolCall.input ?? {}) as Record<string, unknown>
-  if (
-    typeof input.command === 'string' &&
-    (input.variant === 'Bash' ||
-      input.variant === 'CursorShell' ||
-      toolCall.name === 'Shell' ||
-      toolCall.name === 'shell' ||
-      toolCall.name === 'execute')
+    normalizedName === 'Bash'
   ) {
     return false
   }
@@ -830,6 +817,16 @@ export function normalizeToolCallForDisplay(
   delete withoutVariant.variant
 
   switch (normalizedName) {
+    case 'Bash':
+    case 'shell_command':
+    case 'run_terminal_command':
+    case 'Shell':
+    case 'shell':
+    case 'execute':
+      return {
+        name: 'Bash',
+        input: withoutVariant,
+      }
     case 'read_file':
     case 'Read':
       return {
@@ -881,8 +878,6 @@ export function normalizeToolCallForDisplay(
           path: input.path ?? input.targetDirectory,
         },
       }
-    case 'shell_command':
-      return { name: 'Bash', input }
     case 'read_directory':
       return { name: 'List', input }
     case 'glob':

--- a/src/components/chat/ToolCallInline.tsx
+++ b/src/components/chat/ToolCallInline.tsx
@@ -57,6 +57,7 @@ function isPlaceholderToolOutput(output: string | undefined | null): boolean {
 
 function shouldRenderRawOutput(toolCall: ToolCall): boolean {
   if (!toolCall.output?.trim()) return false
+  if (isPlaceholderToolOutput(toolCall.output)) return false
   // These tools already surface output (results/path/etc.) in expandedContent.
   if (
     toolCall.name === 'FileChange' ||
@@ -64,7 +65,24 @@ function shouldRenderRawOutput(toolCall: ToolCall): boolean {
     toolCall.name === 'CodexWebSearch' ||
     toolCall.name === 'CodexImageView' ||
     toolCall.name === 'CodexImageGeneration' ||
-    toolCall.name === 'CodexContextCompaction'
+    toolCall.name === 'CodexContextCompaction' ||
+    // Bash/shell expandedContent includes stdout when present (issue #572).
+    toolCall.name === 'Bash' ||
+    toolCall.name === 'shell_command' ||
+    toolCall.name === 'run_terminal_command'
+  ) {
+    return false
+  }
+  // Grok/Cursor may keep a generic name until normalized; if the input looks
+  // like a shell command, expandedContent for Bash handles the output.
+  const input = (toolCall.input ?? {}) as Record<string, unknown>
+  if (
+    typeof input.command === 'string' &&
+    (input.variant === 'Bash' ||
+      input.variant === 'CursorShell' ||
+      toolCall.name === 'Shell' ||
+      toolCall.name === 'shell' ||
+      toolCall.name === 'execute')
   ) {
     return false
   }
@@ -1044,13 +1062,32 @@ function getToolDisplay(toolCall: ToolCall): ToolDisplay {
         command && command.length > 50
           ? command.substring(0, 50) + '...'
           : command
+      const header = description
+        ? `${description}\n\n$ ${command ?? '(no command)'}`
+        : `$ ${command ?? '(no command)'}`
+      // Surface stdout/stderr in the main expanded body so bash results are
+      // visible without relying on a separate "Output:" panel (issue #572).
+      const output = toolCall.output?.trim()
+      const hasOutput = Boolean(output) && !isPlaceholderToolOutput(output)
       return {
         icon: <Terminal className="h-4 w-4 shrink-0" />,
         label: 'Bash',
         detail: truncatedCommand,
-        expandedContent: description
-          ? `${description}\n\n$ ${command}`
-          : `$ ${command ?? '(no command)'}`,
+        expandedContent: hasOutput ? (
+          <div className="space-y-2">
+            <div className="whitespace-pre-wrap">{header}</div>
+            <div>
+              <div className="text-xs text-muted-foreground/60 mb-1">
+                Output:
+              </div>
+              <pre className="max-h-64 overflow-auto whitespace-pre-wrap text-xs font-mono text-foreground/80 bg-muted/50 rounded p-2">
+                {output}
+              </pre>
+            </div>
+          </div>
+        ) : (
+          header
+        ),
       }
     }
 

--- a/src/components/chat/ToolCallsDisplay.test.tsx
+++ b/src/components/chat/ToolCallsDisplay.test.tsx
@@ -14,6 +14,27 @@ describe('ToolCallsDisplay', () => {
     getSubmittedAnswers: () => undefined,
   }
 
+  it('shows bash tool stdout when expanded (issue #572)', () => {
+    const toolCalls: ToolCall[] = [
+      {
+        id: 'bash-1',
+        name: 'Bash',
+        input: { command: 'cd /blah; command; command2' },
+        output: 'hello from bash\nline 2\n',
+      },
+    ]
+
+    render(<ToolCallsDisplay {...baseProps} toolCalls={toolCalls} />)
+
+    // Collapsed by default — expand the tools list
+    fireEvent.click(screen.getByRole('button', { name: /1 tool used/i }))
+
+    expect(screen.getByText('Bash')).toBeInTheDocument()
+    expect(screen.getByText('Output:')).toBeInTheDocument()
+    expect(screen.getByText(/hello from bash/)).toBeInTheDocument()
+    expect(screen.getByText(/line 2/)).toBeInTheDocument()
+  })
+
   it('renders native Codex request_user_input as an interactive question card', () => {
     const onQuestionAnswer =
       vi.fn<

--- a/src/components/chat/ToolCallsDisplay.test.tsx
+++ b/src/components/chat/ToolCallsDisplay.test.tsx
@@ -35,6 +35,26 @@ describe('ToolCallsDisplay', () => {
     expect(screen.getByText(/line 2/)).toBeInTheDocument()
   })
 
+  it.each(['completed', 'ok', 'success', 'context compacted'])(
+    'hides placeholder tool output "%s"',
+    output => {
+      const toolCalls: ToolCall[] = [
+        {
+          id: 'tool-1',
+          name: 'ExampleTool',
+          input: { value: 'test' },
+          output,
+        },
+      ]
+
+      render(<ToolCallsDisplay {...baseProps} toolCalls={toolCalls} />)
+      fireEvent.click(screen.getByRole('button', { name: /1 tool used/i }))
+
+      expect(screen.queryByText('Output:')).not.toBeInTheDocument()
+      expect(screen.queryByText(output)).not.toBeInTheDocument()
+    }
+  )
+
   it('renders native Codex request_user_input as an interactive question card', () => {
     const onQuestionAnswer =
       vi.fn<

--- a/src/components/chat/ToolCallsDisplay.tsx
+++ b/src/components/chat/ToolCallsDisplay.tsx
@@ -11,6 +11,18 @@ import {
 } from '@/types/chat'
 import { AskUserQuestion } from './AskUserQuestion'
 
+/** Placeholder outputs that add no value next to already-rendered tool details. */
+function isPlaceholderToolOutput(output: string): boolean {
+  const trimmed = output.trim().toLowerCase()
+  return (
+    trimmed === '' ||
+    trimmed === 'completed' ||
+    trimmed === 'ok' ||
+    trimmed === 'success' ||
+    trimmed === 'context compacted'
+  )
+}
+
 /**
  * Merge multiple AskUserQuestion tool calls into a single question set.
  * Claude sometimes emits multiple AskUserQuestion calls during streaming.
@@ -145,7 +157,7 @@ export const ToolCallsDisplay = memo(function ToolCallsDisplay({
                   )}
                   {/* Show tool stdout/result (bash and others) — was missing before #572 */}
                   {typeof tool.output === 'string' &&
-                    tool.output.trim() !== '' && (
+                    !isPlaceholderToolOutput(tool.output) && (
                       <div className="mt-1 overflow-x-auto">
                         <div className="text-[0.625rem] text-muted-foreground/50 mb-0.5">
                           Output:

--- a/src/components/chat/ToolCallsDisplay.tsx
+++ b/src/components/chat/ToolCallsDisplay.tsx
@@ -143,6 +143,18 @@ export const ToolCallsDisplay = memo(function ToolCallsDisplay({
                       </pre>
                     </div>
                   )}
+                  {/* Show tool stdout/result (bash and others) — was missing before #572 */}
+                  {typeof tool.output === 'string' &&
+                    tool.output.trim() !== '' && (
+                      <div className="mt-1 overflow-x-auto">
+                        <div className="text-[0.625rem] text-muted-foreground/50 mb-0.5">
+                          Output:
+                        </div>
+                        <pre className="max-h-40 max-w-full overflow-auto whitespace-pre-wrap break-words rounded bg-muted/40 p-1.5 text-[0.625rem] font-mono leading-tight text-foreground/80">
+                          {tool.output}
+                        </pre>
+                      </div>
+                    )}
                 </div>
               ))}
             </div>

--- a/src/store/chat-store.test.ts
+++ b/src/store/chat-store.test.ts
@@ -530,6 +530,56 @@ describe('ChatStore', () => {
       expect(toolCalls?.[0]?.output).toBe('exit: 0\nhello\n')
     })
 
+    it('filters a large Read result that arrives before tool_use', () => {
+      const { addToolCall, updateToolCallOutput } = useChatStore.getState()
+      const largeFileContents = 'file contents\n'.repeat(10_000)
+
+      updateToolCallOutput('session-1', 'tool-read-1', largeFileContents)
+      addToolCall('session-1', {
+        id: 'tool-read-1',
+        name: 'Read',
+        input: { file_path: '/large-file.txt' },
+      })
+
+      const toolCall =
+        useChatStore.getState().activeToolCalls['session-1']?.[0]
+      expect(toolCall?.name).toBe('Read')
+      expect(toolCall?.input).toEqual({ file_path: '/large-file.txt' })
+      expect(toolCall?.output).toBe('')
+    })
+
+    it('removes a Monitor result that arrives before tool_use', () => {
+      const { addToolCall, updateToolCallOutput } = useChatStore.getState()
+
+      updateToolCallOutput('session-1', 'tool-monitor-1', 'duplicate output')
+      addToolCall('session-1', {
+        id: 'tool-monitor-1',
+        name: 'Monitor',
+        input: {},
+      })
+
+      const toolCall =
+        useChatStore.getState().activeToolCalls['session-1']?.[0]
+      expect(toolCall?.name).toBe('Monitor')
+      expect(toolCall?.output).toBeUndefined()
+    })
+
+    it('keeps an early question result until answer handling replaces it', () => {
+      const { addToolCall, updateToolCallOutput } = useChatStore.getState()
+
+      updateToolCallOutput('session-1', 'tool-question-1', 'Answer questions?')
+      addToolCall('session-1', {
+        id: 'tool-question-1',
+        name: 'question',
+        input: { questions: [{ question: 'Continue?' }] },
+      })
+
+      const toolCall =
+        useChatStore.getState().activeToolCalls['session-1']?.[0]
+      expect(toolCall?.name).toBe('question')
+      expect(toolCall?.output).toBe('Answer questions?')
+    })
+
     it('clears tool calls', () => {
       const { addToolCall, clearToolCalls } = useChatStore.getState()
 

--- a/src/store/chat-store.test.ts
+++ b/src/store/chat-store.test.ts
@@ -505,6 +505,31 @@ describe('ChatStore', () => {
       expect(toolCalls?.[0]?.output).toBe('file contents')
     })
 
+    it('keeps tool_result when it arrives before tool_use (issue #572)', () => {
+      const { addToolCall, updateToolCallOutput } = useChatStore.getState()
+
+      // Result first (out-of-order) — must not drop stdout
+      updateToolCallOutput('session-1', 'tool-bash-1', 'exit: 0\nhello\n')
+
+      let toolCalls = useChatStore.getState().activeToolCalls['session-1']
+      expect(toolCalls).toHaveLength(1)
+      expect(toolCalls?.[0]?.id).toBe('tool-bash-1')
+      expect(toolCalls?.[0]?.output).toBe('exit: 0\nhello\n')
+
+      // Later tool_use enriches name/input without wiping output
+      addToolCall('session-1', {
+        id: 'tool-bash-1',
+        name: 'Bash',
+        input: { command: 'echo hello' },
+      })
+
+      toolCalls = useChatStore.getState().activeToolCalls['session-1']
+      expect(toolCalls).toHaveLength(1)
+      expect(toolCalls?.[0]?.name).toBe('Bash')
+      expect(toolCalls?.[0]?.input).toEqual({ command: 'echo hello' })
+      expect(toolCalls?.[0]?.output).toBe('exit: 0\nhello\n')
+    })
+
     it('clears tool calls', () => {
       const { addToolCall, clearToolCalls } = useChatStore.getState()
 

--- a/src/store/chat-store.ts
+++ b/src/store/chat-store.ts
@@ -1401,8 +1401,9 @@ export const useChatStore = create<ChatUIState>()(
               tc => tc.id === toolCall.id
             )
             if (existingIndex !== -1) {
-              // Already exists — update input if the new one has richer or newer data
-              // (e.g., enriched question data or streaming Codex plan deltas)
+              // Already exists — update name/input if the new one has richer or newer data
+              // (e.g., enriched question data, streaming Codex plan deltas, or a real
+              // tool_use arriving after an early tool_result stub — see updateToolCallOutput).
               const old = existing[existingIndex]
               if (!old) return state
               const oldEmpty =
@@ -1416,11 +1417,25 @@ export const useChatStore = create<ChatUIState>()(
               const inputChanged =
                 JSON.stringify(old.input ?? null) !==
                 JSON.stringify(toolCall.input ?? null)
-              if ((oldEmpty && newHasData) || (newHasData && inputChanged)) {
+              const nameChanged =
+                Boolean(toolCall.name) &&
+                toolCall.name !== old.name &&
+                // Prefer real tool names over the generic stub created for early results
+                (old.name === 'Tool' || old.name === 'Unknown' || !old.name)
+              if (
+                (oldEmpty && newHasData) ||
+                (newHasData && inputChanged) ||
+                nameChanged
+              ) {
                 const updated = [...existing]
                 updated[existingIndex] = {
                   ...old,
-                  input: toolCall.input,
+                  // Preserve any output already attached by a prior tool_result
+                  name: nameChanged ? toolCall.name : old.name,
+                  input:
+                    (oldEmpty && newHasData) || (newHasData && inputChanged)
+                      ? toolCall.input
+                      : old.input,
                 }
                 return {
                   activeToolCalls: {
@@ -1447,14 +1462,33 @@ export const useChatStore = create<ChatUIState>()(
           state => {
             const toolCalls = state.activeToolCalls[sessionId] ?? []
             const existing = toolCalls.find(tc => tc.id === toolUseId)
-            if (!existing || existing.output === output) return state
-            const updatedToolCalls = toolCalls.map(tc =>
-              tc.id === toolUseId ? { ...tc, output } : tc
-            )
+            if (existing) {
+              if (existing.output === output) return state
+              const updatedToolCalls = toolCalls.map(tc =>
+                tc.id === toolUseId ? { ...tc, output } : tc
+              )
+              return {
+                activeToolCalls: {
+                  ...state.activeToolCalls,
+                  [sessionId]: updatedToolCalls,
+                },
+              }
+            }
+            // tool_result can arrive before tool_use (out-of-order events / race).
+            // Keep the output on a stub so chat:done and the optimistic message
+            // still surface bash/shell stdout instead of only the command.
             return {
               activeToolCalls: {
                 ...state.activeToolCalls,
-                [sessionId]: updatedToolCalls,
+                [sessionId]: [
+                  ...toolCalls,
+                  {
+                    id: toolUseId,
+                    name: 'Tool',
+                    input: {},
+                    output,
+                  },
+                ],
               },
             }
           },

--- a/src/store/chat-store.ts
+++ b/src/store/chat-store.ts
@@ -1427,15 +1427,25 @@ export const useChatStore = create<ChatUIState>()(
                 (newHasData && inputChanged) ||
                 nameChanged
               ) {
+                const output =
+                  nameChanged && toolCall.name === 'Read'
+                    ? ''
+                    : nameChanged && toolCall.name === 'Monitor'
+                      ? undefined
+                      : old.output
                 const updated = [...existing]
                 updated[existingIndex] = {
                   ...old,
-                  // Preserve any output already attached by a prior tool_result
+                  // Reconcile early results once the real tool name is known.
+                  // Read contents can be large, while Monitor output duplicates
+                  // its streamed events. Other tools (including Bash and
+                  // questions) keep the result until normal handling replaces it.
                   name: nameChanged ? toolCall.name : old.name,
                   input:
                     (oldEmpty && newHasData) || (newHasData && inputChanged)
                       ? toolCall.input
                       : old.input,
+                  output,
                 }
                 return {
                   activeToolCalls: {


### PR DESCRIPTION
## Summary

- Surface bash/shell tool stdout in chat tool UI so expanded tool calls show command results, not only the command itself
- Preserve tool results that arrive before the matching tool_use event so output is not dropped
- Add coverage for bash/`shell_command` display and out-of-order tool_result handling

fixes #572

---

Fixes #572