### PR TITLE
fix(chat): handle Jean MCP tool calls in UI

### DIFF
--- a/src/components/chat/CompactStreamingTicker.test.tsx
+++ b/src/components/chat/CompactStreamingTicker.test.tsx
@@ -23,6 +23,35 @@ describe('CompactStreamingTicker', () => {
     areQuestionsSkipped: vi.fn(() => false),
   }
 
+  it('shows Jean MCP details from normalized wrapper arguments', () => {
+    render(
+      <CompactStreamingTicker
+        {...baseProps}
+        contentBlocks={[{ type: 'tool_use', tool_call_id: 'jean-1' }]}
+        toolCalls={[
+          {
+            id: 'jean-1',
+            name: 'use_tool',
+            input: {
+              tool_name: 'jean_create_worktree',
+              tool_input: {
+                customName: 'fix-streaming-ticker',
+                baseBranch: 'main',
+                model: 'gpt-5.6',
+              },
+            },
+          },
+        ]}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: /Jean: Create Worktree.*fix-streaming-ticker · main · gpt-5\.6/,
+      })
+    ).toBeVisible()
+  })
+
   it('keeps plan-mode tool batches compact while rendering the Codex plan', () => {
     render(
       <CompactStreamingTicker

--- a/src/components/chat/CompactStreamingTicker.tsx
+++ b/src/components/chat/CompactStreamingTicker.tsx
@@ -10,6 +10,9 @@ import {
 import {
   TOOL_CALL_ROW_CLASS,
   TOOL_CALL_DETAIL_PILL_CLASS,
+  formatJeanMcpToolLabel,
+  isJeanMcpToolName,
+  normalizeToolCallForDisplay,
 } from './ToolCallInline'
 import { EditedFilesDisplay } from './EditedFilesDisplay'
 import { StreamingMessage } from './StreamingMessage'
@@ -63,7 +66,11 @@ function summarizeLatest(
 }
 
 function summarizeToolCall(tc: ToolCall): { label: string; detail?: string } {
-  const input = (tc.input ?? {}) as Record<string, unknown>
+  const normalized = normalizeToolCallForDisplay(
+    tc.name,
+    (tc.input ?? {}) as Record<string, unknown>
+  )
+  const input = normalized.input
   const filePath =
     typeof input.file_path === 'string' ? input.file_path : undefined
   const path = typeof input.path === 'string' ? input.path : undefined
@@ -73,6 +80,13 @@ function summarizeToolCall(tc: ToolCall): { label: string; detail?: string } {
   const description =
     typeof input.description === 'string' ? input.description : undefined
   const query = typeof input.query === 'string' ? input.query : undefined
+  const backend = typeof input.backend === 'string' ? input.backend : undefined
+  const toolName =
+    typeof input.tool_name === 'string'
+      ? input.tool_name
+      : typeof input.toolName === 'string'
+        ? input.toolName
+        : undefined
   // Codex web search may nest the query under action
   const action =
     input.action && typeof input.action === 'object'
@@ -86,15 +100,17 @@ function summarizeToolCall(tc: ToolCall): { label: string; detail?: string } {
         : undefined
 
   const friendlyLabel =
-    tc.name === 'CodexWebSearch'
+    normalized.name === 'CodexWebSearch'
       ? 'Web Search'
-      : tc.name === 'CodexImageView'
+      : normalized.name === 'CodexImageView'
         ? 'Image View'
-        : tc.name === 'CodexImageGeneration'
+        : normalized.name === 'CodexImageGeneration'
           ? 'Image Generation'
-          : tc.name === 'CodexContextCompaction'
+          : normalized.name === 'CodexContextCompaction'
             ? 'Context Compaction'
-            : tc.name
+            : isJeanMcpToolName(normalized.name)
+              ? formatJeanMcpToolLabel(normalized.name)
+              : normalized.name
 
   const detail =
     query ??
@@ -105,6 +121,8 @@ function summarizeToolCall(tc: ToolCall): { label: string; detail?: string } {
     url ??
     pattern ??
     description ??
+    backend ??
+    toolName ??
     undefined
   return {
     label: friendlyLabel,

--- a/src/components/chat/CompactStreamingTicker.tsx
+++ b/src/components/chat/CompactStreamingTicker.tsx
@@ -10,6 +10,7 @@ import {
 import {
   TOOL_CALL_ROW_CLASS,
   TOOL_CALL_DETAIL_PILL_CLASS,
+  formatJeanMcpToolDetail,
   formatJeanMcpToolLabel,
   isJeanMcpToolName,
   normalizeToolCallForDisplay,
@@ -112,18 +113,19 @@ function summarizeToolCall(tc: ToolCall): { label: string; detail?: string } {
               ? formatJeanMcpToolLabel(normalized.name)
               : normalized.name
 
-  const detail =
-    query ??
-    actionQuery ??
-    filePath ??
-    path ??
-    command ??
-    url ??
-    pattern ??
-    description ??
-    backend ??
-    toolName ??
-    undefined
+  const detail = isJeanMcpToolName(normalized.name)
+    ? formatJeanMcpToolDetail(input)
+    : (query ??
+      actionQuery ??
+      filePath ??
+      path ??
+      command ??
+      url ??
+      pattern ??
+      description ??
+      backend ??
+      toolName ??
+      undefined)
   return {
     label: friendlyLabel,
     detail: detail ? truncate(detail, 80) : undefined,

--- a/src/components/chat/ToolCallInline.test.tsx
+++ b/src/components/chat/ToolCallInline.test.tsx
@@ -1,6 +1,9 @@
 import { fireEvent, render, screen } from '@/test/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import {
+  extractJeanMcpBareToolName,
+  formatJeanMcpToolLabel,
+  isJeanMcpToolName,
   normalizeToolCallForDisplay,
   TaskCallInline,
   ToolCallInline,
@@ -426,6 +429,169 @@ describe('normalizeToolCallForDisplay', () => {
       screen.getByText('DynamicToolCall:lookup (unhandled tool)')
     ).toBeInTheDocument()
     expect(screen.getByText('session recovery')).toBeInTheDocument()
+  })
+
+  it('renders Jean MCP tools via use_tool wrapper without unhandled fallback', () => {
+    // Matches issue #573 screenshot: use_tool({ tool_name, tool_input })
+    const cases = [
+      {
+        id: 'jean-ctx',
+        tool_name: 'jean_get_current_context',
+        tool_input: {},
+        label: 'Jean: Get Current Context',
+      },
+      {
+        id: 'jean-projects',
+        tool_name: 'jean_list_projects',
+        tool_input: {},
+        label: 'Jean: List Projects',
+      },
+      {
+        id: 'jean-worktrees',
+        tool_name: 'jean_list_worktrees',
+        tool_input: { projectId: 'b11f5add-ad7a-487c-b236-356ca6b4f18e' },
+        label: 'Jean: List Worktrees',
+        detail: 'project b11f5add',
+      },
+      {
+        id: 'jean-session',
+        tool_name: 'jean_create_session',
+        tool_input: {
+          backend: 'codex',
+          name: 'pg-moderation-verify',
+          worktreeId: '77a6074b-8035-4bdc-a477-06653f5af4d8',
+        },
+        label: 'Jean: Create Session',
+        detail: 'codex · pg-moderation-verify',
+      },
+    ]
+
+    for (const tc of cases) {
+      const { unmount } = render(
+        <ToolCallInline
+          toolCall={{
+            id: tc.id,
+            name: 'use_tool',
+            input: {
+              tool_name: tc.tool_name,
+              tool_input: tc.tool_input,
+            },
+          }}
+        />
+      )
+
+      expect(screen.getByText(tc.label)).toBeInTheDocument()
+      expect(screen.queryByText(/unhandled tool/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/^use_tool$/)).not.toBeInTheDocument()
+      if (tc.detail) {
+        expect(screen.getByText(tc.detail)).toBeInTheDocument()
+      }
+      unmount()
+    }
+  })
+
+  it('renders bare and mcp-prefixed Jean tools without unhandled fallback', () => {
+    const names = [
+      'get_current_context',
+      'list_projects',
+      'mcp:jean:list_worktrees',
+      'mcp__jean__create_session',
+      'mcp__jean-dev__get_current_context',
+      'jean_list_sessions',
+    ]
+
+    for (const name of names) {
+      const { unmount } = render(
+        <ToolCallInline
+          toolCall={{
+            id: `tool-${name}`,
+            name,
+            input: {},
+          }}
+        />
+      )
+
+      expect(screen.getByText(/^Jean:/)).toBeInTheDocument()
+      expect(screen.queryByText(/unhandled tool/i)).not.toBeInTheDocument()
+      unmount()
+    }
+  })
+
+  it('still labels true unknowns as unhandled', () => {
+    render(
+      <ToolCallInline
+        toolCall={{
+          id: 'mystery-1',
+          name: 'SomeFutureTool',
+          input: { foo: 'bar' },
+        }}
+      />
+    )
+
+    expect(
+      screen.getByText('SomeFutureTool (unhandled tool)')
+    ).toBeInTheDocument()
+  })
+})
+
+describe('Jean MCP tool helpers', () => {
+  it('extracts bare names from prefixed forms', () => {
+    expect(extractJeanMcpBareToolName('jean_get_current_context')).toBe(
+      'get_current_context'
+    )
+    expect(extractJeanMcpBareToolName('jean-dev_list_projects')).toBe(
+      'list_projects'
+    )
+    expect(extractJeanMcpBareToolName('mcp:jean:list_worktrees')).toBe(
+      'list_worktrees'
+    )
+    expect(extractJeanMcpBareToolName('mcp__jean__create_session')).toBe(
+      'create_session'
+    )
+    expect(
+      extractJeanMcpBareToolName('mcp__jean-dev__get_current_context')
+    ).toBe('get_current_context')
+    expect(extractJeanMcpBareToolName('get_current_context')).toBe(
+      'get_current_context'
+    )
+    expect(extractJeanMcpBareToolName('Bash')).toBeNull()
+    expect(extractJeanMcpBareToolName('mcp__github__search')).toBeNull()
+  })
+
+  it('formats friendly Jean labels', () => {
+    expect(formatJeanMcpToolLabel('jean_get_current_context')).toBe(
+      'Jean: Get Current Context'
+    )
+    expect(formatJeanMcpToolLabel('mcp:jean:create_session')).toBe(
+      'Jean: Create Session'
+    )
+    expect(isJeanMcpToolName('jean_list_projects')).toBe(true)
+    expect(isJeanMcpToolName('Read')).toBe(false)
+  })
+
+  it('unwraps use_tool in normalizeToolCallForDisplay', () => {
+    expect(
+      normalizeToolCallForDisplay('use_tool', {
+        tool_name: 'jean_create_session',
+        tool_input: {
+          backend: 'codex',
+          worktreeId: 'wt-1',
+        },
+      })
+    ).toMatchObject({
+      name: 'jean_create_session',
+      input: { backend: 'codex', worktreeId: 'wt-1' },
+    })
+
+    expect(
+      normalizeToolCallForDisplay('useTool', {
+        toolName: 'list_projects',
+        toolInput: {},
+      })
+    ).toMatchObject({
+      name: 'list_projects',
+      input: {},
+    })
   })
 })
 

--- a/src/components/chat/ToolCallInline.test.tsx
+++ b/src/components/chat/ToolCallInline.test.tsx
@@ -5,6 +5,7 @@ import {
   formatJeanMcpToolLabel,
   isJeanMcpToolName,
   normalizeToolCallForDisplay,
+  StackedGroup,
   TaskCallInline,
   ToolCallInline,
 } from './ToolCallInline'
@@ -490,10 +491,8 @@ describe('normalizeToolCallForDisplay', () => {
     }
   })
 
-  it('renders bare and mcp-prefixed Jean tools without unhandled fallback', () => {
+  it('renders prefixed Jean tools without unhandled fallback', () => {
     const names = [
-      'get_current_context',
-      'list_projects',
       'mcp:jean:list_worktrees',
       'mcp__jean__create_session',
       'mcp__jean-dev__get_current_context',
@@ -551,9 +550,7 @@ describe('Jean MCP tool helpers', () => {
     expect(
       extractJeanMcpBareToolName('mcp__jean-dev__get_current_context')
     ).toBe('get_current_context')
-    expect(extractJeanMcpBareToolName('get_current_context')).toBe(
-      'get_current_context'
-    )
+    expect(extractJeanMcpBareToolName('get_current_context')).toBeNull()
     expect(extractJeanMcpBareToolName('Bash')).toBeNull()
     expect(extractJeanMcpBareToolName('mcp__github__search')).toBeNull()
   })
@@ -592,6 +589,31 @@ describe('Jean MCP tool helpers', () => {
       name: 'list_projects',
       input: {},
     })
+  })
+})
+
+describe('StackedGroup', () => {
+  it('uses the wrapped Jean tool name in its summary', () => {
+    render(
+      <StackedGroup
+        items={[
+          {
+            type: 'tool',
+            tool: {
+              id: 'wrapped-jean-1',
+              name: 'use_tool',
+              input: {
+                tool_name: 'jean_list_projects',
+                tool_input: {},
+              },
+            },
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('1 Jean: List Projects')).toBeInTheDocument()
+    expect(screen.queryByText('1 use_tool')).not.toBeInTheDocument()
   })
 })
 

--- a/src/components/chat/ToolCallInline.tsx
+++ b/src/components/chat/ToolCallInline.tsx
@@ -83,51 +83,6 @@ function firstStringField(
   return undefined
 }
 
-/** Jean MCP bare tool names (registry in jean_mcp_core.rs). */
-const JEAN_MCP_BARE_TOOLS = new Set([
-  'list_projects',
-  'add_project',
-  'clone_project',
-  'init_project',
-  'list_worktrees',
-  'get_worktree',
-  'get_project_context',
-  'list_github_issues',
-  'list_github_prs',
-  'list_security_issues',
-  'list_security_advisories',
-  'list_linear_issues',
-  'create_worktree',
-  'create_worktree_from_existing_branch',
-  'import_worktree',
-  'rename_worktree',
-  'archive_worktree',
-  'unarchive_worktree',
-  'list_archived_worktrees',
-  'delete_worktree',
-  'permanently_delete_worktree',
-  'update_worktree_labels',
-  'list_sessions',
-  'create_session',
-  'send_chat_message',
-  'archive_session',
-  'unarchive_session',
-  'get_session_status',
-  'cancel_session_run',
-  'read_session_messages',
-  'set_session_model',
-  'get_usage',
-  'get_worktree_changes',
-  'get_worktree_diff',
-  'get_current_context',
-  'create_commit',
-  'push_worktree',
-  'detect_open_pr',
-  'create_pull_request',
-  'merge_pull_request',
-  'run_review',
-])
-
 /**
  * Strip MCP / client prefixes from a Jean tool name and return the bare registry name.
  * Handles: jean_get_current_context, jean-dev_list_projects, mcp:jean:list_worktrees,
@@ -145,7 +100,9 @@ export function extractJeanMcpBareToolName(name: string): string | null {
       const server = rest.slice(0, serverSep)
       const tool = rest.slice(serverSep + 2)
       if (
-        (server === 'jean' || server === 'jean-dev' || server.startsWith('jean')) &&
+        (server === 'jean' ||
+          server === 'jean-dev' ||
+          server.startsWith('jean')) &&
         tool
       ) {
         return tool
@@ -161,7 +118,9 @@ export function extractJeanMcpBareToolName(name: string): string | null {
       const server = parts[1] ?? ''
       const tool = parts.slice(2).join(':')
       if (
-        (server === 'jean' || server === 'jean-dev' || server.startsWith('jean')) &&
+        (server === 'jean' ||
+          server === 'jean-dev' ||
+          server.startsWith('jean')) &&
         tool
       ) {
         return tool
@@ -178,7 +137,6 @@ export function extractJeanMcpBareToolName(name: string): string | null {
     }
   }
 
-  if (JEAN_MCP_BARE_TOOLS.has(trimmed)) return trimmed
   return null
 }
 
@@ -211,7 +169,7 @@ export function formatJeanMcpToolLabel(name: string): string {
 }
 
 /** Detail line for Jean MCP tools from common argument fields. */
-function formatJeanMcpToolDetail(
+export function formatJeanMcpToolDetail(
   input: Record<string, unknown>
 ): string | undefined {
   const parts: string[] = []
@@ -235,7 +193,8 @@ function formatJeanMcpToolDetail(
   if (branch) parts.push(branch)
   if (model) parts.push(model)
   if (path) parts.push(path)
-  if (message) parts.push(message.length > 40 ? `${message.slice(0, 40)}…` : message)
+  if (message)
+    parts.push(message.length > 40 ? `${message.slice(0, 40)}…` : message)
   // Short id suffixes only when nothing more descriptive is available
   if (parts.length === 0) {
     if (worktreeId) parts.push(`worktree ${worktreeId.slice(0, 8)}`)
@@ -279,11 +238,7 @@ function unwrapMetaToolCall(
     input.parameters
 
   let nestedInput: Record<string, unknown> = {}
-  if (
-    rawNested &&
-    typeof rawNested === 'object' &&
-    !Array.isArray(rawNested)
-  ) {
+  if (rawNested && typeof rawNested === 'object' && !Array.isArray(rawNested)) {
     nestedInput = rawNested as Record<string, unknown>
   }
 
@@ -670,7 +625,7 @@ export function StackedGroup({
     if (item.type === 'thinking') {
       thinkingCount++
     } else {
-      const name = getToolSummaryName(item.tool.name)
+      const name = getToolSummaryName(item.tool)
       toolCounts.set(name, (toolCounts.get(name) ?? 0) + 1)
     }
   }
@@ -1114,8 +1069,8 @@ export function normalizeToolCallForDisplay(
   }
 }
 
-function getToolSummaryName(name: string): string {
-  switch (name) {
+function getToolSummaryName(toolCall: ToolCall): string {
+  switch (toolCall.name) {
     case 'CodexWebSearch':
       return 'Web Search'
     case 'CodexImageGeneration':
@@ -1125,8 +1080,11 @@ function getToolSummaryName(name: string): string {
     case 'CodexContextCompaction':
       return 'Context Compaction'
     default: {
-      const normalized = normalizeToolCallForDisplay(name, {}).name
-      if (isJeanMcpToolName(normalized) || isJeanMcpToolName(name)) {
+      const normalized = normalizeToolCallForDisplay(
+        toolCall.name,
+        (toolCall.input ?? {}) as Record<string, unknown>
+      ).name
+      if (isJeanMcpToolName(normalized) || isJeanMcpToolName(toolCall.name)) {
         return formatJeanMcpToolLabel(normalized)
       }
       return normalized

--- a/src/components/chat/ToolCallInline.tsx
+++ b/src/components/chat/ToolCallInline.tsx
@@ -83,6 +83,213 @@ function firstStringField(
   return undefined
 }
 
+/** Jean MCP bare tool names (registry in jean_mcp_core.rs). */
+const JEAN_MCP_BARE_TOOLS = new Set([
+  'list_projects',
+  'add_project',
+  'clone_project',
+  'init_project',
+  'list_worktrees',
+  'get_worktree',
+  'get_project_context',
+  'list_github_issues',
+  'list_github_prs',
+  'list_security_issues',
+  'list_security_advisories',
+  'list_linear_issues',
+  'create_worktree',
+  'create_worktree_from_existing_branch',
+  'import_worktree',
+  'rename_worktree',
+  'archive_worktree',
+  'unarchive_worktree',
+  'list_archived_worktrees',
+  'delete_worktree',
+  'permanently_delete_worktree',
+  'update_worktree_labels',
+  'list_sessions',
+  'create_session',
+  'send_chat_message',
+  'archive_session',
+  'unarchive_session',
+  'get_session_status',
+  'cancel_session_run',
+  'read_session_messages',
+  'set_session_model',
+  'get_usage',
+  'get_worktree_changes',
+  'get_worktree_diff',
+  'get_current_context',
+  'create_commit',
+  'push_worktree',
+  'detect_open_pr',
+  'create_pull_request',
+  'merge_pull_request',
+  'run_review',
+])
+
+/**
+ * Strip MCP / client prefixes from a Jean tool name and return the bare registry name.
+ * Handles: jean_get_current_context, jean-dev_list_projects, mcp:jean:list_worktrees,
+ * mcp__jean__create_session, mcp__jean-dev__get_current_context.
+ */
+export function extractJeanMcpBareToolName(name: string): string | null {
+  const trimmed = name.trim()
+  if (!trimmed) return null
+
+  if (trimmed.startsWith('mcp__')) {
+    // mcp__jean__tool or mcp__jean-dev__tool (tool may contain underscores)
+    const rest = trimmed.slice('mcp__'.length)
+    const serverSep = rest.indexOf('__')
+    if (serverSep > 0) {
+      const server = rest.slice(0, serverSep)
+      const tool = rest.slice(serverSep + 2)
+      if (
+        (server === 'jean' || server === 'jean-dev' || server.startsWith('jean')) &&
+        tool
+      ) {
+        return tool
+      }
+    }
+    return null
+  }
+
+  if (trimmed.startsWith('mcp:')) {
+    // mcp:jean:tool or mcp:jean-dev:tool
+    const parts = trimmed.split(':')
+    if (parts.length >= 3) {
+      const server = parts[1] ?? ''
+      const tool = parts.slice(2).join(':')
+      if (
+        (server === 'jean' || server === 'jean-dev' || server.startsWith('jean')) &&
+        tool
+      ) {
+        return tool
+      }
+    }
+    return null
+  }
+
+  // Client-side prefix: jean_get_current_context / jean-dev_list_projects
+  for (const prefix of ['jean-dev_', 'jean_']) {
+    if (trimmed.startsWith(prefix)) {
+      const bare = trimmed.slice(prefix.length)
+      if (bare) return bare
+    }
+  }
+
+  if (JEAN_MCP_BARE_TOOLS.has(trimmed)) return trimmed
+  return null
+}
+
+export function isJeanMcpToolName(name: string): boolean {
+  return extractJeanMcpBareToolName(name) != null
+}
+
+/** True for tools that should not get the "(unhandled tool)" suffix. */
+function isRecognizedExternalTool(name: string): boolean {
+  return (
+    name.startsWith('mcp__') ||
+    name.startsWith('mcp:') ||
+    isJeanMcpToolName(name)
+  )
+}
+
+/** Title-case a snake_case / kebab-case tool id for display. */
+function humanizeSnakeCase(name: string): string {
+  return name
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ')
+}
+
+/** Friendly label for a Jean MCP tool call. */
+export function formatJeanMcpToolLabel(name: string): string {
+  const bare = extractJeanMcpBareToolName(name) ?? name
+  return `Jean: ${humanizeSnakeCase(bare)}`
+}
+
+/** Detail line for Jean MCP tools from common argument fields. */
+function formatJeanMcpToolDetail(
+  input: Record<string, unknown>
+): string | undefined {
+  const parts: string[] = []
+  const backend = firstStringField(input, ['backend'])
+  const projectId = firstStringField(input, ['projectId', 'project_id'])
+  const worktreeId = firstStringField(input, ['worktreeId', 'worktree_id'])
+  const sessionId = firstStringField(input, ['sessionId', 'session_id'])
+  const path = firstStringField(input, ['path'])
+  const name = firstStringField(input, ['name', 'customName', 'custom_name'])
+  const branch = firstStringField(input, [
+    'baseBranch',
+    'base_branch',
+    'branchName',
+    'branch_name',
+  ])
+  const model = firstStringField(input, ['model'])
+  const message = firstStringField(input, ['message'])
+
+  if (backend) parts.push(backend)
+  if (name) parts.push(name)
+  if (branch) parts.push(branch)
+  if (model) parts.push(model)
+  if (path) parts.push(path)
+  if (message) parts.push(message.length > 40 ? `${message.slice(0, 40)}…` : message)
+  // Short id suffixes only when nothing more descriptive is available
+  if (parts.length === 0) {
+    if (worktreeId) parts.push(`worktree ${worktreeId.slice(0, 8)}`)
+    else if (projectId) parts.push(`project ${projectId.slice(0, 8)}`)
+    else if (sessionId) parts.push(`session ${sessionId.slice(0, 8)}`)
+  }
+  return parts.length > 0 ? parts.join(' · ') : undefined
+}
+
+/**
+ * Unwrap meta tool wrappers (e.g. Grok/MCP bridge `use_tool`) that nest the
+ * real tool name + args under tool_name / tool_input.
+ */
+function unwrapMetaToolCall(
+  name: string,
+  input: Record<string, unknown>
+): { name: string; input: Record<string, unknown> } | null {
+  const isMeta =
+    name === 'use_tool' ||
+    name === 'useTool' ||
+    name === 'UseTool' ||
+    name === 'call_tool' ||
+    name === 'callTool' ||
+    name === 'CallTool'
+  if (!isMeta) return null
+
+  const nestedName = firstStringField(input, [
+    'tool_name',
+    'toolName',
+    'name',
+    'tool',
+  ])
+  if (!nestedName) return null
+
+  const rawNested =
+    input.tool_input ??
+    input.toolInput ??
+    input.arguments ??
+    input.args ??
+    input.input ??
+    input.parameters
+
+  let nestedInput: Record<string, unknown> = {}
+  if (
+    rawNested &&
+    typeof rawNested === 'object' &&
+    !Array.isArray(rawNested)
+  ) {
+    nestedInput = rawNested as Record<string, unknown>
+  }
+
+  return { name: nestedName, input: nestedInput }
+}
+
 function formatCodexWebSearchDetail(
   input: Record<string, unknown>
 ): string | undefined {
@@ -769,6 +976,13 @@ export function normalizeToolCallForDisplay(
   name: string,
   input: Record<string, unknown>
 ): { name: string; input: Record<string, unknown> } {
+  // Unwrap meta wrappers (use_tool / call_tool) before other normalization so
+  // Jean MCP and other nested tools get the right renderer.
+  const unwrapped = unwrapMetaToolCall(name, input)
+  if (unwrapped) {
+    return normalizeToolCallForDisplay(unwrapped.name, unwrapped.input)
+  }
+
   const variant = typeof input.variant === 'string' ? input.variant : undefined
   const normalizedName = (() => {
     switch (variant) {
@@ -910,8 +1124,13 @@ function getToolSummaryName(name: string): string {
       return 'Image View'
     case 'CodexContextCompaction':
       return 'Context Compaction'
-    default:
-      return normalizeToolCallForDisplay(name, {}).name
+    default: {
+      const normalized = normalizeToolCallForDisplay(name, {}).name
+      if (isJeanMcpToolName(normalized) || isJeanMcpToolName(name)) {
+        return formatJeanMcpToolLabel(normalized)
+      }
+      return normalized
+    }
   }
 }
 
@@ -1612,23 +1831,43 @@ function getToolDisplay(toolCall: ToolCall): ToolDisplay {
     }
 
     default: {
-      const isMcpTool =
-        normalized.name.startsWith('mcp__') ||
-        normalized.name.startsWith('mcp:')
+      const jeanBare = extractJeanMcpBareToolName(normalized.name)
+      if (jeanBare) {
+        const detail = formatJeanMcpToolDetail(input)
+        const expanded = toolCall.output?.trim()
+          ? toolCall.output
+          : Object.keys(input).length > 0
+            ? JSON.stringify(input, null, 2)
+            : 'No details available'
+        return {
+          icon: <Bot className="h-4 w-4 shrink-0" />,
+          label: formatJeanMcpToolLabel(normalized.name),
+          detail,
+          expandedContent: expanded,
+        }
+      }
+
+      const isKnownExternal = isRecognizedExternalTool(normalized.name)
       // Surface something useful even for tools without a dedicated renderer.
-      const detail = firstStringField(input, [
-        'query',
-        'command',
-        'path',
-        'file_path',
-        'filePath',
-        'url',
-        'pattern',
-        'description',
-        'prompt',
-        'title',
-        'name',
-      ])
+      const detail =
+        firstStringField(input, [
+          'query',
+          'command',
+          'path',
+          'file_path',
+          'filePath',
+          'url',
+          'pattern',
+          'description',
+          'prompt',
+          'title',
+          'name',
+          'tool_name',
+          'toolName',
+          'backend',
+          'projectId',
+          'worktreeId',
+        ]) ?? formatJeanMcpToolDetail(input)
       const expanded = toolCall.output?.trim()
         ? toolCall.output
         : Object.keys(input).length > 0
@@ -1636,7 +1875,7 @@ function getToolDisplay(toolCall: ToolCall): ToolDisplay {
           : 'No details available'
       return {
         icon: <Terminal className="h-4 w-4 shrink-0" />,
-        label: isMcpTool
+        label: isKnownExternal
           ? normalized.name
           : `${normalized.name} (unhandled tool)`,
         detail,


### PR DESCRIPTION
## Summary

- Recognize Jean MCP tools (including `use_tool` wrappers and common MCP/client name prefixes) so they render as friendly **Jean:** labels instead of “unhandled tool”
- Surface useful details for Jean tools (backend, session name, project/worktree ids, etc.) in both the inline tool rows and the compact streaming ticker
- Keep true unknown tools labeled as unhandled; add coverage for the issue #573 cases

fixes #573

---

Fixes #573