### PR TITLE
fix(windows): recover from invisible window after WebView2 crash

### DIFF
--- a/docs/developer/troubleshooting.md
+++ b/docs/developer/troubleshooting.md
@@ -1,5 +1,24 @@
 # Troubleshooting Guide
 
+## Windows: Jean window goes "invisible" / shows desktop wallpaper
+
+**Symptoms:**
+- Jean window frame remains but content shows the desktop wallpaper (or is blank).
+- Task Manager may show only the Jean host process with no WebView2 child processes.
+- Reported after opening menus/dialogs (e.g. sidebar **New**) and alt-tabbing while connected to a remote Jean (issue [#575](https://github.com/coollabsio/jean/issues/575)).
+
+**Root cause:**
+WebView2's browser or renderer process crashed. Jean's window was historically transparent on all platforms; when the webview stops painting, the transparent host shows whatever is behind it (wallpaper), which looks like the app went invisible.
+
+**Fixes in current releases:**
+1. Windows builds force an opaque main window (`tauri.windows.conf.json` sets `transparent: false`).
+2. A WebView2 `ProcessFailed` handler reloads the page on renderer exits, or restarts Jean when the browser process dies (`src-tauri/src/platform/windows_webview.rs`).
+3. New Project no longer nests the remote `DirectoryBrowser` dialog inside another Radix dialog (focus-trap stacking).
+
+**If it still happens:** restart Jean (or wait for auto-restart after browser-process exit). Update WebView2 Runtime via Windows Update / Evergreen installer. Note GPU driver issues if crashes correlate with sleep/wake or multi-monitor changes.
+
+---
+
 ## Linux Graphics Issues
 
 ### White Screen on Ubuntu 24.04+ (AppImage)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2518,6 +2518,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "webkit2gtk",
+ "webview2-com",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,8 @@ gtk = "=0.18.2"
 
 [target.'cfg(windows)'.dependencies]
 tauri-winrt-notification = "0.7.2"
+# Match Tauri/wry's WebView2 bindings for ProcessFailed recovery (issue #575).
+webview2-com = "0.38"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -324,6 +324,11 @@ fn setup_runtime(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
         create_app_menu(app)?;
         install_menu_events(app);
     }
+
+    // Recover from WebView2 process death on Windows (issue #575 — blank /
+    // "invisible" window after the browser process exits). No-op elsewhere.
+    platform::install_process_failed_recovery(app);
+
     Ok(())
 }
 

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -5,3 +5,6 @@ pub mod linux_webkit;
 
 #[cfg(target_os = "linux")]
 pub use linux_webkit::apply_linux_webkit_env;
+
+pub mod windows_webview;
+pub use windows_webview::install_process_failed_recovery;

--- a/src-tauri/src/platform/windows_webview.rs
+++ b/src-tauri/src/platform/windows_webview.rs
@@ -1,0 +1,139 @@
+//! Windows WebView2 stability helpers.
+//!
+//! Transparent windows + WebView2 process death leave an empty native frame
+//! that shows the desktop wallpaper through the app ("Jean went invisible",
+//! issue #575). Platform config disables transparency on Windows; this module
+//! recovers from WebView2 process failures by reloading or restarting.
+
+/// Classify a WebView2 process-failure kind for recovery decisions.
+///
+/// Returns `"browser"` when the entire browser process exited (must restart
+/// the app), `"reload"` when a renderer/frame failure can try `Reload()`, or
+/// `"ignore"` for GPU/utility subprocesses that WebView2 often recovers on
+/// its own.
+///
+/// Used by the Windows `ProcessFailed` handler; also unit-tested on all hosts.
+#[cfg_attr(not(any(windows, test)), allow(dead_code))]
+pub fn process_failed_recovery(kind: i32) -> &'static str {
+    // Values from COREWEBVIEW2_PROCESS_FAILED_KIND_* (webview2-com-sys).
+    match kind {
+        0 => "browser", // BROWSER_PROCESS_EXITED
+        1 | 2 | 3 => "reload", // RENDER_PROCESS_EXITED / UNRESPONSIVE / FRAME_RENDER
+        _ => "ignore",
+    }
+}
+
+/// Install a WebView2 `ProcessFailed` handler on the main webview.
+///
+/// - Browser-process exit → restart the whole Jean process (the webview is
+///   unusable after this; Task Manager shows only the host process).
+/// - Render/frame process exit/unresponsive → attempt `Reload()`.
+/// - GPU/utility exits → log only; WebView2 usually respawns them.
+#[cfg(windows)]
+pub fn install_process_failed_recovery(app: &tauri::App) {
+    use tauri::Manager;
+    use webview2_com::{
+        Microsoft::Web::WebView2::Win32::{
+            ICoreWebView2ProcessFailedEventArgs, COREWEBVIEW2_PROCESS_FAILED_KIND,
+        },
+        ProcessFailedEventHandler,
+    };
+
+    let Some(window) = app.get_webview_window("main") else {
+        log::warn!("Windows WebView2 recovery: main window missing");
+        return;
+    };
+
+    let app_handle = app.handle().clone();
+    let result = window.with_webview(move |platform| {
+        let controller = platform.controller();
+        let webview = match unsafe { controller.CoreWebView2() } {
+            Ok(wv) => wv,
+            Err(error) => {
+                log::warn!("Windows WebView2 recovery: CoreWebView2 failed: {error}");
+                return;
+            }
+        };
+
+        let handler = ProcessFailedEventHandler::create(Box::new(move |sender, args| {
+            let kind = args
+                .as_ref()
+                .and_then(|args: &ICoreWebView2ProcessFailedEventArgs| {
+                    unsafe { args.ProcessFailedKind() }.ok()
+                })
+                .map(|COREWEBVIEW2_PROCESS_FAILED_KIND(value)| value)
+                .unwrap_or(-1);
+
+            let recovery = process_failed_recovery(kind);
+            log::error!(
+                "WebView2 ProcessFailed kind={kind} recovery={recovery} (issue #575)"
+            );
+
+            match recovery {
+                "browser" => {
+                    // Browser process is gone — only relaunch restores a live webview.
+                    let app = app_handle.clone();
+                    let _ = app.run_on_main_thread(move || {
+                        log::error!("Restarting Jean after WebView2 browser process exit");
+                        app.restart();
+                    });
+                }
+                "reload" => {
+                    let reloaded = sender
+                        .as_ref()
+                        .and_then(|wv| unsafe { wv.Reload() }.ok())
+                        .is_some();
+                    if !reloaded {
+                        log::warn!("WebView2 Reload after process failure failed");
+                        let app = app_handle.clone();
+                        let _ = app.run_on_main_thread(move || {
+                            log::error!("Restarting Jean after failed WebView2 Reload");
+                            app.restart();
+                        });
+                    }
+                }
+                _ => {}
+            }
+            Ok(())
+        }));
+
+        let mut token = 0i64;
+        if let Err(error) = unsafe { webview.add_ProcessFailed(&handler, &mut token) } {
+            log::warn!("Windows WebView2 recovery: add_ProcessFailed failed: {error}");
+        } else {
+            log::info!("Windows WebView2 ProcessFailed recovery installed");
+        }
+    });
+
+    if let Err(error) = result {
+        log::warn!("Windows WebView2 recovery: with_webview failed: {error}");
+    }
+}
+
+#[cfg(not(windows))]
+pub fn install_process_failed_recovery(_app: &tauri::App) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_process_exit_requires_restart() {
+        assert_eq!(process_failed_recovery(0), "browser");
+    }
+
+    #[test]
+    fn render_failures_try_reload() {
+        assert_eq!(process_failed_recovery(1), "reload");
+        assert_eq!(process_failed_recovery(2), "reload");
+        assert_eq!(process_failed_recovery(3), "reload");
+    }
+
+    #[test]
+    fn gpu_and_utility_are_ignored() {
+        assert_eq!(process_failed_recovery(6), "ignore");
+        assert_eq!(process_failed_recovery(5), "ignore");
+        assert_eq!(process_failed_recovery(9), "ignore");
+        assert_eq!(process_failed_recovery(-1), "ignore");
+    }
+}

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,13 +1,9 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "identifier": "com.jean.desktop.dev",
-  "build": {
-    "beforeDevCommand": "bun run scripts/tauri-dev-before.mjs"
-  },
   "app": {
     "windows": [
       {
-        "title": "Jean (Dev)",
+        "title": "Jean",
         "width": 800,
         "height": 600,
         "minWidth": 1000,
@@ -22,7 +18,12 @@
         "alwaysOnTop": false,
         "transparent": false,
         "shadow": true,
-        "dragDropEnabled": false
+        "dragDropEnabled": false,
+        "windowEffects": {
+          "effects": [],
+          "radius": 0,
+          "state": "active"
+        }
       }
     ]
   }

--- a/src/components/projects/AddProjectDialog.structure.test.ts
+++ b/src/components/projects/AddProjectDialog.structure.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Source-structure guards for New Project + remote directory browser.
+ * Nested Radix dialogs trap focus poorly and have been tied to WebView2
+ * freezes when alt-tabbing on Windows (issue #575).
+ */
+describe('AddProjectDialog structure', () => {
+  const source = readFileSync(
+    resolve(__dirname, 'AddProjectDialog.tsx'),
+    'utf8'
+  )
+
+  it('does not nest DirectoryBrowser inside the New Project Dialog', () => {
+    // DirectoryBrowser must be a sibling fragment child, not under <Dialog>.
+    expect(source).toMatch(
+      /return \(\s*<>[\s\S]*<Dialog[\s\S]*<\/Dialog>[\s\S]*<DirectoryBrowser/
+    )
+    // Guard against re-introducing nested-dialog markup.
+    expect(source).not.toMatch(
+      /<Dialog[^>]*>[\s\S]*<>[\s\S]*<DirectoryBrowser/
+    )
+  })
+
+  it('keeps New Project open under the remote directory browser', () => {
+    // Sibling dialogs: New Project stays mounted so canceling the browser
+    // returns to it (no controlled-open race with browserMode).
+    expect(source).toContain('open={addProjectDialogOpen}')
+    expect(source).not.toContain(
+      'open={addProjectDialogOpen && browserMode === null}'
+    )
+  })
+})

--- a/src/components/projects/AddProjectDialog.tsx
+++ b/src/components/projects/AddProjectDialog.tsx
@@ -239,8 +239,16 @@ export function AddProjectDialog() {
   ])
 
   return (
-    <Dialog open={addProjectDialogOpen} onOpenChange={setAddProjectDialogOpen}>
-      <>
+    <>
+      {/*
+        DirectoryBrowser is a sibling Dialog, not nested under New Project.
+        Nested Radix dialogs trap focus poorly and have been implicated in
+        WebView2 freezes when alt-tabbing on Windows (issue #575).
+      */}
+      <Dialog
+        open={addProjectDialogOpen}
+        onOpenChange={setAddProjectDialogOpen}
+      >
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>New Project</DialogTitle>
@@ -308,25 +316,25 @@ export function AddProjectDialog() {
             </button>
           </div>
         </DialogContent>
+      </Dialog>
 
-        <DirectoryBrowser
-          open={browserMode !== null}
-          onOpenChange={handleBrowserOpenChange}
-          onSelect={handleBrowserSelect}
-          mode={browserMode ?? 'select'}
-          title={
-            browserMode === 'save'
-              ? 'Create new project'
-              : 'Select existing project'
-          }
-          description={
-            browserMode === 'save'
-              ? 'Choose a parent directory and enter a new project folder name.'
-              : 'Choose an existing git repository folder.'
-          }
-          defaultName={browserMode === 'save' ? 'my-project' : undefined}
-        />
-      </>
-    </Dialog>
+      <DirectoryBrowser
+        open={browserMode !== null}
+        onOpenChange={handleBrowserOpenChange}
+        onSelect={handleBrowserSelect}
+        mode={browserMode ?? 'select'}
+        title={
+          browserMode === 'save'
+            ? 'Create new project'
+            : 'Select existing project'
+        }
+        description={
+          browserMode === 'save'
+            ? 'Choose a parent directory and enter a new project folder name.'
+            : 'Choose an existing git repository folder.'
+        }
+        defaultName={browserMode === 'save' ? 'my-project' : undefined}
+      />
+    </>
   )
 }

--- a/src/test/tauri-config.test.ts
+++ b/src/test/tauri-config.test.ts
@@ -5,10 +5,47 @@ import { describe, expect, it } from 'vitest'
 function readMainWindowConfig(configPath: string) {
   const rawConfig = readFileSync(join(process.cwd(), configPath), 'utf8')
   const config = JSON.parse(rawConfig) as {
-    app?: { windows?: { dragDropEnabled?: boolean }[] }
+    app?: {
+      windows?: { dragDropEnabled?: boolean; transparent?: boolean }[]
+    }
   }
 
   return config.app?.windows?.[0]
+}
+
+function readConfig(configPath: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(join(process.cwd(), configPath), 'utf8')
+  ) as Record<string, unknown>
+}
+
+function mergeJsonConfig(
+  base: Record<string, unknown>,
+  patch: Record<string, unknown>
+): Record<string, unknown> {
+  const merged = { ...base }
+
+  for (const [key, value] of Object.entries(patch)) {
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      typeof merged[key] === 'object' &&
+      merged[key] !== null &&
+      !Array.isArray(merged[key])
+    ) {
+      merged[key] = mergeJsonConfig(
+        merged[key] as Record<string, unknown>,
+        value as Record<string, unknown>
+      )
+    } else if (value === null) {
+      delete merged[key]
+    } else {
+      merged[key] = value
+    }
+  }
+
+  return merged
 }
 
 describe('Tauri drag/drop configuration', () => {
@@ -18,4 +55,40 @@ describe('Tauri drag/drop configuration', () => {
       expect(readMainWindowConfig(configPath)?.dragDropEnabled).toBe(false)
     }
   )
+})
+
+describe('Tauri Windows configuration', () => {
+  it('preserves the complete main-window configuration when applying the Windows override', () => {
+    const resolved = mergeJsonConfig(
+      readConfig('src-tauri/tauri.conf.json'),
+      readConfig('src-tauri/tauri.windows.conf.json')
+    ) as {
+      app: { windows: Record<string, unknown>[] }
+    }
+
+    expect(resolved.app.windows[0]).toMatchObject({
+      title: 'Jean',
+      width: 800,
+      height: 600,
+      minWidth: 1000,
+      minHeight: 700,
+      center: true,
+      decorations: true,
+      titleBarStyle: 'Overlay',
+      shadow: true,
+      dragDropEnabled: false,
+      transparent: false,
+      windowEffects: {
+        effects: [],
+        radius: 0,
+        state: 'active',
+      },
+    })
+  })
+
+  it('does not enable transparency in the development configuration', () => {
+    expect(
+      readMainWindowConfig('src-tauri/tauri.conf.dev.json')?.transparent
+    ).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary

- Fix Windows “invisible” Jean window (blank/wallpaper-through frame) after WebView2 process death, reported when opening New Project on remote Jean and alt-tabbing.
- Force an opaque main window on Windows and install a WebView2 `ProcessFailed` recovery path (reload on renderer failure, restart on browser process exit).
- Un-nest the remote `DirectoryBrowser` from the New Project dialog to avoid stacked Radix focus traps linked to freezes.
- Document the failure mode and recovery steps in the developer troubleshooting guide.

## Related

fixes #575

---

Fixes #575