### PR TITLE
fix(chat): ignore Enter during IME composition

### DIFF
--- a/src/components/chat/ChatInput.test.tsx
+++ b/src/components/chat/ChatInput.test.tsx
@@ -345,3 +345,105 @@ describe('ChatInput attachments', () => {
     expect(textarea.value).toBe('')
   })
 })
+
+describe('ChatInput IME composition (issue #584)', () => {
+  beforeEach(() => {
+    processAttachmentFile.mockReset()
+    invokeMock.mockReset()
+    storeState.setInputDraft.mockReset()
+    storeState.getPendingFiles.mockReset()
+    storeState.getPendingFiles.mockReturnValue([])
+    storeState.removePendingFile.mockReset()
+    storeState.addPendingFile.mockReset()
+    storeState.addPendingSkill.mockReset()
+    storeState.addPendingImage.mockReset()
+    storeState.addPendingTextFile.mockReset()
+    storeState.inputDrafts = {}
+  })
+
+  const renderWithSubmit = () => {
+    const formRef = createRef<HTMLFormElement>()
+    const inputRef = createRef<HTMLTextAreaElement>()
+    const onSubmit = vi.fn()
+
+    render(
+      <ChatInput
+        activeSessionId="session-1"
+        activeWorktreePath="/tmp/worktree"
+        isSending={false}
+        executionMode="build"
+        focusChatShortcut="⌘K"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        formRef={formRef}
+        inputRef={inputRef}
+      />
+    )
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    return { textarea, onSubmit }
+  }
+
+  it('submits on normal Enter when not composing', () => {
+    const { textarea, onSubmit } = renderWithSubmit()
+    textarea.value = 'hello'
+    fireEvent.change(textarea, { target: { value: 'hello' } })
+
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', keyCode: 13 })
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not submit when Enter confirms IME composition (isComposing)', () => {
+    const { textarea, onSubmit } = renderWithSubmit()
+    textarea.value = 'こんにちは'
+    fireEvent.change(textarea, { target: { value: 'こんにちは' } })
+
+    fireEvent.keyDown(textarea, {
+      key: 'Enter',
+      code: 'Enter',
+      keyCode: 13,
+      isComposing: true,
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(textarea.value).toBe('こんにちは')
+  })
+
+  it('does not submit on Safari/WKWebView IME Enter (keyCode 229, isComposing false)', () => {
+    // compositionend can run before keydown on Safari, so isComposing is
+    // already false; keyCode 229 still marks the event as IME-handled.
+    const { textarea, onSubmit } = renderWithSubmit()
+    textarea.value = '日本語'
+    fireEvent.change(textarea, { target: { value: '日本語' } })
+
+    fireEvent.keyDown(textarea, {
+      key: 'Enter',
+      code: 'Enter',
+      keyCode: 229,
+      isComposing: false,
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(textarea.value).toBe('日本語')
+  })
+
+  it('submits on the Enter after composition has finished', () => {
+    const { textarea, onSubmit } = renderWithSubmit()
+    textarea.value = '日本語'
+    fireEvent.change(textarea, { target: { value: '日本語' } })
+
+    // Confirm composition (must not submit)
+    fireEvent.keyDown(textarea, {
+      key: 'Enter',
+      code: 'Enter',
+      keyCode: 229,
+      isComposing: false,
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    // Second Enter sends the message
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', keyCode: 13 })
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -45,6 +45,7 @@ import {
   listControlChars,
   sanitizeTextInputValue,
 } from '@/lib/input-sanitization'
+import { isImeComposingEvent } from '@/lib/ime-composition'
 import {
   decodePromptAttachmentMetadata,
   parsePlainTextPromptMetadata,
@@ -481,6 +482,14 @@ export const ChatInput = memo(function ChatInput({
   // Handle keyboard events
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Japanese/CJK IME: Enter confirms composition — must not submit or
+      // select mentions. Do not preventDefault; let the IME handle the key.
+      // keyCode 229 covers Safari/WKWebView where compositionend can fire
+      // before keydown and leave isComposing false (issue #584).
+      if (isImeComposingEvent(e)) {
+        return
+      }
+
       // When file mention popover is open, handle navigation
       if (fileMentionOpen) {
         if (e.ctrlKey && e.shiftKey && e.key === 'ArrowLeft') {

--- a/src/components/chat/QueuedPromptsPanel.tsx
+++ b/src/components/chat/QueuedPromptsPanel.tsx
@@ -11,6 +11,7 @@ import {
   TooltipContent,
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { isImeComposingEvent } from '@/lib/ime-composition'
 import type { QueuedMessage } from '@/types/chat'
 
 interface QueuedPromptsPanelProps {
@@ -207,6 +208,10 @@ export const QueuedPromptsPanel = memo(function QueuedPromptsPanel({
                       onClick={e => e.stopPropagation()}
                       onKeyDown={e => {
                         e.stopPropagation()
+                        // Don't commit edit when Enter confirms IME composition
+                        if (isImeComposingEvent(e)) {
+                          return
+                        }
                         if (e.key === 'Escape') {
                           e.preventDefault()
                           cancelEditing()

--- a/src/lib/ime-composition.test.ts
+++ b/src/lib/ime-composition.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { isImeComposingEvent } from './ime-composition'
+
+function makeNativeEvent(overrides: {
+  isComposing?: boolean
+  keyCode?: number
+}): Pick<KeyboardEvent, 'isComposing' | 'keyCode'> {
+  return {
+    isComposing: overrides.isComposing ?? false,
+    keyCode: overrides.keyCode ?? 0,
+  }
+}
+
+describe('isImeComposingEvent', () => {
+  it('returns false for a normal Enter keydown', () => {
+    expect(
+      isImeComposingEvent(makeNativeEvent({ isComposing: false, keyCode: 13 }))
+    ).toBe(false)
+  })
+
+  it('returns true when isComposing is set (Chromium/Firefox during IME)', () => {
+    expect(
+      isImeComposingEvent(makeNativeEvent({ isComposing: true, keyCode: 13 }))
+    ).toBe(true)
+  })
+
+  it('returns true for keyCode 229 even when isComposing is false (Safari/WKWebView)', () => {
+    // Safari can fire compositionend before the confirming Enter keydown,
+    // so isComposing is already false but keyCode remains 229.
+    expect(
+      isImeComposingEvent(makeNativeEvent({ isComposing: false, keyCode: 229 }))
+    ).toBe(true)
+  })
+
+  it('reads React synthetic events via nativeEvent', () => {
+    const synthetic = {
+      nativeEvent: makeNativeEvent({ isComposing: true, keyCode: 229 }),
+    }
+    expect(isImeComposingEvent(synthetic)).toBe(true)
+  })
+
+  it('does not treat other keyCodes as composing', () => {
+    expect(
+      isImeComposingEvent(makeNativeEvent({ isComposing: false, keyCode: 65 }))
+    ).toBe(false)
+  })
+})

--- a/src/lib/ime-composition.ts
+++ b/src/lib/ime-composition.ts
@@ -1,0 +1,23 @@
+/**
+ * Detect keyboard events that belong to an active IME composition session
+ * (Japanese / Chinese / Korean conversion, etc.).
+ *
+ * App shortcuts that treat Enter/Tab as "submit" or "select" must ignore these
+ * events so confirming a conversion does not also fire the shortcut.
+ *
+ * Checks both:
+ * - `isComposing` — set during composition on Chromium/Firefox/modern WebKit
+ * - `keyCode === 229` — legacy IME keydown code; required on Safari/WKWebView
+ *   where `compositionend` can run before the confirming Enter `keydown`,
+ *   leaving `isComposing` already false for that key event
+ *
+ * Accepts either a native KeyboardEvent or a React synthetic keyboard event.
+ */
+export function isImeComposingEvent(
+  event:
+    | Pick<KeyboardEvent, 'isComposing' | 'keyCode'>
+    | { nativeEvent: Pick<KeyboardEvent, 'isComposing' | 'keyCode'> }
+): boolean {
+  const native = 'nativeEvent' in event ? event.nativeEvent : event
+  return native.isComposing === true || native.keyCode === 229
+}


### PR DESCRIPTION
## Summary

- Fix Japanese/CJK IME Enter confirming composition also submitting the chat message (fixes #584)
- Guard Enter handling with `isComposing` and keyCode 229 (Safari/WKWebView) in chat input and queued prompt editing
- Add unit tests for IME composition detection and ChatInput submit behavior

## Breaking Changes

None.

---

Fixes #584