### PR TITLE
fix(mcp): respect session model on message send

### DIFF
--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -415,6 +415,42 @@ fn default_model_for_backend(
     }
 }
 
+/// Trim and drop empty optional strings (MCP/UI may send `""` or whitespace).
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Resolve the model used for a send.
+///
+/// Precedence:
+/// 1. Explicit `model` on the send (one-shot override, e.g. MCP `send_chat_message`)
+/// 2. Session `selected_model` (set via UI or MCP `set_session_model`)
+/// 3. Backend default from preferences (when available)
+///
+/// Without (2), Jean MCP agents that call `set_session_model` then send without
+/// `model` would fall through to the CLI default (often Opus) instead of the
+/// session's chosen model.
+fn resolve_send_model(
+    explicit_model: Option<String>,
+    session_selected_model: Option<String>,
+    backend_default_model: Option<String>,
+) -> Option<String> {
+    normalize_optional_string(explicit_model)
+        .or_else(|| normalize_optional_string(session_selected_model))
+        .or_else(|| normalize_optional_string(backend_default_model))
+}
+
+/// Resolve execution mode for a send: explicit override → session selection.
+fn resolve_send_execution_mode(
+    explicit_mode: Option<String>,
+    session_selected_mode: Option<String>,
+) -> Option<String> {
+    normalize_optional_string(explicit_mode)
+        .or_else(|| normalize_optional_string(session_selected_mode))
+}
+
 fn build_kimi_system_prompt(
     app: &AppHandle,
     worktree_id: &str,
@@ -2737,15 +2773,34 @@ pub async fn send_chat_message(
     // Capture session info for run log before borrowing session mutably
     let session_name = session.name.clone();
     let session_order = session.order;
+    let session_backend = session.backend.clone();
+    let session_selected_model = session.selected_model.clone();
+    let session_selected_execution_mode = session.selected_execution_mode.clone();
+    let session_selected_thinking_level = session.selected_thinking_level.clone();
+    let session_selected_effort_level = session.selected_effort_level.clone();
+    let session_selected_provider = session.selected_provider.clone();
 
     // Note: User message is stored in NDJSON run entry (run.user_message),
     // not in sessions JSON. Messages are loaded from NDJSON on demand.
 
+    // MCP (and other non-UI callers) often omit per-turn settings. Fall back to
+    // the session's persisted choices so `set_session_model` / toolbar selection
+    // are respected when `model` / `executionMode` are not passed on the send.
+    // Explicit non-empty values remain one-shot overrides.
+    let mut model = resolve_send_model(model, session_selected_model, None);
+    let execution_mode =
+        resolve_send_execution_mode(execution_mode, session_selected_execution_mode);
+    let thinking_level = thinking_level.or(session_selected_thinking_level);
+    let effort_level = effort_level.or(session_selected_effort_level);
+    // selected_provider may be a sentinel (__anthropic__/__default__) rather than
+    // a real custom profile name — only use it when it looks like a profile id.
+    let custom_profile_name = normalize_optional_string(custom_profile_name).or_else(|| {
+        normalize_optional_string(session_selected_provider).filter(|provider| {
+            provider != "__anthropic__" && provider != "__default__"
+        })
+    });
+
     // Determine backend from session (or explicit param, or default to claude)
-    let session_backend = sessions
-        .find_session(&session_id)
-        .map(|s| s.backend.clone())
-        .unwrap_or_default();
     let effective_backend = match backend.as_deref() {
         Some("codex") => Backend::Codex,
         Some("opencode") => Backend::Opencode,
@@ -2763,6 +2818,18 @@ pub async fn send_chat_message(
     } else {
         effective_backend
     };
+
+    // Final model fallback: preferences default for the resolved backend.
+    // Covers sessions created before selected_model was persisted, or when
+    // create_session could not load preferences.
+    if model.is_none() {
+        if let Ok(prefs) = crate::load_preferences(app.clone()).await {
+            model = default_model_for_backend(&effective_backend, &prefs);
+        }
+    }
+    log::info!(
+        "[SendChat] resolved session={session_id} model={model:?} backend={effective_backend:?} execution_mode={execution_mode:?}"
+    );
 
     // Sync session.backend when model-based resolution overrides it
     // (e.g. user switched from Claude model to Codex model mid-session).
@@ -10012,6 +10079,65 @@ mod tests {
         assert_eq!(
             default_model_for_backend(&Backend::Commandcode, &prefs),
             Some("commandcode/deepseek/deepseek-v4-flash".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_send_model_prefers_explicit_over_session_and_prefs() {
+        assert_eq!(
+            resolve_send_model(
+                Some("claude-fable-5".to_string()),
+                Some("claude-opus-4-8[1m]".to_string()),
+                Some("claude-sonnet-4-6[1m]".to_string()),
+            ),
+            Some("claude-fable-5".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_send_model_falls_back_to_session_selected_model() {
+        // MCP set_session_model then send_chat_message without model
+        assert_eq!(
+            resolve_send_model(
+                None,
+                Some("claude-fable-5".to_string()),
+                Some("claude-opus-4-8[1m]".to_string()),
+            ),
+            Some("claude-fable-5".to_string())
+        );
+        // Empty / whitespace explicit model is treated as omitted
+        assert_eq!(
+            resolve_send_model(
+                Some("   ".to_string()),
+                Some("claude-fable-5".to_string()),
+                None,
+            ),
+            Some("claude-fable-5".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_send_model_falls_back_to_preferences_default() {
+        assert_eq!(
+            resolve_send_model(None, None, Some("claude-sonnet-4-6[1m]".to_string())),
+            Some("claude-sonnet-4-6[1m]".to_string())
+        );
+        assert_eq!(resolve_send_model(None, Some("".to_string()), None), None);
+    }
+
+    #[test]
+    fn resolve_send_execution_mode_falls_back_to_session() {
+        assert_eq!(
+            resolve_send_execution_mode(Some("yolo".to_string()), Some("plan".to_string())),
+            Some("yolo".to_string())
+        );
+        assert_eq!(
+            resolve_send_execution_mode(None, Some("build".to_string())),
+            Some("build".to_string())
+        );
+        assert_eq!(
+            resolve_send_execution_mode(Some("".to_string()), Some("plan".to_string())),
+            Some("plan".to_string())
         );
     }
 

--- a/jean-core/src/jean_mcp_core.rs
+++ b/jean-core/src/jean_mcp_core.rs
@@ -190,7 +190,7 @@ fn tool_registry_session() -> Value {
     json!([
         {"name":"list_sessions","description":"List chat sessions in a worktree without loading full message history. Use before creating a session to avoid duplicates.","inputSchema":{"type":"object","properties":{"worktreeId":{"type":"string"},"includeArchived":{"type":"boolean","default":false}},"required":["worktreeId"],"additionalProperties":false}},
         {"name":"create_session","description":"Create a new chat session in an existing non-archived worktree. Returns the session id needed for send_chat_message. Fails if the worktree is archived — call unarchive_worktree first.","inputSchema":{"type":"object","properties":{"worktreeId":{"type":"string"},"name":{"type":"string"},"backend":{"type":"string","enum":["claude","codex","cursor","opencode"]}},"required":["worktreeId"],"additionalProperties":false}},
-        {"name":"send_chat_message","description":"Send a message to an existing non-archived session. Fire-and-forget: returns immediately as the session begins processing. Fails immediately if the session or its worktree is archived — call unarchive_session / unarchive_worktree first. Use this to kick off investigations.","inputSchema":{"type":"object","properties":{"sessionId":{"type":"string"},"message":{"type":"string"},"model":{"type":"string"},"executionMode":{"type":"string","enum":["plan","build","yolo"]}},"required":["sessionId","message"],"additionalProperties":false}},
+        {"name":"send_chat_message","description":"Send a message to an existing non-archived session. Fire-and-forget: returns immediately as the session begins processing. Fails immediately if the session or its worktree is archived — call unarchive_session / unarchive_worktree first. Use this to kick off investigations. When model/executionMode are omitted, Jean uses the session's selected model and execution mode (set via set_session_model or the Jean UI). Pass model for a one-shot override of this turn only.","inputSchema":{"type":"object","properties":{"sessionId":{"type":"string"},"message":{"type":"string"},"model":{"type":"string","description":"Optional one-shot model override. When omitted, uses the session selected model (set_session_model / UI)."},"executionMode":{"type":"string","enum":["plan","build","yolo"],"description":"Optional one-shot execution mode. When omitted, uses the session selected execution mode."}},"required":["sessionId","message"],"additionalProperties":false}},
         {"name":"archive_session","description":"Archive a chat session (hide it from the active session list). Prefer this over delete when history may still be useful. Cannot run send_chat_message on an archived session until unarchive_session is called.","inputSchema":{"type":"object","properties":{"sessionId":{"type":"string"}},"required":["sessionId"],"additionalProperties":false}},
         {"name":"unarchive_session","description":"Restore an archived chat session so it can run again. Also unarchives the parent worktree when it is archived. Call this before send_chat_message if a previous attempt failed because the session was archived.","inputSchema":{"type":"object","properties":{"sessionId":{"type":"string"}},"required":["sessionId"],"additionalProperties":false}},
         {"name":"get_session_status","description":"Get whether a Jean session is idle/running/resumable/cancelled/error plus latest run metadata. Use after send_chat_message to poll fire-and-forget work.","inputSchema":{"type":"object","properties":{"sessionId":{"type":"string"}},"required":["sessionId"],"additionalProperties":false}},
@@ -2677,12 +2677,15 @@ mod tests {
             unarchive["inputSchema"]["required"],
             json!(["sessionId"])
         );
+        let send = find_tool(&tools, "send_chat_message");
+        let send_desc = send["description"].as_str().unwrap_or("");
         assert!(
-            find_tool(&tools, "send_chat_message")["description"]
-                .as_str()
-                .unwrap_or("")
-                .contains("archived"),
+            send_desc.contains("archived"),
             "send_chat_message description should mention archive rejection"
+        );
+        assert!(
+            send_desc.contains("selected model"),
+            "send_chat_message description should mention session model fallback"
         );
     }
 


### PR DESCRIPTION
## Summary

- Fix `send_chat_message` so omitted model/execution settings fall back to the session’s selected values (e.g. after `set_session_model`), instead of defaulting to the CLI preference (often Opus)
- Preserve explicit one-shot overrides for model and execution mode; empty/whitespace values are treated as omitted
- Also fall back session thinking level, effort level, and non-sentinel provider when MCP/UI callers omit them
- Document the fallback behavior in the Jean MCP `send_chat_message` tool schema

fixes #585

---

Fixes #585