### PR TITLE
fix(session): distinguish actionable session and agent states

### DIFF
--- a/src/components/chat/AgentWidget.tsx
+++ b/src/components/chat/AgentWidget.tsx
@@ -3,6 +3,7 @@ import {
   CheckCircle2,
   Loader2,
   ChevronRight,
+  CirclePause,
   Users,
   XCircle,
   X,
@@ -111,11 +112,22 @@ function AgentItem({ agent }: AgentItemProps) {
     <li className="flex items-start gap-2 py-0.5 text-xs">
       <span className="mt-0.5 shrink-0">
         {agent.status === 'completed' ? (
-          <CheckCircle2 className="h-4 w-4 text-green-500" />
+          <CheckCircle2
+            className="h-4 w-4 text-green-500"
+            aria-label="Completed"
+          />
         ) : agent.status === 'errored' ? (
-          <XCircle className="h-4 w-4 text-amber-500" />
+          <XCircle className="h-4 w-4 text-amber-500" aria-label="Errored" />
+        ) : agent.status === 'interrupted' ? (
+          <CirclePause
+            className="h-4 w-4 text-muted-foreground"
+            aria-label="Interrupted"
+          />
         ) : (
-          <Loader2 className="h-4 w-4 animate-spin text-primary" />
+          <Loader2
+            className="h-4 w-4 animate-spin text-primary"
+            aria-label="In progress"
+          />
         )}
       </span>
       <span
@@ -123,10 +135,17 @@ function AgentItem({ agent }: AgentItemProps) {
           'text-muted-foreground',
           agent.status === 'completed' &&
             'line-through text-muted-foreground/60',
-          agent.status === 'errored' && 'text-muted-foreground/60'
+          (agent.status === 'errored' || agent.status === 'interrupted') &&
+            'text-muted-foreground/60'
         )}
+        title={agent.message}
       >
         {agent.prompt}
+        {agent.status === 'interrupted' && (
+          <span className="ml-1 text-[10px] uppercase tracking-wide">
+            Interrupted
+          </span>
+        )}
       </span>
     </li>
   )

--- a/src/components/chat/SessionChatModal.removal-behavior.test.ts
+++ b/src/components/chat/SessionChatModal.removal-behavior.test.ts
@@ -101,9 +101,8 @@ describe('SessionChatModal removal behavior', () => {
   it('keeps a yellow background on waiting session tabs', () => {
     const source = readSource('src/components/chat/SessionChatModal.tsx')
 
-    expect(source).toContain(
-      "status === 'waiting' &&\n                                'bg-yellow-500/10"
-    )
+    expect(source).toContain('isActionableWaitingStatus(status)')
+    expect(source).toContain("'bg-yellow-500/10")
   })
 
   it('offers to open resumable chat sessions in a separate native client session', () => {

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -93,6 +93,7 @@ import {
   buildNativeClientSessionInput,
   computeSessionCardData,
   getResumeCommand,
+  isActionableWaitingStatus,
   statusConfig,
   type SessionCardData,
 } from './session-card-utils'
@@ -143,7 +144,7 @@ function useOffScreenWaiting(
     if (!viewport) return
 
     const waitingIds = sortedCards
-      .filter(c => c.status === 'waiting')
+      .filter(c => isActionableWaitingStatus(c.status))
       .map(c => c.session.id)
 
     if (waitingIds.length === 0) {
@@ -778,7 +779,7 @@ export function SessionChatModal({
       if (!viewport) return
       const { scrollLeft, clientWidth } = viewport
       for (const card of sortedCards) {
-        if (card.status !== 'waiting') continue
+        if (!isActionableWaitingStatus(card.status)) continue
         const el = viewport.querySelector(
           `[data-session-id="${card.session.id}"]`
         ) as HTMLElement | null
@@ -1337,13 +1338,15 @@ export function SessionChatModal({
                                 ? 'bg-muted text-foreground'
                                 : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
                               draggedSessionId === session.id && 'opacity-60',
-                              status === 'waiting' &&
+                              isActionableWaitingStatus(status) &&
                                 'bg-yellow-500/10 text-yellow-700 border-yellow-500 hover:bg-yellow-500/20 hover:text-yellow-800 dark:bg-yellow-400/10 dark:text-yellow-300 dark:border-yellow-400 dark:hover:bg-yellow-400/20 dark:hover:text-yellow-200'
                             )}
                           >
                             <StatusIndicator
                               status={config.indicatorStatus}
                               variant={config.indicatorVariant}
+                              shape={config.indicatorShape}
+                              label={config.label}
                               className="h-1.5 w-1.5"
                             />
                             {idx < 9 && (

--- a/src/components/chat/SessionListRow.tsx
+++ b/src/components/chat/SessionListRow.tsx
@@ -27,6 +27,11 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import {
   getResumeCommand,
   statusConfig,
   type SessionCardProps,
@@ -100,12 +105,21 @@ export const SessionListRow = forwardRef<HTMLDivElement, SessionCardProps>(
                 'border-primary/50 bg-primary/5 hover:border-primary/50 hover:bg-primary/10'
             )}
           >
-            {/* Status dot */}
-            <StatusIndicator
-              status={config.indicatorStatus}
-              variant={config.indicatorVariant}
-              className="h-2 w-2 shrink-0"
-            />
+            {/* Status indicator — shape + tooltip/label so status is not color-only */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex shrink-0">
+                  <StatusIndicator
+                    status={config.indicatorStatus}
+                    variant={config.indicatorVariant}
+                    shape={config.indicatorShape}
+                    label={config.label}
+                    className="h-2 w-2 shrink-0"
+                  />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="right">{config.label}</TooltipContent>
+            </Tooltip>
 
             {/* Session name */}
             {isRenaming ? (

--- a/src/components/chat/hooks/useActiveTodosAndAgents.test.ts
+++ b/src/components/chat/hooks/useActiveTodosAndAgents.test.ts
@@ -69,7 +69,7 @@ describe('extractCodexAgents', () => {
     ])
   })
 
-  it('marks interrupted v2 agents as errored', () => {
+  it('marks interrupted v2 agents as interrupted (not completed/errored)', () => {
     const tools = [
       toolCall('SpawnAgent', {
         receiver_thread_ids: ['agent-a'],
@@ -90,9 +90,33 @@ describe('extractCodexAgents', () => {
       {
         id: 'agent-a',
         prompt: '/root/reviewer',
-        status: 'errored',
+        status: 'interrupted',
         message: undefined,
       },
     ])
+  })
+
+  it('does not convert unresolved in_progress agents to completed when parent stream ends', () => {
+    const tools = [
+      toolCall('SpawnAgent', {
+        receiver_thread_ids: ['agent-a'],
+        prompt: 'Still working',
+        agents_states: {
+          'agent-a': { status: 'running', message: null },
+        },
+      }),
+    ]
+
+    expect(extractCodexAgents(tools, false)).toEqual([
+      {
+        id: 'agent-a',
+        prompt: 'Still working',
+        status: 'interrupted',
+        message: 'Interrupted before completion',
+      },
+    ])
+
+    // While parent is still sending, leave as in_progress
+    expect(extractCodexAgents(tools, true)[0]?.status).toBe('in_progress')
   })
 })

--- a/src/components/chat/hooks/useActiveTodosAndAgents.ts
+++ b/src/components/chat/hooks/useActiveTodosAndAgents.ts
@@ -85,9 +85,12 @@ function normalizeCodexAgentStatus(
   if (agentStatus === 'completed' || agentStatus === 'shutdown') {
     return 'completed'
   }
+  if (agentStatus === 'interrupted') {
+    // Authoritative interrupted terminal state — do not conflate with error
+    return 'interrupted'
+  }
   if (
     agentStatus === 'errored' ||
-    agentStatus === 'interrupted' ||
     agentStatus === 'notFound' ||
     toolCallStatus === 'failed'
   ) {
@@ -152,9 +155,16 @@ export function extractCodexAgents(
     }
   }
 
+  // Never invent a terminal "completed" state just because the parent stream
+  // ended. Unresolved in_progress agents become "interrupted" so the widget
+  // does not show a green completion treatment for cancelled/abandoned work.
   return Array.from(agents.values()).map(agent => {
     if (isSending || agent.status !== 'in_progress') return agent
-    return { ...agent, status: 'completed' }
+    return {
+      ...agent,
+      status: 'interrupted' as const,
+      message: agent.message ?? 'Interrupted before completion',
+    }
   })
 }
 

--- a/src/components/chat/hooks/useCanvasStoreState.ts
+++ b/src/components/chat/hooks/useCanvasStoreState.ts
@@ -35,6 +35,21 @@ export function useCanvasStoreState(): ChatStoreState {
   const pendingPermissionDenials = useChatStore(
     state => state.pendingPermissionDenials
   )
+  const pendingCodexPermissionRequests = useChatStore(
+    state => state.pendingCodexPermissionRequests
+  )
+  const pendingCodexCommandApprovalRequests = useChatStore(
+    state => state.pendingCodexCommandApprovalRequests
+  )
+  const pendingCodexUserInputRequests = useChatStore(
+    state => state.pendingCodexUserInputRequests
+  )
+  const pendingCodexMcpElicitationRequests = useChatStore(
+    state => state.pendingCodexMcpElicitationRequests
+  )
+  const pendingCodexDynamicToolCallRequests = useChatStore(
+    state => state.pendingCodexDynamicToolCallRequests
+  )
   const sessionLabels = useChatStore(state => state.sessionLabels)
 
   return useMemo(
@@ -48,6 +63,11 @@ export function useCanvasStoreState(): ChatStoreState {
       waitingForInputSessionIds,
       reviewingSessions,
       pendingPermissionDenials,
+      pendingCodexPermissionRequests,
+      pendingCodexCommandApprovalRequests,
+      pendingCodexUserInputRequests,
+      pendingCodexMcpElicitationRequests,
+      pendingCodexDynamicToolCallRequests,
       sessionLabels,
     }),
     [
@@ -59,6 +79,11 @@ export function useCanvasStoreState(): ChatStoreState {
       waitingForInputSessionIds,
       reviewingSessions,
       pendingPermissionDenials,
+      pendingCodexPermissionRequests,
+      pendingCodexCommandApprovalRequests,
+      pendingCodexUserInputRequests,
+      pendingCodexMcpElicitationRequests,
+      pendingCodexDynamicToolCallRequests,
       sessionLabels,
     ]
   )

--- a/src/components/chat/session-card-utils.test.ts
+++ b/src/components/chat/session-card-utils.test.ts
@@ -149,6 +149,11 @@ describe('computeSessionCardData', () => {
       waitingForInputSessionIds: {},
       reviewingSessions: {},
       pendingPermissionDenials: {},
+      pendingCodexPermissionRequests: {},
+      pendingCodexCommandApprovalRequests: {},
+      pendingCodexUserInputRequests: {},
+      pendingCodexMcpElicitationRequests: {},
+      pendingCodexDynamicToolCallRequests: {},
       sessionLabels: {},
       ...overrides,
     }
@@ -241,7 +246,7 @@ describe('computeSessionCardData', () => {
     expect(card.planContent).toBe('Plan:\n- Implement changes\n- Add tests')
     expect(card.hasExitPlanMode).toBe(true)
     expect(card.isWaiting).toBe(true)
-    expect(card.status).toBe('waiting')
+    expect(card.status).toBe('plan_approval')
   })
 
   it('ignores stale Zustand waiting flag when session is completed and reviewing', () => {
@@ -433,7 +438,7 @@ describe('computeSessionCardData', () => {
     const card = computeSessionCardData(session, storeState)
 
     expect(card.isWaiting).toBe(true)
-    expect(card.status).toBe('waiting')
+    expect(card.status).toBe('plan_approval')
   })
 
   it('honors persisted waiting_for_input when completed run paused on a question', () => {
@@ -450,7 +455,7 @@ describe('computeSessionCardData', () => {
 
     expect(card.isWaiting).toBe(true)
     expect(card.hasQuestion).toBe(true)
-    expect(card.status).toBe('waiting')
+    expect(card.status).toBe('input_required')
   })
 
   it('clears waiting once a completed question run is answered', () => {
@@ -487,7 +492,7 @@ describe('computeSessionCardData', () => {
 
     expect(getEffectiveSessionWaiting(session, storeState)).toBe(true)
     expect(card.isWaiting).toBe(true)
-    expect(card.status).toBe('waiting')
+    expect(card.status).toBe('plan_approval')
   })
 
   it('honors persisted waiting_for_input while run still active', () => {
@@ -503,6 +508,178 @@ describe('computeSessionCardData', () => {
     const card = computeSessionCardData(session, storeState)
 
     expect(card.isWaiting).toBe(true)
-    expect(card.status).toBe('waiting')
+    expect(card.status).toBe('input_required')
+  })
+
+  it('maps cancelled last_run_status to cancelled (not idle)', () => {
+    const session = createBaseSession({ last_run_status: 'cancelled' })
+    const card = computeSessionCardData(session, createBaseStoreState())
+    expect(card.status).toBe('cancelled')
+    expect(statusConfig[card.status].label).toBe('Cancelled')
+  })
+
+  it('maps crashed last_run_status to crashed (not idle)', () => {
+    const session = createBaseSession({ last_run_status: 'crashed' })
+    const card = computeSessionCardData(session, createBaseStoreState())
+    expect(card.status).toBe('crashed')
+    expect(statusConfig[card.status].label).toBe('Crashed')
+  })
+
+  it('maps pending Claude permission denials to permission', () => {
+    const session = createBaseSession({
+      pending_permission_denials: [
+        {
+          tool_name: 'Bash',
+          tool_use_id: 'tu-1',
+          tool_input: {},
+        } as never,
+      ],
+    })
+    const card = computeSessionCardData(session, createBaseStoreState())
+    expect(card.status).toBe('permission')
+    expect(card.hasPermissionDenials).toBe(true)
+  })
+
+  it('maps Codex pending queues to specific actionable statuses', () => {
+    const base = createBaseSession({ last_run_status: 'running' })
+
+    expect(
+      computeSessionCardData(
+        {
+          ...base,
+          pending_codex_command_approval_requests: [
+            { rpc_id: 1, item_id: 'i', thread_id: 't', turn_id: 'u' },
+          ],
+        },
+        createBaseStoreState()
+      ).status
+    ).toBe('command_approval')
+
+    expect(
+      computeSessionCardData(
+        {
+          ...base,
+          pending_codex_user_input_requests: [
+            { rpc_id: 1, item_id: 'i' } as never,
+          ],
+        },
+        createBaseStoreState()
+      ).status
+    ).toBe('input_required')
+
+    expect(
+      computeSessionCardData(
+        {
+          ...base,
+          pending_codex_mcp_elicitation_requests: [
+            { rpc_id: 1, item_id: 'i' } as never,
+          ],
+        },
+        createBaseStoreState()
+      ).status
+    ).toBe('mcp_input')
+
+    expect(
+      computeSessionCardData(
+        {
+          ...base,
+          pending_codex_dynamic_tool_call_requests: [
+            { rpc_id: 1, item_id: 'i' } as never,
+          ],
+        },
+        createBaseStoreState()
+      ).status
+    ).toBe('tool_approval')
+
+    expect(
+      computeSessionCardData(
+        {
+          ...base,
+          pending_codex_permission_requests: [
+            {
+              rpc_id: 1,
+              item_id: 'i',
+              permissions: {},
+            },
+          ],
+        },
+        createBaseStoreState()
+      ).status
+    ).toBe('permission')
+  })
+
+  it('maps scheduled_wakeup to scheduled when otherwise idle', () => {
+    const session = createBaseSession({
+      last_run_status: 'completed',
+      scheduled_wakeup: {
+        fire_at_unix: Date.now() / 1000 + 60,
+        scheduled_at_unix: Date.now() / 1000,
+        delay_seconds: 60,
+        prompt: 'continue',
+        reason: 'wait',
+        tool_call_id: 'tc-1',
+      },
+    })
+    // completed normally wins over scheduled when last_run is completed
+    // and no waiting — but scheduled is checked before completed
+    const card = computeSessionCardData(session, createBaseStoreState())
+    expect(card.status).toBe('scheduled')
+  })
+
+  it('keeps review and completed distinguishable', () => {
+    const reviewCard = computeSessionCardData(
+      createBaseSession({
+        is_reviewing: true,
+        last_run_status: 'completed',
+      }),
+      createBaseStoreState({ reviewingSessions: { 'session-1': true } })
+    )
+    const completedCard = computeSessionCardData(
+      createBaseSession({ last_run_status: 'completed' }),
+      createBaseStoreState()
+    )
+    expect(reviewCard.status).toBe('review')
+    expect(completedCard.status).toBe('completed')
+    expect(statusConfig[reviewCard.status].label).toBe('Review ready')
+    expect(statusConfig[completedCard.status].label).toBe('Completed')
+  })
+
+  it('prefers input_required over plan_approval when both are waiting', () => {
+    const session = createBaseSession({
+      waiting_for_input: true,
+      waiting_for_input_type: 'question',
+      last_run_status: 'completed',
+      pending_plan_message_id: 'plan-msg',
+    })
+    // hasExitPlanMode from pending plan id inference only when type is plan;
+    // force both flags via messages
+    const withMessages: Session = {
+      ...session,
+      messages: [
+        {
+          id: 'msg-1',
+          session_id: 'session-1',
+          role: 'assistant',
+          content: 'Choose and plan',
+          timestamp: 1,
+          tool_calls: [
+            {
+              id: 'q1',
+              name: 'AskUserQuestion',
+              input: { questions: [] },
+            },
+            {
+              id: 'p1',
+              name: 'ExitPlanMode',
+              input: {},
+            },
+          ],
+        },
+      ],
+    }
+    const card = computeSessionCardData(withMessages, createBaseStoreState())
+    expect(card.hasQuestion).toBe(true)
+    expect(card.hasExitPlanMode).toBe(true)
+    expect(card.status).toBe('input_required')
   })
 })

--- a/src/components/chat/session-card-utils.tsx
+++ b/src/components/chat/session-card-utils.tsx
@@ -1,4 +1,5 @@
 import type {
+  IndicatorShape,
   IndicatorStatus,
   IndicatorVariant,
 } from '@/components/ui/status-indicator'
@@ -11,6 +12,11 @@ import {
   type ContentBlock,
   type PermissionDenial,
   type LabelData,
+  type CodexPermissionRequest,
+  type CodexCommandApprovalRequest,
+  type CodexUserInputRequest,
+  type CodexMcpElicitationRequest,
+  type CodexDynamicToolCallRequest,
 } from '@/types/chat'
 import {
   buildNativeResumeArgs,
@@ -19,6 +25,11 @@ import {
 } from '@/lib/native-cli-session'
 import { findPlanFilePath, resolvePlanContent } from './tool-call-utils'
 
+/**
+ * Lossless session status for canvas/sidebar/tabs/summaries.
+ * Priority is applied in computeSessionCardData — do not collapse
+ * actionable states before rendering.
+ */
 export type SessionStatus =
   | 'idle'
   | 'planning'
@@ -26,9 +37,32 @@ export type SessionStatus =
   | 'yoloing'
   | 'reviewing'
   | 'waiting'
-  | 'review'
+  | 'plan_approval'
+  | 'input_required'
   | 'permission'
+  | 'command_approval'
+  | 'mcp_input'
+  | 'tool_approval'
+  | 'scheduled'
+  | 'review'
   | 'completed'
+  | 'cancelled'
+  | 'crashed'
+
+/** Statuses that require user action before the session can continue. */
+export const ACTIONABLE_WAITING_STATUSES: readonly SessionStatus[] = [
+  'waiting',
+  'plan_approval',
+  'input_required',
+  'permission',
+  'command_approval',
+  'mcp_input',
+  'tool_approval',
+] as const
+
+export function isActionableWaitingStatus(status: SessionStatus): boolean {
+  return (ACTIONABLE_WAITING_STATUSES as readonly string[]).includes(status)
+}
 
 export interface SessionCardData {
   session: Session
@@ -77,6 +111,7 @@ export const statusConfig: Record<
     label: string
     indicatorStatus: IndicatorStatus
     indicatorVariant?: IndicatorVariant
+    indicatorShape?: IndicatorShape
   }
 > = {
   idle: {
@@ -104,18 +139,60 @@ export const statusConfig: Record<
   waiting: {
     label: 'Waiting',
     indicatorStatus: 'waiting',
+    indicatorShape: 'diamond',
   },
-  review: {
-    label: 'Review',
-    indicatorStatus: 'review',
+  plan_approval: {
+    label: 'Plan approval required',
+    indicatorStatus: 'plan_approval',
+    indicatorShape: 'square',
+  },
+  input_required: {
+    label: 'Input required',
+    indicatorStatus: 'input_required',
+    indicatorShape: 'diamond',
   },
   permission: {
-    label: 'Permission',
-    indicatorStatus: 'waiting',
+    label: 'Permission required',
+    indicatorStatus: 'permission',
+    indicatorShape: 'square',
+  },
+  command_approval: {
+    label: 'Command approval required',
+    indicatorStatus: 'permission',
+    indicatorShape: 'square',
+  },
+  mcp_input: {
+    label: 'MCP input required',
+    indicatorStatus: 'input_required',
+    indicatorShape: 'diamond',
+  },
+  tool_approval: {
+    label: 'Tool approval required',
+    indicatorStatus: 'permission',
+    indicatorShape: 'square',
+  },
+  scheduled: {
+    label: 'Scheduled',
+    indicatorStatus: 'scheduled',
+    indicatorShape: 'diamond',
+  },
+  review: {
+    label: 'Review ready',
+    indicatorStatus: 'review',
   },
   completed: {
     label: 'Completed',
     indicatorStatus: 'completed',
+  },
+  cancelled: {
+    label: 'Cancelled',
+    indicatorStatus: 'cancelled',
+    indicatorShape: 'ring',
+  },
+  crashed: {
+    label: 'Crashed',
+    indicatorStatus: 'crashed',
+    indicatorShape: 'square',
   },
 }
 
@@ -139,6 +216,20 @@ export interface ChatStoreState {
   waitingForInputSessionIds: Record<string, boolean>
   reviewingSessions: Record<string, boolean>
   pendingPermissionDenials: Record<string, PermissionDenial[]>
+  pendingCodexPermissionRequests: Record<string, CodexPermissionRequest[]>
+  pendingCodexCommandApprovalRequests: Record<
+    string,
+    CodexCommandApprovalRequest[]
+  >
+  pendingCodexUserInputRequests: Record<string, CodexUserInputRequest[]>
+  pendingCodexMcpElicitationRequests: Record<
+    string,
+    CodexMcpElicitationRequest[]
+  >
+  pendingCodexDynamicToolCallRequests: Record<
+    string,
+    CodexDynamicToolCallRequest[]
+  >
   sessionLabels: Record<string, LabelData>
 }
 
@@ -229,6 +320,13 @@ export function shouldShowReviewFullWidth({
   return isDedicatedEmptyCodeReviewSession(session)
 }
 
+function hasPendingEntries<T>(
+  storeEntries: T[] | undefined,
+  sessionEntries: T[] | undefined
+): boolean {
+  return (storeEntries?.length ?? 0) > 0 || (sessionEntries?.length ?? 0) > 0
+}
+
 export function computeSessionCardData(
   session: Session,
   storeState: ChatStoreState
@@ -243,6 +341,11 @@ export function computeSessionCardData(
     waitingForInputSessionIds,
     reviewingSessions,
     pendingPermissionDenials,
+    pendingCodexPermissionRequests,
+    pendingCodexCommandApprovalRequests,
+    pendingCodexUserInputRequests,
+    pendingCodexMcpElicitationRequests,
+    pendingCodexDynamicToolCallRequests,
     sessionLabels,
   } = storeState
 
@@ -388,13 +491,37 @@ export function computeSessionCardData(
       hasPendingQuestion ||
       (persistedWaitingForInput && inferredWaitingType === 'question')
 
-  // Check for pending permission denials
+  // Check for pending permission denials (Claude-style)
   const sessionDenials = pendingPermissionDenials[session.id] ?? []
   const persistedDenials = session.pending_permission_denials ?? []
   const hasPermissionDenials =
     sessionDenials.length > 0 || persistedDenials.length > 0
   const permissionDenialCount =
     sessionDenials.length > 0 ? sessionDenials.length : persistedDenials.length
+
+  // Codex pending approval/input queues (store first, then session persistence)
+  const hasCodexPermission = hasPendingEntries(
+    pendingCodexPermissionRequests[session.id],
+    session.pending_codex_permission_requests
+  )
+  const hasCodexCommandApproval = hasPendingEntries(
+    pendingCodexCommandApprovalRequests[session.id],
+    session.pending_codex_command_approval_requests
+  )
+  const hasCodexUserInput = hasPendingEntries(
+    pendingCodexUserInputRequests[session.id],
+    session.pending_codex_user_input_requests
+  )
+  const hasCodexMcpInput = hasPendingEntries(
+    pendingCodexMcpElicitationRequests[session.id],
+    session.pending_codex_mcp_elicitation_requests
+  )
+  const hasCodexToolApproval = hasPendingEntries(
+    pendingCodexDynamicToolCallRequests[session.id],
+    session.pending_codex_dynamic_tool_call_requests
+  )
+
+  const hasScheduledWakeup = !!session.scheduled_wakeup
 
   // Execution mode
   const executionMode = sessionSending
@@ -404,11 +531,33 @@ export function computeSessionCardData(
       'plan')
     : (executionModes[session.id] ?? session.selected_execution_mode ?? 'plan')
 
-  // Determine status
-  // Priority: permission > waiting > sending (active) > review > restart recovery > completed > idle
+  // Determine status — lossless priority matrix (actionable first, then active,
+  // then terminal run outcomes). Never collapse cancelled/crashed into idle.
+  // Priority:
+  //   permission > command_approval > tool_approval > mcp_input >
+  //   input_required > plan_approval > waiting >
+  //   sending modes > reviewing > review >
+  //   restart recovery (running/resumable) > scheduled >
+  //   cancelled > crashed > completed > idle
+  //
+  // Plan/question flags can be true while still streaming (hasExitPlanMode from
+  // live tool calls). Only promote them to actionable statuses once the session
+  // is actually waiting — otherwise keep the active planning/vibing status.
   let status: SessionStatus = 'idle'
-  if (hasPermissionDenials) {
+  if (hasPermissionDenials || hasCodexPermission) {
     status = 'permission'
+  } else if (hasCodexCommandApproval) {
+    status = 'command_approval'
+  } else if (hasCodexToolApproval) {
+    status = 'tool_approval'
+  } else if (hasCodexMcpInput) {
+    status = 'mcp_input'
+  } else if (hasCodexUserInput || (isWaiting && hasQuestion)) {
+    // Questions win over plan approval when both are present (UI hides Approve
+    // while a question is open).
+    status = 'input_required'
+  } else if (isWaiting && hasExitPlanMode) {
+    status = 'plan_approval'
   } else if (isWaiting) {
     status = 'waiting'
   } else if (sessionSending && executionMode === 'plan') {
@@ -440,6 +589,12 @@ export function computeSessionCardData(
     if (mode === 'plan') status = 'planning'
     else if (mode === 'build') status = 'vibing'
     else if (mode === 'yolo') status = 'yoloing'
+  } else if (!sessionSending && hasScheduledWakeup) {
+    status = 'scheduled'
+  } else if (!sessionSending && session.last_run_status === 'cancelled') {
+    status = 'cancelled'
+  } else if (!sessionSending && session.last_run_status === 'crashed') {
+    status = 'crashed'
   } else if (!sessionSending && session.last_run_status === 'completed') {
     status = 'completed'
   }
@@ -452,11 +607,24 @@ export function computeSessionCardData(
     status,
     executionMode: executionMode as ExecutionMode,
     isSending: sessionSending,
-    isWaiting,
+    isWaiting:
+      isWaiting ||
+      hasPermissionDenials ||
+      hasCodexPermission ||
+      hasCodexCommandApproval ||
+      hasCodexUserInput ||
+      hasCodexMcpInput ||
+      hasCodexToolApproval,
     hasExitPlanMode,
-    hasQuestion,
-    hasPermissionDenials,
-    permissionDenialCount,
+    hasQuestion: hasQuestion || hasCodexUserInput,
+    hasPermissionDenials: hasPermissionDenials || hasCodexPermission,
+    permissionDenialCount:
+      permissionDenialCount ||
+      (hasCodexPermission
+        ? (pendingCodexPermissionRequests[session.id]?.length ??
+          session.pending_codex_permission_requests?.length ??
+          0)
+        : 0),
     planFilePath,
     planContent,
     pendingPlanMessageId,
@@ -585,13 +753,22 @@ const STATUS_GROUP_ORDER: {
   title: string
   statuses: SessionStatus[]
 }[] = [
-  { key: 'waiting', title: 'Waiting', statuses: ['waiting', 'permission'] },
+  {
+    key: 'waiting',
+    title: 'Waiting',
+    statuses: [...ACTIONABLE_WAITING_STATUSES],
+  },
   {
     key: 'inProgress',
     title: 'In Progress',
-    statuses: ['planning', 'vibing', 'yoloing', 'reviewing'],
+    statuses: ['planning', 'vibing', 'yoloing', 'reviewing', 'scheduled'],
   },
-  { key: 'review', title: 'Review', statuses: ['review', 'completed'] },
+  {
+    key: 'review',
+    title: 'Review',
+    // Keep completed distinct from review-ready within the group via statusConfig labels
+    statuses: ['review', 'completed', 'cancelled', 'crashed'],
+  },
   { key: 'idle', title: 'Idle', statuses: ['idle'] },
 ]
 

--- a/src/components/chat/session-tab-order.ts
+++ b/src/components/chat/session-tab-order.ts
@@ -1,14 +1,25 @@
 import type { SessionCardData } from './session-card-utils'
 
 const STATUS_PRIORITY: Record<string, number> = {
-  waiting: 0,
+  // Actionable waiting — highest priority in tab order
   permission: 0,
+  command_approval: 0,
+  tool_approval: 0,
+  mcp_input: 0,
+  input_required: 0,
+  plan_approval: 0,
+  waiting: 0,
+  // Active runs
   planning: 1,
+  scheduled: 1,
   vibing: 2,
   yoloing: 3,
   reviewing: 4,
+  // Terminal / review
   review: 4,
   completed: 4,
+  cancelled: 4,
+  crashed: 4,
   idle: 5,
 }
 

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -142,6 +142,7 @@ import {
   computeSessionCardData,
   groupCardsByStatus,
   flattenGroups,
+  isActionableWaitingStatus,
 } from '@/components/chat/session-card-utils'
 import { WorktreeSetupCard } from '@/components/chat/WorktreeSetupCard'
 import { OpenInButton } from '@/components/open-in/OpenInButton'
@@ -378,13 +379,16 @@ function isLabelFilterTabItem(
 }
 
 function getActiveStatus(cards: SessionCardData[]): ActiveStatus {
-  if (cards.some(c => c.status === 'waiting' || c.status === 'permission'))
-    return 'waiting'
-  if (cards.some(c => c.status === 'planning')) return 'planning'
+  // Actionable waiting (plan/input/permission/codex queues) collapses only at
+  // the worktree *summary* level — individual cards keep distinct statuses.
+  if (cards.some(c => isActionableWaitingStatus(c.status))) return 'waiting'
+  if (cards.some(c => c.status === 'planning' || c.status === 'scheduled'))
+    return 'planning'
   if (cards.some(c => c.status === 'vibing')) return 'vibing'
   if (cards.some(c => c.status === 'yoloing')) return 'yoloing'
-  if (cards.some(c => c.status === 'review' || c.status === 'completed'))
-    return 'review'
+  // Prefer review-ready over completed for worktree-level summary
+  if (cards.some(c => c.status === 'review')) return 'review'
+  if (cards.some(c => c.status === 'completed')) return 'review'
   return null
 }
 
@@ -413,13 +417,17 @@ function formatRelativeTime(timestamp?: number): string | null {
 }
 
 function getSessionMetrics(cards: SessionCardData[]) {
-  const waitingCount = cards.filter(
-    c => c.status === 'waiting' || c.status === 'permission'
+  const waitingCount = cards.filter(c =>
+    isActionableWaitingStatus(c.status)
   ).length
+  // Keep review-ready and completed countable together for metrics, but
+  // cancelled/crashed are not "ready for review".
   const reviewCount = cards.filter(
     c => c.status === 'review' || c.status === 'completed'
   ).length
-  const planningCount = cards.filter(c => c.status === 'planning').length
+  const planningCount = cards.filter(
+    c => c.status === 'planning' || c.status === 'scheduled'
+  ).length
   const buildingCount = cards.filter(c => c.status === 'vibing').length
   const yoloCount = cards.filter(c => c.status === 'yoloing').length
   const activeCount = planningCount + buildingCount + yoloCount

--- a/src/components/projects/WorktreeItem.tsx
+++ b/src/components/projects/WorktreeItem.tsx
@@ -780,9 +780,14 @@ export function WorktreeItem({
                     <StatusIndicator
                       status={config.indicatorStatus}
                       variant={config.indicatorVariant}
+                      shape={config.indicatorShape}
+                      label={config.label}
                       className="h-1.5 w-1.5 shrink-0"
                     />
-                    <span className="truncate text-xs">
+                    <span
+                      className="truncate text-xs"
+                      title={`${config.label}: ${card.session.name || 'Untitled'}`}
+                    >
                       {card.session.name || 'Untitled'}
                     </span>
                   </div>

--- a/src/components/ui/status-indicator.tsx
+++ b/src/components/ui/status-indicator.tsx
@@ -4,39 +4,100 @@ export type IndicatorStatus =
   | 'idle'
   | 'running'
   | 'waiting'
+  | 'plan_approval'
+  | 'input_required'
+  | 'permission'
   | 'review'
   | 'completed'
+  | 'cancelled'
+  | 'crashed'
+  | 'scheduled'
+
 export type IndicatorVariant = 'default' | 'destructive' | 'loading'
-export type IndicatorShape = 'circle' | 'square'
+export type IndicatorShape = 'circle' | 'square' | 'diamond' | 'ring'
 
 interface StatusIndicatorProps {
   status: IndicatorStatus
   variant?: IndicatorVariant
   shape?: IndicatorShape
+  /** Accessible name describing the status (also used as title fallback). */
+  label?: string
   className?: string
+}
+
+function resolveShape(
+  status: IndicatorStatus,
+  shape?: IndicatorShape
+): IndicatorShape {
+  if (shape) return shape
+  switch (status) {
+    case 'plan_approval':
+      return 'square'
+    case 'input_required':
+      return 'diamond'
+    case 'permission':
+      return 'square'
+    case 'cancelled':
+      return 'ring'
+    case 'crashed':
+      return 'square'
+    case 'scheduled':
+      return 'diamond'
+    case 'waiting':
+      return 'diamond'
+    default:
+      return 'circle'
+  }
+}
+
+function shapeClasses(shape: IndicatorShape): string {
+  switch (shape) {
+    case 'square':
+      return 'rounded-sm'
+    case 'diamond':
+      return 'rounded-sm rotate-45'
+    case 'ring':
+      return 'rounded-full border-2 border-current bg-transparent'
+    case 'circle':
+    default:
+      return 'rounded-full'
+  }
 }
 
 export function StatusIndicator({
   status,
   variant = 'default',
-  shape = 'circle',
+  shape,
+  label,
   className,
 }: StatusIndicatorProps) {
-  const shapeClass = shape === 'square' ? 'rounded-sm' : 'rounded-full'
+  const resolvedShape = resolveShape(status, shape)
+  const shapeClass = shapeClasses(resolvedShape)
+  const title = label
 
-  // Running state: CSS border spinner
+  // Running state: CSS border spinner (shape still communicates meaning without color)
   if (status === 'running') {
     const colorClass =
       variant === 'destructive'
-        ? 'border-t-destructive bg-destructive/10 '
+        ? 'border-t-destructive bg-destructive/10 forced-colors:border-t-[Highlight]'
         : variant === 'loading'
-          ? 'border-t-cyan-500 bg-cyan-500/10 '
-          : 'border-t-yellow-500 bg-yellow-500/10'
+          ? 'border-t-cyan-500 bg-cyan-500/10 forced-colors:border-t-[Highlight]'
+          : 'border-t-yellow-500 bg-yellow-500/10 forced-colors:border-t-[Highlight]'
 
     return (
       <span
+        role="img"
+        aria-label={label}
+        title={title}
         className={cn(
-          'shrink-0 block animate-spin border-2 border-transparent',
+          'shrink-0 block animate-spin border-2 border-transparent motion-reduce:animate-none',
+          // Reduced motion: solid fill instead of spinner so status remains visible
+          'motion-reduce:border-0 motion-reduce:bg-current',
+          variant === 'destructive'
+            ? 'motion-reduce:text-destructive'
+            : variant === 'loading'
+              ? 'motion-reduce:text-cyan-500'
+              : 'motion-reduce:text-yellow-500',
           shapeClass,
           colorClass,
           className
@@ -45,19 +106,35 @@ export function StatusIndicator({
     )
   }
 
-  // Static states: use simple filled shapes
+  // Static states: filled/outline shapes with distinct colors + shapes
   const colorClass =
-    status === 'waiting'
-      ? 'text-yellow-500 animate-blink '
+    status === 'waiting' ||
+    status === 'plan_approval' ||
+    status === 'input_required' ||
+    status === 'permission'
+      ? 'text-yellow-500 animate-blink motion-reduce:animate-none forced-colors:text-[Highlight]'
       : status === 'review' || status === 'completed'
-        ? 'text-green-500'
-        : 'text-muted-foreground/50'
+        ? 'text-green-500 forced-colors:text-[Highlight]'
+        : status === 'crashed'
+          ? 'text-destructive forced-colors:text-[Mark]'
+          : status === 'scheduled'
+            ? 'text-cyan-500 forced-colors:text-[Highlight]'
+            : status === 'cancelled'
+              ? 'text-muted-foreground forced-colors:text-[GrayText]'
+              : 'text-muted-foreground/50 forced-colors:text-[GrayText]'
+
+  // Ring shape already uses border + transparent fill; others fill with currentColor
+  const fillClass = resolvedShape === 'ring' ? '' : 'bg-current'
 
   return (
     <span
+      role="img"
+      aria-label={label}
+      title={title}
       className={cn(
-        'shrink-0 block bg-current',
-        shape === 'circle' ? 'rounded-full' : 'rounded-sm',
+        'shrink-0 block',
+        fillClass,
+        shapeClass,
         colorClass,
         className
       )}

--- a/src/components/unread/UnreadBell.tsx
+++ b/src/components/unread/UnreadBell.tsx
@@ -51,12 +51,67 @@ interface UnreadItem {
 }
 
 function getSessionStatus(session: Session) {
-  if (session.waiting_for_input) {
-    const isplan = session.waiting_for_input_type === 'plan'
+  // Prefer specific actionable reasons over generic waiting (matches canvas)
+  const hasCodexPermission =
+    (session.pending_codex_permission_requests?.length ?? 0) > 0 ||
+    (session.pending_permission_denials?.length ?? 0) > 0
+  const hasCodexCommand =
+    (session.pending_codex_command_approval_requests?.length ?? 0) > 0
+  const hasCodexUserInput =
+    (session.pending_codex_user_input_requests?.length ?? 0) > 0
+  const hasCodexMcp =
+    (session.pending_codex_mcp_elicitation_requests?.length ?? 0) > 0
+  const hasCodexTool =
+    (session.pending_codex_dynamic_tool_call_requests?.length ?? 0) > 0
+
+  if (hasCodexPermission) {
     return {
-      icon: isplan ? FileText : HelpCircle,
-      label: isplan ? 'Needs approval' : 'Needs input',
+      icon: AlertTriangle,
+      label: 'Permission required',
       className: 'text-yellow-500',
+    }
+  }
+  if (hasCodexCommand) {
+    return {
+      icon: AlertTriangle,
+      label: 'Command approval required',
+      className: 'text-yellow-500',
+    }
+  }
+  if (hasCodexTool) {
+    return {
+      icon: AlertTriangle,
+      label: 'Tool approval required',
+      className: 'text-yellow-500',
+    }
+  }
+  if (hasCodexMcp) {
+    return {
+      icon: HelpCircle,
+      label: 'MCP input required',
+      className: 'text-yellow-500',
+    }
+  }
+  if (hasCodexUserInput) {
+    return {
+      icon: HelpCircle,
+      label: 'Input required',
+      className: 'text-yellow-500',
+    }
+  }
+  if (session.waiting_for_input) {
+    const isPlan = session.waiting_for_input_type === 'plan'
+    return {
+      icon: isPlan ? FileText : HelpCircle,
+      label: isPlan ? 'Plan approval required' : 'Input required',
+      className: 'text-yellow-500',
+    }
+  }
+  if (session.scheduled_wakeup) {
+    return {
+      icon: CirclePause,
+      label: 'Scheduled',
+      className: 'text-cyan-500',
     }
   }
   const config: Record<

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1132,7 +1132,7 @@ export interface CodexAgent {
   /** The prompt given to the agent (truncated for display) */
   prompt: string
   /** Agent lifecycle status */
-  status: 'in_progress' | 'completed' | 'errored'
+  status: 'in_progress' | 'completed' | 'errored' | 'interrupted'
   /** Completion message from agents_states */
   message?: string
 }


### PR DESCRIPTION
## Summary

- Expand session status derivation so plan approval, input, permissions, scheduled wakeups, cancelled, and crashed states stay distinct instead of collapsing into Waiting or Idle
- Surface specific Codex pending queues (permission, command approval, user input, MCP elicitation, tool approval) with clear labels across canvas, sidebar, tabs, and unread UI
- Keep Codex child agents as interrupted when parent streaming stops mid-run, instead of marking them completed
- Add accessible labels/tooltips on compact indicators so status is understandable without color or animation alone

fixes #590

---

Fixes #590