### PR TITLE
feat(chat): add Copy Session ID context menu

### DIFF
--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -1494,6 +1494,18 @@ export function SessionChatModal({
                             <Archive className="mr-2 h-4 w-4" />
                             Archive Session
                           </ContextMenuItem>
+                          <ContextMenuItem
+                            onSelect={() => {
+                              void copyToClipboard(session.id)
+                                .then(() => toast.success('Session ID copied'))
+                                .catch(() =>
+                                  toast.error('Failed to copy session ID')
+                                )
+                            }}
+                          >
+                            <Copy className="mr-2 h-4 w-4" />
+                            Copy Session ID
+                          </ContextMenuItem>
                           <ContextMenuSeparator />
                           <ContextMenuItem
                             variant="destructive"

--- a/src/components/chat/SessionListRow.tsx
+++ b/src/components/chat/SessionListRow.tsx
@@ -284,6 +284,16 @@ export const SessionListRow = forwardRef<HTMLDivElement, SessionCardProps>(
             <Archive className="mr-2 h-4 w-4" />
             Archive Session
           </ContextMenuItem>
+          <ContextMenuItem
+            onSelect={() => {
+              void copyToClipboard(card.session.id)
+                .then(() => toast.success('Session ID copied'))
+                .catch(() => toast.error('Failed to copy session ID'))
+            }}
+          >
+            <Copy className="mr-2 h-4 w-4" />
+            Copy Session ID
+          </ContextMenuItem>
           {resumeCommand && (
             <ContextMenuItem
               onSelect={() => {

--- a/src/components/chat/copy-session-id-menu.test.ts
+++ b/src/components/chat/copy-session-id-menu.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const sourceFiles = [
+  'src/components/chat/SessionChatModal.tsx',
+  'src/components/chat/SessionListRow.tsx',
+]
+
+describe('copy session ID context menu', () => {
+  it('exposes Copy Session ID on session right-click menus', () => {
+    for (const path of sourceFiles) {
+      const source = readFileSync(join(process.cwd(), path), 'utf8')
+      expect(source).toContain('Copy Session ID')
+      expect(source).toMatch(/copyToClipboard\((?:card\.)?session\.id\)/)
+      expect(source).toContain("toast.success('Session ID copied')")
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Add a **Copy Session ID** option to session right-click menus in the session list and session chat modal
- Copies the Jean session ID to the clipboard with success/error toasts, so sessions can be handed off without using the debug menu
- Includes a regression test that the menu entry is present and copies `session.id`

closes #595

---

Fixes #595