### PR TITLE
fix(focus): restore keyboard focus after alt-tab

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1215,6 +1215,7 @@ export const ChatInput = memo(function ChatInput({
       />
       <Textarea
         ref={inputRef}
+        data-chat-input
         placeholder={
           isSending
             ? executionMode === 'yolo'

--- a/src/components/chat/hooks/useChatWindowEvents.test.ts
+++ b/src/components/chat/hooks/useChatWindowEvents.test.ts
@@ -162,6 +162,38 @@ describe('useChatWindowEvents worktree approval shortcuts', () => {
     expect(document.activeElement).toBe(params.inputRef.current)
   })
 
+  it('re-focuses chat input when the window is re-activated after alt-tab', () => {
+    const params = renderUseChatWindowEvents()
+    const input = params.inputRef.current
+    expect(input).toBeTruthy()
+
+    // Simulate lost keyboard focus after alt-tab (focus sinks to body)
+    document.body.tabIndex = -1
+    document.body.focus()
+    expect(document.activeElement).toBe(document.body)
+
+    window.dispatchEvent(new Event('focus'))
+
+    expect(document.activeElement).toBe(input)
+  })
+
+  it('does not steal focus from a terminal when the window is re-activated', () => {
+    const params = renderUseChatWindowEvents()
+
+    const terminal = document.createElement('div')
+    terminal.className = 'xterm'
+    const terminalInput = document.createElement('textarea')
+    terminal.appendChild(terminalInput)
+    document.body.appendChild(terminal)
+    terminalInput.focus()
+
+    window.dispatchEvent(new Event('focus'))
+
+    expect(document.activeElement).toBe(terminalInput)
+    // Chat input should not have been focused
+    expect(document.activeElement).not.toBe(params.inputRef.current)
+  })
+
   it('opens the new session mode picker for CMD+T events', () => {
     renderUseChatWindowEvents()
 
@@ -174,7 +206,6 @@ describe('useChatWindowEvents worktree approval shortcuts', () => {
       intent: 'picker',
     })
   })
-
 
   it('saves browser grabbed context as a named pasted text attachment', async () => {
     vi.mocked(invoke).mockResolvedValueOnce({

--- a/src/components/chat/hooks/useChatWindowEvents.test.ts
+++ b/src/components/chat/hooks/useChatWindowEvents.test.ts
@@ -4,6 +4,7 @@ import { useChatWindowEvents } from './useChatWindowEvents'
 import { useUIStore } from '@/store/ui-store'
 import { useChatStore } from '@/store/chat-store'
 import { invoke } from '@/lib/transport'
+import { installWindowKeyboardFocusRestore } from '@/lib/restore-keyboard-focus'
 
 vi.mock('@/hooks/use-mobile', () => ({
   useIsMobile: () => false,
@@ -162,36 +163,41 @@ describe('useChatWindowEvents worktree approval shortcuts', () => {
     expect(document.activeElement).toBe(params.inputRef.current)
   })
 
-  it('re-focuses chat input when the window is re-activated after alt-tab', () => {
+  it('does not steal focus from a button when the window is re-activated', () => {
     const params = renderUseChatWindowEvents()
-    const input = params.inputRef.current
-    expect(input).toBeTruthy()
-
-    // Simulate lost keyboard focus after alt-tab (focus sinks to body)
-    document.body.tabIndex = -1
-    document.body.focus()
-    expect(document.activeElement).toBe(document.body)
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+    button.focus()
+    const cleanupFocusRestore = installWindowKeyboardFocusRestore()
 
     window.dispatchEvent(new Event('focus'))
 
-    expect(document.activeElement).toBe(input)
+    expect(document.activeElement).toBe(button)
+    expect(document.activeElement).not.toBe(params.inputRef.current)
+    cleanupFocusRestore()
   })
 
-  it('does not steal focus from a terminal when the window is re-activated', () => {
+  it('re-asserts focus inside an open dialog without focusing chat input', () => {
     const params = renderUseChatWindowEvents()
+    const chatFocusSpy = vi.spyOn(params.inputRef.current!, 'focus')
+    chatFocusSpy.mockClear()
 
-    const terminal = document.createElement('div')
-    terminal.className = 'xterm'
-    const terminalInput = document.createElement('textarea')
-    terminal.appendChild(terminalInput)
-    document.body.appendChild(terminal)
-    terminalInput.focus()
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    dialog.setAttribute('data-state', 'open')
+    const dialogInput = document.createElement('input')
+    dialog.appendChild(dialogInput)
+    document.body.appendChild(dialog)
+    dialogInput.focus()
+    const dialogFocusSpy = vi.spyOn(dialogInput, 'focus')
+    const cleanupFocusRestore = installWindowKeyboardFocusRestore()
 
     window.dispatchEvent(new Event('focus'))
 
-    expect(document.activeElement).toBe(terminalInput)
-    // Chat input should not have been focused
-    expect(document.activeElement).not.toBe(params.inputRef.current)
+    expect(dialogFocusSpy).toHaveBeenCalledWith({ preventScroll: true })
+    expect(document.activeElement).toBe(dialogInput)
+    expect(chatFocusSpy).not.toHaveBeenCalled()
+    cleanupFocusRestore()
   })
 
   it('opens the new session mode picker for CMD+T events', () => {

--- a/src/components/chat/hooks/useChatWindowEvents.ts
+++ b/src/components/chat/hooks/useChatWindowEvents.ts
@@ -186,6 +186,46 @@ export function useChatWindowEvents({
     return () => window.removeEventListener('focus-chat-input', handler)
   }, [focusChatInput])
 
+  // After alt-tab back into Jean, re-focus the prompt when nothing else owns
+  // focus (terminal, dialogs, other inputs). Complements the global
+  // restore-keyboard-focus helper so prompt entry is ready without a click.
+  // Issue #577.
+  useEffect(() => {
+    if (isMobile) return
+
+    const onWindowFocus = () => {
+      if (
+        document.querySelector(
+          '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"], [role="menu"][data-state="open"], [role="listbox"][data-state="open"]'
+        )
+      ) {
+        return
+      }
+
+      const active = document.activeElement as HTMLElement | null
+      if (
+        active &&
+        active !== document.body &&
+        active !== document.documentElement &&
+        active !== inputRef.current &&
+        (active.tagName === 'INPUT' ||
+          active.tagName === 'TEXTAREA' ||
+          active.isContentEditable ||
+          !!active.closest('.xterm, [data-terminal-emulator]'))
+      ) {
+        // Another intentional target still has DOM focus — leave it, but
+        // re-assert so the webview re-attaches keyboard input.
+        active.focus({ preventScroll: true })
+        return
+      }
+
+      focusChatInput()
+    }
+
+    window.addEventListener('focus', onWindowFocus)
+    return () => window.removeEventListener('focus', onWindowFocus)
+  }, [focusChatInput, inputRef, isMobile])
+
   // P key: Open plan dialog
   useEffect(() => {
     const handler = () => {

--- a/src/components/chat/hooks/useChatWindowEvents.ts
+++ b/src/components/chat/hooks/useChatWindowEvents.ts
@@ -186,46 +186,6 @@ export function useChatWindowEvents({
     return () => window.removeEventListener('focus-chat-input', handler)
   }, [focusChatInput])
 
-  // After alt-tab back into Jean, re-focus the prompt when nothing else owns
-  // focus (terminal, dialogs, other inputs). Complements the global
-  // restore-keyboard-focus helper so prompt entry is ready without a click.
-  // Issue #577.
-  useEffect(() => {
-    if (isMobile) return
-
-    const onWindowFocus = () => {
-      if (
-        document.querySelector(
-          '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"], [role="menu"][data-state="open"], [role="listbox"][data-state="open"]'
-        )
-      ) {
-        return
-      }
-
-      const active = document.activeElement as HTMLElement | null
-      if (
-        active &&
-        active !== document.body &&
-        active !== document.documentElement &&
-        active !== inputRef.current &&
-        (active.tagName === 'INPUT' ||
-          active.tagName === 'TEXTAREA' ||
-          active.isContentEditable ||
-          !!active.closest('.xterm, [data-terminal-emulator]'))
-      ) {
-        // Another intentional target still has DOM focus — leave it, but
-        // re-assert so the webview re-attaches keyboard input.
-        active.focus({ preventScroll: true })
-        return
-      }
-
-      focusChatInput()
-    }
-
-    window.addEventListener('focus', onWindowFocus)
-    return () => window.removeEventListener('focus', onWindowFocus)
-  }, [focusChatInput, inputRef, isMobile])
-
   // P key: Open plan dialog
   useEffect(() => {
     const handler = () => {

--- a/src/hooks/useMainWindowEventListeners.test.tsx
+++ b/src/hooks/useMainWindowEventListeners.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
 import { useChatStore } from '@/store/chat-store'
 import { useTerminalStore } from '@/store/terminal-store'
 import { useUIStore } from '@/store/ui-store'
@@ -16,6 +17,7 @@ import {
   shouldAllowKeybindingThroughOpenOverlay,
   shouldLetPlanDialogHandleAction,
   switchActiveTerminalTabByIndexForShortcut,
+  useWindowKeyboardFocusRestore,
 } from './useMainWindowEventListeners'
 import { chatQueryKeys } from '@/services/chat'
 import { projectsQueryKeys } from '@/services/projects'
@@ -26,17 +28,32 @@ import type {
   WorktreeSessions,
 } from '@/types/chat'
 
-const { mockInvoke, mockListen, mockDisposeTerminal } = vi.hoisted(() => ({
-  mockInvoke: vi.fn().mockResolvedValue(undefined),
-  mockListen: vi.fn().mockResolvedValue(() => {
-    /* noop cleanup */
-  }),
-  mockDisposeTerminal: vi.fn(),
-}))
+const { mockInvoke, mockListen, mockDisposeTerminal, mockEnvironment } =
+  vi.hoisted(() => ({
+    mockInvoke: vi.fn().mockResolvedValue(undefined),
+    mockListen: vi.fn().mockResolvedValue(() => {
+      /* noop cleanup */
+    }),
+    mockDisposeTerminal: vi.fn(),
+    mockEnvironment: {
+      native: true,
+      mobile: false,
+    },
+  }))
 
 vi.mock('@/lib/transport', () => ({
   invoke: mockInvoke,
   listen: mockListen,
+  listenLocal: mockListen,
+}))
+
+vi.mock('@/lib/environment', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/environment')>()),
+  isNativeApp: () => mockEnvironment.native,
+}))
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => mockEnvironment.mobile,
 }))
 
 vi.mock('@/lib/terminal-instances', () => ({
@@ -75,6 +92,43 @@ function focusPlainSessionTerminal() {
   input.focus()
   return input
 }
+
+describe('useWindowKeyboardFocusRestore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockEnvironment.native = true
+    mockEnvironment.mobile = false
+    document.body.innerHTML = ''
+    document.body.tabIndex = -1
+    document.body.focus()
+  })
+
+  it.each([
+    ['mobile', true, true],
+    ['web', false, false],
+  ])(
+    'does not focus the chat input after %s activation',
+    (_, native, mobile) => {
+      mockEnvironment.native = native
+      mockEnvironment.mobile = mobile
+
+      const input = document.createElement('textarea')
+      document.body.appendChild(input)
+      const focusInput = () => input.focus()
+      window.addEventListener('focus-chat-input', focusInput)
+
+      const { unmount } = renderHook(() => useWindowKeyboardFocusRestore())
+      window.dispatchEvent(new Event('focus'))
+      vi.runAllTimers()
+
+      expect(document.activeElement).toBe(document.body)
+
+      unmount()
+      window.removeEventListener('focus-chat-input', focusInput)
+      vi.useRealTimers()
+    }
+  )
+})
 
 describe('useMainWindowEventListeners terminal shortcuts', () => {
   beforeEach(() => {
@@ -345,9 +399,9 @@ describe('useMainWindowEventListeners terminal shortcuts', () => {
       terminalId: 'term-running',
     })
     expect(mockDisposeTerminal).not.toHaveBeenCalled()
-    expect(useTerminalStore.getState().terminals['modal-worktree']).toHaveLength(
-      1
-    )
+    expect(
+      useTerminalStore.getState().terminals['modal-worktree']
+    ).toHaveLength(1)
 
     window.removeEventListener('confirm-close-terminal', confirmListener)
   })
@@ -523,7 +577,10 @@ describe('applySessionRenamedToCaches', () => {
       [...chatQueryKeys.sessions(worktreeId), 'with-counts'],
       sessions
     )
-    queryClient.setQueryData(chatQueryKeys.session(sessionId), sessions.sessions[0])
+    queryClient.setQueryData(
+      chatQueryKeys.session(sessionId),
+      sessions.sessions[0]
+    )
     queryClient.setQueryData<AllSessionsResponse>(['all-sessions'], {
       entries: [
         {

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -28,6 +28,7 @@ import {
   type KeybindingsMap,
 } from '@/types/keybindings'
 import { installWindowKeyboardFocusRestore } from '@/lib/restore-keyboard-focus'
+import { useIsMobile } from '@/hooks/use-mobile'
 
 const PLAN_DIALOG_APPROVAL_ACTIONS = new Set<KeybindingAction>([
   'approve_plan',
@@ -54,6 +55,15 @@ export function findKeybindingAction(
   }
 
   return null
+}
+
+export function useWindowKeyboardFocusRestore() {
+  const isMobile = useIsMobile()
+
+  useEffect(() => {
+    if (!isNativeApp() || isMobile) return
+    return installWindowKeyboardFocusRestore()
+  }, [isMobile])
 }
 
 /**
@@ -731,7 +741,7 @@ export function useMainWindowEventListeners() {
   // without keyboard focus until a click. Restore the last focused element
   // (or chat input / body) so typing and shortcuts like Ctrl/Cmd+L work again.
   // Issue #577.
-  useEffect(() => installWindowKeyboardFocusRestore(), [])
+  useWindowKeyboardFocusRestore()
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -27,6 +27,7 @@ import {
   type KeybindingAction,
   type KeybindingsMap,
 } from '@/types/keybindings'
+import { installWindowKeyboardFocusRestore } from '@/lib/restore-keyboard-focus'
 
 const PLAN_DIALOG_APPROVAL_ACTIONS = new Set<KeybindingAction>([
   'approve_plan',
@@ -726,6 +727,12 @@ export function useMainWindowEventListeners() {
     }
   }, [preferences?.keybindings])
 
+  // After alt-tab / OS window reactivation, WebViews often leave the document
+  // without keyboard focus until a click. Restore the last focused element
+  // (or chat input / body) so typing and shortcuts like Ctrl/Cmd+L work again.
+  // Issue #577.
+  useEffect(() => installWindowKeyboardFocusRestore(), [])
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Convert the keyboard event to our shortcut string format
@@ -964,7 +971,10 @@ export function useMainWindowEventListeners() {
             return
           }
           if (ui.isUpdateInstalling) {
-            commandContext.showToast('Update download already in progress', 'info')
+            commandContext.showToast(
+              'Update download already in progress',
+              'info'
+            )
             return
           }
           try {

--- a/src/lib/restore-keyboard-focus.test.ts
+++ b/src/lib/restore-keyboard-focus.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ensureBodyCanReceiveFocus,
+  hasFocusOwningOverlay,
+  installWindowKeyboardFocusRestore,
+  isMeaningfulFocusTarget,
+  restoreKeyboardFocusAfterWindowActivation,
+} from './restore-keyboard-focus'
+
+describe('restore-keyboard-focus', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    document.body.removeAttribute('tabindex')
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    document.body.removeAttribute('tabindex')
+  })
+
+  describe('isMeaningfulFocusTarget', () => {
+    it('rejects body and documentElement', () => {
+      expect(isMeaningfulFocusTarget(document.body)).toBe(false)
+      expect(isMeaningfulFocusTarget(document.documentElement)).toBe(false)
+      expect(isMeaningfulFocusTarget(null)).toBe(false)
+    })
+
+    it('accepts input elements', () => {
+      const input = document.createElement('textarea')
+      document.body.appendChild(input)
+      expect(isMeaningfulFocusTarget(input)).toBe(true)
+    })
+  })
+
+  describe('hasFocusOwningOverlay', () => {
+    it('detects open dialogs', () => {
+      const dialog = document.createElement('div')
+      dialog.setAttribute('role', 'dialog')
+      dialog.setAttribute('data-state', 'open')
+      document.body.appendChild(dialog)
+      expect(hasFocusOwningOverlay()).toBe(true)
+    })
+
+    it('is false when no overlay is open', () => {
+      expect(hasFocusOwningOverlay()).toBe(false)
+    })
+  })
+
+  describe('ensureBodyCanReceiveFocus', () => {
+    it('sets tabindex=-1 when missing', () => {
+      ensureBodyCanReceiveFocus()
+      expect(document.body.getAttribute('tabindex')).toBe('-1')
+    })
+
+    it('does not overwrite an existing tabindex', () => {
+      document.body.tabIndex = 0
+      ensureBodyCanReceiveFocus()
+      expect(document.body.tabIndex).toBe(0)
+    })
+  })
+
+  describe('restoreKeyboardFocusAfterWindowActivation', () => {
+    it('re-asserts focus on the current active element', () => {
+      const input = document.createElement('textarea')
+      document.body.appendChild(input)
+      input.focus()
+      const focusSpy = vi.spyOn(input, 'focus')
+
+      expect(restoreKeyboardFocusAfterWindowActivation(null)).toBe('active')
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+      expect(document.activeElement).toBe(input)
+    })
+
+    it('restores last focused element when activeElement is body', () => {
+      const input = document.createElement('textarea')
+      document.body.appendChild(input)
+      document.body.tabIndex = -1
+      document.body.focus()
+      expect(document.activeElement).toBe(document.body)
+
+      expect(restoreKeyboardFocusAfterWindowActivation(input)).toBe('last')
+      expect(document.activeElement).toBe(input)
+    })
+
+    it('dispatches focus-chat-input when nothing else can be restored', () => {
+      const handler = vi.fn()
+      window.addEventListener('focus-chat-input', handler)
+
+      // Simulate ChatWindow listener focusing a textarea
+      const input = document.createElement('textarea')
+      document.body.appendChild(input)
+      window.addEventListener('focus-chat-input', () => input.focus())
+
+      document.body.tabIndex = -1
+      document.body.focus()
+
+      expect(restoreKeyboardFocusAfterWindowActivation(null)).toBe('chat')
+      expect(handler).toHaveBeenCalled()
+      expect(document.activeElement).toBe(input)
+
+      window.removeEventListener('focus-chat-input', handler)
+    })
+
+    it('falls back to body when chat is not mounted', () => {
+      document.body.tabIndex = -1
+      // Ensure no meaningful focus
+      document.body.focus()
+
+      expect(restoreKeyboardFocusAfterWindowActivation(null)).toBe('body')
+      expect(document.activeElement).toBe(document.body)
+      expect(document.body.getAttribute('tabindex')).toBe('-1')
+    })
+
+    it('does not steal focus when a dialog is open', () => {
+      const dialog = document.createElement('div')
+      dialog.setAttribute('role', 'dialog')
+      dialog.setAttribute('data-state', 'open')
+      const dialogInput = document.createElement('input')
+      dialog.appendChild(dialogInput)
+      document.body.appendChild(dialog)
+      dialogInput.focus()
+
+      const outside = document.createElement('textarea')
+      document.body.appendChild(outside)
+
+      expect(restoreKeyboardFocusAfterWindowActivation(outside)).toBe('overlay')
+      expect(document.activeElement).toBe(dialogInput)
+    })
+
+    it('ignores lastFocused when it was removed from the document', () => {
+      const detached = document.createElement('textarea')
+      // never appended
+      const handler = vi.fn(() => {
+        /* no chat listener */
+      })
+      window.addEventListener('focus-chat-input', handler)
+
+      document.body.tabIndex = -1
+      document.body.focus()
+
+      expect(restoreKeyboardFocusAfterWindowActivation(detached)).toBe('body')
+      expect(handler).toHaveBeenCalled()
+
+      window.removeEventListener('focus-chat-input', handler)
+    })
+  })
+
+  describe('installWindowKeyboardFocusRestore', () => {
+    it('restores last focused element on window focus', () => {
+      vi.useFakeTimers()
+
+      const input = document.createElement('textarea')
+      document.body.appendChild(input)
+
+      const cleanup = installWindowKeyboardFocusRestore()
+      input.focus()
+
+      // Simulate alt-tab away: focus moves to body
+      document.body.tabIndex = -1
+      document.body.focus()
+      expect(document.activeElement).toBe(document.body)
+
+      // Simulate alt-tab back
+      window.dispatchEvent(new Event('focus'))
+      vi.runAllTimers()
+
+      expect(document.activeElement).toBe(input)
+
+      cleanup()
+      vi.useRealTimers()
+    })
+
+    it('cleans up listeners', () => {
+      const cleanup = installWindowKeyboardFocusRestore()
+      cleanup()
+
+      const input = document.createElement('textarea')
+      document.body.appendChild(input)
+      input.focus()
+
+      document.body.tabIndex = -1
+      document.body.focus()
+      window.dispatchEvent(new Event('focus'))
+
+      // Without the listener, focus stays on body
+      expect(document.activeElement).toBe(document.body)
+    })
+  })
+})

--- a/src/lib/restore-keyboard-focus.test.ts
+++ b/src/lib/restore-keyboard-focus.test.ts
@@ -119,11 +119,48 @@ describe('restore-keyboard-focus', () => {
       dialog.appendChild(dialogInput)
       document.body.appendChild(dialog)
       dialogInput.focus()
+      const focusSpy = vi.spyOn(dialogInput, 'focus')
 
       const outside = document.createElement('textarea')
       document.body.appendChild(outside)
 
       expect(restoreKeyboardFocusAfterWindowActivation(outside)).toBe('overlay')
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+      expect(document.activeElement).toBe(dialogInput)
+    })
+
+    it('re-asserts meaningful active focus when an overlay is open', () => {
+      const dialog = document.createElement('div')
+      dialog.setAttribute('role', 'dialog')
+      dialog.setAttribute('data-state', 'open')
+      document.body.appendChild(dialog)
+
+      const activeInput = document.createElement('input')
+      document.body.appendChild(activeInput)
+      activeInput.focus()
+      const focusSpy = vi.spyOn(activeInput, 'focus')
+      const chatFocusHandler = vi.fn()
+      window.addEventListener('focus-chat-input', chatFocusHandler)
+
+      expect(restoreKeyboardFocusAfterWindowActivation(null)).toBe('overlay')
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+      expect(chatFocusHandler).not.toHaveBeenCalled()
+      expect(document.activeElement).toBe(activeInput)
+
+      window.removeEventListener('focus-chat-input', chatFocusHandler)
+    })
+
+    it('focuses an overlay control when activeElement is body', () => {
+      const dialog = document.createElement('div')
+      dialog.setAttribute('role', 'dialog')
+      dialog.setAttribute('data-state', 'open')
+      const dialogInput = document.createElement('input')
+      dialog.appendChild(dialogInput)
+      document.body.appendChild(dialog)
+      document.body.tabIndex = -1
+      document.body.focus()
+
+      expect(restoreKeyboardFocusAfterWindowActivation(null)).toBe('overlay')
       expect(document.activeElement).toBe(dialogInput)
     })
 

--- a/src/lib/restore-keyboard-focus.test.ts
+++ b/src/lib/restore-keyboard-focus.test.ts
@@ -89,7 +89,8 @@ describe('restore-keyboard-focus', () => {
       // Simulate ChatWindow listener focusing a textarea
       const input = document.createElement('textarea')
       document.body.appendChild(input)
-      window.addEventListener('focus-chat-input', () => input.focus())
+      const chatListener = () => input.focus()
+      window.addEventListener('focus-chat-input', chatListener)
 
       document.body.tabIndex = -1
       document.body.focus()
@@ -99,6 +100,7 @@ describe('restore-keyboard-focus', () => {
       expect(document.activeElement).toBe(input)
 
       window.removeEventListener('focus-chat-input', handler)
+      window.removeEventListener('focus-chat-input', chatListener)
     })
 
     it('falls back to body when chat is not mounted', () => {

--- a/src/lib/restore-keyboard-focus.ts
+++ b/src/lib/restore-keyboard-focus.ts
@@ -15,12 +15,14 @@
  */
 
 const BODY_FOCUSABLE_TAB_INDEX = -1
+const FOCUS_OWNING_OVERLAY_SELECTOR =
+  '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"], [role="menu"][data-state="open"], [role="listbox"][data-state="open"]'
+const OVERLAY_FOCUSABLE_SELECTOR =
+  'input:not([disabled]), textarea:not([disabled]), select:not([disabled]), button:not([disabled]), a[href], [tabindex]'
 
 /** Whether an open overlay should own focus (do not steal). */
 export function hasFocusOwningOverlay(): boolean {
-  return !!document.querySelector(
-    '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"], [role="menu"][data-state="open"], [role="listbox"][data-state="open"]'
-  )
+  return !!document.querySelector(FOCUS_OWNING_OVERLAY_SELECTOR)
 }
 
 /** True when the active element can meaningfully receive keyboard input. */
@@ -54,11 +56,19 @@ export function ensureBodyCanReceiveFocus(): void {
 export function restoreKeyboardFocusAfterWindowActivation(
   lastFocused: HTMLElement | null
 ): 'active' | 'last' | 'chat' | 'body' | 'overlay' {
+  const active = document.activeElement
+
   if (hasFocusOwningOverlay()) {
+    if (isMeaningfulFocusTarget(active)) {
+      active.focus({ preventScroll: true })
+    } else {
+      document
+        .querySelector(FOCUS_OWNING_OVERLAY_SELECTOR)
+        ?.querySelector<HTMLElement>(OVERLAY_FOCUSABLE_SELECTOR)
+        ?.focus({ preventScroll: true })
+    }
     return 'overlay'
   }
-
-  const active = document.activeElement
 
   // Case 1: DOM still reports a real focus target (common after alt-tab).
   // Re-calling focus() re-attaches WebView keyboard input without moving caret.

--- a/src/lib/restore-keyboard-focus.ts
+++ b/src/lib/restore-keyboard-focus.ts
@@ -1,0 +1,141 @@
+/**
+ * Restore keyboard focus after the Jean window is re-activated (alt-tab, etc.).
+ *
+ * On some platforms (notably Windows WebView2), the OS focuses the window but
+ * the webview does not re-attach keyboard focus until a mouse click. That makes
+ * the chat prompt and global shortcuts (e.g. Ctrl/Cmd+L) appear broken.
+ *
+ * Strategy:
+ * 1. Track the last focused element via focusin
+ * 2. On window focus, re-assert focus on that element if still mounted
+ * 3. Otherwise prefer the chat input (via custom event) when present
+ * 4. Fall back to focusing <body> so capture-phase keybindings receive keys
+ *
+ * @see https://github.com/coollabsio/jean/issues/577
+ */
+
+const BODY_FOCUSABLE_TAB_INDEX = -1
+
+/** Whether an open overlay should own focus (do not steal). */
+export function hasFocusOwningOverlay(): boolean {
+  return !!document.querySelector(
+    '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"], [role="menu"][data-state="open"], [role="listbox"][data-state="open"]'
+  )
+}
+
+/** True when the active element can meaningfully receive keyboard input. */
+export function isMeaningfulFocusTarget(
+  element: Element | null
+): element is HTMLElement {
+  if (!(element instanceof HTMLElement)) return false
+  if (element === document.body || element === document.documentElement) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Ensure document.body can receive programmatic focus (needed for shortcut
+ * delivery when no input is focused).
+ */
+export function ensureBodyCanReceiveFocus(): void {
+  // Without an explicit tabindex, body.focus() is a no-op in some webviews.
+  if (!document.body.hasAttribute('tabindex')) {
+    document.body.tabIndex = BODY_FOCUSABLE_TAB_INDEX
+  }
+}
+
+/**
+ * Re-attach keyboard focus after the window becomes active.
+ *
+ * @param lastFocused - Element that last held focus (from focusin tracking)
+ * @returns which restore path was taken (for tests / diagnostics)
+ */
+export function restoreKeyboardFocusAfterWindowActivation(
+  lastFocused: HTMLElement | null
+): 'active' | 'last' | 'chat' | 'body' | 'overlay' {
+  if (hasFocusOwningOverlay()) {
+    return 'overlay'
+  }
+
+  const active = document.activeElement
+
+  // Case 1: DOM still reports a real focus target (common after alt-tab).
+  // Re-calling focus() re-attaches WebView keyboard input without moving caret.
+  if (isMeaningfulFocusTarget(active)) {
+    active.focus({ preventScroll: true })
+    return 'active'
+  }
+
+  // Case 2: Restore the last focused element if it is still in the document.
+  if (
+    lastFocused &&
+    document.contains(lastFocused) &&
+    isMeaningfulFocusTarget(lastFocused)
+  ) {
+    lastFocused.focus({ preventScroll: true })
+    if (isMeaningfulFocusTarget(document.activeElement)) {
+      return 'last'
+    }
+  }
+
+  // Case 3: Prefer chat prompt when ChatWindow is mounted.
+  window.dispatchEvent(new CustomEvent('focus-chat-input'))
+  if (isMeaningfulFocusTarget(document.activeElement)) {
+    return 'chat'
+  }
+
+  // Case 4: Focus body so document-level keybindings receive keydown events.
+  ensureBodyCanReceiveFocus()
+  document.body.focus({ preventScroll: true })
+  return 'body'
+}
+
+/**
+ * Install listeners that restore keyboard focus when the window is re-activated.
+ * Returns a cleanup function.
+ */
+export function installWindowKeyboardFocusRestore(): () => void {
+  let lastFocused: HTMLElement | null = null
+  let restoreFrame: number | null = null
+
+  const onFocusIn = (event: FocusEvent) => {
+    const target = event.target
+    if (!(target instanceof HTMLElement)) return
+    // Never treat body/html as a restore target — they are focus sinks
+    // used when the real control lost keyboard focus (alt-tab / blur).
+    if (target === document.body || target === document.documentElement) return
+    // Ignore ephemeral non-visible focus sinks
+    if (target.closest?.('.sr-only')) return
+    lastFocused = target
+  }
+
+  const onWindowFocus = () => {
+    if (restoreFrame !== null) {
+      cancelAnimationFrame(restoreFrame)
+    }
+    // Defer one frame so the browser finishes activation first.
+    restoreFrame = requestAnimationFrame(() => {
+      restoreFrame = null
+      restoreKeyboardFocusAfterWindowActivation(lastFocused)
+    })
+  }
+
+  // Seed from current focus if the app already has one.
+  if (isMeaningfulFocusTarget(document.activeElement)) {
+    lastFocused = document.activeElement
+  }
+
+  ensureBodyCanReceiveFocus()
+  document.addEventListener('focusin', onFocusIn)
+  window.addEventListener('focus', onWindowFocus)
+
+  return () => {
+    document.removeEventListener('focusin', onFocusIn)
+    window.removeEventListener('focus', onWindowFocus)
+    if (restoreFrame !== null) {
+      cancelAnimationFrame(restoreFrame)
+      restoreFrame = null
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Restore keyboard focus when Jean is re-activated after alt-tab or window switch, so the chat prompt and shortcuts like Ctrl/Cmd+L work without a mouse click
- Prefer the last focused control (or chat input), and avoid stealing focus from terminals, dialogs, menus, or other intentional inputs
- Add unit coverage for restore paths and chat window re-focus behavior

fixes #577

---

Fixes #577