### PR TITLE
fix(grok): surface rate limits and ACP errors

### DIFF
--- a/jean-core/src/chat/codex.rs
+++ b/jean-core/src/chat/codex.rs
@@ -735,10 +735,7 @@ pub fn apply_codex_provider_to_config(
         provider_entry.insert("wire_api".to_string(), serde_json::json!(wire));
     }
 
-    config.insert(
-        "model_provider".to_string(),
-        serde_json::json!(provider_id),
-    );
+    config.insert("model_provider".to_string(), serde_json::json!(provider_id));
     config.insert(
         "model_providers".to_string(),
         serde_json::json!({ provider_id: provider_entry }),
@@ -3247,9 +3244,7 @@ fn handle_approval_request(
                     .get("permissions")
                     .cloned()
                     .unwrap_or_else(|| serde_json::json!({}));
-                log::trace!(
-                    "Auto-granting permissions request in yolo mode (rpc_id={rpc_id})"
-                );
+                log::trace!("Auto-granting permissions request in yolo mode (rpc_id={rpc_id})");
                 if let Err(e) = super::codex_server::send_response(
                     rpc_id,
                     serde_json::json!({
@@ -3826,8 +3821,7 @@ fn process_codex_event(
                 | "entered_review_mode"
                 | "exited_review_mode" => {}
                 "plan" => {
-                    let tool_id =
-                        resolve_codex_plan_tool_id(tool_calls, None, Some(item_id));
+                    let tool_id = resolve_codex_plan_tool_id(tool_calls, None, Some(item_id));
                     let existing = tool_calls
                         .iter()
                         .find(|tc| tc.id == tool_id)
@@ -3928,8 +3922,7 @@ fn process_codex_event(
                     }
                 }
                 "plan" => {
-                    let tool_id =
-                        resolve_codex_plan_tool_id(tool_calls, None, Some(item_id));
+                    let tool_id = resolve_codex_plan_tool_id(tool_calls, None, Some(item_id));
                     let existing = tool_calls
                         .iter()
                         .find(|tc| tc.id == tool_id)
@@ -4628,8 +4621,7 @@ pub fn parse_codex_run_to_message(
                     }
                     // Informational items (web search, image tools) — history path
                     "web_search" | "image_generation" | "image_view" | "context_compaction" => {
-                        let tool_name =
-                            informational_tool_name(item_type).unwrap_or("CodexTool");
+                        let tool_name = informational_tool_name(item_type).unwrap_or("CodexTool");
                         let tool_id = if item_id.is_empty() {
                             Uuid::new_v4().to_string()
                         } else {
@@ -4861,8 +4853,7 @@ pub fn parse_codex_run_to_message(
                     "web_search" | "image_generation" | "image_view" | "context_compaction" => {
                         let input = informational_tool_input(item_type, item);
                         let output = informational_tool_output(item_type, item);
-                        let tool_name =
-                            informational_tool_name(item_type).unwrap_or("CodexTool");
+                        let tool_name = informational_tool_name(item_type).unwrap_or("CodexTool");
                         let tool_id = pending_tool_ids.remove(item_id).unwrap_or_else(|| {
                             if item_id.is_empty() {
                                 Uuid::new_v4().to_string()
@@ -5222,9 +5213,7 @@ fn build_one_shot_codex_args(
                 provider.name.trim()
             };
             args.push("-c".into());
-            args.push(
-                format!("model_providers.{provider_id}.name=\"{display_name}\"").into(),
-            );
+            args.push(format!("model_providers.{provider_id}.name=\"{display_name}\"").into());
             args.push("-c".into());
             args.push(
                 format!(
@@ -5250,9 +5239,7 @@ fn build_one_shot_codex_args(
                 .filter(|w| !w.is_empty())
             {
                 args.push("-c".into());
-                args.push(
-                    format!("model_providers.{provider_id}.wire_api=\"{wire}\"").into(),
-                );
+                args.push(format!("model_providers.{provider_id}.wire_api=\"{wire}\"").into());
             }
         }
     }
@@ -5710,7 +5697,8 @@ mod tests {
         let schema_file = std::path::Path::new("/tmp/jean-codex-schema.json");
         let working_dir = std::path::Path::new("/tmp/project");
 
-        let args = build_one_shot_codex_args("gpt-5.4", false, schema_file, Some(working_dir), None);
+        let args =
+            build_one_shot_codex_args("gpt-5.4", false, schema_file, Some(working_dir), None);
 
         assert!(args.windows(2).any(|window| {
             window
@@ -6043,9 +6031,13 @@ mod tests {
     #[test]
     fn codex_yolo_auto_approve_flag_tracks_session() {
         super::super::registry::set_codex_yolo_auto_approve("sess-328", true);
-        assert!(super::super::registry::is_codex_yolo_auto_approve("sess-328"));
+        assert!(super::super::registry::is_codex_yolo_auto_approve(
+            "sess-328"
+        ));
         super::super::registry::set_codex_yolo_auto_approve("sess-328", false);
-        assert!(!super::super::registry::is_codex_yolo_auto_approve("sess-328"));
+        assert!(!super::super::registry::is_codex_yolo_auto_approve(
+            "sess-328"
+        ));
     }
 
     #[test]
@@ -6259,7 +6251,11 @@ mod tests {
             .iter()
             .filter(|tool| tool.name == CODEX_PLAN_TOOL_NAME)
             .collect();
-        assert_eq!(plan_tools.len(), 1, "split plan tools should collapse to one");
+        assert_eq!(
+            plan_tools.len(),
+            1,
+            "split plan tools should collapse to one"
+        );
         let plan_tool = plan_tools[0];
         assert_eq!(
             plan_tool.input.get("plan").and_then(|v| v.as_str()),
@@ -6334,7 +6330,10 @@ mod tests {
         });
         let line = notification_to_history_line("item/completed", &params).expect("history line");
         let parsed: serde_json::Value = serde_json::from_str(&line).expect("json");
-        assert_eq!(parsed.get("turn_id").and_then(|v| v.as_str()), Some("turn-99"));
+        assert_eq!(
+            parsed.get("turn_id").and_then(|v| v.as_str()),
+            Some("turn-99")
+        );
         assert_eq!(
             parsed
                 .get("item")

--- a/jean-core/src/chat/codex_server.rs
+++ b/jean-core/src/chat/codex_server.rs
@@ -868,7 +868,13 @@ fn request_debug_summary(method: &str, params: &Value) -> Option<Value> {
             "approvalPolicy",
             "config",
         ],
-        "turn/start" => &["threadId", "effort", "cwd", "sandboxPolicy", "approvalPolicy"],
+        "turn/start" => &[
+            "threadId",
+            "effort",
+            "cwd",
+            "sandboxPolicy",
+            "approvalPolicy",
+        ],
         _ => return None,
     };
 

--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -34,6 +34,22 @@ use crate::projects::types::{SessionType, Worktree};
 const QUEUE_DEFAULT_ALLOWED_TOOLS: [&str; 4] = ["Bash(git:*)", "Read", "Glob", "Grep"];
 const IMAGE_ONLY_DEFAULT_PROMPT: &str = "Please check this image and tell me what is wrong.";
 const TEXT_ONLY_DEFAULT_PROMPT: &str = "Please check the attached text as reference.";
+
+fn resumed_grok_tail_error_event(
+    session_id: &str,
+    worktree_id: &str,
+    error: &str,
+) -> (&'static str, super::grok::ErrorEvent) {
+    (
+        "chat:error",
+        super::grok::ErrorEvent {
+            session_id: session_id.to_string(),
+            worktree_id: worktree_id.to_string(),
+            error: error.to_string(),
+        },
+    )
+}
+
 const CODEX_DEFAULT_NOT_PLAN_MODE_PROMPT: &str = "\
 ## Not Plan Mode
 
@@ -8037,7 +8053,12 @@ pub async fn resume_session(
                                 log::error!("Failed to mark Grok run as crashed: {e}");
                             }
                         }
-                        emit_done(&app_clone, &session_id_clone, &worktree_id_clone);
+                        let (event_name, event) = resumed_grok_tail_error_event(
+                            &session_id_clone,
+                            &worktree_id_clone,
+                            &e,
+                        );
+                        let _ = app_clone.emit_all(event_name, &event);
                         return;
                     }
                 };
@@ -9635,6 +9656,17 @@ pub async fn answer_opencode_question(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resumed_grok_host_error_uses_chat_error_event() {
+        let (event_name, event) =
+            resumed_grok_tail_error_event("session-1", "worktree-1", "rate limit reached");
+
+        assert_eq!(event_name, "chat:error");
+        assert_eq!(event.session_id, "session-1");
+        assert_eq!(event.worktree_id, "worktree-1");
+        assert_eq!(event.error, "rate limit reached");
+    }
 
     fn naming_test_worktree(branch: &str, base_branch: Option<&str>) -> Worktree {
         serde_json::from_value(serde_json::json!({

--- a/jean-core/src/chat/grok.rs
+++ b/jean-core/src/chat/grok.rs
@@ -1353,11 +1353,7 @@ fn inject_synthetic_plan(response: &mut GrokResponse) -> Option<String> {
             .to_string();
         // Enrich thin/empty plan bodies with full assistant plan text.
         if existing_plan.len() < plan_body.trim().len() {
-            if let Some(tool) = response
-                .tool_calls
-                .iter_mut()
-                .find(|tool| tool.id == id)
-            {
+            if let Some(tool) = response.tool_calls.iter_mut().find(|tool| tool.id == id) {
                 tool.input = serde_json::json!({
                     "source": "grok",
                     "plan": plan_body,
@@ -1371,9 +1367,9 @@ fn inject_synthetic_plan(response: &mut GrokResponse) -> Option<String> {
                 ContentBlock::ToolUse { tool_call_id } if tool_call_id == &id
             )
         });
-        response
-            .content_blocks
-            .push(ContentBlock::ToolUse { tool_call_id: id.clone() });
+        response.content_blocks.push(ContentBlock::ToolUse {
+            tool_call_id: id.clone(),
+        });
         return Some(id);
     }
 
@@ -1388,9 +1384,9 @@ fn inject_synthetic_plan(response: &mut GrokResponse) -> Option<String> {
         output: None,
         parent_tool_use_id: None,
     });
-    response
-        .content_blocks
-        .push(ContentBlock::ToolUse { tool_call_id: id.clone() });
+    response.content_blocks.push(ContentBlock::ToolUse {
+        tool_call_id: id.clone(),
+    });
     Some(id)
 }
 
@@ -1723,7 +1719,12 @@ fn grok_line_is_completion_result(line: &str) -> bool {
 fn grok_line_is_error_marker(line: &str) -> bool {
     serde_json::from_str::<Value>(line)
         .ok()
-        .and_then(|value| value.get("type").and_then(Value::as_str).map(str::to_string))
+        .and_then(|value| {
+            value
+                .get("type")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
         .is_some_and(|event_type| event_type == "error")
 }
 
@@ -1755,22 +1756,29 @@ pub(crate) fn extract_grok_error_message(error: &Value) -> String {
         let message = message.trim();
         if message.is_empty() {
             // fall through
-        } else if let Some(data) = error.get("data") {
-            let data_str = if let Some(s) = data.as_str() {
-                s.trim().to_string()
-            } else if let Some(s) = data.get("message").and_then(Value::as_str) {
-                s.trim().to_string()
-            } else if data.is_null() {
-                String::new()
-            } else {
-                data.to_string()
-            };
-            if !data_str.is_empty() && data_str != "null" {
-                return format!("{message}: {data_str}");
-            }
-            return message.to_string();
         } else {
-            return message.to_string();
+            let message = if let Some(data) = error.get("data") {
+                let data_str = if let Some(s) = data.as_str() {
+                    s.trim().to_string()
+                } else if let Some(s) = data.get("message").and_then(Value::as_str) {
+                    s.trim().to_string()
+                } else if data.is_null() {
+                    String::new()
+                } else {
+                    data.to_string()
+                };
+                if !data_str.is_empty() && data_str != "null" {
+                    format!("{message}: {data_str}")
+                } else {
+                    message.to_string()
+                }
+            } else {
+                message.to_string()
+            };
+            if let Some(code) = error.get("code").and_then(Value::as_i64) {
+                return format!("[{code}] {message}");
+            }
+            return message;
         }
     }
 
@@ -1788,6 +1796,12 @@ pub(crate) fn format_grok_user_error(raw: &str) -> String {
     if trimmed.is_empty() {
         return "Grok error: unknown failure".to_string();
     }
+    if trimmed.starts_with("Grok rate/usage limit reached")
+        || trimmed.starts_with("Grok authentication failed")
+        || trimmed.starts_with("Grok error:")
+    {
+        return trimmed.to_string();
+    }
     let lower = trimmed.to_ascii_lowercase();
 
     let is_rate_or_quota = lower.contains("rate limit")
@@ -1803,6 +1817,7 @@ pub(crate) fn format_grok_user_error(raw: &str) -> String {
         || lower.contains("\"code\":429")
         || lower.contains("status code 429")
         || lower.contains(" http 429")
+        || lower.starts_with("[429]")
         || lower.starts_with("429 ")
         || lower.contains(" 429 ");
 
@@ -1841,10 +1856,7 @@ pub(crate) fn format_grok_user_error(raw: &str) -> String {
 ///
 /// On success: `{"type":"result",…}`. On JSON-RPC prompt failure: `{"type":"error",…}`.
 /// Never both — writing both caused empty completed runs (#580).
-pub(crate) fn grok_host_terminal_marker(
-    session_id: &str,
-    prompt_error: Option<&Value>,
-) -> Value {
+pub(crate) fn grok_host_terminal_marker(session_id: &str, prompt_error: Option<&Value>) -> Value {
     match prompt_error {
         Some(error) => serde_json::json!({
             "type": "error",
@@ -2731,12 +2743,15 @@ pub(crate) fn parse_grok_run_to_message(
     response.content = response.content.trim().to_string();
     // Surface host-recorded failures (rate limit / auth / JSON-RPC) so history
     // does not collapse into the empty "content was not captured" placeholder.
-    if response.content.is_empty() {
-        if let Some(err) = response.error.as_deref() {
-            let formatted = format_grok_user_error(err);
-            push_text_block(&mut response.content_blocks, &formatted);
-            response.content = formatted;
-        }
+    if let Some(err) = response.error.as_deref() {
+        let formatted = format_grok_user_error(err);
+        let error_text = if response.content.is_empty() {
+            formatted
+        } else {
+            format!("\n\n{formatted}")
+        };
+        push_text_block(&mut response.content_blocks, &error_text);
+        response.content.push_str(&error_text);
     }
     Ok(ChatMessage {
         id: run
@@ -4289,9 +4304,7 @@ fn extract_json_object(text: &str) -> Result<String, String> {
                 .and_then(Value::as_str)
                 .filter(|s| !s.trim().is_empty())
             {
-                return Err(format!(
-                    "Grok structured output failed: {err} ({last_err})"
-                ));
+                return Err(format!("Grok structured output failed: {err} ({last_err})"));
             }
 
             return Err(last_err);
@@ -4347,9 +4360,7 @@ fn build_one_shot_grok_cli_args(
         "--sandbox".to_string(),
         "read-only".to_string(),
         "--model".to_string(),
-        raw_grok_model(Some(model))
-            .unwrap_or(model)
-            .to_string(),
+        raw_grok_model(Some(model)).unwrap_or(model).to_string(),
     ];
     // Prefer native constrained decoding when a schema is available. Implies
     // --output-format json and populates structuredOutput on success.
@@ -4518,9 +4529,13 @@ mod tests {
         assert!(args.contains(&"--prompt-file".to_string()));
         let prompt_file_idx = args.iter().position(|a| a == "--prompt-file").unwrap();
         assert_eq!(args[prompt_file_idx + 1], "/tmp/jean-prompt.txt");
-        assert!(!args.iter().any(|a| a == "-p" || a == "--prompt" || a == "--single"));
+        assert!(!args
+            .iter()
+            .any(|a| a == "-p" || a == "--prompt" || a == "--single"));
         // Prompt body must not appear as an argv entry.
-        assert!(!args.iter().any(|a| a.contains("diff --git") || a.len() > 10_000));
+        assert!(!args
+            .iter()
+            .any(|a| a.contains("diff --git") || a.len() > 10_000));
         assert!(args.contains(&"--json-schema".to_string()));
         assert!(args.contains(&"--effort".to_string()));
         assert!(args.contains(&"high".to_string()));
@@ -4529,8 +4544,7 @@ mod tests {
 
     #[test]
     fn one_shot_cli_args_without_schema_use_json_output() {
-        let args =
-            build_one_shot_grok_cli_args("/tmp/p.txt", ".", "grok-build", None, None);
+        let args = build_one_shot_grok_cli_args("/tmp/p.txt", ".", "grok-build", None, None);
         assert!(args.contains(&"--output-format".to_string()));
         assert!(args.contains(&"json".to_string()));
         assert!(!args.iter().any(|a| a == "--json-schema"));
@@ -4850,7 +4864,10 @@ Integrate Hermes as a first-class Jean AI backend with profile support.
         assert_eq!(response.tool_calls.len(), 1);
         assert_eq!(response.tool_calls[0].name, "ExitPlanMode");
         assert_eq!(
-            response.tool_calls[0].input.get("plan").and_then(|v| v.as_str()),
+            response.tool_calls[0]
+                .input
+                .get("plan")
+                .and_then(|v| v.as_str()),
             Some(plan)
         );
     }
@@ -4901,7 +4918,10 @@ Ship the feature end-to-end with tests and clear handoff notes for YOLO.
         assert_eq!(plan_id, "existing-plan");
         assert_eq!(response.tool_calls.len(), 1);
         assert_eq!(
-            response.tool_calls[0].input.get("plan").and_then(|v| v.as_str()),
+            response.tool_calls[0]
+                .input
+                .get("plan")
+                .and_then(|v| v.as_str()),
             Some(plan)
         );
         // Plan tool_use is last so mid-turn text stays between research tools and plan.
@@ -4978,10 +4998,38 @@ Ship the feature end-to-end with tests and clear handoff notes for YOLO.
     }
 
     #[test]
+    fn extract_and_format_grok_rate_limit_from_json_rpc_code() {
+        let rpc = serde_json::json!({
+            "code": 429,
+            "message": "Please slow down"
+        });
+        let raw = extract_grok_error_message(&rpc);
+        assert!(raw.contains("429"));
+
+        let formatted = format_grok_user_error(&raw);
+        assert!(
+            formatted.contains("rate/usage limit"),
+            "expected friendly rate-limit copy, got: {formatted}"
+        );
+    }
+
+    #[test]
     fn format_grok_user_error_auth_guidance() {
         let formatted = format_grok_user_error("Run `grok login` first, or set XAI_API_KEY.");
         assert!(formatted.contains("authentication failed"));
         assert!(formatted.contains("grok login"));
+    }
+
+    #[test]
+    fn format_grok_user_error_is_idempotent() {
+        for raw in [
+            "Rate limit exceeded",
+            "Run `grok login` first",
+            "Unexpected Grok failure",
+        ] {
+            let formatted = format_grok_user_error(raw);
+            assert_eq!(format_grok_user_error(&formatted), formatted);
+        }
     }
 
     #[test]
@@ -4995,7 +5043,10 @@ Ship the feature end-to-end with tests and clear handoff notes for YOLO.
         let err = grok_host_terminal_marker("sess-2", Some(&err_payload));
         assert_eq!(err.get("type").and_then(Value::as_str), Some("error"));
         assert_eq!(err.get("error"), Some(&err_payload));
-        assert_eq!(err.get("session_id").and_then(Value::as_str), Some("sess-2"));
+        assert_eq!(
+            err.get("session_id").and_then(Value::as_str),
+            Some("sess-2")
+        );
     }
 
     #[test]
@@ -5018,6 +5069,7 @@ Ship the feature end-to-end with tests and clear handoff notes for YOLO.
     fn parse_grok_run_to_message_surfaces_rate_limit_error() {
         let lines = vec![
             r#"{"type":"session","session_id":"grok-hist-err"}"#.to_string(),
+            r#"{"type":"assistant","delta":"Partial reply before failure."}"#.to_string(),
             r#"{"type":"error","error":{"code":-32000,"message":"Rate limit exceeded"},"session_id":"grok-hist-err"}"#.to_string(),
         ];
         let run = RunEntry {
@@ -5046,6 +5098,7 @@ Ship the feature end-to-end with tests and clear handoff notes for YOLO.
             kimi_session_id: None,
         };
         let message = parse_grok_run_to_message(&lines, &run).unwrap();
+        assert!(message.content.contains("Partial reply before failure."));
         assert!(
             message.content.contains("rate/usage limit")
                 || message.content.to_ascii_lowercase().contains("rate limit"),
@@ -5138,7 +5191,13 @@ Ship the feature end-to-end with tests and clear handoff notes for YOLO.
             value.get("summary").and_then(Value::as_str),
             Some("Looks good")
         );
-        assert_eq!(value.get("findings").and_then(Value::as_array).map(|a| a.len()), Some(0));
+        assert_eq!(
+            value
+                .get("findings")
+                .and_then(Value::as_array)
+                .map(|a| a.len()),
+            Some(0)
+        );
     }
 
     #[test]

--- a/jean-core/src/chat/grok.rs
+++ b/jean-core/src/chat/grok.rs
@@ -73,6 +73,9 @@ pub struct GrokResponse {
     pub content_blocks: Vec<ContentBlock>,
     pub cancelled: bool,
     pub usage: Option<UsageData>,
+    /// Host/stream-recorded failure (rate limit, auth, JSON-RPC error, …).
+    /// When set, the turn must surface `chat:error` instead of completing empty.
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -1102,6 +1105,7 @@ where
     let mut tool_calls = Vec::new();
     let mut session_id = initial_session_id.unwrap_or_default().to_string();
     let mut usage = None;
+    let mut error: Option<String> = None;
 
     for line in reader.lines() {
         let raw_line = line.map_err(|e| format!("Failed to read Grok CLI output: {e}"))?;
@@ -1131,6 +1135,23 @@ where
                 content_blocks.push(ContentBlock::UserInput {
                     text: text.to_string(),
                 });
+            }
+            continue;
+        }
+
+        // Host terminal error marker from ACP prompt JSON-RPC failure (#580).
+        // Capture and keep scanning so a legacy trailing `type:result` does not
+        // wipe the failure — callers treat `error` as fatal.
+        if parsed.get("type").and_then(Value::as_str) == Some("error") {
+            if let Some(err) = parsed.get("error") {
+                error = Some(extract_grok_error_message(err));
+            } else {
+                error = Some("Unknown Grok error".to_string());
+            }
+            if let Some(sid) = parsed.get("session_id").and_then(Value::as_str) {
+                if !sid.is_empty() {
+                    session_id = sid.to_string();
+                }
             }
             continue;
         }
@@ -1252,6 +1273,7 @@ where
         content_blocks,
         cancelled: false,
         usage,
+        error,
     })
 }
 
@@ -1695,6 +1717,145 @@ fn grok_line_is_completion_result(line: &str) -> bool {
                 .map(str::to_string)
         })
         .is_some_and(|event_type| event_type == "result" || event_type == "complete")
+}
+
+/// True when a host JSONL line is a terminal `type: "error"` marker.
+fn grok_line_is_error_marker(line: &str) -> bool {
+    serde_json::from_str::<Value>(line)
+        .ok()
+        .and_then(|value| value.get("type").and_then(Value::as_str).map(str::to_string))
+        .is_some_and(|event_type| event_type == "error")
+}
+
+/// Extract a human-readable message from a Grok/ACP error payload.
+///
+/// Handles:
+/// - string: `"message"`
+/// - JSON-RPC object: `{"code":…,"message":"…","data":…}`
+/// - nested: `{"error":{"message":"…"}}`
+pub(crate) fn extract_grok_error_message(error: &Value) -> String {
+    if let Some(s) = error.as_str() {
+        let trimmed = s.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+
+    // Nested `error` wrapper (host may re-nest JSON-RPC payloads).
+    if let Some(inner) = error.get("error") {
+        if inner.as_object().is_some() || inner.as_str().is_some() {
+            let nested = extract_grok_error_message(inner);
+            if !nested.is_empty() && nested != "null" {
+                return nested;
+            }
+        }
+    }
+
+    if let Some(message) = error.get("message").and_then(Value::as_str) {
+        let message = message.trim();
+        if message.is_empty() {
+            // fall through
+        } else if let Some(data) = error.get("data") {
+            let data_str = if let Some(s) = data.as_str() {
+                s.trim().to_string()
+            } else if let Some(s) = data.get("message").and_then(Value::as_str) {
+                s.trim().to_string()
+            } else if data.is_null() {
+                String::new()
+            } else {
+                data.to_string()
+            };
+            if !data_str.is_empty() && data_str != "null" {
+                return format!("{message}: {data_str}");
+            }
+            return message.to_string();
+        } else {
+            return message.to_string();
+        }
+    }
+
+    let rendered = error.to_string();
+    if rendered == "null" || rendered.is_empty() {
+        "Unknown Grok error".to_string()
+    } else {
+        rendered
+    }
+}
+
+/// Format a raw Grok error into a user-facing string (rate limit, auth, generic).
+pub(crate) fn format_grok_user_error(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return "Grok error: unknown failure".to_string();
+    }
+    let lower = trimmed.to_ascii_lowercase();
+
+    let is_rate_or_quota = lower.contains("rate limit")
+        || lower.contains("ratelimit")
+        || lower.contains("rate_limit")
+        || lower.contains("too many requests")
+        || lower.contains("resource_exhausted")
+        || lower.contains("resource exhausted")
+        || lower.contains("quota")
+        || lower.contains("usage limit")
+        || lower.contains("limit exceeded")
+        || lower.contains("limit reached")
+        || lower.contains("\"code\":429")
+        || lower.contains("status code 429")
+        || lower.contains(" http 429")
+        || lower.starts_with("429 ")
+        || lower.contains(" 429 ");
+
+    if is_rate_or_quota {
+        return format!(
+            "Grok rate/usage limit reached. Wait for the limit to reset or check usage in Settings, then try again.\n\nDetails: {trimmed}"
+        );
+    }
+
+    let is_auth = lower.contains("not authenticated")
+        || lower.contains("unauthenticated")
+        || lower.contains("unauthorized")
+        || lower.contains("401 unauthorized")
+        || lower.contains("invalid api key")
+        || lower.contains("invalid_api_key")
+        || lower.contains("xai_api_key")
+        || lower.contains("run `grok login`")
+        || lower.contains("run grok login")
+        || lower.contains("please log in")
+        || lower.contains("please login");
+
+    if is_auth {
+        return format!(
+            "Grok authentication failed. Run `grok login` or set XAI_API_KEY in Settings.\n\nDetails: {trimmed}"
+        );
+    }
+
+    if trimmed.starts_with("Grok ") {
+        trimmed.to_string()
+    } else {
+        format!("Grok error: {trimmed}")
+    }
+}
+
+/// Build the single terminal host marker for a Grok ACP turn.
+///
+/// On success: `{"type":"result",…}`. On JSON-RPC prompt failure: `{"type":"error",…}`.
+/// Never both — writing both caused empty completed runs (#580).
+pub(crate) fn grok_host_terminal_marker(
+    session_id: &str,
+    prompt_error: Option<&Value>,
+) -> Value {
+    match prompt_error {
+        Some(error) => serde_json::json!({
+            "type": "error",
+            "error": error,
+            "session_id": session_id,
+        }),
+        None => serde_json::json!({
+            "type": "result",
+            "session_id": session_id,
+        }),
+    }
 }
 
 #[cfg(unix)]
@@ -2179,7 +2340,6 @@ pub fn run_grok_acp_host_from_args() -> Result<(), String> {
     )?;
 
     let mut line = String::new();
-    let mut completed = false;
     loop {
         if abort.load(Ordering::SeqCst) {
             break;
@@ -2239,26 +2399,17 @@ pub fn run_grok_acp_host_from_args() -> Result<(), String> {
             }
         }
         if value.get("id").and_then(Value::as_i64) == Some(prompt_request_id) {
-            if let Some(error) = value.get("error") {
-                let err_line = serde_json::json!({
-                    "type": "error",
-                    "error": error,
-                    "session_id": acp_session_id,
-                });
-                host_write_output_line(&output, &err_line.to_string())?;
-            }
-            completed = true;
+            // Write exactly one terminal marker: error OR result (never both).
+            // Writing both made Jean treat failed turns as empty completed runs (#580).
+            let prompt_error = value.get("error");
+            let marker = grok_host_terminal_marker(&acp_session_id, prompt_error);
+            host_write_output_line(&output, &marker.to_string())?;
             break;
         }
     }
 
-    if completed {
-        let result = serde_json::json!({
-            "type": "result",
-            "session_id": acp_session_id,
-        });
-        host_write_output_line(&output, &result.to_string())?;
-    }
+    // Abort/disconnect without a prompt response: no terminal marker (tail
+    // treats process death as cancel). Success/error markers are written above.
 
     stop.store(true, Ordering::SeqCst);
     let _ = UnixStream::connect(&socket_path);
@@ -2386,6 +2537,7 @@ pub fn tail_grok_output(
         content_blocks: Vec::new(),
         cancelled: false,
         usage: None,
+        error: None,
     };
     let started_at = Instant::now();
     let startup_timeout = Duration::from_secs(120);
@@ -2406,6 +2558,29 @@ pub fn tail_grok_output(
             if line.trim().is_empty() {
                 continue;
             }
+
+            // Fatal host error marker (rate limit, auth, JSON-RPC prompt failure).
+            // Fail the turn immediately — do not wait for a trailing result and
+            // never emit chat:done for empty "completed" runs (#580).
+            if grok_line_is_error_marker(&line) {
+                flush_coalesced_chunks(app, session_id, worktree_id, &mut chunk_coalescer);
+                let raw = serde_json::from_str::<Value>(line.trim())
+                    .ok()
+                    .and_then(|value| {
+                        if let Some(sid) = value.get("session_id").and_then(Value::as_str) {
+                            if !sid.is_empty() {
+                                response.session_id = sid.to_string();
+                            }
+                        }
+                        value.get("error").map(extract_grok_error_message)
+                    })
+                    .unwrap_or_else(|| "Grok ACP host failed".to_string());
+                let msg = format_grok_user_error(&raw);
+                response.error = Some(msg.clone());
+                log::warn!("[Grok tail] host error session={session_id}: {msg}");
+                return Err(msg);
+            }
+
             if grok_line_is_completion_result(&line) {
                 completed = true;
             }
@@ -2425,6 +2600,9 @@ pub fn tail_grok_output(
                     }
                     if let Some(usage) = partial.usage {
                         response.usage = Some(usage);
+                    }
+                    if let Some(err) = partial.error {
+                        response.error = Some(err);
                     }
                     // Preserve mid-turn steered prompts in block order. Live UI
                     // already gets `chat:steered` from steer_grok_turn; this keeps
@@ -2526,6 +2704,14 @@ pub fn tail_grok_output(
     flush_coalesced_chunks(app, session_id, worktree_id, &mut chunk_coalescer);
     response.cancelled = cancelled && !completed;
     response.content = response.content.trim().to_string();
+
+    // Legacy logs may still have type:error followed by type:result; prefer error.
+    if let Some(err) = response.error.take() {
+        let msg = format_grok_user_error(&err);
+        log::warn!("[Grok tail] turn ended with error session={session_id}: {msg}");
+        return Err(msg);
+    }
+
     if !response.cancelled {
         // Plan-mode synthetic tool injection happens in execute_grok after tail.
         // Pass authoritative content so the UI can replace any space-glued
@@ -2543,6 +2729,15 @@ pub(crate) fn parse_grok_run_to_message(
     let joined = lines.join("\n");
     let mut response = parse_grok_stream_inner(BufReader::new(joined.as_bytes()), None)?;
     response.content = response.content.trim().to_string();
+    // Surface host-recorded failures (rate limit / auth / JSON-RPC) so history
+    // does not collapse into the empty "content was not captured" placeholder.
+    if response.content.is_empty() {
+        if let Some(err) = response.error.as_deref() {
+            let formatted = format_grok_user_error(err);
+            push_text_block(&mut response.content_blocks, &formatted);
+            response.content = formatted;
+        }
+    }
     Ok(ChatMessage {
         id: run
             .assistant_message_id
@@ -3513,6 +3708,7 @@ fn send_grok_acp_prompt(
         content_blocks: Vec::new(),
         cancelled: false,
         usage: None,
+        error: None,
     };
     let mut chunk_coalescer = ChunkCoalescer::new();
     let mut line = String::new();
@@ -3639,7 +3835,8 @@ fn send_grok_acp_prompt(
         if value.get("id").and_then(Value::as_i64) == Some(prompt_request_id) {
             if let Some(error) = value.get("error") {
                 flush_coalesced_chunks(app, jean_session_id, worktree_id, &mut chunk_coalescer);
-                return Err(format!("Grok ACP prompt failed: {error}"));
+                let raw = extract_grok_error_message(error);
+                return Err(format_grok_user_error(&raw));
             }
             if response.usage.is_none() {
                 response.usage =
@@ -3773,6 +3970,7 @@ pub fn execute_grok(options: GrokExecutionOptions<'_>) -> Result<GrokResponse, S
                 content_blocks: vec![],
                 cancelled: true,
                 usage: None,
+                error: None,
             });
         }
 
@@ -3895,6 +4093,7 @@ pub fn execute_grok(options: GrokExecutionOptions<'_>) -> Result<GrokResponse, S
                 content_blocks: vec![],
                 cancelled: true,
                 usage: None,
+                error: None,
             });
         }
 
@@ -3927,17 +4126,19 @@ pub fn execute_grok(options: GrokExecutionOptions<'_>) -> Result<GrokResponse, S
                         content_blocks: vec![],
                         cancelled: true,
                         usage: None,
+                        error: None,
                     });
                 }
+                let user_error = format_grok_user_error(&error);
                 let _ = app.emit_all(
                     "chat:error",
                     &ErrorEvent {
                         session_id: jean_session_id.to_string(),
                         worktree_id: worktree_id.to_string(),
-                        error: error.clone(),
+                        error: user_error.clone(),
                     },
                 );
-                return Err(error);
+                return Err(user_error);
             }
         };
 
@@ -4612,6 +4813,7 @@ mod tests {
             content_blocks: vec![],
             cancelled: false,
             usage: None,
+            error: None,
         };
         assert!(inject_synthetic_plan(&mut response).is_none());
         assert!(response.tool_calls.is_empty());
@@ -4641,6 +4843,7 @@ Integrate Hermes as a first-class Jean AI backend with profile support.
             content_blocks: vec![],
             cancelled: false,
             usage: None,
+            error: None,
         };
         let plan_id = inject_synthetic_plan(&mut response).expect("plan tool");
         assert_eq!(plan_id, "grok-plan");
@@ -4692,6 +4895,7 @@ Ship the feature end-to-end with tests and clear handoff notes for YOLO.
             ],
             cancelled: false,
             usage: None,
+            error: None,
         };
         let plan_id = inject_synthetic_plan(&mut response).expect("plan tool");
         assert_eq!(plan_id, "existing-plan");
@@ -4721,6 +4925,134 @@ Ship the feature end-to-end with tests and clear handoff notes for YOLO.
         assert_eq!(response.content, "Hello from Grok");
         assert_eq!(response.session_id, "grok-session-1");
         assert_eq!(response.usage.unwrap().output_tokens, 4);
+        assert!(response.error.is_none());
+    }
+
+    #[test]
+    fn parse_grok_stream_captures_host_error_marker() {
+        // Host writes type:error when session/prompt returns a JSON-RPC error (#580).
+        let input = r#"
+{"type":"session","session_id":"grok-err-1"}
+{"type":"error","error":{"code":-32000,"message":"Rate limit exceeded","data":"retry after 60s"},"session_id":"grok-err-1"}
+"#;
+        let response = parse_grok_stream_inner(BufReader::new(input.as_bytes()), None).unwrap();
+        assert!(response.content.is_empty());
+        assert_eq!(response.session_id, "grok-err-1");
+        let err = response.error.expect("error captured");
+        assert!(err.to_ascii_lowercase().contains("rate limit"));
+        assert!(err.contains("retry after 60s"));
+    }
+
+    #[test]
+    fn parse_grok_stream_error_survives_legacy_trailing_result() {
+        // Old hosts wrote type:error then type:result — error must still win.
+        let input = r#"
+{"type":"error","error":"usage limit reached for this period","session_id":"s-legacy"}
+{"type":"result","session_id":"s-legacy"}
+"#;
+        let response = parse_grok_stream_inner(BufReader::new(input.as_bytes()), None).unwrap();
+        assert_eq!(
+            response.error.as_deref(),
+            Some("usage limit reached for this period")
+        );
+        assert!(response.content.is_empty());
+    }
+
+    #[test]
+    fn extract_and_format_grok_rate_limit_errors() {
+        let rpc = serde_json::json!({
+            "code": -32000,
+            "message": "Rate limit exceeded",
+            "data": {"message": "Too many requests"}
+        });
+        let raw = extract_grok_error_message(&rpc);
+        assert!(raw.contains("Rate limit exceeded"));
+        assert!(raw.contains("Too many requests"));
+
+        let formatted = format_grok_user_error(&raw);
+        assert!(
+            formatted.contains("rate/usage limit"),
+            "expected friendly rate-limit copy, got: {formatted}"
+        );
+        assert!(formatted.contains("Rate limit exceeded"));
+    }
+
+    #[test]
+    fn format_grok_user_error_auth_guidance() {
+        let formatted = format_grok_user_error("Run `grok login` first, or set XAI_API_KEY.");
+        assert!(formatted.contains("authentication failed"));
+        assert!(formatted.contains("grok login"));
+    }
+
+    #[test]
+    fn grok_host_terminal_marker_is_error_or_result_not_both() {
+        let ok = grok_host_terminal_marker("sess-1", None);
+        assert_eq!(ok.get("type").and_then(Value::as_str), Some("result"));
+        assert!(ok.get("error").is_none());
+        assert_eq!(ok.get("session_id").and_then(Value::as_str), Some("sess-1"));
+
+        let err_payload = serde_json::json!({"code": 429, "message": "rate limit"});
+        let err = grok_host_terminal_marker("sess-2", Some(&err_payload));
+        assert_eq!(err.get("type").and_then(Value::as_str), Some("error"));
+        assert_eq!(err.get("error"), Some(&err_payload));
+        assert_eq!(err.get("session_id").and_then(Value::as_str), Some("sess-2"));
+    }
+
+    #[test]
+    fn grok_line_classifiers_distinguish_error_and_result() {
+        assert!(grok_line_is_error_marker(
+            r#"{"type":"error","error":"nope","session_id":"s"}"#
+        ));
+        assert!(!grok_line_is_error_marker(
+            r#"{"type":"result","session_id":"s"}"#
+        ));
+        assert!(grok_line_is_completion_result(
+            r#"{"type":"result","session_id":"s"}"#
+        ));
+        assert!(!grok_line_is_completion_result(
+            r#"{"type":"error","error":"nope","session_id":"s"}"#
+        ));
+    }
+
+    #[test]
+    fn parse_grok_run_to_message_surfaces_rate_limit_error() {
+        let lines = vec![
+            r#"{"type":"session","session_id":"grok-hist-err"}"#.to_string(),
+            r#"{"type":"error","error":{"code":-32000,"message":"Rate limit exceeded"},"session_id":"grok-hist-err"}"#.to_string(),
+        ];
+        let run = RunEntry {
+            run_id: "run-err".to_string(),
+            user_message_id: "u-err".to_string(),
+            user_message: "hello grok".to_string(),
+            model: Some("grok-4.5".to_string()),
+            execution_mode: Some("plan".to_string()),
+            thinking_level: None,
+            effort_level: None,
+            backend: Some(super::super::types::Backend::Grok),
+            custom_profile_name: None,
+            started_at: 1,
+            ended_at: Some(2),
+            status: super::super::types::RunStatus::Completed,
+            assistant_message_id: Some("a-err".to_string()),
+            cancelled: false,
+            recovered: false,
+            claude_session_id: None,
+            pid: None,
+            usage: None,
+            codex_thread_id: None,
+            codex_turn_id: None,
+            cursor_chat_id: None,
+            grok_session_id: Some("grok-hist-err".to_string()),
+            kimi_session_id: None,
+        };
+        let message = parse_grok_run_to_message(&lines, &run).unwrap();
+        assert!(
+            message.content.contains("rate/usage limit")
+                || message.content.to_ascii_lowercase().contains("rate limit"),
+            "expected rate-limit message, got: {}",
+            message.content
+        );
+        assert!(!message.content.contains("not captured"));
     }
 
     #[test]

--- a/jean-core/src/chat/handoff.rs
+++ b/jean-core/src/chat/handoff.rs
@@ -254,11 +254,7 @@ pub(crate) fn format_handoff_history_from_runs(runs: &[RunEntry], max_chars: usi
         }
 
         if run.renders_assistant_message() {
-            let backend_note = run
-                .backend
-                .as_ref()
-                .map(backend_label)
-                .unwrap_or("unknown");
+            let backend_note = run.backend.as_ref().map(backend_label).unwrap_or("unknown");
             let model_note = run.model.as_deref().unwrap_or("unknown-model");
             let status_note = match run.status {
                 RunStatus::Completed => "completed",

--- a/jean-core/src/chat/naming.rs
+++ b/jean-core/src/chat/naming.rs
@@ -279,7 +279,8 @@ fn extract_text_from_stream_json(output: &str) -> Result<String, String> {
                                 text_content.push_str(text);
                             }
                         } else if block_type == Some("tool_use")
-                            && block.get("name").and_then(|n| n.as_str()) == Some("StructuredOutput")
+                            && block.get("name").and_then(|n| n.as_str())
+                                == Some("StructuredOutput")
                         {
                             if let Some(input) = block.get("input") {
                                 structured_json = Some(input.to_string());

--- a/jean-core/src/chat/registry.rs
+++ b/jean-core/src/chat/registry.rs
@@ -816,9 +816,7 @@ pub fn cancel_process(
             .remove(session_id)
             .is_some();
         if removed {
-            log::info!(
-                "[Registry] freed OpenCode cancel flag after cancel session={session_id}"
-            );
+            log::info!("[Registry] freed OpenCode cancel flag after cancel session={session_id}");
         }
 
         // Mark run as cancelled immediately (before HTTP call returns)

--- a/jean-core/src/chat/run_log.rs
+++ b/jean-core/src/chat/run_log.rs
@@ -2484,14 +2484,22 @@ pub fn jsonl_has_result_line(app: &tauri::AppHandle, session_id: &str, run_id: &
         BufReader::new(file)
     };
 
+    // Prefer error over result: legacy Grok ACP hosts wrote both, and salvaging
+    // those as completed produced empty "content was not captured" runs (#580).
+    let mut has_result = false;
+    let mut has_error = false;
     for line in reader.lines() {
         if let Ok(line) = line {
+            // Compact JSON from serde_json::json! uses no space after `:`.
+            if line.contains("\"type\":\"error\"") {
+                has_error = true;
+            }
             if line.contains("\"type\":\"result\"") {
-                return true;
+                has_result = true;
             }
         }
     }
-    false
+    has_result && !has_error
 }
 
 /// Extract the Claude session ID from a run's JSONL file.

--- a/jean-core/src/chat/run_log.rs
+++ b/jean-core/src/chat/run_log.rs
@@ -1351,7 +1351,9 @@ pub fn load_session_messages_window(
                             .unwrap_or_else(|| format!("missing-{}", run.run_id)),
                         session_id: session_id.to_string(),
                         role: MessageRole::Assistant,
-                        content: "*Assistant response unavailable (run log missing or unreadable).*".to_string(),
+                        content:
+                            "*Assistant response unavailable (run log missing or unreadable).*"
+                                .to_string(),
                         timestamp: run.ended_at.unwrap_or(run.started_at),
                         tool_calls: vec![],
                         content_blocks: vec![],
@@ -1401,7 +1403,8 @@ pub fn load_session_messages_window(
                             .unwrap_or_else(|| format!("unparsed-{}", run.run_id)),
                         session_id: session_id.to_string(),
                         role: MessageRole::Assistant,
-                        content: "*Assistant response unavailable (run log parse failed).*".to_string(),
+                        content: "*Assistant response unavailable (run log parse failed).*"
+                            .to_string(),
                         timestamp: run.ended_at.unwrap_or(run.started_at),
                         tool_calls: vec![],
                         content_blocks: vec![],

--- a/jean-core/src/codex_cli/commands.rs
+++ b/jean-core/src/codex_cli/commands.rs
@@ -1787,12 +1787,8 @@ pub async fn install_codex_cli(app: AppHandle, version: Option<String>) -> Resul
     #[cfg(windows)]
     for helper in &windows_helpers {
         let helper_path = cli_dir.join(&helper.file_name);
-        crate::platform::write_binary_file(&helper_path, &helper.bytes).map_err(|e| {
-            format!(
-                "Failed to write Codex helper '{}': {e}",
-                helper.file_name
-            )
-        })?;
+        crate::platform::write_binary_file(&helper_path, &helper.bytes)
+            .map_err(|e| format!("Failed to write Codex helper '{}': {e}", helper.file_name))?;
         log::info!(
             "Installed Codex Windows helper {} ({} bytes)",
             helper.file_name,

--- a/jean-core/src/codex_cli/config.rs
+++ b/jean-core/src/codex_cli/config.rs
@@ -85,8 +85,7 @@ fn jean_managed_path(app: &AppHandle) -> Result<PathBuf, String> {
     if wsl.enabled {
         return get_wsl_cli_binary_path(&wsl.distro).map(PathBuf::from);
     }
-    get_cli_binary_path(app)
-        .or_else(|_| Ok(PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME)))
+    get_cli_binary_path(app).or_else(|_| Ok(PathBuf::from(CLI_DIR_NAME).join(CLI_BINARY_NAME)))
 }
 
 /// Resolve Codex binary path based on the user's preference.

--- a/jean-core/src/http_server/dispatch.rs
+++ b/jean-core/src/http_server/dispatch.rs
@@ -3553,7 +3553,10 @@ mod tests {
             for (command, args) in [
                 ("open_worktree_in_finder", json!({ "worktreePath": "/tmp" })),
                 ("open_worktree_in_editor", json!({ "worktreePath": "/tmp" })),
-                ("open_worktree_in_terminal", json!({ "worktreePath": "/tmp" })),
+                (
+                    "open_worktree_in_terminal",
+                    json!({ "worktreePath": "/tmp" }),
+                ),
                 ("open_file_in_default_app", json!({ "path": "/tmp/file" })),
             ] {
                 let error = runtime

--- a/jean-core/src/jean_mcp_config.rs
+++ b/jean-core/src/jean_mcp_config.rs
@@ -389,12 +389,7 @@ fn install_grok(entry: &JeanMcpEntry) -> Result<(PathBuf, Option<PathBuf>), Stri
     // Grok also gates servers via top-level `disabled_mcp_servers`. Jean rewrites
     // that list during turns; clear our name on install so Grok TUI + discovery
     // don't keep Jean MCP hidden after a prior session disabled it.
-    install_toml_mcp_server(
-        home.join(".grok").join("config.toml"),
-        entry,
-        "Grok",
-        true,
-    )
+    install_toml_mcp_server(home.join(".grok").join("config.toml"), entry, "Grok", true)
 }
 
 fn install_toml_mcp_server(
@@ -1214,8 +1209,7 @@ installer = "npm"
         .unwrap();
 
         let prod = test_entry(JeanMcpInstallMode::Prod);
-        let (written, backup) =
-            install_toml_mcp_server(path.clone(), &prod, "Grok", true).unwrap();
+        let (written, backup) = install_toml_mcp_server(path.clone(), &prod, "Grok", true).unwrap();
         assert_eq!(written, path);
         assert!(backup.is_some());
 

--- a/jean-core/src/jean_mcp_core.rs
+++ b/jean-core/src/jean_mcp_core.rs
@@ -146,10 +146,7 @@ pub fn handle_protocol_message(
 
 pub fn tool_registry() -> Value {
     // Split into multiple json! arrays so the macro does not hit recursion_limit.
-    let mut tools = tool_registry_core()
-        .as_array()
-        .cloned()
-        .unwrap_or_default();
+    let mut tools = tool_registry_core().as_array().cloned().unwrap_or_default();
     if let Some(session) = tool_registry_session().as_array() {
         tools.extend(session.iter().cloned());
     }
@@ -268,8 +265,8 @@ async fn run_tool(
             .map_err(ToolError::internal),
         "add_project" => {
             let path = require_nonempty_str(&args, "path")?;
-            let parent_id = optional_str(&args, "parentId")
-                .or_else(|| optional_str(&args, "parent_id"));
+            let parent_id =
+                optional_str(&args, "parentId").or_else(|| optional_str(&args, "parent_id"));
             let mut payload = serde_json::Map::new();
             payload.insert("path".to_string(), Value::String(path));
             if let Some(parent_id) = parent_id {
@@ -282,8 +279,8 @@ async fn run_tool(
         "clone_project" => {
             let url = require_nonempty_str(&args, "url")?;
             let path = require_nonempty_str(&args, "path")?;
-            let parent_id = optional_str(&args, "parentId")
-                .or_else(|| optional_str(&args, "parent_id"));
+            let parent_id =
+                optional_str(&args, "parentId").or_else(|| optional_str(&args, "parent_id"));
             let mut payload = serde_json::Map::new();
             payload.insert("url".to_string(), Value::String(url));
             payload.insert("path".to_string(), Value::String(path));
@@ -296,8 +293,8 @@ async fn run_tool(
         }
         "init_project" => {
             let path = require_nonempty_str(&args, "path")?;
-            let parent_id = optional_str(&args, "parentId")
-                .or_else(|| optional_str(&args, "parent_id"));
+            let parent_id =
+                optional_str(&args, "parentId").or_else(|| optional_str(&args, "parent_id"));
             let mut payload = serde_json::Map::new();
             payload.insert("path".to_string(), Value::String(path));
             if let Some(parent_id) = parent_id {
@@ -456,8 +453,8 @@ async fn run_tool(
             .map_err(ToolError::internal)
         }
         "list_archived_worktrees" => {
-            let project_id = optional_str(&args, "projectId")
-                .or_else(|| optional_str(&args, "project_id"));
+            let project_id =
+                optional_str(&args, "projectId").or_else(|| optional_str(&args, "project_id"));
             let result = dispatch_command(app, "list_archived_worktrees", json!({}))
                 .await
                 .map_err(ToolError::internal)?;
@@ -484,13 +481,9 @@ async fn run_tool(
         }
         "delete_worktree" => {
             let worktree_id = require_str(&args, "worktreeId")?;
-            dispatch_command(
-                app,
-                "delete_worktree",
-                json!({ "worktreeId": worktree_id }),
-            )
-            .await
-            .map_err(ToolError::internal)?;
+            dispatch_command(app, "delete_worktree", json!({ "worktreeId": worktree_id }))
+                .await
+                .map_err(ToolError::internal)?;
             Ok(deletion_started_result(&worktree_id, "delete"))
         }
         "permanently_delete_worktree" => {
@@ -502,10 +495,7 @@ async fn run_tool(
             )
             .await
             .map_err(ToolError::internal)?;
-            Ok(deletion_started_result(
-                &worktree_id,
-                "permanently_delete",
-            ))
+            Ok(deletion_started_result(&worktree_id, "permanently_delete"))
         }
         "create_worktree" => {
             let project_id = require_str(&args, "projectId")?;
@@ -1170,8 +1160,8 @@ async fn run_tool(
             let worktree_id = require_str(&args, "worktreeId")?;
             ensure_mcp_worktree_not_archived(app, &worktree_id)?;
             let worktree_path = resolve_worktree_path(app, &worktree_id)?;
-            let session_id = optional_str(&args, "sessionId")
-                .or_else(|| optional_str(&args, "session_id"));
+            let session_id =
+                optional_str(&args, "sessionId").or_else(|| optional_str(&args, "session_id"));
             let custom_prompt = optional_str(&args, "customPrompt")
                 .or_else(|| optional_str(&args, "custom_prompt"));
             let model = optional_str(&args, "model");
@@ -1655,7 +1645,11 @@ pub(crate) fn apply_yolo_investigation_fix_directive(
     }
 
     let cleaned = strip_investigation_anti_fix_lines(message);
-    format!("{}\n\n{}\n", cleaned.trim_end(), YOLO_INVESTIGATION_FIX_APPEND)
+    format!(
+        "{}\n\n{}\n",
+        cleaned.trim_end(),
+        YOLO_INVESTIGATION_FIX_APPEND
+    )
 }
 
 fn strip_investigation_anti_fix_lines(prompt: &str) -> String {
@@ -2393,8 +2387,7 @@ mod tests {
         let tools = tool_registry();
         let create_worktree = find_tool(&tools, "create_worktree");
         assert_eq!(
-            create_worktree["inputSchema"]["properties"]["ghsaId"]["type"],
-            "string",
+            create_worktree["inputSchema"]["properties"]["ghsaId"]["type"], "string",
             "create_worktree must expose a ghsaId input for security advisories"
         );
         let description = create_worktree["description"].as_str().unwrap_or_default();
@@ -2403,7 +2396,8 @@ mod tests {
             "create_worktree description must document ghsaId"
         );
         assert!(
-            description.contains("security advisory") || description.contains("security advisories"),
+            description.contains("security advisory")
+                || description.contains("security advisories"),
             "create_worktree description must mention security advisories"
         );
     }
@@ -2501,8 +2495,7 @@ mod tests {
         let worktree = json!({
             "advisory_ghsa_id": "GHSA-xxxx-yyyy-zzzz",
         });
-        let prompt =
-            build_investigation_prompt(&prefs, &worktree, InvestigationKind::Advisory);
+        let prompt = build_investigation_prompt(&prefs, &worktree, InvestigationKind::Advisory);
         assert!(
             prompt.contains("GHSA-xxxx-yyyy-zzzz"),
             "advisory investigation prompt should include the GHSA id"
@@ -2668,15 +2661,9 @@ mod tests {
         }
 
         let archive = find_tool(&tools, "archive_session");
-        assert_eq!(
-            archive["inputSchema"]["required"],
-            json!(["sessionId"])
-        );
+        assert_eq!(archive["inputSchema"]["required"], json!(["sessionId"]));
         let unarchive = find_tool(&tools, "unarchive_session");
-        assert_eq!(
-            unarchive["inputSchema"]["required"],
-            json!(["sessionId"])
-        );
+        assert_eq!(unarchive["inputSchema"]["required"], json!(["sessionId"]));
         let send = find_tool(&tools, "send_chat_message");
         let send_desc = send["description"].as_str().unwrap_or("");
         assert!(
@@ -2781,15 +2768,10 @@ mod tests {
         );
 
         let create_pr = find_tool(&tools, "create_pull_request");
-        assert_eq!(
-            create_pr["inputSchema"]["required"],
-            json!(["worktreeId"])
-        );
-        assert!(
-            create_pr["inputSchema"]["properties"]
-                .get("sessionId")
-                .is_some()
-        );
+        assert_eq!(create_pr["inputSchema"]["required"], json!(["worktreeId"]));
+        assert!(create_pr["inputSchema"]["properties"]
+            .get("sessionId")
+            .is_some());
 
         for limited in [
             "create_commit",
@@ -2842,9 +2824,7 @@ mod tests {
 
         for name in ["delete_worktree", "permanently_delete_worktree"] {
             let tool = find_tool(&tools, name);
-            let description = tool["description"]
-                .as_str()
-                .expect("tool description");
+            let description = tool["description"].as_str().expect("tool description");
 
             assert!(description.contains("background"));
             assert!(description.contains("started"));
@@ -3052,8 +3032,12 @@ mod tests {
         let result = apply_yolo_investigation_fix_directive(prompt, "yolo");
         assert!(result.contains(YOLO_INVESTIGATION_FIX_MARKER));
         assert!(result.contains("After investigation, fix the issue"));
-        assert!(!result.to_ascii_lowercase().contains("if you are in yolo mode"));
-        assert!(!result.to_ascii_lowercase().contains("do not implement fixes"));
+        assert!(!result
+            .to_ascii_lowercase()
+            .contains("if you are in yolo mode"));
+        assert!(!result
+            .to_ascii_lowercase()
+            .contains("do not implement fixes"));
         assert!(result.contains("Propose solution"));
     }
 

--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -699,10 +699,7 @@ fn maybe_auto_select_system_coderabbit(
 /// Runtime `resolve_cli_binary` also falls back to PATH when Jean-managed is
 /// missing; this persists the source so the UI does not show a misleading
 /// "Jean" selection.
-fn maybe_auto_select_system_cli_sources(
-    app: &AppHandle,
-    preferences: &mut AppPreferences,
-) -> bool {
+fn maybe_auto_select_system_cli_sources(app: &AppHandle, preferences: &mut AppPreferences) -> bool {
     let mut changed = false;
 
     if preferences.claude_cli_source == "jean" && claude_cli::should_auto_use_system(app) {
@@ -868,7 +865,8 @@ mod tests {
 
         assert!(prompt.contains("backend-native interactive question UI"));
         assert!(prompt.contains("Codex request_user_input"));
-        assert!(prompt.contains("when the current execution mode is plan: do not write plan files or code"));
+        assert!(prompt
+            .contains("when the current execution mode is plan: do not write plan files or code"));
         assert!(prompt.contains("<proposed_plan>"));
         assert!(prompt.contains("Every Codex response that contains or revises a plan while the current execution mode is plan"));
         assert!(prompt.contains("Claude AskUserQuestion"));
@@ -992,11 +990,8 @@ mod tests {
 
     #[test]
     fn parse_cli_args_reads_allow_native_open_from_env_and_flag() {
-        let from_env = parse_cli_args_from(
-            ["jean", "--headless"],
-            [("JEAN_ALLOW_NATIVE_OPEN", "1")],
-        )
-        .unwrap();
+        let from_env =
+            parse_cli_args_from(["jean", "--headless"], [("JEAN_ALLOW_NATIVE_OPEN", "1")]).unwrap();
         assert!(from_env.allow_native_open);
 
         let from_flag = parse_cli_args_from(
@@ -1006,11 +1001,8 @@ mod tests {
         .unwrap();
         assert!(from_flag.allow_native_open);
 
-        let off = parse_cli_args_from(
-            ["jean", "--headless"],
-            std::iter::empty::<(&str, &str)>(),
-        )
-        .unwrap();
+        let off = parse_cli_args_from(["jean", "--headless"], std::iter::empty::<(&str, &str)>())
+            .unwrap();
         assert!(!off.allow_native_open);
     }
 
@@ -2559,23 +2551,26 @@ fn migrate_automation_magic_prompt_preferences(
 
     // GitHub bugs automation mirrors investigate_issue
     {
-        let backend_missing = backends_raw.is_none_or(|b| !b.contains_key("automate_github_bugs_backend"));
+        let backend_missing =
+            backends_raw.is_none_or(|b| !b.contains_key("automate_github_bugs_backend"));
         if backend_missing {
-            preferences.magic_prompt_backends.automate_github_bugs_backend =
-                preferences
-                    .magic_prompt_backends
-                    .investigate_issue_backend
-                    .clone();
+            preferences
+                .magic_prompt_backends
+                .automate_github_bugs_backend = preferences
+                .magic_prompt_backends
+                .investigate_issue_backend
+                .clone();
             changed = true;
         }
         let provider_missing =
             providers_raw.is_none_or(|p| !p.contains_key("automate_github_bugs_provider"));
         if provider_missing {
-            preferences.magic_prompt_providers.automate_github_bugs_provider =
-                preferences
-                    .magic_prompt_providers
-                    .investigate_issue_provider
-                    .clone();
+            preferences
+                .magic_prompt_providers
+                .automate_github_bugs_provider = preferences
+                .magic_prompt_providers
+                .investigate_issue_provider
+                .clone();
             changed = true;
         }
         let effort_missing =
@@ -2627,8 +2622,8 @@ fn migrate_automation_magic_prompt_preferences(
                 .clone();
             changed = true;
         }
-        let provider_missing = providers_raw
-            .is_none_or(|p| !p.contains_key("automate_security_advisories_provider"));
+        let provider_missing =
+            providers_raw.is_none_or(|p| !p.contains_key("automate_security_advisories_provider"));
         if provider_missing {
             preferences
                 .magic_prompt_providers
@@ -2661,7 +2656,9 @@ fn migrate_automation_magic_prompt_preferences(
             .unwrap_or(&preferences.default_backend);
         let investigate_model = &preferences.magic_prompt_models.investigate_advisory_model;
         let model_matches = magic_prompt_model_matches_backend(
-            &preferences.magic_prompt_models.automate_security_advisories_model,
+            &preferences
+                .magic_prompt_models
+                .automate_security_advisories_model,
             backend,
         );
         if model_missing || !model_matches {
@@ -4175,8 +4172,7 @@ where
     let mut no_token = env_truthy(env.get("JEAN_NO_TOKEN").map(String::as_str));
     let mut allow_unsafe_no_token =
         env_truthy(env.get("JEAN_ALLOW_UNSAFE_NO_TOKEN").map(String::as_str));
-    let mut allow_native_open =
-        env_truthy(env.get("JEAN_ALLOW_NATIVE_OPEN").map(String::as_str));
+    let mut allow_native_open = env_truthy(env.get("JEAN_ALLOW_NATIVE_OPEN").map(String::as_str));
     let mut host = env
         .get("JEAN_HOST")
         .map(|h| h.trim().to_string())
@@ -4247,11 +4243,7 @@ where
     }
 
     if !headless
-        && (host.is_some()
-            || port.is_some()
-            || token.is_some()
-            || no_token
-            || allow_native_open)
+        && (host.is_some() || port.is_some() || token.is_some() || no_token || allow_native_open)
     {
         eprintln!(
             "Warning: --host, --port, --token, --no-token, --allow-native-open are only effective with --headless"

--- a/jean-core/src/projects/commands.rs
+++ b/jean-core/src/projects/commands.rs
@@ -12164,8 +12164,7 @@ pub async fn fetch_worktrees_status(app: AppHandle, project_id: String) -> Resul
                 }
             };
 
-            let base_branch =
-                resolve_worktree_status_base(&worktree, &project_default_branch);
+            let base_branch = resolve_worktree_status_base(&worktree, &project_default_branch);
 
             let info = ActiveWorktreeInfo {
                 worktree_id: worktree.id.clone(),
@@ -13080,7 +13079,8 @@ mod tests {
         );
 
         let other = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
-        assert!(format_open_error("vscodium", &other).starts_with("Failed to open VSCodium ('codium'):"));
+        assert!(format_open_error("vscodium", &other)
+            .starts_with("Failed to open VSCodium ('codium'):"));
     }
 
     #[test]

--- a/jean-core/src/projects/git.rs
+++ b/jean-core/src/projects/git.rs
@@ -2761,12 +2761,14 @@ mod tests {
 
     #[test]
     fn strip_non_tty_shell_noise_removes_bash_job_control_messages() {
-        let noisy = "bash: cannot set terminal process group (346967): Inappropriate ioctl for device\n\
+        let noisy =
+            "bash: cannot set terminal process group (346967): Inappropriate ioctl for device\n\
                      bash: no job control in this shell\n\
                      copied .env";
         assert_eq!(strip_non_tty_shell_noise(noisy), "copied .env");
 
-        let only_noise = "bash: cannot set terminal process group (1): Inappropriate ioctl for device\n\
+        let only_noise =
+            "bash: cannot set terminal process group (1): Inappropriate ioctl for device\n\
                           bash: no job control in this shell\n";
         assert_eq!(strip_non_tty_shell_noise(only_noise), "");
 

--- a/jean-core/src/projects/git_status.rs
+++ b/jean-core/src/projects/git_status.rs
@@ -379,7 +379,11 @@ pub fn base_ref(base_remote: Option<&str>, base_branch: &str) -> String {
 }
 
 /// Get the number of lines added and removed compared to the base branch
-fn get_branch_diff_stats(repo_path: &str, base_branch: &str, base_remote: Option<&str>) -> (u32, u32) {
+fn get_branch_diff_stats(
+    repo_path: &str,
+    base_branch: &str,
+    base_remote: Option<&str>,
+) -> (u32, u32) {
     // git diff --numstat <remote>/main...HEAD shows changes in current branch vs base
     let origin_ref = base_ref(base_remote, base_branch);
     let output = wsl_aware_command("git", Some(Path::new(repo_path)))

--- a/jean-core/src/server_update/mod.rs
+++ b/jean-core/src/server_update/mod.rs
@@ -164,9 +164,7 @@ async fn check_desktop_host_update() -> Result<ServerUpdateStatus, String> {
         // Install is performed by the native shell via host:install-desktop-update.
         can_update: available,
         reason: if available {
-            Some(
-                "Install runs on the host Jean desktop app (native updater)".to_string(),
-            )
+            Some("Install runs on the host Jean desktop app (native updater)".to_string())
         } else {
             None
         },


### PR DESCRIPTION
## Summary

- Fix Grok turns that failed with rate limits, auth errors, or JSON-RPC prompt failures completing as empty runs instead of showing an error
- Write a single host terminal marker (`error` or `result`, never both) so failed ACP prompts are not salvaged as successful completions
- Parse and format user-facing messages for rate/usage limits and authentication failures, and surface them via `chat:error`
- Prefer error markers over result lines when recovering run history so legacy dual-marker logs no longer produce “content was not captured”

fixes #580

---

Fixes #580