### PR TITLE
fix(opencode): surface child errors and stop POST retries

### DIFF
--- a/jean-core/src/chat/opencode.rs
+++ b/jean-core/src/chat/opencode.rs
@@ -5,7 +5,7 @@ use crate::http_server::EmitExt;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use once_cell::sync::Lazy;
 use regex::Regex;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -342,6 +342,10 @@ fn clear_listener_cooldown(state: &SharedSseListenerState) {
 struct SharedSseCoordinator {
     subscribers: Arc<Mutex<HashMap<String, SharedSseSubscriberEntry>>>,
     listeners: Arc<Mutex<HashMap<String, SharedSseListenerState>>>,
+    /// Maps descendant OpenCode session IDs (subagents/children) to a known
+    /// ancestor ID. Walked until a registered primary-session subscriber is found
+    /// so child `session.error` events fail the owning Jean run.
+    session_parents: Arc<Mutex<HashMap<String, String>>>,
 }
 
 impl Default for SharedSseCoordinator {
@@ -349,6 +353,7 @@ impl Default for SharedSseCoordinator {
         Self {
             subscribers: Arc::new(Mutex::new(HashMap::new())),
             listeners: Arc::new(Mutex::new(HashMap::new())),
+            session_parents: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -461,6 +466,12 @@ impl Drop for SharedSseSubscription {
                 subscribers.len()
             );
         }
+        // Drop parent-chain entries that point at (or are) this root so a later
+        // session never inherits a stale child→parent mapping.
+        let mut parents = lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS");
+        parents.retain(|child, parent| {
+            child != &self.opencode_session_id && parent != &self.opencode_session_id
+        });
     }
 }
 
@@ -1125,9 +1136,63 @@ fn extract_opencode_error_message(message: &serde_json::Value) -> Option<String>
     format_opencode_error_object(error)
 }
 
+/// Record a child→parent OpenCode session relationship from `session.created` /
+/// `session.updated` events. Subagent sessions carry `info.parentID`; Jean only
+/// registers the primary session as an SSE subscriber, so this map lets child
+/// provider errors resolve to the owning run.
+fn remember_opencode_session_parent(session_id: &str, parent_id: &str) {
+    let session_id = session_id.trim();
+    let parent_id = parent_id.trim();
+    if session_id.is_empty() || parent_id.is_empty() || session_id == parent_id {
+        return;
+    }
+    let mut parents = lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS");
+    let previous = parents.insert(session_id.to_string(), parent_id.to_string());
+    if previous.as_deref() != Some(parent_id) {
+        log::info!("OpenCode shared SSE: session lineage child={session_id} parent={parent_id}");
+    }
+}
+
+/// Resolve an OpenCode session ID to a registered Jean SSE subscriber.
+///
+/// Lookup order:
+/// 1. Exact subscriber match (primary session)
+/// 2. Walk `session_parents` until a registered ancestor is found
+fn resolve_opencode_subscriber(
+    subscribers: &HashMap<String, SharedSseSubscriberEntry>,
+    session_parents: &HashMap<String, String>,
+    opencode_session_id: &str,
+) -> Option<(String, SharedSseSubscriberEntry)> {
+    if opencode_session_id.is_empty() {
+        return None;
+    }
+
+    if let Some(entry) = subscribers.get(opencode_session_id) {
+        return Some((opencode_session_id.to_string(), entry.clone()));
+    }
+
+    let mut current = opencode_session_id;
+    let mut seen = HashSet::new();
+    seen.insert(current.to_string());
+    while let Some(parent) = session_parents.get(current) {
+        if !seen.insert(parent.clone()) {
+            break;
+        }
+        if let Some(entry) = subscribers.get(parent) {
+            return Some((parent.clone(), entry.clone()));
+        }
+        current = parent.as_str();
+    }
+
+    None
+}
+
 /// Record an upstream OpenCode error observed on the SSE stream, emit
 /// `chat:error`, flag the run cancelled so the blocking `/message` POST unblocks,
 /// and abort the OpenCode session server-side.
+///
+/// `opencode_session_id` may be a child/subagent session — it is resolved to the
+/// owning primary-session subscriber via parent lineage when needed.
 fn surface_opencode_sse_error(
     app: &AppHandle,
     subscribers: &Arc<Mutex<HashMap<String, SharedSseSubscriberEntry>>>,
@@ -1138,11 +1203,17 @@ fn surface_opencode_sse_error(
         return false;
     };
 
-    let (subscriber_handle, working_dir) = {
+    let (root_session_id, subscriber_handle, abort_working_dir) = {
         let subscribers = lock_recover(subscribers, "OPENCODE_SSE_SUBSCRIBERS");
-        match subscribers.get(opencode_session_id) {
-            Some(entry) => (entry.handle.clone(), entry.working_dir.clone()),
-            None => return false,
+        let parents = lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS");
+        match resolve_opencode_subscriber(&subscribers, &parents, opencode_session_id) {
+            Some((root_id, entry)) => (root_id, entry.handle.clone(), entry.working_dir.clone()),
+            None => {
+                log::warn!(
+                    "OpenCode shared SSE: upstream error for unknown session={opencode_session_id} (no parent subscriber)"
+                );
+                return false;
+            }
         }
     };
 
@@ -1168,7 +1239,7 @@ fn surface_opencode_sse_error(
     }
 
     log::warn!(
-        "OpenCode shared SSE: upstream error opencode_session={opencode_session_id} msg={msg}"
+        "OpenCode shared SSE: upstream error event_session={opencode_session_id} root_session={root_session_id} msg={msg}"
     );
     let _ = app.emit_all(
         "chat:error",
@@ -1178,7 +1249,15 @@ fn surface_opencode_sse_error(
             error: msg,
         },
     );
-    super::registry::abort_opencode_session(opencode_session_id.to_string(), Some(working_dir));
+    // Abort both the errored session (may be a child) and the root primary
+    // session so the blocking parent turn cannot keep waiting.
+    if root_session_id != opencode_session_id {
+        super::registry::abort_opencode_session(
+            opencode_session_id.to_string(),
+            Some(abort_working_dir.clone()),
+        );
+    }
+    super::registry::abort_opencode_session(root_session_id, Some(abort_working_dir));
     true
 }
 
@@ -2042,10 +2121,26 @@ fn process_shared_sse_event(
 
     match event_type.as_str() {
         "server.connected" | "server.heartbeat" => Some(false),
+        "session.created" | "session.updated" => {
+            // Track parentID lineage so child/subagent session.error events can
+            // resolve to the primary Jean subscriber.
+            let info = properties.get("info").unwrap_or(&properties);
+            let session_id = info
+                .get("id")
+                .and_then(|v| v.as_str())
+                .or_else(|| properties.get("sessionID").and_then(|v| v.as_str()))
+                .unwrap_or("");
+            if let Some(parent_id) = info.get("parentID").and_then(|v| v.as_str()) {
+                remember_opencode_session_parent(session_id, parent_id);
+            }
+            Some(false)
+        }
         "message.part.updated" | "message.part" | "message.part.added" => {
+            // Stream parts only for the primary subscribed session. Child/subagent
+            // parts stay isolated; only errors (below) fan in to the parent run.
             let part = properties.get("part").unwrap_or(&properties);
             let opencode_session_id = part.get("sessionID").and_then(|v| v.as_str()).unwrap_or("");
-            let (subscriber_handle, working_dir) = {
+            let (subscriber_handle, part_working_dir) = {
                 let lock_start = Instant::now();
                 let subscribers = lock_recover(subscribers, "OPENCODE_SSE_SUBSCRIBERS");
                 let lock_wait = lock_start.elapsed();
@@ -2063,7 +2158,7 @@ fn process_shared_sse_event(
                 }
             };
             let mut subscriber = lock_recover(&subscriber_handle, "OPENCODE_SSE_SUBSCRIBER");
-            process_message_part_event(app, part, &mut subscriber, &working_dir)
+            process_message_part_event(app, part, &mut subscriber, &part_working_dir)
         }
         "message.part.delta" => {
             let opencode_session_id = properties
@@ -2092,7 +2187,7 @@ fn process_shared_sse_event(
             let mut subscriber = lock_recover(&subscriber, "OPENCODE_SSE_SUBSCRIBER");
             process_message_part_delta_event(app, &properties, &mut subscriber)
         }
-        "message.created" | "session.updated" => Some(false),
+        "message.created" => Some(false),
         "message.updated" => {
             // Assistant messages may land with `info.error` set when a local /
             // custom provider fails. Surface that immediately — the blocking
@@ -2141,6 +2236,8 @@ fn process_shared_sse_event(
         "session.idle" => {
             // The session's whole queue (original turn + any steered prompts)
             // has drained. Flag the subscriber so a steered run can finalize.
+            // Only the primary (subscribed) session matters — child/subagent
+            // idle events must not mark the parent run idle.
             let opencode_session_id = properties
                 .get("sessionID")
                 .and_then(|v| v.as_str())
@@ -2197,22 +2294,14 @@ where
     }
 }
 
-async fn sleep_or_cancel_opencode_http(
-    duration: Duration,
-    cancelled: Arc<AtomicBool>,
-    force_abort: Arc<AtomicBool>,
-    opencode_session_id: String,
-    working_dir: String,
-) -> bool {
-    await_opencode_http_or_cancel(
-        tokio::time::sleep(duration),
-        cancelled,
-        force_abort,
-        opencode_session_id,
-        working_dir,
-    )
-    .await
-    .is_none()
+/// Whether a failed OpenCode `/message` POST may be automatically retried.
+///
+/// Always `false`: the POST is non-idempotent (it appends a user message to the
+/// OpenCode session). Timeouts and ambiguous request-level errors can mean the
+/// server already accepted the prompt; replaying produces duplicate messages and
+/// masks the real provider failure (see #587).
+fn should_retry_opencode_message_post(_err: &reqwest::Error) -> bool {
+    false
 }
 
 fn post_opencode_message_cancellable(
@@ -2224,6 +2313,28 @@ fn post_opencode_message_cancellable(
     jean_session_id: String,
     opencode_session_id: String,
 ) -> Result<Option<(reqwest::StatusCode, String)>, String> {
+    post_opencode_message_cancellable_with_timeout(
+        msg_url,
+        working_dir,
+        payload,
+        cancelled,
+        force_abort,
+        jean_session_id,
+        opencode_session_id,
+        Duration::from_secs(1800),
+    )
+}
+
+fn post_opencode_message_cancellable_with_timeout(
+    msg_url: String,
+    working_dir: String,
+    payload: serde_json::Value,
+    cancelled: Arc<AtomicBool>,
+    force_abort: Arc<AtomicBool>,
+    jean_session_id: String,
+    opencode_session_id: String,
+    request_timeout: Duration,
+) -> Result<Option<(reqwest::StatusCode, String)>, String> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -2231,20 +2342,17 @@ fn post_opencode_message_cancellable(
 
     runtime.block_on(async move {
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(1800))
+            .timeout(request_timeout)
             .build()
             .map_err(|e| format!("Failed to build OpenCode async HTTP client: {e}"))?;
 
-        let send_once = || {
+        // Single attempt only — never replay a non-idempotent message POST.
+        let response = match await_opencode_http_or_cancel(
             client
                 .post(&msg_url)
                 .query(&[("directory", working_dir.as_str())])
                 .json(&payload)
-                .send()
-        };
-
-        let response = match await_opencode_http_or_cancel(
-            send_once(),
+                .send(),
             cancelled.clone(),
             force_abort.clone(),
             opencode_session_id.clone(),
@@ -2253,35 +2361,13 @@ fn post_opencode_message_cancellable(
         .await
         {
             Some(Ok(resp)) => resp,
-            Some(Err(e)) if e.is_connect() || e.is_request() => {
-                log::warn!("OpenCode message connection error, retrying in 2s: {e}");
-                if sleep_or_cancel_opencode_http(
-                    std::time::Duration::from_secs(2),
-                    cancelled.clone(),
-                    force_abort.clone(),
-                    opencode_session_id.clone(),
-                    working_dir.clone(),
-                )
-                .await
-                {
-                    return Ok(None);
+            Some(Err(e)) => {
+                if should_retry_opencode_message_post(&e) {
+                    // Kept as a guarded branch for clarity/tests; currently always false.
+                    log::warn!("OpenCode message error would retry (disabled): {e}");
                 }
-
-                match await_opencode_http_or_cancel(
-                    send_once(),
-                    cancelled.clone(),
-                    force_abort.clone(),
-                    opencode_session_id.clone(),
-                    working_dir.clone(),
-                )
-                .await
-                {
-                    Some(Ok(resp)) => resp,
-                    Some(Err(e)) => return Err(format!("Failed to send OpenCode message: {e}")),
-                    None => return Ok(None),
-                }
+                return Err(format!("Failed to send OpenCode message: {e}"));
             }
-            Some(Err(e)) => return Err(format!("Failed to send OpenCode message: {e}")),
             None => return Ok(None),
         };
 
@@ -3453,5 +3539,302 @@ mod tests {
         })
         .join()
         .unwrap();
+    }
+
+    #[test]
+    fn should_retry_opencode_message_post_is_always_false() {
+        // Non-idempotent POST must never auto-retry, even for connect/timeout-shaped
+        // errors. Integration coverage is in post_opencode_message_times_out_once.
+        let err = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_millis(50))
+            .build()
+            .unwrap()
+            .get("http://127.0.0.1:1/")
+            .send()
+            .expect_err("closed port should error");
+        assert!(!should_retry_opencode_message_post(&err));
+    }
+
+    #[test]
+    fn resolve_opencode_subscriber_maps_child_to_parent_root() {
+        let force_abort = Arc::new(AtomicBool::new(false));
+        let upstream_error = Arc::new(Mutex::new(None));
+        let handle = Arc::new(Mutex::new(SharedSseSubscriber {
+            jean_session_id: "jean-1".into(),
+            worktree_id: "wt-1".into(),
+            run_id: "run-1".into(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+            streamed_any: Arc::new(AtomicBool::new(false)),
+            turn_started: Arc::new(AtomicBool::new(false)),
+            session_idle: Arc::new(AtomicBool::new(false)),
+            steered: Arc::new(AtomicBool::new(false)),
+            upstream_error,
+            force_abort,
+            tracked_parts: HashMap::new(),
+            accumulated_blocks: Vec::new(),
+            accumulated_tool_calls: Vec::new(),
+        }));
+        let mut subscribers = HashMap::new();
+        subscribers.insert(
+            "ses_parent".to_string(),
+            SharedSseSubscriberEntry {
+                working_dir: "/tmp/project".into(),
+                handle,
+            },
+        );
+        let mut parents = HashMap::new();
+        parents.insert("ses_child".to_string(), "ses_parent".to_string());
+        parents.insert("ses_grandchild".to_string(), "ses_child".to_string());
+
+        let resolved =
+            resolve_opencode_subscriber(&subscribers, &parents, "ses_grandchild").unwrap();
+        assert_eq!(resolved.0, "ses_parent");
+
+        // A matching directory does not prove lineage: the shared stream can
+        // contain unrelated sessions from the same project.
+        assert!(
+            resolve_opencode_subscriber(&subscribers, &HashMap::new(), "ses_unknown",).is_none()
+        );
+
+        // Unknown session with no unique fallback is None.
+        assert!(
+            resolve_opencode_subscriber(&subscribers, &HashMap::new(), "ses_unknown").is_none()
+        );
+    }
+
+    #[test]
+    fn child_session_error_surfaces_on_parent_subscriber() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = AppHandle::new(tmp.path().join("data"), tmp.path().join("res")).unwrap();
+        let force_abort = Arc::new(AtomicBool::new(false));
+        let upstream_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let handle = Arc::new(Mutex::new(SharedSseSubscriber {
+            jean_session_id: "jean-parent".into(),
+            worktree_id: "wt-parent".into(),
+            run_id: "run-parent".into(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+            streamed_any: Arc::new(AtomicBool::new(false)),
+            turn_started: Arc::new(AtomicBool::new(false)),
+            session_idle: Arc::new(AtomicBool::new(false)),
+            steered: Arc::new(AtomicBool::new(false)),
+            upstream_error: upstream_error.clone(),
+            force_abort: force_abort.clone(),
+            tracked_parts: HashMap::new(),
+            accumulated_blocks: Vec::new(),
+            accumulated_tool_calls: Vec::new(),
+        }));
+
+        // Isolate global maps for this test.
+        {
+            let mut subscribers = lock_recover(&SHARED_SSE.subscribers, "OPENCODE_SSE_SUBSCRIBERS");
+            subscribers.clear();
+            subscribers.insert(
+                "ses_parent".to_string(),
+                SharedSseSubscriberEntry {
+                    working_dir: "/tmp/wt".into(),
+                    handle,
+                },
+            );
+        }
+        {
+            let mut parents =
+                lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS");
+            parents.clear();
+            parents.insert("ses_child".to_string(), "ses_parent".to_string());
+        }
+
+        let error = serde_json::json!({
+            "name": "APIError",
+            "data": { "message": "5-hour usage limit reached." }
+        });
+        let surfaced =
+            surface_opencode_sse_error(&app, &SHARED_SSE.subscribers, "ses_child", &error);
+        assert!(surfaced, "child error must surface via parent subscriber");
+        assert!(
+            force_abort.load(Ordering::SeqCst),
+            "must force-abort parent POST"
+        );
+        assert_eq!(
+            take_upstream_error(&upstream_error).as_deref(),
+            Some("5-hour usage limit reached.")
+        );
+
+        // Cleanup global state.
+        lock_recover(&SHARED_SSE.subscribers, "OPENCODE_SSE_SUBSCRIBERS").clear();
+        lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS").clear();
+    }
+
+    #[test]
+    fn process_shared_sse_records_parent_and_surfaces_child_session_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = AppHandle::new(tmp.path().join("data"), tmp.path().join("res")).unwrap();
+        let force_abort = Arc::new(AtomicBool::new(false));
+        let upstream_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let handle = Arc::new(Mutex::new(SharedSseSubscriber {
+            jean_session_id: "jean-2".into(),
+            worktree_id: "wt-2".into(),
+            run_id: "run-2".into(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+            streamed_any: Arc::new(AtomicBool::new(false)),
+            turn_started: Arc::new(AtomicBool::new(false)),
+            session_idle: Arc::new(AtomicBool::new(false)),
+            steered: Arc::new(AtomicBool::new(false)),
+            upstream_error: upstream_error.clone(),
+            force_abort: force_abort.clone(),
+            tracked_parts: HashMap::new(),
+            accumulated_blocks: Vec::new(),
+            accumulated_tool_calls: Vec::new(),
+        }));
+
+        {
+            let mut subscribers = lock_recover(&SHARED_SSE.subscribers, "OPENCODE_SSE_SUBSCRIBERS");
+            subscribers.clear();
+            subscribers.insert(
+                "ses_root".to_string(),
+                SharedSseSubscriberEntry {
+                    working_dir: "/tmp/proj".into(),
+                    handle,
+                },
+            );
+        }
+        lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS").clear();
+
+        // session.created for a subagent child.
+        let created = r#"{"type":"session.created","properties":{"sessionID":"ses_sub","info":{"id":"ses_sub","parentID":"ses_root","title":"explore"}}}"#;
+        assert_eq!(
+            process_shared_sse_event(&app, created, &SHARED_SSE.subscribers),
+            Some(false)
+        );
+        assert_eq!(
+            lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS")
+                .get("ses_sub")
+                .map(String::as_str),
+            Some("ses_root")
+        );
+
+        // session.error on the child must fail the parent run.
+        let err_event = r#"{"type":"session.error","properties":{"sessionID":"ses_sub","error":{"name":"APIError","data":{"message":"provider offline"}}}}"#;
+        assert_eq!(
+            process_shared_sse_event(&app, err_event, &SHARED_SSE.subscribers),
+            Some(true)
+        );
+        assert!(force_abort.load(Ordering::SeqCst));
+        assert_eq!(
+            take_upstream_error(&upstream_error).as_deref(),
+            Some("provider offline")
+        );
+
+        lock_recover(&SHARED_SSE.subscribers, "OPENCODE_SSE_SUBSCRIBERS").clear();
+        lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS").clear();
+    }
+
+    #[test]
+    fn post_opencode_message_times_out_once_without_retry() {
+        use std::net::TcpListener;
+        use std::sync::atomic::AtomicUsize;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_bg = hits.clone();
+
+        // Accept connections but never complete the HTTP response so the client times out.
+        let server = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + Duration::from_secs(1);
+            let mut connections = Vec::new();
+            while std::time::Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        hits_bg.fetch_add(1, Ordering::SeqCst);
+                        connections.push(stream);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("failed to accept test connection: {error}"),
+                }
+            }
+        });
+
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let force_abort = Arc::new(AtomicBool::new(false));
+        let result = post_opencode_message_cancellable_with_timeout(
+            format!("http://{addr}/session/ses_test/message"),
+            "/tmp".into(),
+            serde_json::json!({"parts": []}),
+            cancelled,
+            force_abort,
+            "jean-test".into(),
+            "ses_test".into(),
+            Duration::from_millis(300),
+        );
+
+        assert!(result.is_err(), "expected timeout error, got {result:?}");
+        // Give the accept thread a brief window in case a second attempt was made.
+        std::thread::sleep(Duration::from_millis(400));
+        server.join().unwrap();
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1,
+            "timed-out message POST must be attempted exactly once"
+        );
+    }
+
+    #[test]
+    fn sse_provider_error_unblocks_force_abort_distinct_from_user_cancel() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = AppHandle::new(tmp.path().join("data"), tmp.path().join("res")).unwrap();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let force_abort = Arc::new(AtomicBool::new(false));
+        let upstream_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let handle = Arc::new(Mutex::new(SharedSseSubscriber {
+            jean_session_id: "jean-3".into(),
+            worktree_id: "wt-3".into(),
+            run_id: "run-3".into(),
+            cancelled: cancelled.clone(),
+            streamed_any: Arc::new(AtomicBool::new(false)),
+            turn_started: Arc::new(AtomicBool::new(false)),
+            session_idle: Arc::new(AtomicBool::new(false)),
+            steered: Arc::new(AtomicBool::new(false)),
+            upstream_error: upstream_error.clone(),
+            force_abort: force_abort.clone(),
+            tracked_parts: HashMap::new(),
+            accumulated_blocks: Vec::new(),
+            accumulated_tool_calls: Vec::new(),
+        }));
+
+        {
+            let mut subscribers = lock_recover(&SHARED_SSE.subscribers, "OPENCODE_SSE_SUBSCRIBERS");
+            subscribers.clear();
+            subscribers.insert(
+                "ses_primary".to_string(),
+                SharedSseSubscriberEntry {
+                    working_dir: "/tmp/x".into(),
+                    handle,
+                },
+            );
+        }
+
+        let err_event = r#"{"type":"session.error","properties":{"sessionID":"ses_primary","error":"quota exceeded"}}"#;
+        assert_eq!(
+            process_shared_sse_event(&app, err_event, &SHARED_SSE.subscribers),
+            Some(true)
+        );
+        assert!(
+            force_abort.load(Ordering::SeqCst),
+            "provider error must set force_abort"
+        );
+        assert!(
+            !cancelled.load(Ordering::SeqCst),
+            "provider error must not look like user cancellation"
+        );
+        assert_eq!(
+            take_upstream_error(&upstream_error).as_deref(),
+            Some("quota exceeded")
+        );
+
+        lock_recover(&SHARED_SSE.subscribers, "OPENCODE_SSE_SUBSCRIBERS").clear();
+        lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS").clear();
     }
 }

--- a/jean-core/src/chat/opencode.rs
+++ b/jean-core/src/chat/opencode.rs
@@ -346,6 +346,10 @@ struct SharedSseCoordinator {
     /// ancestor ID. Walked until a registered primary-session subscriber is found
     /// so child `session.error` events fail the owning Jean run.
     session_parents: Arc<Mutex<HashMap<String, String>>>,
+    /// Working directories observed for OpenCode sessions (from SSE envelope
+    /// `directory` or session info). Used so child/subagent aborts target the
+    /// session's own directory rather than the root worktree.
+    session_directories: Arc<Mutex<HashMap<String, String>>>,
 }
 
 impl Default for SharedSseCoordinator {
@@ -354,6 +358,7 @@ impl Default for SharedSseCoordinator {
             subscribers: Arc::new(Mutex::new(HashMap::new())),
             listeners: Arc::new(Mutex::new(HashMap::new())),
             session_parents: Arc::new(Mutex::new(HashMap::new())),
+            session_directories: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -466,13 +471,50 @@ impl Drop for SharedSseSubscription {
                 subscribers.len()
             );
         }
-        // Drop parent-chain entries that point at (or are) this root so a later
-        // session never inherits a stale child→parent mapping.
+        // Drop the full descendant closure of this root (child, grandchild, …)
+        // so multi-level chains cannot leak after the primary session ends.
         let mut parents = lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS");
-        parents.retain(|child, parent| {
-            child != &self.opencode_session_id && parent != &self.opencode_session_id
-        });
+        let removed_ids = prune_session_parent_descendants(&mut parents, &self.opencode_session_id);
+        let mut directories =
+            lock_recover(&SHARED_SSE.session_directories, "OPENCODE_SSE_SESSION_DIRS");
+        directories.retain(|id, _| !removed_ids.contains(id));
     }
+}
+
+/// Remove `root_id` and every transitive descendant from the child→parent map.
+///
+/// OpenCode subagents form trees (`grandchild → child → root`). A shallow prune
+/// that only matches the immediate parent leaves deeper links behind as a slow
+/// leak and a stale-lineage hazard if session IDs are recycled.
+///
+/// Returns the set of session IDs that were pruned (including `root_id`).
+fn prune_session_parent_descendants(
+    parents: &mut HashMap<String, String>,
+    root_id: &str,
+) -> HashSet<String> {
+    let mut remove = HashSet::new();
+    if root_id.is_empty() {
+        return remove;
+    }
+
+    remove.insert(root_id.to_string());
+
+    // Expand until fixpoint: any child of a session marked for removal is also
+    // removed (covers grandchild → child → root and wider trees).
+    loop {
+        let mut added = false;
+        for (child, parent) in parents.iter() {
+            if remove.contains(parent) && remove.insert(child.clone()) {
+                added = true;
+            }
+        }
+        if !added {
+            break;
+        }
+    }
+
+    parents.retain(|child, _parent| !remove.contains(child));
+    remove
 }
 
 fn lock_recover<'a, T>(mutex: &'a Mutex<T>, name: &str) -> std::sync::MutexGuard<'a, T> {
@@ -1153,6 +1195,36 @@ fn remember_opencode_session_parent(session_id: &str, parent_id: &str) {
     }
 }
 
+/// Remember the working directory associated with an OpenCode session.
+///
+/// Sourced from the SSE envelope `directory` field (and optionally session info).
+/// Child/subagent sessions can be rooted outside the primary worktree; aborts
+/// must use that directory rather than the root subscriber's.
+fn remember_opencode_session_directory(session_id: &str, directory: &str) {
+    let session_id = session_id.trim();
+    let directory = directory.trim();
+    if session_id.is_empty() || directory.is_empty() {
+        return;
+    }
+    let mut dirs = lock_recover(&SHARED_SSE.session_directories, "OPENCODE_SSE_SESSION_DIRS");
+    let previous = dirs.insert(session_id.to_string(), directory.to_string());
+    if previous.as_deref() != Some(directory) {
+        log::info!(
+            "OpenCode shared SSE: session directory session={session_id} directory={directory}"
+        );
+    }
+}
+
+fn lookup_opencode_session_directory(session_id: &str) -> Option<String> {
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return None;
+    }
+    lock_recover(&SHARED_SSE.session_directories, "OPENCODE_SSE_SESSION_DIRS")
+        .get(session_id)
+        .cloned()
+}
+
 /// Resolve an OpenCode session ID to a registered Jean SSE subscriber.
 ///
 /// Lookup order:
@@ -1203,7 +1275,7 @@ fn surface_opencode_sse_error(
         return false;
     };
 
-    let (root_session_id, subscriber_handle, abort_working_dir) = {
+    let (root_session_id, subscriber_handle, root_working_dir) = {
         let subscribers = lock_recover(subscribers, "OPENCODE_SSE_SUBSCRIBERS");
         let parents = lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS");
         match resolve_opencode_subscriber(&subscribers, &parents, opencode_session_id) {
@@ -1251,13 +1323,16 @@ fn surface_opencode_sse_error(
     );
     // Abort both the errored session (may be a child) and the root primary
     // session so the blocking parent turn cannot keep waiting.
+    //
+    // Each session is aborted with its own working directory. Child/subagent
+    // sessions can be rooted outside the primary worktree — never pass the
+    // root directory for a different session id (that can mis-scope the abort
+    // and leave the subagent burning tokens).
     if root_session_id != opencode_session_id {
-        super::registry::abort_opencode_session(
-            opencode_session_id.to_string(),
-            Some(abort_working_dir.clone()),
-        );
+        let child_working_dir = lookup_opencode_session_directory(opencode_session_id);
+        super::registry::abort_opencode_session(opencode_session_id.to_string(), child_working_dir);
     }
-    super::registry::abort_opencode_session(root_session_id, Some(abort_working_dir));
+    super::registry::abort_opencode_session(root_session_id, Some(root_working_dir));
     true
 }
 
@@ -2109,6 +2184,15 @@ fn process_shared_sse_event(
         }
     };
 
+    // OpenCode SSE wire format nests the event under `payload` and may include
+    // a top-level `directory` for the session instance that emitted it.
+    let event_directory = json
+        .get("directory")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+
     let (event_type, properties) = if let Some(payload) = json.get("payload") {
         let t = payload.get("type")?.as_str()?;
         let p = payload.get("properties").cloned().unwrap_or_default();
@@ -2132,6 +2216,17 @@ fn process_shared_sse_event(
                 .unwrap_or("");
             if let Some(parent_id) = info.get("parentID").and_then(|v| v.as_str()) {
                 remember_opencode_session_parent(session_id, parent_id);
+            }
+            // Prefer info.directory when present; otherwise the envelope directory.
+            let session_dir = info
+                .get("directory")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .or_else(|| event_directory.clone());
+            if let Some(dir) = session_dir.as_deref() {
+                remember_opencode_session_directory(session_id, dir);
             }
             Some(false)
         }
@@ -2208,6 +2303,9 @@ fn process_shared_sse_event(
             if opencode_session_id.is_empty() {
                 return Some(false);
             }
+            if let Some(dir) = event_directory.as_deref() {
+                remember_opencode_session_directory(opencode_session_id, dir);
+            }
             Some(surface_opencode_sse_error(
                 app,
                 subscribers,
@@ -2225,6 +2323,9 @@ fn process_shared_sse_event(
             };
             if opencode_session_id.is_empty() {
                 return Some(false);
+            }
+            if let Some(dir) = event_directory.as_deref() {
+                remember_opencode_session_directory(opencode_session_id, dir);
             }
             Some(surface_opencode_sse_error(
                 app,
@@ -2294,16 +2395,6 @@ where
     }
 }
 
-/// Whether a failed OpenCode `/message` POST may be automatically retried.
-///
-/// Always `false`: the POST is non-idempotent (it appends a user message to the
-/// OpenCode session). Timeouts and ambiguous request-level errors can mean the
-/// server already accepted the prompt; replaying produces duplicate messages and
-/// masks the real provider failure (see #587).
-fn should_retry_opencode_message_post(_err: &reqwest::Error) -> bool {
-    false
-}
-
 fn post_opencode_message_cancellable(
     msg_url: String,
     working_dir: String,
@@ -2362,10 +2453,10 @@ fn post_opencode_message_cancellable_with_timeout(
         {
             Some(Ok(resp)) => resp,
             Some(Err(e)) => {
-                if should_retry_opencode_message_post(&e) {
-                    // Kept as a guarded branch for clarity/tests; currently always false.
-                    log::warn!("OpenCode message error would retry (disabled): {e}");
-                }
+                // Never retried: the POST is non-idempotent (it appends a user
+                // message). A timeout may mean the server already accepted the
+                // prompt, so replaying duplicates it and masks the real provider
+                // failure (see #587).
                 return Err(format!("Failed to send OpenCode message: {e}"));
             }
             None => return Ok(None),
@@ -3307,6 +3398,10 @@ pub fn answer_opencode_question(
 mod tests {
     use super::*;
 
+    /// Serializes tests that mutate process-global `SHARED_SSE` maps so parallel
+    /// test threads cannot clear each other's subscribers/parents mid-assertion.
+    static SSE_TEST_GUARD: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
     #[test]
     fn turn_started_gate_returns_false_for_unknown_session_quickly() {
         // No subscriber registered → gate must time out (not block forever) and
@@ -3542,20 +3637,6 @@ mod tests {
     }
 
     #[test]
-    fn should_retry_opencode_message_post_is_always_false() {
-        // Non-idempotent POST must never auto-retry, even for connect/timeout-shaped
-        // errors. Integration coverage is in post_opencode_message_times_out_once.
-        let err = reqwest::blocking::Client::builder()
-            .timeout(Duration::from_millis(50))
-            .build()
-            .unwrap()
-            .get("http://127.0.0.1:1/")
-            .send()
-            .expect_err("closed port should error");
-        assert!(!should_retry_opencode_message_post(&err));
-    }
-
-    #[test]
     fn resolve_opencode_subscriber_maps_child_to_parent_root() {
         let force_abort = Arc::new(AtomicBool::new(false));
         let upstream_error = Arc::new(Mutex::new(None));
@@ -3590,20 +3671,144 @@ mod tests {
             resolve_opencode_subscriber(&subscribers, &parents, "ses_grandchild").unwrap();
         assert_eq!(resolved.0, "ses_parent");
 
-        // A matching directory does not prove lineage: the shared stream can
-        // contain unrelated sessions from the same project.
+        // A lineage that never reaches a registered subscriber resolves to None.
+        let mut orphan_parents = HashMap::new();
+        orphan_parents.insert("ses_orphan".to_string(), "ses_unsubscribed".to_string());
         assert!(
-            resolve_opencode_subscriber(&subscribers, &HashMap::new(), "ses_unknown",).is_none()
+            resolve_opencode_subscriber(&subscribers, &orphan_parents, "ses_orphan").is_none()
         );
 
-        // Unknown session with no unique fallback is None.
+        // Unknown session with no lineage at all is None.
         assert!(
             resolve_opencode_subscriber(&subscribers, &HashMap::new(), "ses_unknown").is_none()
         );
     }
 
     #[test]
+    fn prune_session_parent_descendants_removes_full_closure() {
+        let mut parents = HashMap::new();
+        // Multi-level chain under the dropped root (the shape resolve tests use).
+        parents.insert("ses_child".to_string(), "ses_root".to_string());
+        parents.insert("ses_grandchild".to_string(), "ses_child".to_string());
+        parents.insert("ses_great_grandchild".to_string(), "ses_grandchild".to_string());
+        // Sibling branch under the same root.
+        parents.insert("ses_other_child".to_string(), "ses_root".to_string());
+        // Unrelated tree must survive.
+        parents.insert("ses_unrelated_child".to_string(), "ses_other_root".to_string());
+        parents.insert(
+            "ses_unrelated_grandchild".to_string(),
+            "ses_unrelated_child".to_string(),
+        );
+
+        let removed = prune_session_parent_descendants(&mut parents, "ses_root");
+
+        assert!(
+            !parents.contains_key("ses_child")
+                && !parents.contains_key("ses_grandchild")
+                && !parents.contains_key("ses_great_grandchild")
+                && !parents.contains_key("ses_other_child"),
+            "full descendant closure of ses_root must be removed, got {parents:?}"
+        );
+        assert!(
+            removed.contains("ses_root")
+                && removed.contains("ses_child")
+                && removed.contains("ses_grandchild")
+                && removed.contains("ses_great_grandchild")
+                && removed.contains("ses_other_child"),
+            "prune must report the full removed set, got {removed:?}"
+        );
+        assert_eq!(
+            parents.get("ses_unrelated_child").map(String::as_str),
+            Some("ses_other_root")
+        );
+        assert_eq!(
+            parents
+                .get("ses_unrelated_grandchild")
+                .map(String::as_str),
+            Some("ses_unrelated_child")
+        );
+    }
+
+    #[test]
+    fn shared_sse_subscription_drop_prunes_multi_level_lineage() {
+        let _guard = lock_recover(&SSE_TEST_GUARD, "SSE_TEST_GUARD");
+        // Isolate global maps so this exercises Drop cleanup only.
+        lock_recover(&SHARED_SSE.subscribers, "OPENCODE_SSE_SUBSCRIBERS").clear();
+        lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS").clear();
+        lock_recover(&SHARED_SSE.session_directories, "OPENCODE_SSE_SESSION_DIRS").clear();
+
+        {
+            let mut parents =
+                lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS");
+            parents.insert("ses_child".to_string(), "ses_drop_root".to_string());
+            parents.insert("ses_grandchild".to_string(), "ses_child".to_string());
+            parents.insert("ses_keep_child".to_string(), "ses_keep_root".to_string());
+        }
+        {
+            let mut dirs =
+                lock_recover(&SHARED_SSE.session_directories, "OPENCODE_SSE_SESSION_DIRS");
+            dirs.insert("ses_drop_root".to_string(), "/tmp/root".into());
+            dirs.insert("ses_child".to_string(), "/tmp/child".into());
+            dirs.insert("ses_grandchild".to_string(), "/tmp/grand".into());
+            dirs.insert("ses_keep_child".to_string(), "/tmp/keep".into());
+        }
+
+        // Construct a subscription handle and drop it — Drop must prune the full
+        // descendant chain, not only direct children of the root.
+        let subscription = SharedSseSubscription {
+            opencode_session_id: "ses_drop_root".to_string(),
+            handle: Arc::new(Mutex::new(SharedSseSubscriber {
+                jean_session_id: "jean-drop".into(),
+                worktree_id: "wt-drop".into(),
+                run_id: "run-drop".into(),
+                cancelled: Arc::new(AtomicBool::new(false)),
+                streamed_any: Arc::new(AtomicBool::new(false)),
+                turn_started: Arc::new(AtomicBool::new(false)),
+                session_idle: Arc::new(AtomicBool::new(false)),
+                steered: Arc::new(AtomicBool::new(false)),
+                upstream_error: Arc::new(Mutex::new(None)),
+                force_abort: Arc::new(AtomicBool::new(false)),
+                tracked_parts: HashMap::new(),
+                accumulated_blocks: Vec::new(),
+                accumulated_tool_calls: Vec::new(),
+            })),
+        };
+        drop(subscription);
+
+        let parents = lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS");
+        assert!(
+            !parents.contains_key("ses_child") && !parents.contains_key("ses_grandchild"),
+            "Drop must prune multi-level descendants, got {parents:?}"
+        );
+        assert_eq!(
+            parents.get("ses_keep_child").map(String::as_str),
+            Some("ses_keep_root"),
+            "unrelated lineage must remain"
+        );
+        drop(parents);
+
+        let dirs = lock_recover(&SHARED_SSE.session_directories, "OPENCODE_SSE_SESSION_DIRS");
+        assert!(
+            !dirs.contains_key("ses_drop_root")
+                && !dirs.contains_key("ses_child")
+                && !dirs.contains_key("ses_grandchild"),
+            "Drop must prune session directories for the root closure, got {dirs:?}"
+        );
+        assert_eq!(
+            dirs.get("ses_keep_child").map(String::as_str),
+            Some("/tmp/keep"),
+            "unrelated session directories must remain"
+        );
+        drop(dirs);
+
+        lock_recover(&SHARED_SSE.subscribers, "OPENCODE_SSE_SUBSCRIBERS").clear();
+        lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS").clear();
+        lock_recover(&SHARED_SSE.session_directories, "OPENCODE_SSE_SESSION_DIRS").clear();
+    }
+
+    #[test]
     fn child_session_error_surfaces_on_parent_subscriber() {
+        let _guard = lock_recover(&SSE_TEST_GUARD, "SSE_TEST_GUARD");
         let tmp = tempfile::tempdir().unwrap();
         let app = AppHandle::new(tmp.path().join("data"), tmp.path().join("res")).unwrap();
         let force_abort = Arc::new(AtomicBool::new(false));
@@ -3642,6 +3847,7 @@ mod tests {
             parents.clear();
             parents.insert("ses_child".to_string(), "ses_parent".to_string());
         }
+        lock_recover(&SHARED_SSE.session_directories, "OPENCODE_SSE_SESSION_DIRS").clear();
 
         let error = serde_json::json!({
             "name": "APIError",
@@ -3662,10 +3868,12 @@ mod tests {
         // Cleanup global state.
         lock_recover(&SHARED_SSE.subscribers, "OPENCODE_SSE_SUBSCRIBERS").clear();
         lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS").clear();
+        lock_recover(&SHARED_SSE.session_directories, "OPENCODE_SSE_SESSION_DIRS").clear();
     }
 
     #[test]
     fn process_shared_sse_records_parent_and_surfaces_child_session_error() {
+        let _guard = lock_recover(&SSE_TEST_GUARD, "SSE_TEST_GUARD");
         let tmp = tempfile::tempdir().unwrap();
         let app = AppHandle::new(tmp.path().join("data"), tmp.path().join("res")).unwrap();
         let force_abort = Arc::new(AtomicBool::new(false));
@@ -3698,9 +3906,11 @@ mod tests {
             );
         }
         lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS").clear();
+        lock_recover(&SHARED_SSE.session_directories, "OPENCODE_SSE_SESSION_DIRS").clear();
 
-        // session.created for a subagent child.
-        let created = r#"{"type":"session.created","properties":{"sessionID":"ses_sub","info":{"id":"ses_sub","parentID":"ses_root","title":"explore"}}}"#;
+        // session.created for a subagent child rooted outside the primary worktree.
+        // Envelope `directory` is the child session's own working directory.
+        let created = r#"{"directory":"/tmp/child-work","payload":{"type":"session.created","properties":{"sessionID":"ses_sub","info":{"id":"ses_sub","parentID":"ses_root","title":"explore"}}}}"#;
         assert_eq!(
             process_shared_sse_event(&app, created, &SHARED_SSE.subscribers),
             Some(false)
@@ -3711,9 +3921,14 @@ mod tests {
                 .map(String::as_str),
             Some("ses_root")
         );
+        assert_eq!(
+            lookup_opencode_session_directory("ses_sub").as_deref(),
+            Some("/tmp/child-work"),
+            "child session must retain its own directory for abort"
+        );
 
         // session.error on the child must fail the parent run.
-        let err_event = r#"{"type":"session.error","properties":{"sessionID":"ses_sub","error":{"name":"APIError","data":{"message":"provider offline"}}}}"#;
+        let err_event = r#"{"directory":"/tmp/child-work","payload":{"type":"session.error","properties":{"sessionID":"ses_sub","error":{"name":"APIError","data":{"message":"provider offline"}}}}}"#;
         assert_eq!(
             process_shared_sse_event(&app, err_event, &SHARED_SSE.subscribers),
             Some(true)
@@ -3723,9 +3938,16 @@ mod tests {
             take_upstream_error(&upstream_error).as_deref(),
             Some("provider offline")
         );
+        // After the error path, the child directory is still the child's own
+        // path (not the root subscriber's /tmp/proj).
+        assert_eq!(
+            lookup_opencode_session_directory("ses_sub").as_deref(),
+            Some("/tmp/child-work")
+        );
 
         lock_recover(&SHARED_SSE.subscribers, "OPENCODE_SSE_SUBSCRIBERS").clear();
         lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS").clear();
+        lock_recover(&SHARED_SSE.session_directories, "OPENCODE_SSE_SESSION_DIRS").clear();
     }
 
     #[test]
@@ -3783,6 +4005,7 @@ mod tests {
 
     #[test]
     fn sse_provider_error_unblocks_force_abort_distinct_from_user_cancel() {
+        let _guard = lock_recover(&SSE_TEST_GUARD, "SSE_TEST_GUARD");
         let tmp = tempfile::tempdir().unwrap();
         let app = AppHandle::new(tmp.path().join("data"), tmp.path().join("res")).unwrap();
         let cancelled = Arc::new(AtomicBool::new(false));
@@ -3815,6 +4038,8 @@ mod tests {
                 },
             );
         }
+        // Clear lineage left by sibling tests so session resolution stays deterministic.
+        lock_recover(&SHARED_SSE.session_parents, "OPENCODE_SSE_SESSION_PARENTS").clear();
 
         let err_event = r#"{"type":"session.error","properties":{"sessionID":"ses_primary","error":"quota exceeded"}}"#;
         assert_eq!(

--- a/jean-core/src/opencode_server/mod.rs
+++ b/jean-core/src/opencode_server/mod.rs
@@ -1,6 +1,8 @@
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{Child, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -12,6 +14,9 @@ use crate::opencode_cli::resolve_cli_binary;
 
 const DEFAULT_PORT: u16 = 4096;
 const DEFAULT_HOSTNAME: &str = "127.0.0.1";
+/// Keep a short ring of sanitized managed-server lines for startup failure messages.
+const DIAGNOSTIC_RING_CAP: usize = 80;
+const DIAGNOSTIC_LINE_MAX: usize = 400;
 
 /// Number of active consumers (prompts) using the managed server.
 /// Server is shut down only when this drops to 0.
@@ -19,6 +24,10 @@ static USAGE_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 /// Cached AppHandle so stop/release paths can access app data dir without param changes.
 static APP_HANDLE: once_cell::sync::OnceCell<AppHandle> = once_cell::sync::OnceCell::new();
+
+/// Recent sanitized stdout/stderr lines from the Jean-managed OpenCode server.
+static RECENT_DIAGNOSTICS: Lazy<Mutex<VecDeque<String>>> =
+    Lazy::new(|| Mutex::new(VecDeque::with_capacity(DIAGNOSTIC_RING_CAP)));
 
 #[derive(Debug)]
 struct OpenCodeServerProcess {
@@ -40,6 +49,96 @@ static OPENCODE_SERVER: Lazy<Mutex<Option<OpenCodeServerProcess>>> = Lazy::new(|
 
 fn server_url(hostname: &str, port: u16) -> String {
     format!("http://{hostname}:{port}")
+}
+
+/// Strip control characters, truncate, and redact obvious secret-looking tokens
+/// before logging or surfacing managed OpenCode server output.
+fn sanitize_diagnostic_line(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let mut cleaned: String = trimmed
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect();
+    // Collapse runs of whitespace introduced by control-char replacement.
+    while cleaned.contains("  ") {
+        cleaned = cleaned.replace("  ", " ");
+    }
+    let cleaned = cleaned.trim();
+    if cleaned.is_empty() {
+        return None;
+    }
+    let lowercase = cleaned.to_ascii_lowercase();
+    let secret_start = [
+        "sk-",
+        "api_key",
+        "apikey",
+        "authorization:",
+        "bearer ",
+        "token=",
+        "secret=",
+    ]
+    .iter()
+    .filter_map(|needle| lowercase.find(needle))
+    .min();
+    let mut redacted = match secret_start {
+        Some(idx) => format!("{}[redacted]", &cleaned[..idx]),
+        None => cleaned.to_string(),
+    };
+    if redacted.len() > DIAGNOSTIC_LINE_MAX {
+        redacted.truncate(DIAGNOSTIC_LINE_MAX);
+        redacted.push('…');
+    }
+    Some(redacted)
+}
+
+fn push_diagnostic_line(stream: &str, line: &str) {
+    let Some(sanitized) = sanitize_diagnostic_line(line) else {
+        return;
+    };
+    log::info!("OpenCode managed server {stream}: {sanitized}");
+    if let Ok(mut guard) = RECENT_DIAGNOSTICS.lock() {
+        if guard.len() >= DIAGNOSTIC_RING_CAP {
+            guard.pop_front();
+        }
+        guard.push_back(format!("[{stream}] {sanitized}"));
+    }
+}
+
+/// Snapshot of recent sanitized managed-server output (for error messages / tests).
+pub fn recent_managed_server_diagnostics() -> Vec<String> {
+    RECENT_DIAGNOSTICS
+        .lock()
+        .map(|g| g.iter().cloned().collect())
+        .unwrap_or_default()
+}
+
+fn diagnostics_summary_for_error() -> String {
+    let lines = recent_managed_server_diagnostics();
+    if lines.is_empty() {
+        return "no managed-server output captured".to_string();
+    }
+    let tail: Vec<&str> = lines.iter().rev().take(12).map(String::as_str).collect();
+    tail.into_iter().rev().collect::<Vec<_>>().join(" | ")
+}
+
+fn spawn_stdio_logger(stream: &'static str, pipe: impl std::io::Read + Send + 'static) {
+    let _ = std::thread::Builder::new()
+        .name(format!("opencode-server-{stream}"))
+        .spawn(move || {
+            let reader = BufReader::new(pipe);
+            for line in reader.lines() {
+                match line {
+                    Ok(l) => push_diagnostic_line(stream, &l),
+                    Err(e) => {
+                        log::debug!("OpenCode managed server {stream} read ended: {e}");
+                        break;
+                    }
+                }
+            }
+        });
 }
 
 fn is_healthy(url: &str) -> bool {
@@ -204,8 +303,10 @@ pub fn ensure_running(app: &AppHandle) -> Result<String, String> {
         .arg(&hostname)
         .arg("--port")
         .arg(port.to_string())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        // Capture output for diagnostics (startup failures, provider issues)
+        // instead of discarding it to null.
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
 
     #[cfg(unix)]
     {
@@ -222,9 +323,16 @@ pub fn ensure_running(app: &AppHandle) -> Result<String, String> {
         cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
     }
 
-    let child = cmd
+    let mut child = cmd
         .spawn()
         .map_err(|e| format!("Failed to start OpenCode server: {e}"))?;
+
+    if let Some(stdout) = child.stdout.take() {
+        spawn_stdio_logger("stdout", stdout);
+    }
+    if let Some(stderr) = child.stderr.take() {
+        spawn_stdio_logger("stderr", stderr);
+    }
 
     let server_pid = child.id();
     *guard = Some(OpenCodeServerProcess {
@@ -237,7 +345,12 @@ pub fn ensure_running(app: &AppHandle) -> Result<String, String> {
     write_pid_file(server_pid, port);
 
     if !wait_until_healthy(&url, 50) {
-        return Err("OpenCode server started but did not become healthy in time".to_string());
+        // Give logger threads a moment to flush a few lines after exit.
+        std::thread::sleep(Duration::from_millis(150));
+        let diag = diagnostics_summary_for_error();
+        return Err(format!(
+            "OpenCode server started but did not become healthy in time. Diagnostics: {diag}"
+        ));
     }
 
     Ok(url)
@@ -335,6 +448,58 @@ pub async fn start_opencode_server(app: AppHandle) -> Result<OpenCodeServerStatu
 pub async fn stop_opencode_server() -> Result<(), String> {
     let _ = stop_managed_server_inner()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_diagnostic_line_strips_control_and_truncates() {
+        let line = format!("hello\x00world {}", "x".repeat(500));
+        let cleaned = sanitize_diagnostic_line(&line).unwrap();
+        assert!(!cleaned.contains('\0'));
+        assert!(cleaned.chars().count() <= DIAGNOSTIC_LINE_MAX + 1); // + ellipsis
+        assert!(cleaned.contains("hello"));
+    }
+
+    #[test]
+    fn sanitize_diagnostic_line_redacts_secretish_tokens() {
+        let secret = format!("sk-{}", "super-secret-token-value-".repeat(8));
+        let cleaned =
+            sanitize_diagnostic_line(&format!("request failed Authorization: Bearer {secret}"))
+                .unwrap();
+        assert!(cleaned.contains("[redacted]"), "got {cleaned}");
+        assert!(cleaned.starts_with("request failed "), "got {cleaned}");
+        assert!(
+            !cleaned.contains(&secret) && !cleaned.contains("token-value"),
+            "credential suffix leaked: {cleaned}"
+        );
+    }
+
+    #[test]
+    fn sanitize_diagnostic_line_redacts_long_query_credential_through_line_end() {
+        let secret = "abcdefghijklmnopqrstuvwxyz0123456789".repeat(8);
+        let cleaned =
+            sanitize_diagnostic_line(&format!("provider request failed: token={secret}")).unwrap();
+        assert_eq!(cleaned, "provider request failed: [redacted]");
+        assert!(
+            !cleaned.contains(&secret[24..]),
+            "credential suffix leaked: {cleaned}"
+        );
+    }
+
+    #[test]
+    fn push_diagnostic_line_is_retained_in_ring() {
+        // Clear by pushing past capacity then checking presence of a unique marker.
+        let marker = format!("jean-diag-marker-{}", std::process::id());
+        push_diagnostic_line("stderr", &marker);
+        let snapshot = recent_managed_server_diagnostics();
+        assert!(
+            snapshot.iter().any(|l| l.contains(&marker)),
+            "expected marker in {snapshot:?}"
+        );
+    }
 }
 
 pub async fn get_opencode_server_status() -> Result<OpenCodeServerStatus, String> {

--- a/jean-core/src/opencode_server/mod.rs
+++ b/jean-core/src/opencode_server/mod.rs
@@ -26,8 +26,14 @@ static USAGE_COUNT: AtomicUsize = AtomicUsize::new(0);
 static APP_HANDLE: once_cell::sync::OnceCell<AppHandle> = once_cell::sync::OnceCell::new();
 
 /// Recent sanitized stdout/stderr lines from the Jean-managed OpenCode server.
+/// Scoped to the current spawn generation — cleared before each new process.
 static RECENT_DIAGNOSTICS: Lazy<Mutex<VecDeque<String>>> =
     Lazy::new(|| Mutex::new(VecDeque::with_capacity(DIAGNOSTIC_RING_CAP)));
+
+/// Monotonic generation for managed-server diagnostics. Logger threads from a
+/// prior process only append when their generation still matches, so a later
+/// startup failure cannot report stale lines from an earlier server.
+static DIAGNOSTIC_GENERATION: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug)]
 struct OpenCodeServerProcess {
@@ -84,22 +90,43 @@ fn sanitize_diagnostic_line(line: &str) -> Option<String> {
     .filter_map(|needle| lowercase.find(needle))
     .min();
     let mut redacted = match secret_start {
-        Some(idx) => format!("{}[redacted]", &cleaned[..idx]),
+        Some(idx) => format!("{prefix}[redacted]", prefix = &cleaned[..idx]),
         None => cleaned.to_string(),
     };
-    if redacted.len() > DIAGNOSTIC_LINE_MAX {
-        redacted.truncate(DIAGNOSTIC_LINE_MAX);
+    // Truncate by Unicode scalar values so multi-byte UTF-8 never panics
+    // on a mid-character boundary (String::truncate requires a char boundary).
+    if redacted.chars().count() > DIAGNOSTIC_LINE_MAX {
+        redacted = redacted.chars().take(DIAGNOSTIC_LINE_MAX).collect();
         redacted.push('…');
     }
     Some(redacted)
 }
 
-fn push_diagnostic_line(stream: &str, line: &str) {
+/// Clear the diagnostics ring and advance the generation so prior logger
+/// threads cannot contaminate the next startup failure report.
+fn begin_diagnostics_generation() -> usize {
+    let next = DIAGNOSTIC_GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
+    if let Ok(mut guard) = RECENT_DIAGNOSTICS.lock() {
+        guard.clear();
+    }
+    next
+}
+
+fn push_diagnostic_line(stream: &str, line: &str, generation: usize) {
     let Some(sanitized) = sanitize_diagnostic_line(line) else {
         return;
     };
     log::info!("OpenCode managed server {stream}: {sanitized}");
+    // Drop ring writes from a previous server generation (stale logger threads).
+    if DIAGNOSTIC_GENERATION.load(Ordering::SeqCst) != generation {
+        return;
+    }
     if let Ok(mut guard) = RECENT_DIAGNOSTICS.lock() {
+        // Re-check under the lock: a concurrent begin_diagnostics_generation()
+        // may have advanced the generation and cleared the ring.
+        if DIAGNOSTIC_GENERATION.load(Ordering::SeqCst) != generation {
+            return;
+        }
         if guard.len() >= DIAGNOSTIC_RING_CAP {
             guard.pop_front();
         }
@@ -124,14 +151,18 @@ fn diagnostics_summary_for_error() -> String {
     tail.into_iter().rev().collect::<Vec<_>>().join(" | ")
 }
 
-fn spawn_stdio_logger(stream: &'static str, pipe: impl std::io::Read + Send + 'static) {
+fn spawn_stdio_logger(
+    stream: &'static str,
+    pipe: impl std::io::Read + Send + 'static,
+    generation: usize,
+) {
     let _ = std::thread::Builder::new()
         .name(format!("opencode-server-{stream}"))
         .spawn(move || {
             let reader = BufReader::new(pipe);
             for line in reader.lines() {
                 match line {
-                    Ok(l) => push_diagnostic_line(stream, &l),
+                    Ok(l) => push_diagnostic_line(stream, &l, generation),
                     Err(e) => {
                         log::debug!("OpenCode managed server {stream} read ended: {e}");
                         break;
@@ -323,15 +354,19 @@ pub fn ensure_running(app: &AppHandle) -> Result<String, String> {
         cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
     }
 
+    // Isolate diagnostics to this process so a later startup failure cannot
+    // report output from an earlier managed server (or its dying logger threads).
+    let diagnostics_generation = begin_diagnostics_generation();
+
     let mut child = cmd
         .spawn()
         .map_err(|e| format!("Failed to start OpenCode server: {e}"))?;
 
     if let Some(stdout) = child.stdout.take() {
-        spawn_stdio_logger("stdout", stdout);
+        spawn_stdio_logger("stdout", stdout, diagnostics_generation);
     }
     if let Some(stderr) = child.stderr.take() {
-        spawn_stdio_logger("stderr", stderr);
+        spawn_stdio_logger("stderr", stderr, diagnostics_generation);
     }
 
     let server_pid = child.id();
@@ -454,6 +489,9 @@ pub async fn stop_opencode_server() -> Result<(), String> {
 mod tests {
     use super::*;
 
+    /// Serialize tests that mutate the process-global diagnostics ring/generation.
+    static DIAGNOSTICS_TEST_GUARD: Mutex<()> = Mutex::new(());
+
     #[test]
     fn sanitize_diagnostic_line_strips_control_and_truncates() {
         let line = format!("hello\x00world {}", "x".repeat(500));
@@ -461,6 +499,17 @@ mod tests {
         assert!(!cleaned.contains('\0'));
         assert!(cleaned.chars().count() <= DIAGNOSTIC_LINE_MAX + 1); // + ellipsis
         assert!(cleaned.contains("hello"));
+    }
+
+    #[test]
+    fn sanitize_diagnostic_line_truncates_non_ascii_without_panic() {
+        // Multi-byte chars (each "日" is 3 bytes) would panic if truncate used a
+        // raw byte index inside a UTF-8 sequence.
+        let line = "日".repeat(DIAGNOSTIC_LINE_MAX + 50);
+        let cleaned = sanitize_diagnostic_line(&line).unwrap();
+        assert_eq!(cleaned.chars().count(), DIAGNOSTIC_LINE_MAX + 1);
+        assert!(cleaned.ends_with('…'));
+        assert!(cleaned.is_char_boundary(cleaned.len() - '…'.len_utf8()));
     }
 
     #[test]
@@ -491,13 +540,83 @@ mod tests {
 
     #[test]
     fn push_diagnostic_line_is_retained_in_ring() {
-        // Clear by pushing past capacity then checking presence of a unique marker.
-        let marker = format!("jean-diag-marker-{}", std::process::id());
-        push_diagnostic_line("stderr", &marker);
+        let _guard = DIAGNOSTICS_TEST_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Exercise retention + eviction: overfill with uniquely identifiable lines.
+        // Exact formatted strings avoid substring false-positives (e.g. "-1" in "-10").
+        let generation = begin_diagnostics_generation();
+        let prefix = format!("jean-diag-evict-{}", std::process::id());
+        let overflow = 25;
+        let total = DIAGNOSTIC_RING_CAP + overflow;
+        let line = |i: usize| format!("[stderr] {prefix}-{i}");
+        for i in 0..total {
+            push_diagnostic_line("stderr", &format!("{prefix}-{i}"), generation);
+        }
+
+        let snapshot = recent_managed_server_diagnostics();
+        assert_eq!(
+            snapshot.len(),
+            DIAGNOSTIC_RING_CAP,
+            "ring should be capped at DIAGNOSTIC_RING_CAP, got {}",
+            snapshot.len()
+        );
+
+        // Oldest entries must have been terminated (pop_front on overflow).
+        for i in 0..overflow {
+            let old = line(i);
+            assert!(
+                !snapshot.iter().any(|l| l == &old),
+                "oldest entry still present after eviction: {old}"
+            );
+        }
+
+        // Newest entries must remain, in FIFO order.
+        let expected: Vec<String> = (overflow..total).map(line).collect();
+        assert_eq!(
+            snapshot, expected,
+            "ring contents should be the newest DIAGNOSTIC_RING_CAP entries in order"
+        );
+    }
+
+    #[test]
+    fn begin_diagnostics_generation_clears_prior_lines() {
+        let _guard = DIAGNOSTICS_TEST_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let gen1 = begin_diagnostics_generation();
+        let stale = format!("jean-stale-diag-{}", std::process::id());
+        push_diagnostic_line("stderr", &stale, gen1);
+        assert!(
+            recent_managed_server_diagnostics()
+                .iter()
+                .any(|l| l.contains(&stale)),
+            "precondition: stale line must be present before clear"
+        );
+
+        let gen2 = begin_diagnostics_generation();
+        let snapshot_after_clear = recent_managed_server_diagnostics();
+        assert!(
+            snapshot_after_clear.is_empty(),
+            "expected empty ring after new generation, got {snapshot_after_clear:?}"
+        );
+        // Stale-generation writes must not re-contaminate the ring.
+        push_diagnostic_line("stderr", &stale, gen1);
+        assert!(
+            recent_managed_server_diagnostics().is_empty(),
+            "stale generation must not append after clear"
+        );
+
+        let fresh = format!("jean-fresh-diag-{}", std::process::id());
+        push_diagnostic_line("stderr", &fresh, gen2);
         let snapshot = recent_managed_server_diagnostics();
         assert!(
-            snapshot.iter().any(|l| l.contains(&marker)),
-            "expected marker in {snapshot:?}"
+            snapshot.iter().any(|l| l.contains(&fresh)),
+            "expected fresh marker in {snapshot:?}"
+        );
+        assert!(
+            snapshot.iter().all(|l| !l.contains(&stale)),
+            "stale marker must stay absent, got {snapshot:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Surface OpenCode provider errors from primary **and** descendant/child (subagent) sessions so the owning Jean run fails immediately with the actionable provider message instead of hanging
- Stop automatic retries of non-idempotent OpenCode `/message` POSTs after timeouts or ambiguous request-level failures (one Jean send → one user message)
- Keep provider failures distinct from explicit user cancellation
- Retain sanitized managed OpenCode server stdout/stderr diagnostics instead of discarding them
- Add regression coverage for child-session error routing, SSE error while POST is blocked, single timed-out POST attempt, and diagnostic sanitization/redaction

## Breaking Changes

None.

fixes #587

---

Fixes #587