### PR TITLE
feat(chat): retain scroll position when switching sessions

### DIFF
--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -1248,7 +1248,11 @@ export function ChatWindow({
   } = useScrollManagement({
     messages: session?.messages,
     virtualizedListRef,
-    activeWorktreeId,
+    // Key scroll restoration on the displayed session (deferred) so we save
+    // and restore against the transcript that is actually mounted (issue #594).
+    activeSessionId: deferredSessionId,
+    contentReady:
+      !isLoading && !isSessionsLoading && !isSessionSwitching && !!session,
     isSending,
   })
 

--- a/src/components/chat/VirtualizedMessageList.tsx
+++ b/src/components/chat/VirtualizedMessageList.tsx
@@ -23,9 +23,14 @@ import {
   restorePrependScrollAnchor,
   type PrependScrollAnchor,
 } from './message-scroll-anchor'
+import {
+  getDefaultVisibleCount,
+  getSessionScrollState,
+  updateSessionScrollState,
+} from './session-scroll-state'
 
 /** Number of messages to render initially (from the end) */
-const INITIAL_VISIBLE_COUNT = 10
+const INITIAL_VISIBLE_COUNT = getDefaultVisibleCount()
 /** Number of messages to load when scrolling up */
 const LOAD_MORE_COUNT = 20
 /** Scroll threshold in pixels to trigger loading more */
@@ -194,8 +199,15 @@ export const VirtualizedMessageList = memo(
       }, [messages])
       const getMessages = useCallback(() => messagesRef.current, [])
 
-      // Track how many messages to render (from the end)
-      const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_COUNT)
+      // Track how many messages to render (from the end). Seed from any saved
+      // per-session snapshot so returning to a session re-mounts the same
+      // history window the user had expanded (issue #594).
+      const [visibleCount, setVisibleCount] = useState(() => {
+        const saved = sessionId
+          ? getSessionScrollState(sessionId)?.visibleCount
+          : undefined
+        return saved ?? INITIAL_VISIBLE_COUNT
+      })
 
       // Calculate which messages to render
       const startIndex = Math.max(0, messages.length - visibleCount)
@@ -203,15 +215,24 @@ export const VirtualizedMessageList = memo(
       const hasMoreMessages = startIndex > 0
       const showLoadMoreButton = hasMoreMessages || hasOlderOnDisk
 
-      // Reset visible count when session changes
+      // Restore (or reset) visible count when session changes, and keep the
+      // in-memory snapshot updated as the user expands the window.
       const prevSessionRef = useRef(sessionId)
       useEffect(() => {
         if (sessionId !== prevSessionRef.current) {
+          const saved = sessionId
+            ? getSessionScrollState(sessionId)?.visibleCount
+            : undefined
           // eslint-disable-next-line react-hooks/set-state-in-effect
-          setVisibleCount(INITIAL_VISIBLE_COUNT)
+          setVisibleCount(saved ?? INITIAL_VISIBLE_COUNT)
           prevSessionRef.current = sessionId
         }
       }, [sessionId])
+
+      useEffect(() => {
+        if (!sessionId) return
+        updateSessionScrollState(sessionId, { visibleCount })
+      }, [sessionId, visibleCount])
 
       // Pre-compute hasFollowUpMessage for all messages in O(n) instead of O(n²)
       const hasFollowUpMap = useMemo(() => {

--- a/src/components/chat/VirtualizedMessageList.tsx
+++ b/src/components/chat/VirtualizedMessageList.tsx
@@ -218,6 +218,17 @@ export const VirtualizedMessageList = memo(
       // Restore (or reset) visible count when session changes, and keep the
       // in-memory snapshot updated as the user expands the window.
       const prevSessionRef = useRef(sessionId)
+
+      // Persist only after the current session's visibleCount has settled.
+      // This effect must run *before* the restore effect so that on a session
+      // switch, prevSessionRef still points at the outgoing session and we
+      // skip writing that session's window size under the incoming id.
+      useEffect(() => {
+        if (!sessionId) return
+        if (prevSessionRef.current !== sessionId) return
+        updateSessionScrollState(sessionId, { visibleCount })
+      }, [sessionId, visibleCount])
+
       useEffect(() => {
         if (sessionId !== prevSessionRef.current) {
           const saved = sessionId
@@ -228,11 +239,6 @@ export const VirtualizedMessageList = memo(
           prevSessionRef.current = sessionId
         }
       }, [sessionId])
-
-      useEffect(() => {
-        if (!sessionId) return
-        updateSessionScrollState(sessionId, { visibleCount })
-      }, [sessionId, visibleCount])
 
       // Pre-compute hasFollowUpMessage for all messages in O(n) instead of O(n²)
       const hasFollowUpMap = useMemo(() => {

--- a/src/components/chat/hooks/useScrollManagement.test.tsx
+++ b/src/components/chat/hooks/useScrollManagement.test.tsx
@@ -1,6 +1,12 @@
 import { act, fireEvent, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useScrollManagement } from './useScrollManagement'
+import {
+  __resetSessionScrollStateForTests,
+  getSessionScrollState,
+  saveSessionScrollState,
+} from '../session-scroll-state'
+import type { ChatMessage } from '@/types/chat'
 
 let isMobile = false
 
@@ -43,24 +49,77 @@ function defineReadonlyNumber(
 
 interface SetupHookOptions {
   isSending?: boolean
+  activeSessionId?: string
+  contentReady?: boolean
+  messages?: ChatMessage[]
+  scrollHeight?: number
 }
 
-function setupHook({ isSending = true }: SetupHookOptions = {}) {
-  const virtualizedListRef = { current: null }
+function makeMessages(count: number): ChatMessage[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `m-${i}`,
+    session_id: 'session-a',
+    role: i % 2 === 0 ? 'user' : 'assistant',
+    content: `message ${i}`,
+    timestamp: Date.now(),
+    tool_calls: [],
+  }))
+}
 
-  function TestHarness() {
+function attachViewportMetrics(el: HTMLElement | null, scrollHeight: number) {
+  if (!el) return
+  defineReadonlyNumber(el, 'clientHeight', 400)
+  defineReadonlyNumber(el, 'scrollHeight', scrollHeight)
+  const plan = el.querySelector('[data-testid="plan"]') as HTMLElement | null
+  if (plan) {
+    defineReadonlyNumber(plan, 'offsetTop', 600)
+  }
+}
+
+function setupHook({
+  isSending = true,
+  activeSessionId = 'session-1',
+  contentReady = true,
+  messages = [],
+  scrollHeight = 2000,
+}: SetupHookOptions = {}) {
+  const virtualizedListRef = { current: null }
+  // Keep latest values for rerenderSession defaults
+  let currentSessionId = activeSessionId
+  let currentReady = contentReady
+  let currentMessages = messages
+  let currentSending = isSending
+  let currentScrollHeight = scrollHeight
+
+  function TestHarness({
+    sessionId,
+    ready,
+    msgs,
+    sending,
+  }: {
+    sessionId: string
+    ready: boolean
+    msgs: ChatMessage[]
+    sending: boolean
+  }) {
     const { isAtBottom, scrollViewportRef, handleScroll } = useScrollManagement(
       {
-        messages: [],
+        messages: msgs,
         virtualizedListRef,
-        activeWorktreeId: 'worktree-1',
-        isSending,
+        activeSessionId: sessionId,
+        contentReady: ready,
+        isSending: sending,
       }
     )
 
     return (
       <div
-        ref={scrollViewportRef}
+        ref={el => {
+          // Metrics must be available before useScrollManagement's layout
+          // effects read scrollHeight (session restore / scroll-to-tail).
+          attachViewportMetrics(el, currentScrollHeight)
+          scrollViewportRef.current = el
+        }}
         data-testid="viewport"
         onScroll={handleScroll}
       >
@@ -72,15 +131,47 @@ function setupHook({ isSending = true }: SetupHookOptions = {}) {
     )
   }
 
-  const renderResult = render(<TestHarness />)
+  const renderResult = render(
+    <TestHarness
+      sessionId={activeSessionId}
+      ready={contentReady}
+      msgs={messages}
+      sending={isSending}
+    />
+  )
   const viewport = renderResult.getByTestId('viewport')
   const plan = renderResult.getByTestId('plan')
 
-  defineReadonlyNumber(viewport, 'clientHeight', 400)
-  defineReadonlyNumber(viewport, 'scrollHeight', 2000)
-  defineReadonlyNumber(plan, 'offsetTop', 600)
-
-  return { ...renderResult, viewport, plan }
+  return {
+    ...renderResult,
+    viewport,
+    plan,
+    setScrollHeight: (nextScrollHeight: number) => {
+      currentScrollHeight = nextScrollHeight
+      defineReadonlyNumber(viewport, 'scrollHeight', nextScrollHeight)
+    },
+    rerenderSession: (
+      next: Partial<{
+        sessionId: string
+        ready: boolean
+        msgs: ChatMessage[]
+        sending: boolean
+      }>
+    ) => {
+      currentSessionId = next.sessionId ?? currentSessionId
+      currentReady = next.ready ?? currentReady
+      currentMessages = next.msgs ?? currentMessages
+      currentSending = next.sending ?? currentSending
+      renderResult.rerender(
+        <TestHarness
+          sessionId={currentSessionId}
+          ready={currentReady}
+          msgs={currentMessages}
+          sending={currentSending}
+        />
+      )
+    },
+  }
 }
 
 async function triggerResize() {
@@ -98,6 +189,7 @@ describe('useScrollManagement streaming auto-scroll', () => {
   beforeEach(() => {
     isMobile = false
     resizeObserverCallbacks = []
+    __resetSessionScrollStateForTests()
     Object.defineProperty(globalThis, 'ResizeObserver', {
       configurable: true,
       value: ResizeObserverMock,
@@ -123,6 +215,7 @@ describe('useScrollManagement streaming auto-scroll', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    __resetSessionScrollStateForTests()
     Object.defineProperty(globalThis, 'ResizeObserver', {
       configurable: true,
       value: originalResizeObserver,
@@ -233,6 +326,204 @@ describe('useScrollManagement streaming auto-scroll', () => {
     defineReadonlyNumber(viewport, 'scrollHeight', 350)
     await triggerResize()
 
+    expect(getByTestId('is-at-bottom')).toHaveTextContent('true')
+  })
+})
+
+describe('useScrollManagement session scroll retention (issue #594)', () => {
+  beforeEach(() => {
+    isMobile = false
+    resizeObserverCallbacks = []
+    __resetSessionScrollStateForTests()
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      configurable: true,
+      value: ResizeObserverMock,
+    })
+    Object.defineProperty(globalThis, 'IntersectionObserver', {
+      configurable: true,
+      value: IntersectionObserverMock,
+    })
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: function scrollTo(options: ScrollToOptions) {
+        if (typeof options.top === 'number') {
+          this.scrollTop = options.top
+        }
+      },
+    })
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      callback(performance.now())
+      return 1
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    __resetSessionScrollStateForTests()
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      configurable: true,
+      value: originalResizeObserver,
+    })
+    Object.defineProperty(globalThis, 'IntersectionObserver', {
+      configurable: true,
+      value: originalIntersectionObserver,
+    })
+  })
+
+  it('saves scroll position while scrolling a session', () => {
+    const { viewport } = setupHook({
+      isSending: false,
+      activeSessionId: 'session-a',
+      messages: makeMessages(5),
+    })
+
+    // Start from the post-mount tail position, then scroll up so follow mode
+    // clears the same way a real wheel-up gesture would.
+    expect(viewport.scrollTop).toBe(2000)
+    viewport.scrollTop = 1234
+    fireEvent.scroll(viewport)
+
+    expect(getSessionScrollState('session-a')?.scrollTop).toBe(1234)
+    expect(getSessionScrollState('session-a')?.isFollowingTail).toBe(false)
+  })
+
+  it('does not overwrite a snapshot while content is not ready', () => {
+    saveSessionScrollState('session-a', {
+      scrollTop: 800,
+      isFollowingTail: false,
+      visibleCount: 30,
+    })
+
+    const { viewport } = setupHook({
+      isSending: false,
+      activeSessionId: 'session-a',
+      contentReady: false,
+      messages: makeMessages(5),
+    })
+
+    viewport.scrollTop = 0
+    fireEvent.scroll(viewport)
+
+    expect(getSessionScrollState('session-a')?.scrollTop).toBe(800)
+    expect(getSessionScrollState('session-a')?.isFollowingTail).toBe(false)
+  })
+
+  it('restores a non-tail position when returning to a session', () => {
+    saveSessionScrollState('session-a', {
+      scrollTop: 900,
+      isFollowingTail: false,
+      visibleCount: 40,
+    })
+
+    const { viewport, getByTestId } = setupHook({
+      isSending: false,
+      activeSessionId: 'session-a',
+      contentReady: true,
+      messages: makeMessages(8),
+    })
+
+    expect(viewport.scrollTop).toBe(900)
+    expect(getByTestId('is-at-bottom')).toHaveTextContent('false')
+  })
+
+  it('pins to bottom for sessions that were following the tail', () => {
+    saveSessionScrollState('session-a', {
+      scrollTop: 100,
+      isFollowingTail: true,
+      visibleCount: 20,
+    })
+
+    const { viewport, getByTestId } = setupHook({
+      isSending: false,
+      activeSessionId: 'session-a',
+      contentReady: true,
+      messages: makeMessages(8),
+    })
+
+    expect(viewport.scrollTop).toBe(2000)
+    expect(getByTestId('is-at-bottom')).toHaveTextContent('true')
+  })
+
+  it('restores after content becomes ready following a session switch', () => {
+    saveSessionScrollState('session-b', {
+      scrollTop: 700,
+      isFollowingTail: false,
+      visibleCount: 25,
+    })
+
+    const { viewport, getByTestId, rerenderSession } = setupHook({
+      isSending: false,
+      activeSessionId: 'session-a',
+      contentReady: true,
+      messages: makeMessages(5),
+    })
+
+    // Switch away: content not ready (Loading placeholder)
+    act(() => {
+      rerenderSession({
+        sessionId: 'session-b',
+        ready: false,
+        msgs: makeMessages(5),
+      })
+    })
+
+    // Content mounts for session-b — restore saved offset
+    act(() => {
+      rerenderSession({
+        sessionId: 'session-b',
+        ready: true,
+        msgs: makeMessages(5),
+      })
+    })
+
+    expect(viewport.scrollTop).toBe(700)
+    expect(getByTestId('is-at-bottom')).toHaveTextContent('false')
+  })
+
+  it('keeps a saved restore pending until the expanded history window mounts', async () => {
+    saveSessionScrollState('session-b', {
+      scrollTop: 700,
+      isFollowingTail: false,
+      visibleCount: 40,
+    })
+
+    const { viewport, getByTestId, rerenderSession, setScrollHeight } = setupHook({
+      isSending: false,
+      activeSessionId: 'session-a',
+      messages: makeMessages(10),
+    })
+
+    // The new session first renders with the previous session's short history
+    // window, so there is temporarily no scrollable overflow.
+    setScrollHeight(400)
+    act(() => {
+      rerenderSession({
+        sessionId: 'session-b',
+        msgs: makeMessages(40),
+      })
+    })
+
+    expect(viewport.scrollTop).toBe(0)
+    expect(getByTestId('is-at-bottom')).toHaveTextContent('false')
+
+    // VirtualizedMessageList then applies session-b's saved visibleCount.
+    setScrollHeight(2000)
+    await triggerResize()
+
+    expect(viewport.scrollTop).toBe(700)
+    expect(getByTestId('is-at-bottom')).toHaveTextContent('false')
+  })
+
+  it('defaults new sessions to the bottom', () => {
+    const { viewport, getByTestId } = setupHook({
+      isSending: false,
+      activeSessionId: 'brand-new',
+      contentReady: true,
+      messages: makeMessages(3),
+    })
+
+    expect(viewport.scrollTop).toBe(2000)
     expect(getByTestId('is-at-bottom')).toHaveTextContent('true')
   })
 })

--- a/src/components/chat/hooks/useScrollManagement.test.tsx
+++ b/src/components/chat/hooks/useScrollManagement.test.tsx
@@ -481,6 +481,68 @@ describe('useScrollManagement session scroll retention (issue #594)', () => {
     expect(getByTestId('is-at-bottom')).toHaveTextContent('false')
   })
 
+  it('saves on leave and restores after a full session round-trip', () => {
+    // Do not pre-seed with saveSessionScrollState — the leave layout effect
+    // (persistCurrentSessionScroll) must capture the outgoing session.
+    const { viewport, getByTestId, rerenderSession } = setupHook({
+      isSending: false,
+      activeSessionId: 'session-a',
+      contentReady: true,
+      messages: makeMessages(8),
+    })
+
+    expect(viewport.scrollTop).toBe(2000)
+
+    // Scroll session-a away from the tail the same way a real gesture would.
+    viewport.scrollTop = 1234
+    fireEvent.scroll(viewport)
+
+    // Switch to session-b: save-on-leave should snapshot session-a first.
+    act(() => {
+      rerenderSession({
+        sessionId: 'session-b',
+        ready: false,
+        msgs: makeMessages(5),
+      })
+    })
+
+    expect(getSessionScrollState('session-a')?.scrollTop).toBe(1234)
+    expect(getSessionScrollState('session-a')?.isFollowingTail).toBe(false)
+
+    act(() => {
+      rerenderSession({
+        sessionId: 'session-b',
+        ready: true,
+        msgs: makeMessages(5),
+      })
+    })
+
+    // New / unvisited sessions default to the tail.
+    expect(viewport.scrollTop).toBe(2000)
+    expect(getByTestId('is-at-bottom')).toHaveTextContent('true')
+
+    // Switch back to session-a through the loading → ready path and assert
+    // the leave-time snapshot is restored (not a pre-seeded value).
+    act(() => {
+      rerenderSession({
+        sessionId: 'session-a',
+        ready: false,
+        msgs: makeMessages(8),
+      })
+    })
+
+    act(() => {
+      rerenderSession({
+        sessionId: 'session-a',
+        ready: true,
+        msgs: makeMessages(8),
+      })
+    })
+
+    expect(viewport.scrollTop).toBe(1234)
+    expect(getByTestId('is-at-bottom')).toHaveTextContent('false')
+  })
+
   it('keeps a saved restore pending until the expanded history window mounts', async () => {
     saveSessionScrollState('session-b', {
       scrollTop: 700,
@@ -513,6 +575,36 @@ describe('useScrollManagement session scroll retention (issue #594)', () => {
 
     expect(viewport.scrollTop).toBe(700)
     expect(getByTestId('is-at-bottom')).toHaveTextContent('false')
+  })
+
+  it('gives up on an unreachable restore and re-enables tail-following', async () => {
+    // Saved offset can never be reached (history cleared / compacted).
+    // Deferred restore must not latch pendingRestore forever and leave the
+    // floating Bottom button + streaming auto-scroll stuck off.
+    saveSessionScrollState('session-a', {
+      scrollTop: 5000,
+      isFollowingTail: false,
+      visibleCount: 80,
+    })
+
+    const { getByTestId } = setupHook({
+      isSending: false,
+      activeSessionId: 'session-a',
+      contentReady: true,
+      messages: makeMessages(3),
+      // clientHeight is 400 in the harness — no overflow, target unreachable.
+      scrollHeight: 400,
+    })
+
+    expect(getByTestId('is-at-bottom')).toHaveTextContent('false')
+
+    // Burn the deferred-restore budget via ResizeObserver (and any stall
+    // retries that fire between ticks). Cap is 20 attempts.
+    for (let i = 0; i < 25; i++) {
+      await triggerResize()
+    }
+
+    expect(getByTestId('is-at-bottom')).toHaveTextContent('true')
   })
 
   it('defaults new sessions to the bottom', () => {

--- a/src/components/chat/hooks/useScrollManagement.ts
+++ b/src/components/chat/hooks/useScrollManagement.ts
@@ -9,14 +9,29 @@ import type { RefObject } from 'react'
 import type { VirtualizedMessageListHandle } from '../VirtualizedMessageList'
 import type { ChatMessage } from '@/types/chat'
 import { useIsMobile } from '@/hooks/use-mobile'
+import {
+  getDefaultVisibleCount,
+  getSessionScrollState,
+  saveSessionScrollState,
+  updateSessionScrollState,
+} from '../session-scroll-state'
 
 interface UseScrollManagementOptions {
   /** Messages array for finding findings index */
   messages: ChatMessage[] | undefined
   /** Ref to virtualized list for scrolling to specific message index */
   virtualizedListRef: RefObject<VirtualizedMessageListHandle | null>
-  /** Active worktree ID — used to scroll to bottom before paint on switch */
-  activeWorktreeId: string | null
+  /**
+   * Session whose transcript is currently displayed (deferred session id).
+   * Used as the key for per-session scroll restoration (issue #594).
+   */
+  activeSessionId: string | null | undefined
+  /**
+   * False while the message list is unmounted (session switch loading
+   * placeholder, initial load). Prevents saving a zero scrollTop from the
+   * short "Loading..." content over a real snapshot.
+   */
+  contentReady?: boolean
   /** Whether a message is currently being streamed — enables ResizeObserver auto-scroll */
   isSending?: boolean
 }
@@ -69,7 +84,8 @@ function scrollToTail(viewport: HTMLDivElement) {
 export function useScrollManagement({
   messages,
   virtualizedListRef,
-  activeWorktreeId,
+  activeSessionId,
+  contentReady = true,
   isSending,
 }: UseScrollManagementOptions): UseScrollManagementReturn {
   const isMobile = useIsMobile()
@@ -95,6 +111,53 @@ export function useScrollManagement({
   const userScrollUpUntilRef = useRef(0)
   const lastScrollTopRef = useRef(0)
   const touchStartYRef = useRef<number | null>(null)
+  // Last known good scroll snapshot for the displayed session. Updated on every
+  // real scroll; used when leaving a session so Loading placeholders cannot
+  // overwrite a real position with scrollTop=0.
+  const lastKnownScrollRef = useRef({
+    sessionId: activeSessionId ?? '',
+    scrollTop: 0,
+    isFollowingTail: true,
+  })
+  const prevSessionIdRef = useRef<string | null | undefined>(activeSessionId)
+  // When true, the next content-ready layout pass should apply a saved
+  // non-tail scrollTop instead of pinning to the bottom.
+  const pendingRestoreRef = useRef(false)
+  const contentReadyRef = useRef(contentReady)
+  contentReadyRef.current = contentReady
+
+  const persistCurrentSessionScroll = useCallback(
+    (sessionId: string | null | undefined) => {
+      if (!sessionId) return
+      const known = lastKnownScrollRef.current
+      // Prefer the ref that was continuously updated while this session was
+      // displayed; fall back to whatever is already cached.
+      if (known.sessionId === sessionId) {
+        saveSessionScrollState(sessionId, {
+          scrollTop: known.scrollTop,
+          isFollowingTail: known.isFollowingTail,
+          visibleCount:
+            getSessionScrollState(sessionId)?.visibleCount ??
+            getDefaultVisibleCount(),
+        })
+      }
+    },
+    []
+  )
+
+  const rememberScroll = useCallback(
+    (scrollTop: number, isFollowingTail: boolean) => {
+      const sessionId = activeSessionId
+      if (!sessionId || !contentReadyRef.current) return
+      lastKnownScrollRef.current = {
+        sessionId,
+        scrollTop,
+        isFollowingTail,
+      }
+      updateSessionScrollState(sessionId, { scrollTop, isFollowingTail })
+    },
+    [activeSessionId]
+  )
 
   const stopFollowingTail = useCallback(() => {
     if (scrollTimeoutRef.current) {
@@ -106,7 +169,9 @@ export function useScrollManagement({
     isAtBottomRef.current = false
     setIsAtBottom(false)
     userScrollUpUntilRef.current = Date.now() + 1000
-  }, [])
+    const viewport = scrollViewportRef.current
+    rememberScroll(viewport?.scrollTop ?? lastKnownScrollRef.current.scrollTop, false)
+  }, [rememberScroll])
 
   // Cleanup scroll timeout on unmount
   useEffect(() => {
@@ -254,14 +319,31 @@ export function useScrollManagement({
   // longer overflows (short message list, window got taller, content collapsed),
   // it is necessarily at the bottom. This clears stale "scrolled away" state
   // without changing behavior for genuinely scrollable chats.
+  // Also re-applies a pending non-tail restore once the message list grows tall
+  // enough (e.g. VirtualizedMessageList expands its visible window).
+  const activeSessionIdRef = useRef(activeSessionId)
+  activeSessionIdRef.current = activeSessionId
+  const applySessionScrollStateRef = useRef<
+    (sessionId: string | null | undefined) => void
+  >(() => {})
+
   useEffect(() => {
     const viewport = scrollViewportRef.current
     if (!viewport) return
 
     let rafId = 0
-    const syncNonScrollableState = () => {
+    const syncViewportSize = () => {
       cancelAnimationFrame(rafId)
       rafId = requestAnimationFrame(() => {
+        const sessionId = activeSessionIdRef.current
+        if (
+          pendingRestoreRef.current &&
+          contentReadyRef.current &&
+          sessionId
+        ) {
+          applySessionScrollStateRef.current(sessionId)
+          return
+        }
         if (!hasScrollableOverflow(viewport)) {
           userScrollUpUntilRef.current = 0
           isFollowingTailRef.current = true
@@ -271,9 +353,9 @@ export function useScrollManagement({
       })
     }
 
-    syncNonScrollableState()
+    syncViewportSize()
 
-    const observer = new ResizeObserver(syncNonScrollableState)
+    const observer = new ResizeObserver(syncViewportSize)
     observer.observe(viewport)
     if (viewport.firstElementChild) {
       observer.observe(viewport.firstElementChild)
@@ -409,70 +491,193 @@ export function useScrollManagement({
     wasSendingRef.current = !!isSending
   }, [isSending])
 
-  // Scroll to bottom before paint when switching worktrees to prevent flash of top content
-  useLayoutEffect(() => {
-    const viewport = scrollViewportRef.current
-    if (viewport) {
-      isFollowingTailRef.current = true
-      userScrollUpUntilRef.current = 0
-      scrollToTail(viewport)
-    }
-  }, [activeWorktreeId])
+  // Apply a saved scroll snapshot (or default to bottom) for the given session.
+  const applySessionScrollState = useCallback(
+    (sessionId: string | null | undefined) => {
+      const viewport = scrollViewportRef.current
+      if (!viewport) return
 
-  // Scroll to bottom when messages first load for a session (async data arrival).
-  // Without this, opening a session shows the top of the message list.
+      const saved = sessionId ? getSessionScrollState(sessionId) : undefined
+
+      if (!saved || saved.isFollowingTail) {
+        isFollowingTailRef.current = true
+        isAtBottomRef.current = true
+        userScrollUpUntilRef.current = 0
+        setIsAtBottom(true)
+        scrollToTail(viewport)
+        lastScrollTopRef.current = viewport.scrollTop
+        if (sessionId) {
+          lastKnownScrollRef.current = {
+            sessionId,
+            scrollTop: viewport.scrollTop,
+            isFollowingTail: true,
+          }
+        }
+        pendingRestoreRef.current = false
+        return
+      }
+
+      // Non-tail restore: pin flags first so streaming auto-scroll does not
+      // fight the restored position while content settles.
+      isFollowingTailRef.current = false
+      isAtBottomRef.current = false
+      userScrollUpUntilRef.current = Date.now() + 1000
+      setIsAtBottom(false)
+
+      const maxScroll = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
+      const targetTop = Math.min(Math.max(0, saved.scrollTop), maxScroll)
+      viewport.scrollTop = targetTop
+      lastScrollTopRef.current = targetTop
+      lastKnownScrollRef.current = {
+        sessionId: sessionId ?? '',
+        scrollTop: targetTop,
+        isFollowingTail: false,
+      }
+
+      // If content is still short (message list not fully mounted / virtualized
+      // window not expanded yet), keep pending so ResizeObserver can re-apply
+      // the target after the saved history window mounts. A session switch can
+      // temporarily render the previous session's smaller visibleCount, so no
+      // overflow here does not prove the saved session was following its tail.
+      if (!hasScrollableOverflow(viewport)) {
+        pendingRestoreRef.current = true
+      } else if (
+        saved.scrollTop > 0 &&
+        maxScroll < saved.scrollTop - SCROLL_EPSILON_PX
+      ) {
+        pendingRestoreRef.current = true
+      } else {
+        pendingRestoreRef.current = false
+        // Content may have grown such that the saved offset is now at bottom.
+        if (isViewportAtBottom(viewport)) {
+          isFollowingTailRef.current = true
+          isAtBottomRef.current = true
+          userScrollUpUntilRef.current = 0
+          setIsAtBottom(true)
+          lastKnownScrollRef.current = {
+            sessionId: sessionId ?? '',
+            scrollTop: viewport.scrollTop,
+            isFollowingTail: true,
+          }
+          updateSessionScrollState(sessionId ?? '', {
+            scrollTop: viewport.scrollTop,
+            isFollowingTail: true,
+          })
+        }
+      }
+    },
+    []
+  )
+  applySessionScrollStateRef.current = applySessionScrollState
+
+  // Persist the previous session and prepare restore when the displayed session
+  // changes (covers both tab switches and worktree switches).
+  useLayoutEffect(() => {
+    const prevSessionId = prevSessionIdRef.current
+    if (prevSessionId && prevSessionId !== activeSessionId) {
+      persistCurrentSessionScroll(prevSessionId)
+    }
+    prevSessionIdRef.current = activeSessionId
+
+    if (!activeSessionId) return
+
+    const saved = getSessionScrollState(activeSessionId)
+    pendingRestoreRef.current = Boolean(saved && !saved.isFollowingTail)
+
+    // Only apply immediately when the message list is mounted. Otherwise wait
+    // for the contentReady + messages layout effect below.
+    if (contentReadyRef.current) {
+      applySessionScrollState(activeSessionId)
+    } else if (!saved || saved.isFollowingTail) {
+      // Default: treat as following tail so FloatingButtons / auto-scroll stay
+      // correct once content mounts.
+      isFollowingTailRef.current = true
+      isAtBottomRef.current = true
+      setIsAtBottom(true)
+    } else {
+      isFollowingTailRef.current = false
+      isAtBottomRef.current = false
+      setIsAtBottom(false)
+    }
+  }, [activeSessionId, applySessionScrollState, persistCurrentSessionScroll])
+
+  // Restore (or scroll to bottom) when content becomes ready / messages arrive.
+  // Covers: first open of a session, async session load, and return from the
+  // session-switch Loading placeholder.
   const prevMessageLengthRef = useRef(messages?.length ?? 0)
+  const prevContentReadyRef = useRef(contentReady)
   useLayoutEffect(() => {
     const currentLength = messages?.length ?? 0
     const prevLength = prevMessageLengthRef.current
     prevMessageLengthRef.current = currentLength
 
-    if (prevLength === 0 && currentLength > 0) {
-      const viewport = scrollViewportRef.current
-      if (viewport) {
-        isFollowingTailRef.current = true
-        userScrollUpUntilRef.current = 0
-        scrollToTail(viewport)
-      }
+    const becameReady = contentReady && !prevContentReadyRef.current
+    prevContentReadyRef.current = contentReady
+
+    if (!contentReady || !activeSessionId) return
+
+    const messagesJustLoaded = prevLength === 0 && currentLength > 0
+    if (
+      becameReady ||
+      messagesJustLoaded ||
+      pendingRestoreRef.current
+    ) {
+      applySessionScrollState(activeSessionId)
     }
-  }, [messages?.length])
+  }, [
+    contentReady,
+    messages?.length,
+    activeSessionId,
+    applySessionScrollState,
+  ])
 
   // [Tier 1] Handle scroll events — findings visibility removed (handled by IntersectionObserver)
-  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
-    // Skip updating isAtBottom during auto-scroll to avoid race conditions
-    // This prevents the smooth scroll animation from incorrectly marking us as "not at bottom"
-    if (isAutoScrollingRef.current) {
-      return
-    }
+  const handleScroll = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      // Skip updating isAtBottom during auto-scroll to avoid race conditions
+      // This prevents the smooth scroll animation from incorrectly marking us as "not at bottom"
+      if (isAutoScrollingRef.current) {
+        return
+      }
 
-    const target = e.target as HTMLDivElement
-    const previousScrollTop = lastScrollTopRef.current
-    lastScrollTopRef.current = target.scrollTop
+      // Session-switch Loading placeholder (or other unmounted list): do not
+      // overwrite a real per-session snapshot with a collapsed scrollTop.
+      if (!contentReadyRef.current) {
+        return
+      }
 
-    if (
-      hasScrollableOverflow(target) &&
-      target.scrollTop < previousScrollTop - SCROLL_EPSILON_PX
-    ) {
-      isFollowingTailRef.current = false
-      userScrollUpUntilRef.current = Date.now() + 1000
-    }
+      const target = e.target as HTMLDivElement
+      const previousScrollTop = lastScrollTopRef.current
+      lastScrollTopRef.current = target.scrollTop
 
-    const atBottom = isViewportAtBottom(target)
+      if (
+        hasScrollableOverflow(target) &&
+        target.scrollTop < previousScrollTop - SCROLL_EPSILON_PX
+      ) {
+        isFollowingTailRef.current = false
+        userScrollUpUntilRef.current = Date.now() + 1000
+      }
 
-    if (atBottom) {
-      userScrollUpUntilRef.current = 0
-      isFollowingTailRef.current = true
-    }
+      const atBottom = isViewportAtBottom(target)
 
-    // During cooldown after user scrolled up, only allow transitions to NOT-at-bottom
-    if (Date.now() < userScrollUpUntilRef.current && atBottom) {
-      return
-    }
+      if (atBottom) {
+        userScrollUpUntilRef.current = 0
+        isFollowingTailRef.current = true
+      }
 
-    isAtBottomRef.current = atBottom
-    // PERFORMANCE: Functional setState skips re-render when value hasn't changed
-    setIsAtBottom(prev => (prev === atBottom ? prev : atBottom))
-  }, [])
+      // During cooldown after user scrolled up, only allow transitions to NOT-at-bottom
+      if (Date.now() < userScrollUpUntilRef.current && atBottom) {
+        rememberScroll(target.scrollTop, false)
+        return
+      }
+
+      isAtBottomRef.current = atBottom
+      // PERFORMANCE: Functional setState skips re-render when value hasn't changed
+      setIsAtBottom(prev => (prev === atBottom ? prev : atBottom))
+      rememberScroll(target.scrollTop, isFollowingTailRef.current)
+    },
+    [rememberScroll]
+  )
 
   // Handle scroll-to-bottom completion from VirtualizedMessageList
   const handleScrollToBottomHandled = useCallback(() => {
@@ -480,73 +685,82 @@ export function useScrollManagement({
     userScrollUpUntilRef.current = 0
     isAtBottomRef.current = true
     setIsAtBottom(true)
-  }, [])
+    pendingRestoreRef.current = false
+    const viewport = scrollViewportRef.current
+    rememberScroll(viewport?.scrollTop ?? lastKnownScrollRef.current.scrollTop, true)
+  }, [rememberScroll])
 
   // [Tier 4] Scroll to bottom helper — uses scrollend event instead of 350ms timeout.
   // Findings visibility check removed (handled by IntersectionObserver).
   // Pass instant=true for user-initiated actions (answering questions, approving plans)
   // where DOM changes immediately and smooth scroll would target stale scrollHeight.
   // Default smooth is for auto-scroll during streaming.
-  const scrollToBottom = useCallback((instant?: boolean) => {
-    const viewport = scrollViewportRef.current
-    if (!viewport) return
+  const scrollToBottom = useCallback(
+    (instant?: boolean) => {
+      const viewport = scrollViewportRef.current
+      if (!viewport) return
 
-    // Clear existing timeout to prevent memory leaks
-    if (scrollTimeoutRef.current) {
-      clearTimeout(scrollTimeoutRef.current)
-      scrollTimeoutRef.current = null
-    }
-
-    isAtBottomRef.current = true
-    isFollowingTailRef.current = true
-    userScrollUpUntilRef.current = 0
-    setIsAtBottom(true)
-
-    if (instant) {
-      // Instant scroll — no animation, no correction needed
-      isAutoScrollingRef.current = false
-      scrollToTail(viewport)
-      return
-    }
-
-    // Skip if a smooth scroll is already in flight — it will reach bottom.
-    // This prevents cascading animations when the auto-scroll effect fires
-    // rapidly (e.g. on every streaming content block).
-    if (isAutoScrollingRef.current) return
-
-    isAutoScrollingRef.current = true
-
-    viewport.scrollTo({
-      top: viewport.scrollHeight,
-      behavior: 'smooth',
-    })
-
-    // Use scrollend event to detect when smooth scroll finishes.
-    // Fallback to 400ms timeout for environments without scrollend support.
-    const onScrollEnd = () => {
-      isAutoScrollingRef.current = false
-      cleanup()
-
-      // Correct scroll position if smooth scroll ended at wrong spot
-      // (DOM changes during animation can cause stale scrollHeight targeting)
-      const { scrollTop, scrollHeight, clientHeight } = viewport
-      if (scrollHeight - scrollTop - clientHeight > 2) {
-        scrollToTail(viewport)
-      }
-    }
-
-    const cleanup = () => {
-      viewport.removeEventListener('scrollend', onScrollEnd)
+      // Clear existing timeout to prevent memory leaks
       if (scrollTimeoutRef.current) {
         clearTimeout(scrollTimeoutRef.current)
         scrollTimeoutRef.current = null
       }
-    }
 
-    viewport.addEventListener('scrollend', onScrollEnd, { once: true })
-    // Fallback timeout in case scrollend doesn't fire
-    scrollTimeoutRef.current = setTimeout(onScrollEnd, 400)
-  }, [])
+      isAtBottomRef.current = true
+      isFollowingTailRef.current = true
+      userScrollUpUntilRef.current = 0
+      setIsAtBottom(true)
+      pendingRestoreRef.current = false
+
+      if (instant) {
+        // Instant scroll — no animation, no correction needed
+        isAutoScrollingRef.current = false
+        scrollToTail(viewport)
+        rememberScroll(viewport.scrollTop, true)
+        return
+      }
+
+      // Skip if a smooth scroll is already in flight — it will reach bottom.
+      // This prevents cascading animations when the auto-scroll effect fires
+      // rapidly (e.g. on every streaming content block).
+      if (isAutoScrollingRef.current) return
+
+      isAutoScrollingRef.current = true
+
+      viewport.scrollTo({
+        top: viewport.scrollHeight,
+        behavior: 'smooth',
+      })
+
+      // Use scrollend event to detect when smooth scroll finishes.
+      // Fallback to 400ms timeout for environments without scrollend support.
+      const onScrollEnd = () => {
+        isAutoScrollingRef.current = false
+        cleanup()
+
+        // Correct scroll position if smooth scroll ended at wrong spot
+        // (DOM changes during animation can cause stale scrollHeight targeting)
+        const { scrollTop, scrollHeight, clientHeight } = viewport
+        if (scrollHeight - scrollTop - clientHeight > 2) {
+          scrollToTail(viewport)
+        }
+        rememberScroll(viewport.scrollTop, true)
+      }
+
+      const cleanup = () => {
+        viewport.removeEventListener('scrollend', onScrollEnd)
+        if (scrollTimeoutRef.current) {
+          clearTimeout(scrollTimeoutRef.current)
+          scrollTimeoutRef.current = null
+        }
+      }
+
+      viewport.addEventListener('scrollend', onScrollEnd, { once: true })
+      // Fallback timeout in case scrollend doesn't fire
+      scrollTimeoutRef.current = setTimeout(onScrollEnd, 400)
+    },
+    [rememberScroll]
+  )
 
   // Mark scroll state as "at bottom" without performing any physical scroll.
   // Used when sending a message so VirtualizedMessageList's gentle scrollIntoView
@@ -556,7 +770,10 @@ export function useScrollManagement({
     userScrollUpUntilRef.current = 0
     isAtBottomRef.current = true
     setIsAtBottom(true)
-  }, [])
+    pendingRestoreRef.current = false
+    const viewport = scrollViewportRef.current
+    rememberScroll(viewport?.scrollTop ?? lastKnownScrollRef.current.scrollTop, true)
+  }, [rememberScroll])
 
   // Begin a user-initiated keyboard scroll.
   // Cancels any pending auto-scroll timeout AND keeps isAutoScrollingRef=true
@@ -588,8 +805,9 @@ export function useScrollManagement({
       }
       isAtBottomRef.current = atBottom
       setIsAtBottom(prev => (prev === atBottom ? prev : atBottom))
+      rememberScroll(viewport.scrollTop, isFollowingTailRef.current)
     }
-  }, [])
+  }, [rememberScroll])
 
   // Scroll to findings helper
   // First scroll to the message containing findings using virtualizer, then to the element.

--- a/src/components/chat/hooks/useScrollManagement.ts
+++ b/src/components/chat/hooks/useScrollManagement.ts
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useEffectEvent,
   useLayoutEffect,
   useRef,
   useState,
@@ -61,6 +62,10 @@ interface UseScrollManagementReturn {
 
 const BOTTOM_THRESHOLD_PX = 100
 const SCROLL_EPSILON_PX = 2
+/** Cap deferred non-tail restores so an unreachable scrollTop cannot latch forever. */
+const MAX_PENDING_RESTORE_ATTEMPTS = 20
+/** Re-check a still-pending restore when ResizeObserver goes quiet (history trim, etc.). */
+const PENDING_RESTORE_RETRY_MS = 50
 
 function hasScrollableOverflow(viewport: HTMLDivElement) {
   return viewport.scrollHeight - viewport.clientHeight > SCROLL_EPSILON_PX
@@ -123,8 +128,19 @@ export function useScrollManagement({
   // When true, the next content-ready layout pass should apply a saved
   // non-tail scrollTop instead of pinning to the bottom.
   const pendingRestoreRef = useRef(false)
-  const contentReadyRef = useRef(contentReady)
-  contentReadyRef.current = contentReady
+  // Bounds deferred restores so an unreachable scrollTop cannot latch forever
+  // and permanently disable tail-following (PR #605 review).
+  const pendingRestoreAttemptsRef = useRef(0)
+  const pendingRestoreRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  )
+
+  const clearPendingRestoreRetry = useCallback(() => {
+    if (pendingRestoreRetryTimerRef.current != null) {
+      clearTimeout(pendingRestoreRetryTimerRef.current)
+      pendingRestoreRetryTimerRef.current = null
+    }
+  }, [])
 
   const persistCurrentSessionScroll = useCallback(
     (sessionId: string | null | undefined) => {
@@ -148,7 +164,9 @@ export function useScrollManagement({
   const rememberScroll = useCallback(
     (scrollTop: number, isFollowingTail: boolean) => {
       const sessionId = activeSessionId
-      if (!sessionId || !contentReadyRef.current) return
+      // Skip while the list is unmounted (Loading placeholder) so we don't
+      // overwrite a real snapshot with a collapsed scrollTop.
+      if (!sessionId || !contentReady) return
       lastKnownScrollRef.current = {
         sessionId,
         scrollTop,
@@ -156,7 +174,7 @@ export function useScrollManagement({
       }
       updateSessionScrollState(sessionId, { scrollTop, isFollowingTail })
     },
-    [activeSessionId]
+    [activeSessionId, contentReady]
   )
 
   const stopFollowingTail = useCallback(() => {
@@ -315,17 +333,151 @@ export function useScrollManagement({
     }
   }, [stopFollowingTail])
 
+  // Apply a saved scroll snapshot (or default to bottom) for the given session.
+  // Defined before size-sync / session effects so those closures can capture it
+  // directly (no render-time ref smuggling — issue #594 review).
+  const applySessionScrollState = useCallback(
+    (sessionId: string | null | undefined) => {
+      const viewport = scrollViewportRef.current
+      if (!viewport) return
+
+      const saved = sessionId ? getSessionScrollState(sessionId) : undefined
+
+      if (!saved || saved.isFollowingTail) {
+        isFollowingTailRef.current = true
+        isAtBottomRef.current = true
+        userScrollUpUntilRef.current = 0
+        setIsAtBottom(true)
+        scrollToTail(viewport)
+        lastScrollTopRef.current = viewport.scrollTop
+        if (sessionId) {
+          lastKnownScrollRef.current = {
+            sessionId,
+            scrollTop: viewport.scrollTop,
+            isFollowingTail: true,
+          }
+        }
+        pendingRestoreRef.current = false
+        pendingRestoreAttemptsRef.current = 0
+        clearPendingRestoreRetry()
+        return
+      }
+
+      // Non-tail restore: pin flags first so streaming auto-scroll does not
+      // fight the restored position while content settles.
+      isFollowingTailRef.current = false
+      isAtBottomRef.current = false
+      userScrollUpUntilRef.current = Date.now() + 1000
+      setIsAtBottom(false)
+
+      const maxScroll = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
+      const targetTop = Math.min(Math.max(0, saved.scrollTop), maxScroll)
+      viewport.scrollTop = targetTop
+      lastScrollTopRef.current = targetTop
+      lastKnownScrollRef.current = {
+        sessionId: sessionId ?? '',
+        scrollTop: targetTop,
+        isFollowingTail: false,
+      }
+
+      // If content is still short (message list not fully mounted / virtualized
+      // window not expanded yet), keep pending so ResizeObserver can re-apply
+      // the target after the saved history window mounts. A session switch can
+      // temporarily render the previous session's smaller visibleCount, so no
+      // overflow here does not prove the saved session was following its tail.
+      if (!hasScrollableOverflow(viewport)) {
+        pendingRestoreRef.current = true
+      } else if (
+        saved.scrollTop > 0 &&
+        maxScroll < saved.scrollTop - SCROLL_EPSILON_PX
+      ) {
+        pendingRestoreRef.current = true
+      } else {
+        pendingRestoreRef.current = false
+        pendingRestoreAttemptsRef.current = 0
+        clearPendingRestoreRetry()
+        // Content may have grown such that the saved offset is now at bottom.
+        if (isViewportAtBottom(viewport)) {
+          isFollowingTailRef.current = true
+          isAtBottomRef.current = true
+          userScrollUpUntilRef.current = 0
+          setIsAtBottom(true)
+          lastKnownScrollRef.current = {
+            sessionId: sessionId ?? '',
+            scrollTop: viewport.scrollTop,
+            isFollowingTail: true,
+          }
+          updateSessionScrollState(sessionId ?? '', {
+            scrollTop: viewport.scrollTop,
+            isFollowingTail: true,
+          })
+        }
+      }
+    },
+    [clearPendingRestoreRetry]
+  )
+
   // Keep scroll state honest when content/viewport size changes. If the chat no
   // longer overflows (short message list, window got taller, content collapsed),
   // it is necessarily at the bottom. This clears stale "scrolled away" state
   // without changing behavior for genuinely scrollable chats.
   // Also re-applies a pending non-tail restore once the message list grows tall
   // enough (e.g. VirtualizedMessageList expands its visible window).
-  const activeSessionIdRef = useRef(activeSessionId)
-  activeSessionIdRef.current = activeSessionId
-  const applySessionScrollStateRef = useRef<
-    (sessionId: string | null | undefined) => void
-  >(() => {})
+  //
+  // Pending restores are bounded: if a saved scrollTop never becomes reachable
+  // (history cleared, run trimmed, messages compacted), retry only up to
+  // MAX_PENDING_RESTORE_ATTEMPTS, then clear the latch so tail-following and
+  // the no-overflow self-heal below can run again.
+  //
+  // useEffectEvent reads the latest activeSessionId / contentReady /
+  // applySessionScrollState without re-subscribing the ResizeObserver, and
+  // without render-time ref writes (react-hooks/refs).
+  const onViewportSizeChange = useEffectEvent(() => {
+    const viewport = scrollViewportRef.current
+    if (!viewport) return
+
+    const rePinToTail = () => {
+      userScrollUpUntilRef.current = 0
+      isFollowingTailRef.current = true
+      isAtBottomRef.current = true
+      setIsAtBottom(prev => (prev ? prev : true))
+    }
+
+    if (pendingRestoreRef.current && contentReady && activeSessionId) {
+      if (pendingRestoreAttemptsRef.current < MAX_PENDING_RESTORE_ATTEMPTS) {
+        pendingRestoreAttemptsRef.current += 1
+        applySessionScrollState(activeSessionId)
+        if (pendingRestoreRef.current) {
+          // Still waiting for content to grow tall enough. RO re-enters on real
+          // growth; also schedule a bounded retry so a stalled, unreachable
+          // snapshot cannot latch when no further size events arrive.
+          clearPendingRestoreRetry()
+          pendingRestoreRetryTimerRef.current = setTimeout(() => {
+            pendingRestoreRetryTimerRef.current = null
+            onViewportSizeChange()
+          }, PENDING_RESTORE_RETRY_MS)
+          return
+        }
+        clearPendingRestoreRetry()
+        pendingRestoreAttemptsRef.current = 0
+        return
+      }
+      // Give up on an unreachable snapshot and let the checks below re-pin.
+      clearPendingRestoreRetry()
+      pendingRestoreRef.current = false
+      pendingRestoreAttemptsRef.current = 0
+      // Clamped restores often leave the viewport at the end of shorter content;
+      // treat that as following the tail again so streaming auto-scroll and the
+      // floating Bottom button recover.
+      if (!hasScrollableOverflow(viewport) || isViewportAtBottom(viewport)) {
+        rePinToTail()
+      }
+      return
+    }
+    if (!hasScrollableOverflow(viewport)) {
+      rePinToTail()
+    }
+  })
 
   useEffect(() => {
     const viewport = scrollViewportRef.current
@@ -335,21 +487,7 @@ export function useScrollManagement({
     const syncViewportSize = () => {
       cancelAnimationFrame(rafId)
       rafId = requestAnimationFrame(() => {
-        const sessionId = activeSessionIdRef.current
-        if (
-          pendingRestoreRef.current &&
-          contentReadyRef.current &&
-          sessionId
-        ) {
-          applySessionScrollStateRef.current(sessionId)
-          return
-        }
-        if (!hasScrollableOverflow(viewport)) {
-          userScrollUpUntilRef.current = 0
-          isFollowingTailRef.current = true
-          isAtBottomRef.current = true
-          setIsAtBottom(prev => (prev ? prev : true))
-        }
+        onViewportSizeChange()
       })
     }
 
@@ -363,9 +501,12 @@ export function useScrollManagement({
 
     return () => {
       cancelAnimationFrame(rafId)
+      clearPendingRestoreRetry()
       observer.disconnect()
     }
-  }, [])
+    // onViewportSizeChange is an Effect Event — intentionally omitted from deps
+    // (identity changes every render; React docs require not listing it).
+  }, [clearPendingRestoreRetry])
 
   // [Tier 2 + 5] Auto-scroll during streaming using ResizeObserver.
   // rAF-coalesced: at most one scroll per animation frame.
@@ -491,85 +632,6 @@ export function useScrollManagement({
     wasSendingRef.current = !!isSending
   }, [isSending])
 
-  // Apply a saved scroll snapshot (or default to bottom) for the given session.
-  const applySessionScrollState = useCallback(
-    (sessionId: string | null | undefined) => {
-      const viewport = scrollViewportRef.current
-      if (!viewport) return
-
-      const saved = sessionId ? getSessionScrollState(sessionId) : undefined
-
-      if (!saved || saved.isFollowingTail) {
-        isFollowingTailRef.current = true
-        isAtBottomRef.current = true
-        userScrollUpUntilRef.current = 0
-        setIsAtBottom(true)
-        scrollToTail(viewport)
-        lastScrollTopRef.current = viewport.scrollTop
-        if (sessionId) {
-          lastKnownScrollRef.current = {
-            sessionId,
-            scrollTop: viewport.scrollTop,
-            isFollowingTail: true,
-          }
-        }
-        pendingRestoreRef.current = false
-        return
-      }
-
-      // Non-tail restore: pin flags first so streaming auto-scroll does not
-      // fight the restored position while content settles.
-      isFollowingTailRef.current = false
-      isAtBottomRef.current = false
-      userScrollUpUntilRef.current = Date.now() + 1000
-      setIsAtBottom(false)
-
-      const maxScroll = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
-      const targetTop = Math.min(Math.max(0, saved.scrollTop), maxScroll)
-      viewport.scrollTop = targetTop
-      lastScrollTopRef.current = targetTop
-      lastKnownScrollRef.current = {
-        sessionId: sessionId ?? '',
-        scrollTop: targetTop,
-        isFollowingTail: false,
-      }
-
-      // If content is still short (message list not fully mounted / virtualized
-      // window not expanded yet), keep pending so ResizeObserver can re-apply
-      // the target after the saved history window mounts. A session switch can
-      // temporarily render the previous session's smaller visibleCount, so no
-      // overflow here does not prove the saved session was following its tail.
-      if (!hasScrollableOverflow(viewport)) {
-        pendingRestoreRef.current = true
-      } else if (
-        saved.scrollTop > 0 &&
-        maxScroll < saved.scrollTop - SCROLL_EPSILON_PX
-      ) {
-        pendingRestoreRef.current = true
-      } else {
-        pendingRestoreRef.current = false
-        // Content may have grown such that the saved offset is now at bottom.
-        if (isViewportAtBottom(viewport)) {
-          isFollowingTailRef.current = true
-          isAtBottomRef.current = true
-          userScrollUpUntilRef.current = 0
-          setIsAtBottom(true)
-          lastKnownScrollRef.current = {
-            sessionId: sessionId ?? '',
-            scrollTop: viewport.scrollTop,
-            isFollowingTail: true,
-          }
-          updateSessionScrollState(sessionId ?? '', {
-            scrollTop: viewport.scrollTop,
-            isFollowingTail: true,
-          })
-        }
-      }
-    },
-    []
-  )
-  applySessionScrollStateRef.current = applySessionScrollState
-
   // Persist the previous session and prepare restore when the displayed session
   // changes (covers both tab switches and worktree switches).
   useLayoutEffect(() => {
@@ -579,14 +641,19 @@ export function useScrollManagement({
     }
     prevSessionIdRef.current = activeSessionId
 
+    // Fresh session ⇒ fresh restore budget (do not carry exhausted attempts).
+    clearPendingRestoreRetry()
+    pendingRestoreAttemptsRef.current = 0
+
     if (!activeSessionId) return
 
     const saved = getSessionScrollState(activeSessionId)
     pendingRestoreRef.current = Boolean(saved && !saved.isFollowingTail)
 
     // Only apply immediately when the message list is mounted. Otherwise wait
-    // for the contentReady + messages layout effect below.
-    if (contentReadyRef.current) {
+    // for the contentReady + messages layout effect below. contentReady is read
+    // from this render's props (session-change trigger), not a mutable ref.
+    if (contentReady) {
       applySessionScrollState(activeSessionId)
     } else if (!saved || saved.isFollowingTail) {
       // Default: treat as following tail so FloatingButtons / auto-scroll stay
@@ -599,7 +666,13 @@ export function useScrollManagement({
       isAtBottomRef.current = false
       setIsAtBottom(false)
     }
-  }, [activeSessionId, applySessionScrollState, persistCurrentSessionScroll])
+  }, [
+    activeSessionId,
+    contentReady,
+    applySessionScrollState,
+    persistCurrentSessionScroll,
+    clearPendingRestoreRetry,
+  ])
 
   // Restore (or scroll to bottom) when content becomes ready / messages arrive.
   // Covers: first open of a session, async session load, and return from the
@@ -642,7 +715,7 @@ export function useScrollManagement({
 
       // Session-switch Loading placeholder (or other unmounted list): do not
       // overwrite a real per-session snapshot with a collapsed scrollTop.
-      if (!contentReadyRef.current) {
+      if (!contentReady) {
         return
       }
 
@@ -676,7 +749,7 @@ export function useScrollManagement({
       setIsAtBottom(prev => (prev === atBottom ? prev : atBottom))
       rememberScroll(target.scrollTop, isFollowingTailRef.current)
     },
-    [rememberScroll]
+    [contentReady, rememberScroll]
   )
 
   // Handle scroll-to-bottom completion from VirtualizedMessageList

--- a/src/components/chat/session-scroll-state.test.ts
+++ b/src/components/chat/session-scroll-state.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  __resetSessionScrollStateForTests,
+  clearSessionScrollState,
+  getDefaultVisibleCount,
+  getSessionScrollState,
+  saveSessionScrollState,
+  updateSessionScrollState,
+} from './session-scroll-state'
+
+describe('session-scroll-state', () => {
+  afterEach(() => {
+    __resetSessionScrollStateForTests()
+  })
+
+  it('saves and returns a snapshot per session', () => {
+    saveSessionScrollState('s1', {
+      scrollTop: 420,
+      isFollowingTail: false,
+      visibleCount: 40,
+    })
+
+    expect(getSessionScrollState('s1')).toEqual({
+      scrollTop: 420,
+      isFollowingTail: false,
+      visibleCount: 40,
+    })
+    expect(getSessionScrollState('s2')).toBeUndefined()
+  })
+
+  it('merges partial updates without wiping other fields', () => {
+    saveSessionScrollState('s1', {
+      scrollTop: 100,
+      isFollowingTail: false,
+      visibleCount: 30,
+    })
+
+    updateSessionScrollState('s1', { scrollTop: 250 })
+    expect(getSessionScrollState('s1')).toEqual({
+      scrollTop: 250,
+      isFollowingTail: false,
+      visibleCount: 30,
+    })
+
+    updateSessionScrollState('s1', { isFollowingTail: true })
+    expect(getSessionScrollState('s1')).toEqual({
+      scrollTop: 250,
+      isFollowingTail: true,
+      visibleCount: 30,
+    })
+  })
+
+  it('clamps negative scrollTop and enforces minimum visibleCount', () => {
+    saveSessionScrollState('s1', {
+      scrollTop: -10,
+      isFollowingTail: true,
+      visibleCount: 2,
+    })
+
+    expect(getSessionScrollState('s1')).toEqual({
+      scrollTop: 0,
+      isFollowingTail: true,
+      visibleCount: getDefaultVisibleCount(),
+    })
+  })
+
+  it('clears a single session snapshot', () => {
+    saveSessionScrollState('s1', {
+      scrollTop: 1,
+      isFollowingTail: false,
+      visibleCount: 20,
+    })
+    saveSessionScrollState('s2', {
+      scrollTop: 2,
+      isFollowingTail: true,
+      visibleCount: 20,
+    })
+
+    clearSessionScrollState('s1')
+    expect(getSessionScrollState('s1')).toBeUndefined()
+    expect(getSessionScrollState('s2')?.scrollTop).toBe(2)
+  })
+
+  it('ignores empty session ids', () => {
+    saveSessionScrollState('', {
+      scrollTop: 99,
+      isFollowingTail: false,
+      visibleCount: 20,
+    })
+    expect(getSessionScrollState('')).toBeUndefined()
+  })
+})

--- a/src/components/chat/session-scroll-state.ts
+++ b/src/components/chat/session-scroll-state.ts
@@ -1,0 +1,77 @@
+/**
+ * In-memory per-session scroll snapshots for the active Jean process.
+ *
+ * Issue #594: when switching sessions (or worktrees), restore the user's
+ * previous scroll position instead of always jumping to the bottom. Snapshots
+ * live only for the app lifetime — no disk persistence.
+ */
+
+export interface SessionScrollSnapshot {
+  /** Viewport scrollTop when the user last left this session. */
+  scrollTop: number
+  /**
+   * Whether the user was following the live tail (at bottom). When true on
+   * restore we pin to the bottom so new content is visible; when false we
+   * re-apply scrollTop.
+   */
+  isFollowingTail: boolean
+  /**
+   * VirtualizedMessageList window size (messages rendered from the end).
+   * Restoring this is required so a user who scrolled far up still has the
+   * older messages mounted when they return.
+   */
+  visibleCount: number
+}
+
+const DEFAULT_VISIBLE_COUNT = 10
+
+const snapshots = new Map<string, SessionScrollSnapshot>()
+
+export function getDefaultVisibleCount(): number {
+  return DEFAULT_VISIBLE_COUNT
+}
+
+export function getSessionScrollState(
+  sessionId: string
+): SessionScrollSnapshot | undefined {
+  return snapshots.get(sessionId)
+}
+
+export function saveSessionScrollState(
+  sessionId: string,
+  snapshot: SessionScrollSnapshot
+): void {
+  if (!sessionId) return
+  snapshots.set(sessionId, {
+    scrollTop: Math.max(0, snapshot.scrollTop),
+    isFollowingTail: snapshot.isFollowingTail,
+    visibleCount: Math.max(DEFAULT_VISIBLE_COUNT, snapshot.visibleCount),
+  })
+}
+
+/** Merge partial fields into an existing snapshot (or create one). */
+export function updateSessionScrollState(
+  sessionId: string,
+  partial: Partial<SessionScrollSnapshot>
+): void {
+  if (!sessionId) return
+  const prev = snapshots.get(sessionId)
+  snapshots.set(sessionId, {
+    scrollTop: Math.max(0, partial.scrollTop ?? prev?.scrollTop ?? 0),
+    isFollowingTail:
+      partial.isFollowingTail ?? prev?.isFollowingTail ?? true,
+    visibleCount: Math.max(
+      DEFAULT_VISIBLE_COUNT,
+      partial.visibleCount ?? prev?.visibleCount ?? DEFAULT_VISIBLE_COUNT
+    ),
+  })
+}
+
+export function clearSessionScrollState(sessionId: string): void {
+  snapshots.delete(sessionId)
+}
+
+/** Test-only helper to clear all snapshots between cases. */
+export function __resetSessionScrollStateForTests(): void {
+  snapshots.clear()
+}

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -38,6 +38,7 @@ import { useChatStore } from '@/store/chat-store'
 import { useProjectsStore } from '@/store/projects-store'
 import { useUIStore } from '@/store/ui-store'
 import { useTerminalStore } from '@/store/terminal-store'
+import { clearSessionScrollState } from '@/components/chat/session-scroll-state'
 import { navigateToProjectPicker } from '@/lib/restore-navigation'
 import { isNativeTerminalBackend } from '@/lib/native-cli-session'
 import { getResumeArgs } from '@/components/chat/session-card-utils'
@@ -1115,6 +1116,7 @@ export function useCloseSession() {
 
       // Clear all session-scoped state
       useChatStore.getState().clearSessionState(sessionId)
+      clearSessionScrollState(sessionId)
       cleanupSessionTerminalForRemovedSession(worktreeId, sessionId)
 
       // Switch to the new active session — but only if the caller hasn't already
@@ -1197,6 +1199,7 @@ export function useArchiveSession() {
 
       // Clear all session-scoped state
       useChatStore.getState().clearSessionState(sessionId)
+      clearSessionScrollState(sessionId)
       cleanupSessionTerminalForRemovedSession(worktreeId, sessionId)
 
       // Switch to the new active session — but only if the caller hasn't already
@@ -2094,6 +2097,7 @@ export function useClearSessionHistory() {
 
       // Clear all session-scoped state
       useChatStore.getState().clearSessionState(sessionId)
+      clearSessionScrollState(sessionId)
 
       toast.success('Chat history cleared')
     },


### PR DESCRIPTION
## Summary
- Remember each session’s scroll position and expanded history window while Jean stays open, so switching sessions no longer always jumps to the bottom
- Restore scroll against the actually mounted transcript (deferred session + content-ready), and clear saved state when a session is closed, archived, or history is cleared
- Add coverage for save/restore, readiness guards, and session lifecycle cleanup

fixes #594

---

Fixes #594