### PR TITLE
feat(chat): allow mid-session AI provider switching

### DIFF
--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -764,7 +764,12 @@ export function ChatWindow({
   const zustandProvider = useChatStore(state =>
     deferredSessionId ? state.selectedProviders[deferredSessionId] : undefined
   )
-  const sessionProvider = session?.selected_provider ?? zustandProvider
+  // Prefer in-memory toolbar selection when present so mid-session provider
+  // switches apply immediately (session query can lag until invalidate).
+  const sessionProvider =
+    zustandProvider !== undefined
+      ? zustandProvider
+      : session?.selected_provider
 
   // Installed backends (only these should be selectable)
   const { installedBackends } = useInstalledBackends()

--- a/src/components/chat/hooks/session-setting-sync.test.ts
+++ b/src/components/chat/hooks/session-setting-sync.test.ts
@@ -60,4 +60,26 @@ describe('applySessionSettingToSession', () => {
       selected_thinking_level: 'off',
     })
   })
+
+  it('updates custom provider', () => {
+    expect(
+      applySessionSettingToSession(baseSession, 'provider', 'MiniMax')
+    ).toMatchObject({
+      selected_provider: 'MiniMax',
+    })
+  })
+
+  it('clears provider for default/sentinel values', () => {
+    const withProvider = {
+      ...baseSession,
+      selected_provider: 'Z.ai',
+    }
+
+    for (const value of ['', '__anthropic__', '__default__', 'default']) {
+      expect(
+        applySessionSettingToSession(withProvider, 'provider', value)
+          .selected_provider
+      ).toBeUndefined()
+    }
+  })
 })

--- a/src/components/chat/hooks/session-setting-sync.ts
+++ b/src/components/chat/hooks/session-setting-sync.ts
@@ -12,7 +12,24 @@ export type SessionSettingKey =
   | 'thinkingLevel'
   | 'effortLevel'
   | 'executionMode'
+  | 'provider'
   | 'waitingForInput'
+
+/** Sentinels / empty mean "use backend default" (Anthropic / OpenAI). */
+export function normalizeProviderSettingValue(
+  value: string | null | undefined
+): string | undefined {
+  if (
+    value == null ||
+    value === '' ||
+    value === '__anthropic__' ||
+    value === '__default__' ||
+    value === 'default'
+  ) {
+    return undefined
+  }
+  return value
+}
 
 export function applySessionSettingToSession(
   session: Session,
@@ -44,6 +61,11 @@ export function applySessionSettingToSession(
       return {
         ...session,
         selected_execution_mode: value as ExecutionMode,
+      }
+    case 'provider':
+      return {
+        ...session,
+        selected_provider: normalizeProviderSettingValue(value),
       }
     case 'waitingForInput':
       // Handled in Zustand (useStreamingEvents), not session metadata

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -2198,7 +2198,7 @@ export default function useStreamingEvents({
       }
     )
 
-    // Handle session setting changes (backend, model, thinking level, execution mode)
+    // Handle session setting changes (backend, model, provider, thinking, execution mode)
     // Broadcast by other clients via broadcast_session_setting command
     const unlistenSettingChanged = listen<{
       session_id: string
@@ -2238,6 +2238,17 @@ export default function useStreamingEvents({
           break
         case 'executionMode':
           store.setExecutionMode(session_id, value as 'plan' | 'build' | 'yolo')
+          break
+        case 'provider':
+          store.setSelectedProvider(
+            session_id,
+            value === '' ||
+              value === '__anthropic__' ||
+              value === '__default__' ||
+              value === 'default'
+              ? null
+              : value
+          )
           break
         case 'waitingForInput':
           if (value === 'false') {

--- a/src/components/chat/hooks/useToolbarHandlers.test.tsx
+++ b/src/components/chat/hooks/useToolbarHandlers.test.tsx
@@ -71,7 +71,11 @@ function renderHandlers(
 describe('useToolbarHandlers', () => {
   beforeEach(() => {
     invokeMock.mockClear()
-    useChatStore.setState({ effortLevels: {} })
+    useChatStore.setState({
+      effortLevels: {},
+      selectedProviders: {},
+      selectedBackends: {},
+    })
   })
 
   it('persists effort level changes to session metadata and broadcasts them', () => {
@@ -96,6 +100,90 @@ describe('useToolbarHandlers', () => {
       sessionId: 'session-1',
       key: 'effortLevel',
       value: 'xhigh',
+    })
+  })
+
+  it('persists provider changes mid-session with optimistic cache and broadcast', () => {
+    const setSessionProvider = { mutate: vi.fn() }
+    const { result, queryClient } = renderHandlers({
+      setSessionProvider,
+      session: {
+        ...baseSession,
+        selected_provider: 'Z.ai',
+        messages: [
+          {
+            id: 'message-1',
+            session_id: 'session-1',
+            role: 'user',
+            content: 'hello',
+            timestamp: 1,
+            tool_calls: [],
+          },
+        ],
+      },
+    })
+    queryClient.setQueryData(chatQueryKeys.session('session-1'), {
+      ...baseSession,
+      selected_provider: 'Z.ai',
+    })
+
+    act(() => {
+      result.current.handleToolbarProviderChange('MiniMax')
+    })
+
+    expect(useChatStore.getState().selectedProviders['session-1']).toBe(
+      'MiniMax'
+    )
+    expect(setSessionProvider.mutate).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      worktreeId: 'worktree-1',
+      worktreePath: '/tmp/worktree',
+      provider: 'MiniMax',
+    })
+    expect(
+      queryClient.getQueryData<Session>(chatQueryKeys.session('session-1'))
+        ?.selected_provider
+    ).toBe('MiniMax')
+    expect(invokeMock).toHaveBeenCalledWith('broadcast_session_setting', {
+      sessionId: 'session-1',
+      key: 'provider',
+      value: 'MiniMax',
+    })
+  })
+
+  it('clears provider selection when switching back to the default', () => {
+    const setSessionProvider = { mutate: vi.fn() }
+    const { result, queryClient } = renderHandlers({
+      setSessionProvider,
+      session: {
+        ...baseSession,
+        selected_provider: 'MiniMax',
+      },
+    })
+    queryClient.setQueryData(chatQueryKeys.session('session-1'), {
+      ...baseSession,
+      selected_provider: 'MiniMax',
+    })
+
+    act(() => {
+      result.current.handleToolbarProviderChange(null)
+    })
+
+    expect(useChatStore.getState().selectedProviders['session-1']).toBeNull()
+    expect(setSessionProvider.mutate).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      worktreeId: 'worktree-1',
+      worktreePath: '/tmp/worktree',
+      provider: null,
+    })
+    expect(
+      queryClient.getQueryData<Session>(chatQueryKeys.session('session-1'))
+        ?.selected_provider
+    ).toBeUndefined()
+    expect(invokeMock).toHaveBeenCalledWith('broadcast_session_setting', {
+      sessionId: 'session-1',
+      key: 'provider',
+      value: '',
     })
   })
 

--- a/src/components/chat/hooks/useToolbarHandlers.ts
+++ b/src/components/chat/hooks/useToolbarHandlers.ts
@@ -250,20 +250,42 @@ export function useToolbarHandlers({
 
   const handleToolbarProviderChange = useCallback(
     (provider: string | null) => {
-      if (activeSessionId) {
+      if (activeSessionId && activeWorktreeId && activeWorktreePath) {
         useChatStore.getState().setSelectedProvider(activeSessionId, provider)
-        if (activeWorktreeId && activeWorktreePath) {
-          setSessionProvider.mutate({
-            sessionId: activeSessionId,
-            worktreeId: activeWorktreeId,
-            worktreePath: activeWorktreePath,
-            provider,
-          })
-        }
+        // Optimistically update session cache so mid-session provider switches
+        // are not overridden by stale selected_provider until invalidate lands.
+        queryClient.setQueryData(
+          chatQueryKeys.session(activeSessionId),
+          (old: Session | null | undefined) =>
+            old
+              ? applySessionSettingToSession(
+                  old,
+                  'provider',
+                  provider ?? ''
+                )
+              : old
+        )
+        setSessionProvider.mutate({
+          sessionId: activeSessionId,
+          worktreeId: activeWorktreeId,
+          worktreePath: activeWorktreePath,
+          provider,
+        })
+        invoke('broadcast_session_setting', {
+          sessionId: activeSessionId,
+          key: 'provider',
+          value: provider ?? '',
+        }).catch(() => undefined)
       }
       window.dispatchEvent(new CustomEvent('focus-chat-input'))
     },
-    [activeSessionId, activeWorktreeId, activeWorktreePath, setSessionProvider]
+    [
+      activeSessionId,
+      activeWorktreeId,
+      activeWorktreePath,
+      queryClient,
+      setSessionProvider,
+    ]
   )
 
   const handleToolbarThinkingLevelChange = useCallback(

--- a/src/components/chat/toolbar/BackendModelPickerContent.tsx
+++ b/src/components/chat/toolbar/BackendModelPickerContent.tsx
@@ -72,7 +72,7 @@ export function BackendModelPickerContent({
   installedBackends,
   customCliProfiles,
   sessionHasMessages: _sessionHasMessages,
-  providerLocked,
+  providerLocked: _providerLocked,
   onModelChange,
   onBackendModelChange,
   onRequestClose,
@@ -463,10 +463,11 @@ export function BackendModelPickerContent({
     return () => window.removeEventListener('keydown', handler, true)
   }, [open, sidebarBackends, handleBackendButtonClick])
 
+  // Always surface the active Claude custom provider in the model picker so
+  // mid-session switches stay discoverable (provider is changed via the
+  // dedicated Provider control, not locked after the first message).
   const showProviderHint =
-    Boolean(providerLocked) &&
-    activeBackend === 'claude' &&
-    customCliProfiles.length > 0
+    activeBackend === 'claude' && customCliProfiles.length > 0
 
   const placeholder =
     searchPlaceholder ??


### PR DESCRIPTION
## Summary

- Allow changing the AI/custom provider from the chat toolbar during an active session, not only when starting a new chat
- Persist provider selection optimistically so switches apply immediately and stay in sync across clients
- Keep the Claude custom-provider hint visible mid-session so provider options remain discoverable
- Treat empty/default/sentinel provider values as “use backend default”

closes #391

---

Fixes #391