### PR TITLE
feat(mr-robot): support Claude custom providers

### DIFF
--- a/jean-core/src/auto_fix/scheduler.rs
+++ b/jean-core/src/auto_fix/scheduler.rs
@@ -68,6 +68,8 @@ struct PendingAutoYolo {
     session_id: String,
     backend: String,
     model: Option<String>,
+    /// Claude custom CLI profile name (None = Anthropic direct).
+    provider: Option<String>,
 }
 
 static LAST_PROJECT_CHECKS: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
@@ -487,6 +489,10 @@ async fn start_issue_auto_fix(
         .planning_model
         .clone()
         .unwrap_or_else(|| default_model_for_backend(&settings.planning_backend));
+    let planning_provider = normalize_claude_provider(
+        &settings.planning_backend,
+        settings.planning_provider.as_deref(),
+    );
 
     let result = crate::jean_mcp_core::start_background_investigation_impl(
         app,
@@ -495,9 +501,9 @@ async fn start_issue_auto_fix(
         prompt,
         model,
         settings.planning_backend.clone(),
+        planning_provider.clone(),
         None,
-        None,
-        None,
+        planning_provider.clone(),
         None,
         None,
         None,
@@ -524,6 +530,10 @@ async fn start_issue_auto_fix(
                 session_id: result.session_id,
                 backend: settings.yolo_backend.clone(),
                 model: settings.yolo_model.clone(),
+                provider: normalize_claude_provider(
+                    &settings.yolo_backend,
+                    settings.yolo_provider.as_deref(),
+                ),
             },
         );
     spawn_pending_auto_yolo_watch(app.clone(), pending_session_id);
@@ -789,6 +799,14 @@ async fn approve_plan_and_start_yolo(
         model.clone(),
     )
     .await?;
+    crate::chat::set_session_provider(
+        app.clone(),
+        entry.worktree_id.clone(),
+        entry.worktree_path.clone(),
+        entry.session_id.clone(),
+        entry.provider.clone(),
+    )
+    .await?;
 
     crate::chat::update_session_state(
         app.clone(),
@@ -849,7 +867,7 @@ async fn approve_plan_and_start_yolo(
         None,
         None,
         None,
-        None,
+        entry.provider.clone(),
         Some(entry.backend.clone()),
     )
     .await?;
@@ -894,6 +912,23 @@ fn disable_project_auto_fix(app: &AppHandle, project_id: &str) {
     }
 }
 
+/// Only Claude custom CLI profiles are valid providers; other backends ignore them.
+fn normalize_claude_provider(backend: &str, provider: Option<&str>) -> Option<String> {
+    if backend != "claude" {
+        return None;
+    }
+    let trimmed = provider?.trim();
+    if trimmed.is_empty()
+        || trimmed == "__anthropic__"
+        || trimmed == "__default__"
+        || trimmed.eq_ignore_ascii_case("anthropic")
+        || trimmed.eq_ignore_ascii_case("default")
+    {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
 fn default_model_for_backend(backend: &str) -> String {
     match backend {
         "codex" => "gpt-5.6-sol".to_string(),
@@ -920,9 +955,11 @@ mod tests {
             excluded_labels: Vec::new(),
             planning_backend: "claude".to_string(),
             planning_model: None,
+            planning_provider: None,
             auto_yolo_enabled: false,
             yolo_backend: "claude".to_string(),
             yolo_model: None,
+            yolo_provider: None,
             active_hours_enabled: false,
             active_hours_start: 20,
             active_hours_end: 8,
@@ -1375,6 +1412,7 @@ mod tests {
             session_id: "session-1".to_string(),
             backend: "claude".to_string(),
             model: None,
+            provider: None,
         };
         let entry_for_other_project = PendingAutoYolo {
             project_id: "project-2".to_string(),
@@ -1384,6 +1422,7 @@ mod tests {
             session_id: "session-2".to_string(),
             backend: "claude".to_string(),
             model: None,
+            provider: None,
         };
         {
             let mut pending = pending_yolo().lock().expect("pending auto yolo mutex");
@@ -1410,9 +1449,11 @@ mod tests {
             excluded_labels: Vec::new(),
             planning_backend: "claude".to_string(),
             planning_model: None,
+            planning_provider: None,
             auto_yolo_enabled: false,
             yolo_backend: "claude".to_string(),
             yolo_model: None,
+            yolo_provider: None,
             active_hours_enabled: false,
             active_hours_start: 20,
             active_hours_end: 8,
@@ -1432,14 +1473,33 @@ mod tests {
             excluded_labels: Vec::new(),
             planning_backend: "claude".to_string(),
             planning_model: None,
+            planning_provider: None,
             auto_yolo_enabled: true,
             yolo_backend: "claude".to_string(),
             yolo_model: None,
+            yolo_provider: None,
             active_hours_enabled: false,
             active_hours_start: 20,
             active_hours_end: 8,
         };
 
         assert!(should_queue_auto_yolo(&settings));
+    }
+
+    #[test]
+    fn normalize_claude_provider_only_keeps_claude_profiles() {
+        assert_eq!(
+            normalize_claude_provider("claude", Some("OpenRouter")),
+            Some("OpenRouter".to_string())
+        );
+        assert_eq!(normalize_claude_provider("claude", Some("  ")), None);
+        assert_eq!(
+            normalize_claude_provider("claude", Some("__anthropic__")),
+            None
+        );
+        assert_eq!(
+            normalize_claude_provider("codex", Some("OpenRouter")),
+            None
+        );
     }
 }

--- a/jean-core/src/projects/types.rs
+++ b/jean-core/src/projects/types.rs
@@ -35,11 +35,17 @@ pub struct ProjectAutoFixSettings {
     pub planning_backend: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub planning_model: Option<String>,
+    /// Claude custom CLI profile name for planning (None = Anthropic direct).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub planning_provider: Option<String>,
     #[serde(default)]
     pub auto_yolo_enabled: bool,
     pub yolo_backend: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub yolo_model: Option<String>,
+    /// Claude custom CLI profile name for yolo (None = Anthropic direct).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub yolo_provider: Option<String>,
     #[serde(default)]
     pub active_hours_enabled: bool,
     #[serde(default)]
@@ -814,10 +820,12 @@ mod label_tests {
             included_labels: vec!["bug".to_string()],
             excluded_labels: vec!["wontfix".to_string()],
             planning_backend: "claude".to_string(),
-            planning_model: Some("claude-opus-4-8[1m]".to_string()),
+            planning_model: Some("opus".to_string()),
+            planning_provider: Some("OpenRouter".to_string()),
             auto_yolo_enabled: true,
             yolo_backend: "codex".to_string(),
             yolo_model: Some("gpt-5.3-codex".to_string()),
+            yolo_provider: None,
             active_hours_enabled: true,
             active_hours_start: 20,
             active_hours_end: 8,
@@ -825,6 +833,7 @@ mod label_tests {
 
         let json = serde_json::to_string(&settings).unwrap();
         assert!(json.contains("\"interval_minutes\":15"));
+        assert!(json.contains("\"planning_provider\":\"OpenRouter\""));
         let parsed: ProjectAutoFixSettings = serde_json::from_str(&json).unwrap();
 
         assert_eq!(parsed.issue_limit, 3);
@@ -832,6 +841,9 @@ mod label_tests {
         assert_eq!(parsed.excluded_labels, vec!["wontfix".to_string()]);
         assert!(parsed.auto_yolo_enabled);
         assert_eq!(parsed.yolo_backend, "codex");
+        assert_eq!(parsed.planning_provider.as_deref(), Some("OpenRouter"));
+        assert_eq!(parsed.planning_model.as_deref(), Some("opus"));
+        assert!(parsed.yolo_provider.is_none());
     }
 
     #[test]

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -159,6 +159,7 @@ import {
   notificationSoundOptions,
   type RemovalBehavior,
   type ClaudeModel,
+  getClaudeModelOptionsForProvider,
   type CodexModel,
   type CodexGoalExecutionMode,
   type CodexReasoningEffort,
@@ -335,10 +336,32 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
   >(null)
   const [isDeletingCli, setIsDeletingCli] = useState(false)
 
-  const remoteClaudeModelOptions = useMemo(
-    () => getCatalogModelOptions(modelCatalog, 'claude'),
-    [modelCatalog]
+  const customCliProfiles = useMemo(
+    () => preferences?.custom_cli_profiles ?? [],
+    [preferences?.custom_cli_profiles]
   )
+  const defaultClaudeProvider = preferences?.default_provider ?? null
+  const remoteClaudeModelOptions = useMemo(() => {
+    // When a custom CLI provider is the global default, surface the
+    // provider-routed opus/sonnet/haiku aliases so Settings → Claude can set
+    // a matching default model (issue #418).
+    const options = defaultClaudeProvider
+      ? getClaudeModelOptionsForProvider(
+          defaultClaudeProvider,
+          customCliProfiles
+        )
+      : getCatalogModelOptions(modelCatalog, 'claude')
+    const selected = preferences?.selected_model
+    if (selected && !options.some(option => option.value === selected)) {
+      return [...options, { value: selected as ClaudeModel, label: selected }]
+    }
+    return options
+  }, [
+    modelCatalog,
+    defaultClaudeProvider,
+    customCliProfiles,
+    preferences?.selected_model,
+  ])
   const remoteCodexDefaultModelOptions = useMemo(
     () => getCatalogDefaultModelOptions(modelCatalog, 'codex'),
     [modelCatalog]
@@ -2954,7 +2977,11 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
           <div className="space-y-4">
             <InlineField
               label="Model"
-              description="Claude model for AI assistance"
+              description={
+                defaultClaudeProvider
+                  ? `Claude model for AI assistance (routed via ${defaultClaudeProvider}). Change the default provider under Settings → Providers.`
+                  : 'Claude model for AI assistance. Custom CLI providers are configured under Settings → Providers.'
+              }
             >
               <Select
                 value={preferences?.selected_model ?? 'claude-opus-4-8[1m]'}

--- a/src/components/projects/panes/AutoFixPane.test.tsx
+++ b/src/components/projects/panes/AutoFixPane.test.tsx
@@ -8,6 +8,7 @@ import {
   firstAvailableBackend,
   hasAutoFixSettingsChanges,
   MR_ROBOT_SETTINGS_BADGE,
+  normalizeAutoFixProvider,
   resolveAutoFixBackend,
 } from './AutoFixPane'
 import type { CliBackend } from '@/types/preferences'
@@ -49,12 +50,19 @@ vi.mock('@/services/github', () => ({
   }),
 }))
 
+const preferencesMock = {
+  favorite_models: [] as string[],
+  fast_mode_models: [] as string[],
+  custom_cli_profiles: [] as {
+    name: string
+    settings_json: string
+    supports_thinking?: boolean
+  }[],
+}
+
 vi.mock('@/services/preferences', () => ({
   usePreferences: () => ({
-    data: {
-      favorite_models: [],
-      fast_mode_models: [],
-    },
+    data: preferencesMock,
   }),
   usePatchPreferences: () => ({ mutate: vi.fn() }),
 }))
@@ -69,6 +77,10 @@ vi.mock('@/hooks/useInstalledBackends', () => ({
 
 vi.mock('@/services/opencode-cli', () => ({
   useAvailableOpencodeModels: () => ({ data: undefined }),
+  useRefreshOpencodeModels: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
 }))
 
 vi.mock('@/services/cursor-cli', () => ({
@@ -83,6 +95,43 @@ vi.mock('@/services/commandcode-cli', () => ({
   useAvailableCommandCodeModels: () => ({ data: undefined }),
 }))
 
+vi.mock('@/services/grok-cli', () => ({
+  useAvailableGrokModels: () => ({ data: undefined }),
+}))
+
+vi.mock('@/services/kimi-cli', () => ({
+  useAvailableKimiModels: () => ({ data: undefined }),
+}))
+
+vi.mock('@/services/model-catalog', () => ({
+  useModelCatalog: () => ({ data: undefined }),
+  useRefreshModelCatalog: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+  getCatalogModelOptions: (_catalog: unknown, backend: string) => {
+    if (backend === 'codex') {
+      return [
+        { value: 'gpt-5.4', label: 'GPT 5.4' },
+        { value: 'gpt-5.5', label: 'GPT 5.5' },
+      ]
+    }
+    if (backend === 'claude') {
+      return [
+        { value: 'claude-opus-4-8[1m]', label: 'Claude Opus 4.8 (1M)' },
+        { value: 'haiku', label: 'Claude Haiku' },
+      ]
+    }
+    return []
+  },
+  getCatalogModelFastInfo: () => ({
+    supportsFast: false,
+    fastModel: null,
+    baseModel: null,
+  }),
+  getCatalogModelReasoning: () => undefined,
+}))
+
 const baseAutoFixSettings: ProjectAutoFixSettings = {
   enabled: false,
   interval_minutes: 30,
@@ -90,9 +139,11 @@ const baseAutoFixSettings: ProjectAutoFixSettings = {
   max_parallel_worktrees: 3,
   planning_backend: 'claude',
   planning_model: 'haiku',
+  planning_provider: null,
   auto_yolo_enabled: false,
   yolo_backend: 'claude',
   yolo_model: null,
+  yolo_provider: null,
   active_hours_enabled: false,
   active_hours_start: 20,
   active_hours_end: 8,
@@ -151,6 +202,9 @@ describe('AutoFixPane', () => {
     mutateMock.mockReset()
     projectsMock = [project()]
     installedBackendsMock = ['claude', 'codex', 'cursor']
+    preferencesMock.favorite_models = []
+    preferencesMock.fast_mode_models = []
+    preferencesMock.custom_cli_profiles = []
     HTMLElement.prototype.hasPointerCapture = vi.fn()
     HTMLElement.prototype.releasePointerCapture = vi.fn()
     HTMLElement.prototype.scrollIntoView = vi.fn()
@@ -541,5 +595,103 @@ describe('AutoFixPane', () => {
         yolo_model: null,
       }),
     })
+  })
+
+  it('shows custom Claude providers for planning and yolo', async () => {
+    const user = userEvent.setup()
+    preferencesMock.custom_cli_profiles = [
+      {
+        name: 'MiniMax',
+        settings_json: JSON.stringify({
+          env: {
+            ANTHROPIC_MODEL: 'MiniMax-M2.5',
+            ANTHROPIC_DEFAULT_OPUS_MODEL: 'MiniMax-M2.5',
+            ANTHROPIC_DEFAULT_SONNET_MODEL: 'MiniMax-M2.5',
+            ANTHROPIC_DEFAULT_HAIKU_MODEL: 'MiniMax-M2.5',
+          },
+        }),
+      },
+    ]
+    projectsMock = [
+      project({
+        auto_yolo_enabled: true,
+        planning_provider: null,
+        yolo_provider: null,
+      }),
+    ]
+    renderPane()
+
+    expect(
+      screen.getByRole('combobox', { name: 'Choose planning provider' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('combobox', { name: 'Choose yolo provider' })
+    ).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('combobox', { name: 'Choose planning provider' })
+    )
+    await user.click(await screen.findByRole('option', { name: 'MiniMax' }))
+
+    fireEvent.change(getElementAt(screen.getAllByRole('spinbutton'), 0), {
+      target: { value: '32' },
+    })
+    await user.click(screen.getByRole('button', { name: 'Save settings' }))
+
+    expect(mutateMock).toHaveBeenCalledWith({
+      projectId: 'project-id',
+      autoFixSettings: expect.objectContaining({
+        planning_provider: 'MiniMax',
+        planning_backend: 'claude',
+      }),
+    })
+  })
+
+  it('clears providers when switching away from Claude', async () => {
+    const user = userEvent.setup()
+    preferencesMock.custom_cli_profiles = [
+      {
+        name: 'OpenRouter',
+        settings_json: '{}',
+      },
+    ]
+    projectsMock = [
+      project({
+        planning_provider: 'OpenRouter',
+        planning_model: 'opus',
+        auto_yolo_enabled: true,
+      }),
+    ]
+    renderPane()
+
+    expect(
+      screen.getByRole('button', { name: 'Choose planning backend and model' })
+    ).toHaveTextContent('OpenRouter')
+
+    await user.click(
+      screen.getByRole('button', { name: 'Choose planning backend and model' })
+    )
+    await user.click(await screen.findByRole('tab', { name: 'Codex' }))
+    await user.click(await screen.findByText('Backend default'))
+    await user.click(screen.getByRole('button', { name: 'Save settings' }))
+
+    expect(mutateMock).toHaveBeenCalledWith({
+      projectId: 'project-id',
+      autoFixSettings: expect.objectContaining({
+        planning_backend: 'codex',
+        planning_provider: null,
+        planning_model: null,
+      }),
+    })
+  })
+})
+
+describe('normalizeAutoFixProvider', () => {
+  it('keeps named Claude profiles and drops sentinels/non-Claude', () => {
+    expect(normalizeAutoFixProvider('claude', 'MiniMax')).toBe('MiniMax')
+    expect(normalizeAutoFixProvider('claude', '__anthropic__')).toBeNull()
+    expect(normalizeAutoFixProvider('claude', 'anthropic')).toBeNull()
+    expect(normalizeAutoFixProvider('claude', '  ')).toBeNull()
+    expect(normalizeAutoFixProvider('codex', 'MiniMax')).toBeNull()
   })
 })

--- a/src/components/projects/panes/AutoFixPane.tsx
+++ b/src/components/projects/panes/AutoFixPane.tsx
@@ -30,7 +30,9 @@ import { useProjects, useUpdateProjectSettings } from '@/services/projects'
 import type { ProjectAutoFixSettings } from '@/types/projects'
 import {
   codexDefaultModelOptions,
+  getClaudeModelOptionsForProvider,
   type CliBackend,
+  type CustomCliProfile,
   modelOptions,
 } from '@/types/preferences'
 import { BackendLabel } from '@/components/ui/backend-label'
@@ -45,9 +47,11 @@ import {
 import { useInstalledBackends } from '@/hooks/useInstalledBackends'
 import { useGitHubLabels } from '@/services/github'
 import type { GitHubLabel } from '@/types/github'
+import { usePreferences } from '@/services/preferences'
 
 export const MR_ROBOT_SETTINGS_BADGE = 'Beta'
 const BACKEND_DEFAULT_MODEL_VALUE = '__backend_default__'
+const ANTHROPIC_PROVIDER_VALUE = '__anthropic__'
 
 /** Structural defaults. Backend values are resolved via installed CLIs. */
 const DEFAULT_AUTO_FIX_SETTINGS: ProjectAutoFixSettings = {
@@ -59,9 +63,11 @@ const DEFAULT_AUTO_FIX_SETTINGS: ProjectAutoFixSettings = {
   excluded_labels: [],
   planning_backend: 'claude',
   planning_model: null,
+  planning_provider: null,
   auto_yolo_enabled: false,
   yolo_backend: 'claude',
   yolo_model: null,
+  yolo_provider: null,
   active_hours_enabled: false,
   active_hours_start: 20,
   active_hours_end: 8,
@@ -129,6 +135,25 @@ function parseLabelList(value: string): string[] {
   return labels
 }
 
+/** Normalize provider: empty/Anthropic sentinels become null; only keep for Claude. */
+export function normalizeAutoFixProvider(
+  backend: string,
+  provider: string | null | undefined
+): string | null {
+  if (backend !== 'claude') return null
+  const trimmed = provider?.trim()
+  if (
+    !trimmed ||
+    trimmed === ANTHROPIC_PROVIDER_VALUE ||
+    trimmed === '__default__' ||
+    trimmed === 'anthropic' ||
+    trimmed === 'default'
+  ) {
+    return null
+  }
+  return trimmed
+}
+
 function normalizeAutoFixSettings(
   settings: ProjectAutoFixSettings
 ): ProjectAutoFixSettings {
@@ -137,6 +162,14 @@ function normalizeAutoFixSettings(
     ...settings,
     planning_model: settings.planning_model?.trim() || null,
     yolo_model: settings.yolo_model?.trim() || null,
+    planning_provider: normalizeAutoFixProvider(
+      settings.planning_backend,
+      settings.planning_provider
+    ),
+    yolo_provider: normalizeAutoFixProvider(
+      settings.yolo_backend,
+      settings.yolo_provider
+    ),
     included_labels: parseLabelList((settings.included_labels ?? []).join(',')),
     excluded_labels: parseLabelList((settings.excluded_labels ?? []).join(',')),
   }
@@ -282,7 +315,11 @@ function GitHubLabelMultiSelect({
   )
 }
 
-function getModelOptions(backend: string) {
+function getModelOptions(
+  backend: string,
+  provider: string | null | undefined,
+  customCliProfiles: CustomCliProfile[]
+) {
   switch (backend) {
     case 'codex':
       return codexDefaultModelOptions
@@ -295,17 +332,65 @@ function getModelOptions(backend: string) {
     case 'commandcode':
       return COMMANDCODE_MODEL_OPTIONS
     case 'claude':
+      return getClaudeModelOptionsForProvider(provider, customCliProfiles)
     default:
       return modelOptions
   }
 }
 
-function getModelLabel(backend: string, model: string | null | undefined) {
+function getModelLabel(
+  backend: string,
+  model: string | null | undefined,
+  provider: string | null | undefined,
+  customCliProfiles: CustomCliProfile[]
+) {
   if (!model) return 'Backend default'
 
   return (
-    getModelOptions(backend).find(option => option.value === model)?.label ??
-    model
+    getModelOptions(backend, provider, customCliProfiles).find(
+      option => option.value === model
+    )?.label ?? model
+  )
+}
+
+function AutoFixProviderSelect({
+  label,
+  provider,
+  profiles,
+  disabled,
+  onChange,
+}: {
+  label: string
+  provider: string | null | undefined
+  profiles: CustomCliProfile[]
+  disabled?: boolean
+  onChange: (provider: string | null) => void
+}) {
+  if (profiles.length === 0) return null
+
+  return (
+    <Select
+      value={provider ?? ANTHROPIC_PROVIDER_VALUE}
+      onValueChange={value =>
+        onChange(value === ANTHROPIC_PROVIDER_VALUE ? null : value)
+      }
+      disabled={disabled}
+    >
+      <SelectTrigger
+        aria-label={`Choose ${label} provider`}
+        className="w-full"
+      >
+        <SelectValue placeholder="Anthropic" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={ANTHROPIC_PROVIDER_VALUE}>Anthropic</SelectItem>
+        {profiles.map(profile => (
+          <SelectItem key={profile.name} value={profile.name}>
+            {profile.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   )
 }
 
@@ -313,37 +398,57 @@ function AutoFixBackendModelPicker({
   label,
   backend,
   model,
+  provider,
+  customCliProfiles,
   disabled,
   onChange,
 }: {
   label: string
   backend: string
   model: string | null | undefined
+  provider: string | null | undefined
+  customCliProfiles: CustomCliProfile[]
   disabled?: boolean
-  onChange: (backend: string, model: string | null) => void
+  onChange: (
+    backend: string,
+    model: string | null,
+    provider: string | null
+  ) => void
 }) {
   const [open, setOpen] = useState(false)
   const { installedBackends } = useInstalledBackends()
   const selectedBackend = backend as CliBackend
+  const selectedProvider = normalizeAutoFixProvider(backend, provider)
   const selectedModel = model ?? BACKEND_DEFAULT_MODEL_VALUE
-  const modelLabel = getModelLabel(backend, model)
+  const modelLabel = getModelLabel(
+    backend,
+    model,
+    selectedProvider,
+    customCliProfiles
+  )
+  const providerLabel = selectedProvider ?? null
   const handleModelChange = useCallback(
     (nextModel: string) => {
       onChange(
         backend,
-        nextModel === BACKEND_DEFAULT_MODEL_VALUE ? null : nextModel
+        nextModel === BACKEND_DEFAULT_MODEL_VALUE ? null : nextModel,
+        selectedProvider
       )
     },
-    [backend, onChange]
+    [backend, onChange, selectedProvider]
   )
   const handleBackendModelChange = useCallback(
     (nextBackend: CliBackend, nextModel: string) => {
+      // Switching backends drops Claude-only custom providers.
+      const nextProvider =
+        nextBackend === 'claude' ? selectedProvider : null
       onChange(
         nextBackend,
-        nextModel === BACKEND_DEFAULT_MODEL_VALUE ? null : nextModel
+        nextModel === BACKEND_DEFAULT_MODEL_VALUE ? null : nextModel,
+        nextProvider
       )
     },
-    [onChange]
+    [onChange, selectedProvider]
   )
 
   return (
@@ -360,6 +465,11 @@ function AutoFixBackendModelPicker({
         >
           <span className="min-w-0 flex items-center gap-1.5">
             <BackendLabel backend={selectedBackend} className="shrink-0" />
+            {providerLabel && (
+              <span className="truncate text-muted-foreground">
+                · {providerLabel}
+              </span>
+            )}
             <span className="truncate">· {modelLabel}</span>
           </span>
           <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 opacity-50" />
@@ -373,9 +483,9 @@ function AutoFixBackendModelPicker({
           open={open}
           selectedBackend={selectedBackend}
           selectedModel={selectedModel}
-          selectedProvider={null}
+          selectedProvider={selectedProvider}
           installedBackends={installedBackends}
-          customCliProfiles={[]}
+          customCliProfiles={customCliProfiles}
           onModelChange={handleModelChange}
           onBackendModelChange={handleBackendModelChange}
           onRequestClose={() => setOpen(false)}
@@ -394,6 +504,11 @@ export function AutoFixPane({ projectId }: { projectId: string }) {
   const project = projects.find(p => p.id === projectId)
   const updateSettings = useUpdateProjectSettings()
   const { installedBackends } = useInstalledBackends()
+  const { data: preferences } = usePreferences()
+  const customCliProfiles = useMemo(
+    () => preferences?.custom_cli_profiles ?? [],
+    [preferences?.custom_cli_profiles]
+  )
   const { data: githubLabels = [], isLoading: githubLabelsLoading } =
     useGitHubLabels(project?.path ?? null, {
       enabled: Boolean(project?.path && !project?.is_folder),
@@ -643,16 +758,60 @@ export function AutoFixPane({ projectId }: { projectId: string }) {
               </div>
             </div>
 
+            {settings.planning_backend === 'claude' &&
+              customCliProfiles.length > 0 && (
+                <div className="mb-4">
+                  <Field
+                    label="Provider"
+                    description="Claude custom CLI profile (Settings → Providers)."
+                  >
+                    <AutoFixProviderSelect
+                      label="planning"
+                      provider={settings.planning_provider}
+                      profiles={customCliProfiles}
+                      disabled={updateSettings.isPending}
+                      onChange={planning_provider =>
+                        setSettings(current => {
+                          const nextModel =
+                            planning_provider &&
+                            current.planning_model &&
+                            !['opus', 'sonnet', 'haiku'].includes(
+                              current.planning_model
+                            )
+                              ? 'opus'
+                              : current.planning_model
+                          return {
+                            ...current,
+                            planning_provider,
+                            planning_model: nextModel,
+                          }
+                        })
+                      }
+                    />
+                  </Field>
+                </div>
+              )}
+
             <Field label="Backend + model">
               <AutoFixBackendModelPicker
                 label="planning"
                 backend={settings.planning_backend}
                 model={settings.planning_model}
-                onChange={(planning_backend, planning_model) =>
+                provider={settings.planning_provider}
+                customCliProfiles={customCliProfiles}
+                onChange={(
+                  planning_backend,
+                  planning_model,
+                  planning_provider
+                ) =>
                   setSettings(current => ({
                     ...current,
                     planning_backend,
                     planning_model,
+                    planning_provider:
+                      planning_backend === 'claude'
+                        ? planning_provider
+                        : null,
                   }))
                 }
               />
@@ -678,17 +837,56 @@ export function AutoFixPane({ projectId }: { projectId: string }) {
                 disabled={updateSettings.isPending}
               />
             </div>
+            {settings.yolo_backend === 'claude' &&
+              customCliProfiles.length > 0 && (
+                <div className="mb-4">
+                  <Field
+                    label="Provider"
+                    description="Claude custom CLI profile (Settings → Providers)."
+                  >
+                    <AutoFixProviderSelect
+                      label="yolo"
+                      provider={settings.yolo_provider}
+                      profiles={customCliProfiles}
+                      disabled={
+                        !settings.auto_yolo_enabled || updateSettings.isPending
+                      }
+                      onChange={yolo_provider =>
+                        setSettings(current => {
+                          const nextModel =
+                            yolo_provider &&
+                            current.yolo_model &&
+                            !['opus', 'sonnet', 'haiku'].includes(
+                              current.yolo_model
+                            )
+                              ? 'opus'
+                              : current.yolo_model
+                          return {
+                            ...current,
+                            yolo_provider,
+                            yolo_model: nextModel,
+                          }
+                        })
+                      }
+                    />
+                  </Field>
+                </div>
+              )}
             <Field label="Backend + model">
               <AutoFixBackendModelPicker
                 label="yolo"
                 backend={settings.yolo_backend}
                 model={settings.yolo_model}
+                provider={settings.yolo_provider}
+                customCliProfiles={customCliProfiles}
                 disabled={!settings.auto_yolo_enabled}
-                onChange={(yolo_backend, yolo_model) =>
+                onChange={(yolo_backend, yolo_model, yolo_provider) =>
                   setSettings(current => ({
                     ...current,
                     yolo_backend,
                     yolo_model,
+                    yolo_provider:
+                      yolo_backend === 'claude' ? yolo_provider : null,
                   }))
                 }
               />

--- a/src/services/preferences.test.ts
+++ b/src/services/preferences.test.ts
@@ -133,6 +133,16 @@ describe('model option helpers', () => {
     expect(normalizeClaudeModel('claude-opus-4-7')).toBe('claude-opus-4-7')
     expect(normalizeClaudeModel('claude-opus-4-6')).toBe('claude-opus-4-6')
     expect(normalizeClaudeModel('claude-sonnet-4-6')).toBe('claude-sonnet-4-6')
+    // Custom CLI providers keep Claude Code aliases for ANTHROPIC_DEFAULT_* routing
+    expect(
+      normalizeClaudeModel('sonnet', { preserveProviderAliases: true })
+    ).toBe('sonnet')
+    expect(
+      normalizeClaudeModel('opus', { preserveProviderAliases: true })
+    ).toBe('opus')
+    expect(
+      normalizeClaudeModel('haiku', { preserveProviderAliases: true })
+    ).toBe('haiku')
   })
 
   it('offers GPT 5.6 preview variants in Codex selectors', () => {

--- a/src/services/preferences.ts
+++ b/src/services/preferences.ts
@@ -81,7 +81,11 @@ export function usePreferences() {
         }
         return {
           ...preferences,
-          selected_model: normalizeClaudeModel(preferences.selected_model),
+          selected_model: normalizeClaudeModel(preferences.selected_model, {
+            // Keep opus/sonnet/haiku when a custom CLI provider is the default
+            // so Settings → Claude can show/persist provider-routed models.
+            preserveProviderAliases: Boolean(preferences.default_provider),
+          }),
           selected_codex_model: normalizeCodexModel(
             preferences.selected_codex_model
           ),

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1669,7 +1669,25 @@ const knownClaudeModels = new Set<string>([
   'opus',
 ])
 
-export function normalizeClaudeModel(model: string): ClaudeModel {
+/**
+ * Normalize a Claude model id.
+ *
+ * When `preserveProviderAliases` is true (custom CLI provider is active), keep
+ * the Claude Code aliases `opus` / `sonnet` / `haiku` so they resolve through
+ * the provider's ANTHROPIC_DEFAULT_*_MODEL env vars instead of being rewritten
+ * to first-party Anthropic model IDs.
+ */
+export function normalizeClaudeModel(
+  model: string,
+  options?: { preserveProviderAliases?: boolean }
+): ClaudeModel {
+  if (
+    options?.preserveProviderAliases &&
+    (model === 'opus' || model === 'sonnet' || model === 'haiku')
+  ) {
+    return model
+  }
+
   if (model in legacyClaudeDefaultModelMap) {
     return legacyClaudeDefaultModelMap[
       model as keyof typeof legacyClaudeDefaultModelMap
@@ -1679,6 +1697,49 @@ export function normalizeClaudeModel(model: string): ClaudeModel {
   return knownClaudeModels.has(model)
     ? (model as ClaudeModel)
     : 'claude-opus-4-8[1m]'
+}
+
+/** Claude model options for a custom CLI profile (opus/sonnet/haiku aliases). */
+export function getClaudeModelOptionsForProvider(
+  provider: string | null | undefined,
+  customCliProfiles: CustomCliProfile[]
+): { value: ClaudeModel; label: string }[] {
+  if (
+    !provider ||
+    provider === '__anthropic__' ||
+    provider === '__default__' ||
+    provider === 'anthropic' ||
+    provider === 'default'
+  ) {
+    return modelOptions
+  }
+
+  const profile = customCliProfiles.find(p => p.name === provider)
+  let opusModel: string | undefined
+  let sonnetModel: string | undefined
+  let haikuModel: string | undefined
+  if (profile?.settings_json) {
+    try {
+      const settings = JSON.parse(profile.settings_json) as {
+        env?: Record<string, string>
+      }
+      const env = settings?.env
+      if (env) {
+        opusModel = env.ANTHROPIC_DEFAULT_OPUS_MODEL || env.ANTHROPIC_MODEL
+        sonnetModel = env.ANTHROPIC_DEFAULT_SONNET_MODEL || env.ANTHROPIC_MODEL
+        haikuModel = env.ANTHROPIC_DEFAULT_HAIKU_MODEL || env.ANTHROPIC_MODEL
+      }
+    } catch {
+      // Ignore invalid profile JSON; fall back to short labels.
+    }
+  }
+
+  const suffix = (model?: string) => (model ? ` (${model})` : '')
+  return [
+    { value: 'opus', label: `Opus${suffix(opusModel)}` },
+    { value: 'sonnet', label: `Sonnet${suffix(sonnetModel)}` },
+    { value: 'haiku', label: `Haiku${suffix(haikuModel)}` },
+  ]
 }
 
 // Claude models that support fast service tier. Fast mode is exposed via a

--- a/src/types/projects.ts
+++ b/src/types/projects.ts
@@ -19,9 +19,13 @@ export interface ProjectAutoFixSettings {
   excluded_labels?: string[]
   planning_backend: string
   planning_model?: string | null
+  /** Claude custom CLI profile name for planning (null/undefined = Anthropic). */
+  planning_provider?: string | null
   auto_yolo_enabled?: boolean
   yolo_backend: string
   yolo_model?: string | null
+  /** Claude custom CLI profile name for yolo (null/undefined = Anthropic). */
+  yolo_provider?: string | null
   active_hours_enabled?: boolean
   active_hours_start?: number
   active_hours_end?: number


### PR DESCRIPTION
## Summary

- Add Claude custom CLI profile (provider) support for Mr. Robot planning and auto-yolo sessions
- Persist `planning_provider` and `yolo_provider` in project auto-fix settings with safe defaults for existing configs
- Expose provider selection in the Mr. Robot settings UI and show profile-specific model aliases (opus/sonnet/haiku)
- Wire provider through investigation start, session state, and yolo approval so custom Claude setups are used end-to-end

closes #418

---

Fixes #418