### PR TITLE
feat(onboarding): add local vs remote usage mode

### DIFF
--- a/src/components/onboarding/OnboardingDialog.test.tsx
+++ b/src/components/onboarding/OnboardingDialog.test.tsx
@@ -221,11 +221,44 @@ describe('OnboardingDialog backends', () => {
     expect(onInstall).toHaveBeenCalledOnce()
   })
 
+  async function chooseLocalAndContinue(user: ReturnType<typeof userEvent.setup>) {
+    expect(
+      await screen.findByText('How will you use Jean?')
+    ).toBeInTheDocument()
+    // Local is the default selection
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+  }
+
+  it('starts with local vs remote selection', async () => {
+    const { OnboardingDialog } = await import('./OnboardingDialog')
+    render(<OnboardingDialog />)
+
+    expect(
+      await screen.findByText('How will you use Jean?')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Local/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Remote/i })).toBeInTheDocument()
+  })
+
+  it('shows remote setup after choosing remote', async () => {
+    const user = userEvent.setup()
+    const { OnboardingDialog } = await import('./OnboardingDialog')
+    render(<OnboardingDialog />)
+
+    await user.click(await screen.findByRole('button', { name: /Remote/i }))
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+    expect(
+      await screen.findByText(/Install jean-server over SSH/i)
+    ).toBeInTheDocument()
+  })
+
   it('installs and authenticates Cursor before continuing to GitHub setup', async () => {
     const user = userEvent.setup()
     const { OnboardingDialog } = await import('./OnboardingDialog')
     render(<OnboardingDialog />)
 
+    await chooseLocalAndContinue(user)
     await user.click(
       await screen.findByRole('checkbox', { name: /cursor cli/i })
     )
@@ -253,6 +286,7 @@ describe('OnboardingDialog backends', () => {
     const { OnboardingDialog } = await import('./OnboardingDialog')
     render(<OnboardingDialog />)
 
+    await chooseLocalAndContinue(user)
     await user.click(
       await screen.findByRole('checkbox', { name: /cursor cli/i })
     )

--- a/src/components/onboarding/OnboardingDialog.tsx
+++ b/src/components/onboarding/OnboardingDialog.tsx
@@ -92,7 +92,13 @@ import {
   type MagicPromptModels,
 } from '@/types/preferences'
 import { isServerWindows } from '@/lib/platform'
+import {
+  getActiveConnectionId,
+  LOCAL_CONNECTION_ID,
+} from '@/lib/remote-connections'
 import { WslSetupStep } from './WslSetupStep'
+import { UsageModeStep, type OnboardingUsageMode } from './UsageModeStep'
+import { RemoteSetupStep } from './RemoteSetupStep'
 import { ArrowLeft, Loader2 } from 'lucide-react'
 
 type AIBackend =
@@ -118,6 +124,8 @@ export const AI_BACKENDS: AIBackend[] = [
 ]
 
 type OnboardingStep =
+  | 'usage-mode'
+  | 'remote-setup'
   | 'wsl-setup'
   | 'backend-select'
   | 'claude-setup'
@@ -165,6 +173,8 @@ type OnboardingStep =
  * they never appear as a Back destination.
  */
 const BACK_NAVIGABLE_STEPS: readonly OnboardingStep[] = [
+  'usage-mode',
+  'remote-setup',
   'wsl-setup',
   'backend-select',
   'claude-setup',
@@ -849,18 +859,6 @@ function OnboardingDialogContent() {
       setGhLoginAttempt(0)
     })
 
-    // On Windows, show WSL mode selection first if not yet chosen
-    if (
-      isServerWindows() &&
-      preferences &&
-      !preferences.wsl_mode_chosen &&
-      !onboardingStartStep
-    ) {
-      dbg('init effect: Windows + WSL not chosen → wsl-setup')
-      queueMicrotask(() => setStep('wsl-setup', { replace: true }))
-      return
-    }
-
     if (onboardingStartStep === 'gh') {
       dbg('init effect: startStep=gh → gh-setup')
       queueMicrotask(() => {
@@ -883,37 +881,61 @@ function OnboardingDialogContent() {
 
     const readyBackends = AI_BACKENDS.filter(isBackendReady)
     const ghReady = !!ghSetup.status?.installed && !!ghAuth.data?.authenticated
+    const remoteActive = getActiveConnectionId() !== LOCAL_CONNECTION_ID
     dbg(
       'init effect: readyBackends:',
       readyBackends,
       'ghReady:',
       ghReady,
+      'remoteActive:',
+      remoteActive,
       'manuallyTriggered:',
       onboardingManuallyTriggered
     )
 
-    // When manually triggered, always start at wsl-setup on Windows so users
-    // can change their WSL/native choice, then backend-select (via Continue
-    // on the WSL step). Non-Windows goes straight to backend-select.
+    // Manual re-open always starts with Local vs Remote so users can switch.
     if (onboardingManuallyTriggered) {
-      const firstStep: OnboardingStep = isServerWindows()
-        ? 'wsl-setup'
-        : 'backend-select'
-      dbg('init effect: manual trigger →', firstStep)
+      dbg('init effect: manual trigger → usage-mode')
       queueMicrotask(() => {
         setSelectedBackends(readyBackends)
-        setStep(firstStep, { replace: true })
+        setStep('usage-mode', { replace: true })
       })
       return
     }
 
-    if (ghReady && readyBackends.length > 0) {
+    // Already on a remote: skip usage mode and continue CLI setup there.
+    // WSL mode only applies to local Windows development.
+    if (remoteActive) {
+      if (ghReady && readyBackends.length > 0) {
+        dbg('init effect: remote all ready → complete')
+        queueMicrotask(() => setStep('complete', { replace: true }))
+        return
+      }
+      if (readyBackends.length > 0) {
+        dbg('init effect: remote + some backends ready → after backends')
+        queueMicrotask(() => {
+          setSelectedBackends(readyBackends)
+          setStep(getNextStepAfterBackends(), { replace: true })
+        })
+        return
+      }
+      dbg('init effect: remote + nothing ready → backend-select')
+      queueMicrotask(() => setStep('backend-select', { replace: true }))
+      return
+    }
+
+    const needsWslChoice =
+      isServerWindows() && !!preferences && !preferences.wsl_mode_chosen
+
+    // Local tools already ready and environment chosen → finish.
+    if (ghReady && readyBackends.length > 0 && !needsWslChoice) {
       dbg('init effect: all ready → complete')
       queueMicrotask(() => setStep('complete', { replace: true }))
       return
     }
 
-    if (readyBackends.length > 0) {
+    // Partial local progress (and WSL already chosen): resume CLI setup.
+    if (readyBackends.length > 0 && !needsWslChoice) {
       dbg('init effect: some backends ready → skip to after backends')
       queueMicrotask(() => {
         setSelectedBackends(readyBackends)
@@ -922,8 +944,10 @@ function OnboardingDialogContent() {
       return
     }
 
-    dbg('init effect: nothing ready → backend-select')
-    queueMicrotask(() => setStep('backend-select', { replace: true }))
+    // First-run (or Windows still needs environment choice after Local):
+    // Local vs Remote before any CLI installs.
+    dbg('init effect: nothing ready or needs env choice → usage-mode')
+    queueMicrotask(() => setStep('usage-mode', { replace: true }))
   }, [
     onboardingOpen,
     onboardingStartStep,
@@ -2182,8 +2206,45 @@ function OnboardingDialogContent() {
     },
   })
 
+  const continueAfterLocalChoice = useCallback(() => {
+    if (isServerWindows() && preferences && !preferences.wsl_mode_chosen) {
+      dbg('local chosen → wsl-setup')
+      setStep('wsl-setup')
+      return
+    }
+    dbg('local chosen → backend-select')
+    setStep('backend-select')
+  }, [preferences, setStep])
+
+  const handleUsageModeSelect = useCallback(
+    (mode: OnboardingUsageMode) => {
+      if (mode === 'remote') {
+        dbg('usage-mode → remote-setup')
+        setStep('remote-setup')
+        return
+      }
+      continueAfterLocalChoice()
+    },
+    [continueAfterLocalChoice, setStep]
+  )
+
   const getDialogContent = () => {
     const dialogStep = step as OnboardingStep
+    if (dialogStep === 'usage-mode') {
+      return {
+        title: 'Welcome to Jean',
+        description: 'Choose local development or remote control.',
+      }
+    }
+
+    if (dialogStep === 'remote-setup') {
+      return {
+        title: 'Connect to a remote Jean',
+        description:
+          'Install jean-server over SSH, or connect with an existing Web Access URL.',
+      }
+    }
+
     if (dialogStep === 'wsl-setup') {
       return {
         title: 'Welcome to Jean',
@@ -2462,12 +2523,34 @@ function OnboardingDialogContent() {
         </DialogHeader>
 
         <div className="overflow-y-auto py-4 flex flex-col">
-          {step !== 'wsl-setup' && renderStepIndicator()}
+          {step !== 'usage-mode' &&
+            step !== 'remote-setup' &&
+            step !== 'wsl-setup' &&
+            renderStepIndicator()}
 
           <div className="w-full">
-            {step === 'wsl-setup' ? (
+            {step === 'usage-mode' ? (
+              <UsageModeStep onSelect={handleUsageModeSelect} />
+            ) : step === 'remote-setup' ? (
+              <RemoteSetupStep />
+            ) : step === 'wsl-setup' ? (
               <WslSetupStep
                 onComplete={() => {
+                  const ready = AI_BACKENDS.filter(isBackendReady)
+                  const ghOk =
+                    !!ghSetup.status?.installed && !!ghAuth.data?.authenticated
+                  if (ghOk && ready.length > 0) {
+                    dbg('WSL setup complete → complete')
+                    setSelectedBackends(ready)
+                    setStep('complete')
+                    return
+                  }
+                  if (ready.length > 0) {
+                    dbg('WSL setup complete → after backends')
+                    setSelectedBackends(ready)
+                    setStep(getNextStepAfterBackends())
+                    return
+                  }
                   dbg('WSL setup complete → backend-select')
                   setStep('backend-select')
                 }}

--- a/src/components/onboarding/RemoteSetupStep.test.tsx
+++ b/src/components/onboarding/RemoteSetupStep.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RemoteSetupStep } from './RemoteSetupStep'
+
+const {
+  addRemoteConnection,
+  selectConnection,
+  fetchRemoteServerInfo,
+  warnRemoteVersionMismatch,
+  invoke,
+  isNativeApp,
+  listenLocal,
+  markConnectionSwitch,
+} = vi.hoisted(() => ({
+  addRemoteConnection: vi.fn(() => ({ id: 'remote-1' })),
+  selectConnection: vi.fn(),
+  fetchRemoteServerInfo: vi.fn(async () => ({
+    ok: true,
+    appVersion: '0.1.69',
+    webBuildId: '0.1.69-test',
+  })),
+  warnRemoteVersionMismatch: vi.fn(() => false),
+  invoke: vi.fn(),
+  isNativeApp: vi.fn(() => true),
+  listenLocal: vi.fn(async () => () => {
+    // no-op unsubscribe
+  }),
+  markConnectionSwitch: vi.fn(),
+}))
+
+vi.mock('@/lib/remote-connections', () => ({
+  LOCAL_CONNECTION_ID: 'local',
+  addRemoteConnection,
+  markConnectionSwitch,
+  parseRemoteConnectionInput: (url: string, token: string) => {
+    const parsed = new URL(url)
+    const resolvedToken =
+      token.trim() || parsed.searchParams.get('token')?.trim() || ''
+    parsed.search = ''
+    return {
+      url: parsed.toString().replace(/\/$/, ''),
+      token: resolvedToken,
+    }
+  },
+  selectConnection,
+}))
+
+vi.mock('@/lib/remote-version', () => ({
+  fetchRemoteServerInfo,
+  warnRemoteVersionMismatch,
+}))
+
+vi.mock('@/lib/environment', () => ({
+  isNativeApp: () => isNativeApp(),
+}))
+
+vi.mock('@/lib/transport', () => ({
+  invoke,
+  listenLocal,
+}))
+
+describe('RemoteSetupStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isNativeApp.mockReturnValue(true)
+    fetchRemoteServerInfo.mockResolvedValue({
+      ok: true,
+      appVersion: '0.1.69',
+      webBuildId: '0.1.69-test',
+    })
+  })
+
+  it('installs jean-server via SSH and connects', async () => {
+    invoke.mockResolvedValue({
+      name: 'build-box',
+      url: 'http://192.168.1.50:3456',
+      token: 'tok-abc',
+      alreadyInstalled: false,
+      installMode: 'system',
+      ready: true,
+      log: 'ok',
+    })
+    const reloadApp = vi.fn()
+    render(<RemoteSetupStep reloadApp={reloadApp} />)
+
+    expect(
+      screen.getByRole('tab', { name: /Install via SSH/i })
+    ).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('SSH user'), {
+      target: { value: 'ubuntu' },
+    })
+    fireEvent.change(screen.getByLabelText('Host / IP'), {
+      target: { value: '192.168.1.50' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /Install & Connect/i }))
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('install_remote_jean_server', {
+        name: null,
+        user: 'ubuntu',
+        host: '192.168.1.50',
+        sshPort: 22,
+        jeanPort: 3456,
+        userInstall: null,
+      })
+      expect(addRemoteConnection).toHaveBeenCalled()
+      expect(selectConnection).toHaveBeenCalledWith('remote-1')
+      expect(reloadApp).toHaveBeenCalled()
+    })
+  })
+
+  it('connects with an existing Web Access URL', async () => {
+    const reloadApp = vi.fn()
+    render(<RemoteSetupStep reloadApp={reloadApp} />)
+
+    fireEvent.click(screen.getByRole('tab', { name: /Existing URL/i }))
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'Build server' },
+    })
+    fireEvent.change(screen.getByLabelText('Web Access URL'), {
+      target: { value: 'https://jean.example.com/?token=secret' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save & Connect' }))
+
+    await waitFor(() => {
+      expect(addRemoteConnection).toHaveBeenCalledWith({
+        name: 'Build server',
+        url: 'https://jean.example.com/?token=secret',
+        token: '',
+        sshUser: undefined,
+        sshHost: undefined,
+        sshPort: 22,
+      })
+      expect(selectConnection).toHaveBeenCalledWith('remote-1')
+      expect(reloadApp).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/onboarding/RemoteSetupStep.tsx
+++ b/src/components/onboarding/RemoteSetupStep.tsx
@@ -1,0 +1,522 @@
+/**
+ * Onboarding remote setup: install jean-server over SSH or connect an existing
+ * Web Access URL. On success, selects the connection and reloads so CLI setup
+ * (if needed) continues against the remote.
+ */
+
+import { useEffect, useState, type FormEvent } from 'react'
+import { HardDriveDownload, Link2, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Spinner } from '@/components/ui/spinner'
+import { isNativeApp } from '@/lib/environment'
+import { cn } from '@/lib/utils'
+import {
+  addRemoteConnection,
+  markConnectionSwitch,
+  parseRemoteConnectionInput,
+  selectConnection,
+} from '@/lib/remote-connections'
+import {
+  fetchRemoteServerInfo,
+  warnRemoteVersionMismatch,
+} from '@/lib/remote-version'
+import { invoke, listenLocal } from '@/lib/transport'
+import type { InstallRemoteResult } from '@/components/remote/RemoteConnectionsDialog'
+
+const EMPTY_URL_FORM = {
+  name: '',
+  url: '',
+  token: '',
+  sshUser: '',
+  sshHost: '',
+  sshPort: '22',
+}
+
+const EMPTY_INSTALL_FORM = {
+  name: '',
+  user: '',
+  host: '',
+  sshPort: '22',
+  jeanPort: '3456',
+}
+
+type AddMode = 'url' | 'install'
+
+interface RemoteSetupStepProps {
+  reloadApp?: () => void
+}
+
+export function RemoteSetupStep({
+  reloadApp = () => window.location.reload(),
+}: RemoteSetupStepProps) {
+  const native = isNativeApp()
+  const [addMode, setAddMode] = useState<AddMode>(native ? 'install' : 'url')
+  const [form, setForm] = useState(EMPTY_URL_FORM)
+  const [installForm, setInstallForm] = useState(EMPTY_INSTALL_FORM)
+  const [error, setError] = useState<string | null>(null)
+  const [connecting, setConnecting] = useState(false)
+  const [installing, setInstalling] = useState(false)
+  const [progress, setProgress] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!installing || !native) return
+    let disposed = false
+    let unlisten: (() => void) | undefined
+
+    void listenLocal<{ step: string; message: string }>(
+      'remote-install:progress',
+      event => {
+        if (!disposed) setProgress(event.payload.message)
+      }
+    ).then(fn => {
+      if (disposed) fn()
+      else unlisten = fn
+    })
+
+    return () => {
+      disposed = true
+      unlisten?.()
+    }
+  }, [installing, native])
+
+  const parseOptionalSshPort = (raw: string): number | undefined => {
+    const trimmed = raw.trim()
+    if (!trimmed) return undefined
+    const port = Number(trimmed)
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new Error('SSH port must be an integer between 1 and 65535.')
+    }
+    return port
+  }
+
+  const handleUrlSubmit = async (event: FormEvent) => {
+    event.preventDefault()
+    setError(null)
+    setConnecting(true)
+
+    try {
+      const sshPort = parseOptionalSshPort(form.sshPort)
+      const input = {
+        name: form.name,
+        url: form.url,
+        token: form.token,
+        sshUser: form.sshUser.trim() || undefined,
+        sshHost: form.sshHost.trim() || undefined,
+        sshPort,
+      }
+      const normalized = parseRemoteConnectionInput(input.url, input.token)
+
+      try {
+        const info = await fetchRemoteServerInfo(
+          normalized.url,
+          normalized.token
+        )
+        warnRemoteVersionMismatch(info.appVersion)
+      } catch (probeError) {
+        if (
+          probeError instanceof Error &&
+          probeError.message.includes('Invalid access token')
+        ) {
+          setError(probeError.message)
+          return
+        }
+      }
+
+      const connection = addRemoteConnection(input)
+      markConnectionSwitch()
+      selectConnection(connection.id)
+      reloadApp()
+    } catch (submitError) {
+      setError(
+        submitError instanceof Error ? submitError.message : String(submitError)
+      )
+    } finally {
+      setConnecting(false)
+    }
+  }
+
+  const handleInstallSubmit = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!native) {
+      setError('Remote install is only available in the native Jean app.')
+      return
+    }
+
+    const user = installForm.user.trim()
+    const host = installForm.host.trim()
+    if (!user || !host) {
+      setError('SSH user and host/IP are required.')
+      return
+    }
+
+    const sshPort = Number(installForm.sshPort || '22')
+    const jeanPort = Number(installForm.jeanPort || '3456')
+    if (
+      !Number.isInteger(sshPort) ||
+      sshPort < 1 ||
+      sshPort > 65535 ||
+      !Number.isInteger(jeanPort) ||
+      jeanPort < 1 ||
+      jeanPort > 65535
+    ) {
+      setError('SSH and Jean ports must be integers between 1 and 65535.')
+      return
+    }
+
+    setError(null)
+    setInstalling(true)
+    setProgress('Starting remote install…')
+
+    try {
+      const result = await invoke<InstallRemoteResult>(
+        'install_remote_jean_server',
+        {
+          name: installForm.name.trim() || null,
+          user,
+          host,
+          sshPort,
+          jeanPort,
+          userInstall: null,
+        }
+      )
+
+      if (!result.ready) {
+        throw new Error('Remote jean-server did not report ready.')
+      }
+
+      const connection = addRemoteConnection({
+        name: result.name,
+        url: result.url,
+        token: result.token,
+        sshUser: user,
+        sshHost: host,
+        sshPort,
+      })
+      markConnectionSwitch()
+      selectConnection(connection.id)
+      reloadApp()
+    } catch (installError) {
+      setError(
+        installError instanceof Error
+          ? installError.message
+          : String(installError)
+      )
+      setInstalling(false)
+      setProgress(null)
+    }
+  }
+
+  const busy = connecting || installing
+
+  if (addMode === 'install' && native) {
+    return (
+      <form className="space-y-4" onSubmit={handleInstallSubmit}>
+        <AddModeTabs
+          mode={addMode}
+          onChange={mode => {
+            if (busy) return
+            setAddMode(mode)
+            setError(null)
+          }}
+          disabled={busy}
+        />
+        <div className="space-y-1.5">
+          <Label htmlFor="onboarding-remote-install-name">Name</Label>
+          <Input
+            id="onboarding-remote-install-name"
+            value={installForm.name}
+            onChange={event =>
+              setInstallForm(current => ({
+                ...current,
+                name: event.target.value,
+              }))
+            }
+            placeholder="Build server"
+            disabled={busy}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="onboarding-remote-install-user">SSH user</Label>
+            <Input
+              id="onboarding-remote-install-user"
+              value={installForm.user}
+              onChange={event =>
+                setInstallForm(current => ({
+                  ...current,
+                  user: event.target.value,
+                }))
+              }
+              placeholder="ubuntu"
+              required
+              disabled={busy}
+              autoComplete="username"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="onboarding-remote-install-host">Host / IP</Label>
+            <Input
+              id="onboarding-remote-install-host"
+              value={installForm.host}
+              onChange={event =>
+                setInstallForm(current => ({
+                  ...current,
+                  host: event.target.value,
+                }))
+              }
+              placeholder="192.168.1.50"
+              required
+              disabled={busy}
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="onboarding-remote-install-ssh-port">SSH port</Label>
+            <Input
+              id="onboarding-remote-install-ssh-port"
+              type="number"
+              min={1}
+              max={65535}
+              value={installForm.sshPort}
+              onChange={event =>
+                setInstallForm(current => ({
+                  ...current,
+                  sshPort: event.target.value,
+                }))
+              }
+              disabled={busy}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="onboarding-remote-install-jean-port">
+              Jean port
+            </Label>
+            <Input
+              id="onboarding-remote-install-jean-port"
+              type="number"
+              min={1}
+              max={65535}
+              value={installForm.jeanPort}
+              onChange={event =>
+                setInstallForm(current => ({
+                  ...current,
+                  jeanPort: event.target.value,
+                }))
+              }
+              disabled={busy}
+            />
+          </div>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Requires SSH key auth to the host (no password prompt). Jean installs
+          via the official installer, checks health, then connects. After
+          connecting, AI CLI setup continues on the remote if needed.
+        </p>
+        {progress && (
+          <div className="flex items-start gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
+            <Spinner className="mt-0.5 size-3.5 shrink-0" />
+            <span>{progress}</span>
+          </div>
+        )}
+        {error && (
+          <p className="whitespace-pre-wrap text-sm text-destructive">{error}</p>
+        )}
+        <Button type="submit" className="w-full" size="lg" disabled={busy}>
+          {installing ? (
+            <>
+              <Spinner className="mr-2 size-4" />
+              Installing…
+            </>
+          ) : (
+            <>
+              <HardDriveDownload className="mr-2 size-4" />
+              Install & Connect
+            </>
+          )}
+        </Button>
+      </form>
+    )
+  }
+
+  return (
+    <form className="space-y-4" onSubmit={handleUrlSubmit}>
+      {native && (
+        <AddModeTabs
+          mode={addMode}
+          onChange={mode => {
+            if (busy) return
+            setAddMode(mode)
+            setError(null)
+          }}
+          disabled={busy}
+        />
+      )}
+      <div className="space-y-1.5">
+        <Label htmlFor="onboarding-remote-name">Name</Label>
+        <Input
+          id="onboarding-remote-name"
+          value={form.name}
+          onChange={event =>
+            setForm(current => ({
+              ...current,
+              name: event.target.value,
+            }))
+          }
+          placeholder="Build server"
+          disabled={busy}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="onboarding-remote-url">Web Access URL</Label>
+        <Input
+          id="onboarding-remote-url"
+          value={form.url}
+          onChange={event =>
+            setForm(current => ({
+              ...current,
+              url: event.target.value,
+            }))
+          }
+          placeholder="https://jean.example.com/?token=..."
+          required
+          disabled={busy}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="onboarding-remote-token">Access token</Label>
+        <Input
+          id="onboarding-remote-token"
+          type="password"
+          value={form.token}
+          onChange={event =>
+            setForm(current => ({
+              ...current,
+              token: event.target.value,
+            }))
+          }
+          placeholder="Optional when included in the URL"
+          disabled={busy}
+        />
+      </div>
+      <div className="space-y-2 rounded-md border p-3">
+        <div>
+          <p className="text-sm font-medium">SSH for editor (Zed)</p>
+          <p className="text-xs text-muted-foreground">
+            Used when Open in Editor runs against this remote. Defaults host to
+            the Web Access hostname when left blank.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="onboarding-remote-ssh-user">SSH user</Label>
+            <Input
+              id="onboarding-remote-ssh-user"
+              value={form.sshUser}
+              onChange={event =>
+                setForm(current => ({
+                  ...current,
+                  sshUser: event.target.value,
+                }))
+              }
+              placeholder="ubuntu"
+              autoComplete="username"
+              disabled={busy}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="onboarding-remote-ssh-host">SSH host</Label>
+            <Input
+              id="onboarding-remote-ssh-host"
+              value={form.sshHost}
+              onChange={event =>
+                setForm(current => ({
+                  ...current,
+                  sshHost: event.target.value,
+                }))
+              }
+              placeholder="Same as Web Access host"
+              disabled={busy}
+            />
+          </div>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="onboarding-remote-ssh-port">SSH port</Label>
+          <Input
+            id="onboarding-remote-ssh-port"
+            type="number"
+            min={1}
+            max={65535}
+            value={form.sshPort}
+            onChange={event =>
+              setForm(current => ({
+                ...current,
+                sshPort: event.target.value,
+              }))
+            }
+            disabled={busy}
+          />
+        </div>
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <Button type="submit" className="w-full" size="lg" disabled={busy}>
+        {connecting && <Loader2 className="mr-2 size-4 animate-spin" />}
+        Save & Connect
+      </Button>
+    </form>
+  )
+}
+
+const ADD_MODE_TABS: {
+  id: AddMode
+  label: string
+  icon: typeof HardDriveDownload
+}[] = [
+  { id: 'install', label: 'Install via SSH', icon: HardDriveDownload },
+  { id: 'url', label: 'Existing URL', icon: Link2 },
+]
+
+function AddModeTabs({
+  mode,
+  onChange,
+  disabled = false,
+}: {
+  mode: AddMode
+  onChange: (mode: AddMode) => void
+  disabled?: boolean
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Add connection method"
+      className="flex border-b border-border"
+    >
+      {ADD_MODE_TABS.map(tab => {
+        const selected = mode === tab.id
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            disabled={disabled}
+            onClick={() => onChange(tab.id)}
+            className={cn(
+              'flex flex-1 items-center justify-center gap-1.5 px-3 py-2 text-sm font-medium transition-colors',
+              'border-b-2 hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              'disabled:pointer-events-none disabled:opacity-50',
+              selected
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground'
+            )}
+          >
+            <tab.icon className="size-3.5" />
+            {tab.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/onboarding/UsageModeStep.test.tsx
+++ b/src/components/onboarding/UsageModeStep.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { UsageModeStep } from './UsageModeStep'
+
+describe('UsageModeStep', () => {
+  it('defaults to local and reports the selected mode', () => {
+    const onSelect = vi.fn()
+    render(<UsageModeStep onSelect={onSelect} />)
+
+    expect(screen.getByText('How will you use Jean?')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Local/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Remote/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    expect(onSelect).toHaveBeenCalledWith('local')
+  })
+
+  it('selects remote when the remote card is chosen', () => {
+    const onSelect = vi.fn()
+    render(<UsageModeStep onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Remote/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    expect(onSelect).toHaveBeenCalledWith('remote')
+  })
+})

--- a/src/components/onboarding/UsageModeStep.tsx
+++ b/src/components/onboarding/UsageModeStep.tsx
@@ -1,0 +1,74 @@
+/**
+ * First onboarding step: local Jean vs remote control.
+ *
+ * Local continues into WSL (Windows) / CLI setup.
+ * Remote continues into jean-server install or existing Web Access URL.
+ */
+
+import { Monitor, Server } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useState } from 'react'
+
+export type OnboardingUsageMode = 'local' | 'remote'
+
+interface UsageModeStepProps {
+  onSelect: (mode: OnboardingUsageMode) => void
+}
+
+export function UsageModeStep({ onSelect }: UsageModeStepProps) {
+  const [mode, setMode] = useState<OnboardingUsageMode>('local')
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2 text-center">
+        <h3 className="text-lg font-semibold">How will you use Jean?</h3>
+        <p className="text-muted-foreground text-sm">
+          Use this computer for development, or connect to a Jean server
+          elsewhere. You can add more connections later from the title bar.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <button
+          type="button"
+          onClick={() => setMode('local')}
+          className={`flex flex-col items-center gap-3 rounded-lg border-2 p-4 text-left transition-colors ${
+            mode === 'local'
+              ? 'border-primary bg-primary/5'
+              : 'border-border hover:border-muted-foreground/30'
+          }`}
+        >
+          <Monitor className="h-8 w-8 text-muted-foreground" />
+          <div className="text-center">
+            <div className="font-medium">Local</div>
+            <div className="text-muted-foreground mt-1 text-xs">
+              Install AI CLIs and run projects on this machine
+            </div>
+          </div>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setMode('remote')}
+          className={`flex flex-col items-center gap-3 rounded-lg border-2 p-4 text-left transition-colors ${
+            mode === 'remote'
+              ? 'border-primary bg-primary/5'
+              : 'border-border hover:border-muted-foreground/30'
+          }`}
+        >
+          <Server className="h-8 w-8 text-muted-foreground" />
+          <div className="text-center">
+            <div className="font-medium">Remote</div>
+            <div className="text-muted-foreground mt-1 text-xs">
+              Control a jean-server via SSH install or Web Access URL
+            </div>
+          </div>
+        </button>
+      </div>
+
+      <Button className="w-full" size="lg" onClick={() => onSelect(mode)}>
+        Continue
+      </Button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Ask Local vs Remote first in onboarding so remote-control setups skip forced AI CLI install
- Route Remote into jean-server / Web Access setup; Local keeps WSL (Windows) and backend setup
- Clarify connection-scoped settings and title-bar connection indicators for remote use

closes #506

---

Fixes #506