### PR TITLE
feat(github): hide seen failed workflow run badges

### DIFF
--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -3099,6 +3099,11 @@ pub struct UIState {
     #[serde(default)]
     pub last_opened_per_project: std::collections::HashMap<String, LastOpenedEntry>,
 
+    /// GitHub Actions workflow run database IDs the user has already opened.
+    /// Failed-run badges only count runs not present in this list.
+    #[serde(default)]
+    pub seen_failed_workflow_run_ids: Vec<u64>,
+
     /// Version for future migration support
     #[serde(default = "default_ui_state_version")]
     pub version: u32,
@@ -3207,6 +3212,7 @@ impl Default for UIState {
             project_canvas_settings: std::collections::HashMap::new(),
             github_dashboard_favorite_project_ids: Vec::new(),
             last_opened_per_project: std::collections::HashMap::new(),
+            seen_failed_workflow_run_ids: Vec::new(),
             version: default_ui_state_version(),
         }
     }

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -114,6 +114,7 @@ import type { LabelData, Session, WorktreeSessions } from '@/types/chat'
 import { NewIssuesBadge } from '@/components/shared/NewIssuesBadge'
 import { OpenPRsBadge } from '@/components/shared/OpenPRsBadge'
 import { FailedRunsBadge } from '@/components/shared/FailedRunsBadge'
+import { countUnreadFailedWorkflowRuns } from '@/components/shared/workflow-run-utils'
 import { SecurityAlertsBadge } from '@/components/shared/SecurityAlertsBadge'
 import { PlanDialog } from '@/components/chat/PlanDialog'
 import { SessionChatModal } from '@/components/chat/SessionChatModal'
@@ -936,7 +937,17 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
     (mobileAdvisories?.filter(a => a.state === 'draft' || a.state === 'triage')
       .length ?? 0)
   const mobileWorkflowRunCount = mobileWorkflowRuns?.runs?.length ?? 0
-  const mobileFailedWorkflowCount = mobileWorkflowRuns?.failedCount ?? 0
+  const seenFailedWorkflowRunIds = useUIStore(
+    state => state.seenFailedWorkflowRunIds
+  )
+  const mobileFailedWorkflowCount = useMemo(
+    () =>
+      countUnreadFailedWorkflowRuns(
+        mobileWorkflowRuns?.runs ?? [],
+        seenFailedWorkflowRunIds
+      ),
+    [mobileWorkflowRuns?.runs, seenFailedWorkflowRunIds]
+  )
 
   // Get worktrees
   const { data: worktrees = [], isLoading: worktreesLoading } =

--- a/src/components/projects/WorktreeDropdownMenu.tsx
+++ b/src/components/projects/WorktreeDropdownMenu.tsx
@@ -16,7 +16,7 @@ import {
   Trash2,
   X,
 } from 'lucide-react'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import {
   AlertDialog,
@@ -53,6 +53,7 @@ import { canOpenInEditor, canOpenNativeApps } from '@/lib/environment'
 import { useProjectsStore } from '@/store/projects-store'
 import { useUIStore } from '@/store/ui-store'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { countUnreadFailedWorkflowRuns } from '@/components/shared/workflow-run-utils'
 import type { GhAuthStatus } from '@/types/gh-cli'
 import { useWorktreeMenuActions } from './useWorktreeMenuActions'
 
@@ -122,6 +123,9 @@ export function WorktreeDropdownMenu({
     enabled: isGitHubAuthenticated,
     staleTime: BADGE_STALE_TIME,
   })
+  const seenFailedWorkflowRunIds = useUIStore(
+    state => state.seenFailedWorkflowRunIds
+  )
   const issueCount = issueResult?.totalCount ?? 0
   const prCount = prs?.length ?? 0
   const securityCount =
@@ -129,7 +133,14 @@ export function WorktreeDropdownMenu({
     (advisories?.filter(a => a.state === 'draft' || a.state === 'triage')
       .length ?? 0)
   const workflowRunCount = workflowRuns?.runs?.length ?? 0
-  const failedWorkflowCount = workflowRuns?.failedCount ?? 0
+  const failedWorkflowCount = useMemo(
+    () =>
+      countUnreadFailedWorkflowRuns(
+        workflowRuns?.runs ?? [],
+        seenFailedWorkflowRunIds
+      ),
+    [workflowRuns?.runs, seenFailedWorkflowRunIds]
+  )
   const hasDiff = uncommittedAdded > 0 || uncommittedRemoved > 0
   const hasBranchDiff = branchDiffAdded > 0 || branchDiffRemoved > 0
   const showMobileGitHubItems = isMobile

--- a/src/components/shared/FailedRunsBadge.tsx
+++ b/src/components/shared/FailedRunsBadge.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { AlertCircle, Activity } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -10,6 +10,7 @@ import {
 import { useWorkflowRuns } from '@/services/github'
 import { ghCliQueryKeys } from '@/services/gh-cli'
 import { useUIStore } from '@/store/ui-store'
+import { countUnreadFailedWorkflowRuns } from '@/components/shared/workflow-run-utils'
 import type { GhAuthStatus } from '@/types/gh-cli'
 
 const BADGE_STALE_TIME = 5 * 60 * 1000 // 5 minutes — background badge, not active UI
@@ -28,6 +29,9 @@ export function FailedRunsBadge({
   const queryClient = useQueryClient()
   const authData = queryClient.getQueryData<GhAuthStatus>(ghCliQueryKeys.auth())
   const isAuthenticated = authData?.authenticated ?? false
+  const seenFailedWorkflowRunIds = useUIStore(
+    state => state.seenFailedWorkflowRunIds
+  )
 
   const { data: result } = useWorkflowRuns(projectPath, branch, {
     enabled: isAuthenticated,
@@ -35,7 +39,14 @@ export function FailedRunsBadge({
   })
 
   const totalRuns = result?.runs?.length ?? 0
-  const failedCount = result?.failedCount ?? 0
+  const unreadFailedCount = useMemo(
+    () =>
+      countUnreadFailedWorkflowRuns(
+        result?.runs ?? [],
+        seenFailedWorkflowRunIds
+      ),
+    [result?.runs, seenFailedWorkflowRunIds]
+  )
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
@@ -48,8 +59,8 @@ export function FailedRunsBadge({
 
   if (totalRuns === 0) return null
 
-  // Red badge with count when there are failures
-  if (failedCount > 0) {
+  // Red badge with unread failure count only
+  if (unreadFailedCount > 0) {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
@@ -62,16 +73,16 @@ export function FailedRunsBadge({
           >
             <span className="flex items-center gap-0.5">
               <AlertCircle className="h-3 w-3" />
-              {failedCount}
+              {unreadFailedCount}
             </span>
           </button>
         </TooltipTrigger>
-        <TooltipContent>{`${failedCount} failed workflow run${failedCount > 1 ? 's' : ''}`}</TooltipContent>
+        <TooltipContent>{`${unreadFailedCount} unread failed workflow run${unreadFailedCount > 1 ? 's' : ''}`}</TooltipContent>
       </Tooltip>
     )
   }
 
-  // Subtle icon-only button to open modal when all runs are passing
+  // Subtle icon-only button when all failures have been seen (or none failed)
   return (
     <Tooltip>
       <TooltipTrigger asChild>

--- a/src/components/shared/WorkflowRunsModal.tsx
+++ b/src/components/shared/WorkflowRunsModal.tsx
@@ -58,7 +58,11 @@ import {
 } from '@/types/preferences'
 import type { WorkflowRun } from '@/types/github'
 import type { Project, Worktree } from '@/types/projects'
-import { isReusableWorkflowInvestigationSession } from './workflow-run-utils'
+import {
+  getLatestFailedWorkflowRuns,
+  isFailedWorkflowRun,
+  isReusableWorkflowInvestigationSession,
+} from './workflow-run-utils'
 
 function timeAgo(dateString: string): string {
   const seconds = Math.floor(
@@ -71,10 +75,6 @@ function timeAgo(dateString: string): string {
   if (hours < 24) return `${hours}h ago`
   const days = Math.floor(hours / 24)
   return `${days}d ago`
-}
-
-function isFailedRun(run: WorkflowRun): boolean {
-  return run.conclusion === 'failure' || run.conclusion === 'startup_failure'
 }
 
 /** Extract the numeric run ID from a GitHub Actions URL */
@@ -166,6 +166,9 @@ export function WorkflowRunsModal() {
   const setWorkflowRunsModalOpen = useUIStore(
     state => state.setWorkflowRunsModalOpen
   )
+  const markFailedWorkflowRunsSeen = useUIStore(
+    state => state.markFailedWorkflowRunsSeen
+  )
 
   const {
     data: result,
@@ -188,6 +191,8 @@ export function WorkflowRunsModal() {
   }, [queryClient, workflowRunsModalProjectPath, workflowRunsModalBranch])
 
   const runs = useMemo(() => result?.runs ?? [], [result?.runs])
+  /** Unread failed run IDs for the current modal open (for "New" indicators). */
+  const [unreadOnOpen, setUnreadOnOpen] = useState<Set<number>>(() => new Set())
   const [selectedWorkflow, setSelectedWorkflow] = useState<string | null>(null)
   const [focusedIndex, setFocusedIndex] = useState(0)
   const [focusedPane, setFocusedPane] = useState<'sidebar' | 'list'>('sidebar')
@@ -197,19 +202,52 @@ export function WorkflowRunsModal() {
   const itemRefs = useRef<(HTMLDivElement | null)[]>([])
   const sidebarItemRefs = useRef<(HTMLButtonElement | null)[]>([])
 
+  // When the user opens workflow runs, mark current latest failures as seen so
+  // badges clear across sidebar / header / worktree menus. Keep a session
+  // snapshot of which IDs were unread so the list can still show "New".
+  useEffect(() => {
+    if (!workflowRunsModalOpen) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setUnreadOnOpen(new Set())
+      return
+    }
+    if (runs.length === 0) return
+
+    const seenSet = new Set(useUIStore.getState().seenFailedWorkflowRunIds)
+    const latestFailed = getLatestFailedWorkflowRuns(runs)
+    const unreadRunIds = latestFailed
+      .map(r => r.databaseId)
+      .filter(id => !seenSet.has(id))
+    if (unreadRunIds.length === 0) return
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setUnreadOnOpen(prev => {
+      let changed = false
+      const next = new Set(prev)
+      for (const id of unreadRunIds) {
+        if (!next.has(id)) {
+          next.add(id)
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+    markFailedWorkflowRunsSeen(unreadRunIds)
+  }, [workflowRunsModalOpen, runs, markFailedWorkflowRunsSeen])
+
   const groups = useMemo(() => {
     const groupMap = new Map<string, WorkflowGroup>()
     for (const run of runs) {
       const existing = groupMap.get(run.workflowName)
       if (existing) {
         existing.totalCount++
-        if (isFailedRun(run)) existing.failedCount++
+        if (isFailedWorkflowRun(run)) existing.failedCount++
       } else {
         // First occurrence per workflow = latest (runs are sorted by date)
         const status: WorkflowGroup['latestStatus'] =
           run.status === 'in_progress' || run.status === 'queued'
             ? 'pending'
-            : isFailedRun(run)
+            : isFailedWorkflowRun(run)
               ? 'failure'
               : run.conclusion === 'success'
                 ? 'success'
@@ -217,7 +255,7 @@ export function WorkflowRunsModal() {
         groupMap.set(run.workflowName, {
           workflowName: run.workflowName,
           totalCount: 1,
-          failedCount: isFailedRun(run) ? 1 : 0,
+          failedCount: isFailedWorkflowRun(run) ? 1 : 0,
           latestStatus: status,
         })
       }
@@ -640,7 +678,7 @@ export function WorkflowRunsModal() {
           case 'm': {
             e.preventDefault()
             const run = displayedRuns[focusedIndex]
-            if (run && isFailedRun(run)) handleInvestigate(run)
+            if (run && isFailedWorkflowRun(run)) handleInvestigate(run)
             break
           }
         }
@@ -772,7 +810,12 @@ export function WorkflowRunsModal() {
                           <span className="shrink-0 rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">
                             {run.headBranch}
                           </span>
-                          {isFailedRun(run) && (
+                          {unreadOnOpen.has(run.databaseId) && (
+                            <span className="shrink-0 rounded bg-blue-500/15 px-1 py-0.5 text-[10px] font-medium text-blue-600 dark:text-blue-400">
+                              New
+                            </span>
+                          )}
+                          {isFailedWorkflowRun(run) && (
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <button

--- a/src/components/shared/workflow-run-utils.test.ts
+++ b/src/components/shared/workflow-run-utils.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import type { Session } from '@/types/chat'
-import { isReusableWorkflowInvestigationSession } from './workflow-run-utils'
+import type { WorkflowRun } from '@/types/github'
+import {
+  countUnreadFailedWorkflowRuns,
+  getLatestFailedWorkflowRuns,
+  isFailedWorkflowRun,
+  isReusableWorkflowInvestigationSession,
+  mergeSeenFailedWorkflowRunIds,
+  MAX_SEEN_FAILED_WORKFLOW_RUN_IDS,
+} from './workflow-run-utils'
 
 function session(overrides: Partial<Session> = {}): Session {
   return {
@@ -11,6 +19,23 @@ function session(overrides: Partial<Session> = {}): Session {
     updated_at: 0,
     messages: [],
     message_count: 0,
+    ...overrides,
+  }
+}
+
+function run(
+  overrides: Partial<WorkflowRun> &
+    Pick<WorkflowRun, 'databaseId' | 'workflowName'>
+): WorkflowRun {
+  return {
+    name: 'job',
+    displayTitle: `run ${overrides.databaseId}`,
+    status: 'completed',
+    conclusion: 'failure',
+    event: 'push',
+    headBranch: 'main',
+    createdAt: '2025-01-01T00:00:00Z',
+    url: `https://example.com/${overrides.databaseId}`,
     ...overrides,
   }
 }
@@ -43,5 +68,70 @@ describe('isReusableWorkflowInvestigationSession', () => {
     expect(
       isReusableWorkflowInvestigationSession(session({ archived_at: 1 }))
     ).toBe(false)
+  })
+})
+
+describe('failed workflow unread helpers', () => {
+  it('detects failure conclusions', () => {
+    expect(
+      isFailedWorkflowRun(run({ databaseId: 1, workflowName: 'CI' }))
+    ).toBe(true)
+    expect(
+      isFailedWorkflowRun(
+        run({
+          databaseId: 2,
+          workflowName: 'CI',
+          conclusion: 'startup_failure',
+        })
+      )
+    ).toBe(true)
+    expect(
+      isFailedWorkflowRun(
+        run({ databaseId: 3, workflowName: 'CI', conclusion: 'success' })
+      )
+    ).toBe(false)
+  })
+
+  it('takes only the latest run per workflow when counting failures', () => {
+    const runs = [
+      run({ databaseId: 4, workflowName: 'CI', conclusion: 'success' }),
+      run({ databaseId: 3, workflowName: 'Deploy', conclusion: 'failure' }),
+      run({ databaseId: 2, workflowName: 'CI', conclusion: 'failure' }),
+      run({ databaseId: 1, workflowName: 'Deploy', conclusion: 'failure' }),
+    ]
+
+    expect(getLatestFailedWorkflowRuns(runs).map(r => r.databaseId)).toEqual([
+      3,
+    ])
+    expect(countUnreadFailedWorkflowRuns(runs, [])).toBe(1)
+  })
+
+  it('excludes seen failed run IDs from the unread count', () => {
+    const runs = [
+      run({ databaseId: 3, workflowName: 'CI' }),
+      run({ databaseId: 2, workflowName: 'Deploy' }),
+      run({ databaseId: 1, workflowName: 'Lint', conclusion: 'success' }),
+    ]
+
+    expect(countUnreadFailedWorkflowRuns(runs, [])).toBe(2)
+    expect(countUnreadFailedWorkflowRuns(runs, [3])).toBe(1)
+    expect(countUnreadFailedWorkflowRuns(runs, new Set([3, 2]))).toBe(0)
+  })
+
+  it('merges and caps seen IDs newest-first without duplicates', () => {
+    expect(mergeSeenFailedWorkflowRunIds([2, 3], [3, 1])).toEqual([1, 2, 3])
+
+    const existingRef = [2, 3]
+    expect(mergeSeenFailedWorkflowRunIds(existingRef, [2, 3])).toBe(existingRef)
+    expect(mergeSeenFailedWorkflowRunIds(existingRef, [])).toBe(existingRef)
+
+    const existing = Array.from(
+      { length: MAX_SEEN_FAILED_WORKFLOW_RUN_IDS },
+      (_, i) => i + 1
+    )
+    const merged = mergeSeenFailedWorkflowRunIds(existing, [999_001])
+    expect(merged).toHaveLength(MAX_SEEN_FAILED_WORKFLOW_RUN_IDS)
+    expect(merged[0]).toBe(999_001)
+    expect(merged).not.toContain(MAX_SEEN_FAILED_WORKFLOW_RUN_IDS)
   })
 })

--- a/src/components/shared/workflow-run-utils.ts
+++ b/src/components/shared/workflow-run-utils.ts
@@ -1,4 +1,8 @@
 import type { Session } from '@/types/chat'
+import type { WorkflowRun } from '@/types/github'
+
+/** Cap persisted seen IDs so UI state cannot grow without bound. */
+export const MAX_SEEN_FAILED_WORKFLOW_RUN_IDS = 500
 
 export function isReusableWorkflowInvestigationSession(
   session: Session
@@ -9,4 +13,70 @@ export function isReusableWorkflowInvestigationSession(
     !session.name.startsWith('Code Review') &&
     (session.message_count === 0 || session.message_count == null)
   )
+}
+
+export function isFailedWorkflowRun(run: WorkflowRun): boolean {
+  return run.conclusion === 'failure' || run.conclusion === 'startup_failure'
+}
+
+/**
+ * Latest run per workflow name that failed.
+ * Assumes `runs` are sorted newest-first (gh run list order).
+ */
+export function getLatestFailedWorkflowRuns(
+  runs: WorkflowRun[]
+): WorkflowRun[] {
+  const seenWorkflows = new Set<string>()
+  const latestFailed: WorkflowRun[] = []
+
+  for (const run of runs) {
+    if (seenWorkflows.has(run.workflowName)) continue
+    seenWorkflows.add(run.workflowName)
+    if (isFailedWorkflowRun(run)) {
+      latestFailed.push(run)
+    }
+  }
+
+  return latestFailed
+}
+
+/** Count latest failed runs that the user has not opened yet. */
+export function countUnreadFailedWorkflowRuns(
+  runs: WorkflowRun[],
+  seenIds: Iterable<number>
+): number {
+  const seen = seenIds instanceof Set ? seenIds : new Set(seenIds)
+  let count = 0
+  for (const run of getLatestFailedWorkflowRuns(runs)) {
+    if (!seen.has(run.databaseId)) count++
+  }
+  return count
+}
+
+/**
+ * Merge newly seen failed-run IDs into the existing list, newest-first,
+ * de-duplicated, and capped. Returns the same array reference when nothing
+ * changes.
+ */
+export function mergeSeenFailedWorkflowRunIds(
+  existing: number[],
+  newlySeen: number[]
+): number[] {
+  if (newlySeen.length === 0) return existing
+
+  const existingSet = new Set(existing)
+  const uniqueNovel: number[] = []
+  const novelSeen = new Set<number>()
+  for (const id of newlySeen) {
+    if (existingSet.has(id) || novelSeen.has(id)) continue
+    novelSeen.add(id)
+    uniqueNovel.push(id)
+  }
+  if (uniqueNovel.length === 0) return existing
+
+  const next = [...uniqueNovel, ...existing]
+  if (next.length > MAX_SEEN_FAILED_WORKFLOW_RUN_IDS) {
+    return next.slice(0, MAX_SEEN_FAILED_WORKFLOW_RUN_IDS)
+  }
+  return next
 }

--- a/src/hooks/useUIStatePersistence.ts
+++ b/src/hooks/useUIStatePersistence.ts
@@ -148,6 +148,7 @@ export function useUIStatePersistence() {
       fileBrowserVisible,
       sessionTerminalIds,
       sessionPrimarySurface,
+      seenFailedWorkflowRunIds,
     } = useUIStore.getState()
     const {
       terminals,
@@ -257,6 +258,7 @@ export function useUIStatePersistence() {
           { worktree_id: entry.worktreeId, session_id: entry.sessionId },
         ])
       ),
+      seen_failed_workflow_run_ids: seenFailedWorkflowRunIds,
       version: 1, // Reset for first release
     }
   }, [])
@@ -858,6 +860,16 @@ export function useUIStatePersistence() {
         .setGitHubDashboardFavoriteProjectIds(githubDashboardFavoriteProjectIds)
     }
 
+    const seenFailedWorkflowRunIds = uiState.seen_failed_workflow_run_ids ?? []
+    if (seenFailedWorkflowRunIds.length > 0) {
+      logger.debug('Restoring seen failed workflow run IDs', {
+        count: seenFailedWorkflowRunIds.length,
+      })
+      useUIStore
+        .getState()
+        .setSeenFailedWorkflowRunIds(seenFailedWorkflowRunIds)
+    }
+
     // Restore browser pane state (per-worktree tabs + 3-surface visibility)
     const persistedBrowserTabs = uiState.browser_tabs ?? {}
     const browserActiveTabIds = uiState.browser_active_tab_ids ?? {}
@@ -1022,6 +1034,8 @@ export function useUIStatePersistence() {
     let prevFileBrowserVisible = useUIStore.getState().fileBrowserVisible
     let prevSessionTerminalIds = useUIStore.getState().sessionTerminalIds
     let prevSessionPrimarySurface = useUIStore.getState().sessionPrimarySurface
+    let prevSeenFailedWorkflowRunIds =
+      useUIStore.getState().seenFailedWorkflowRunIds
     let prevWorktreeId = useChatStore.getState().activeWorktreeId
     let prevWorktreePath = useChatStore.getState().activeWorktreePath
     let prevLastActiveWorktreeId = useChatStore.getState().lastActiveWorktreeId
@@ -1109,6 +1123,8 @@ export function useUIStatePersistence() {
         state.sessionTerminalIds !== prevSessionTerminalIds
       const sessionPrimarySurfaceChanged =
         state.sessionPrimarySurface !== prevSessionPrimarySurface
+      const seenFailedWorkflowRunIdsChanged =
+        state.seenFailedWorkflowRunIds !== prevSeenFailedWorkflowRunIds
 
       if (
         sizeChanged ||
@@ -1116,7 +1132,8 @@ export function useUIStatePersistence() {
         fileBrowserSizeChanged ||
         fileBrowserVisibilityChanged ||
         sessionTerminalIdsChanged ||
-        sessionPrimarySurfaceChanged
+        sessionPrimarySurfaceChanged ||
+        seenFailedWorkflowRunIdsChanged
       ) {
         prevLeftSidebarSize = state.leftSidebarSize
         prevLeftSidebarVisible = state.leftSidebarVisible
@@ -1124,6 +1141,7 @@ export function useUIStatePersistence() {
         prevFileBrowserVisible = state.fileBrowserVisible
         prevSessionTerminalIds = state.sessionTerminalIds
         prevSessionPrimarySurface = state.sessionPrimarySurface
+        prevSeenFailedWorkflowRunIds = state.seenFailedWorkflowRunIds
         const currentState = getCurrentUIState()
         debouncedSaveRef.current?.(currentState)
       }

--- a/src/store/ui-store.test.ts
+++ b/src/store/ui-store.test.ts
@@ -36,6 +36,22 @@ describe('UIStore', () => {
     expect(state.rightSidebarVisible).toBe(false)
     expect(state.commandPaletteOpen).toBe(false)
     expect(state.preferencesOpen).toBe(false)
+    expect(state.seenFailedWorkflowRunIds).toEqual([])
+  })
+
+  it('marks failed workflow runs as seen without no-op churn', () => {
+    useUIStore.setState({ seenFailedWorkflowRunIds: [] })
+    const { markFailedWorkflowRunsSeen } = useUIStore.getState()
+
+    markFailedWorkflowRunsSeen([10, 20])
+    expect(useUIStore.getState().seenFailedWorkflowRunIds).toEqual([10, 20])
+
+    const before = useUIStore.getState().seenFailedWorkflowRunIds
+    markFailedWorkflowRunsSeen([10, 20])
+    expect(useUIStore.getState().seenFailedWorkflowRunIds).toBe(before)
+
+    markFailedWorkflowRunsSeen([30])
+    expect(useUIStore.getState().seenFailedWorkflowRunIds).toEqual([30, 10, 20])
   })
 
   it('toggles left sidebar visibility', () => {

--- a/src/store/ui-store.ts
+++ b/src/store/ui-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import type { CliType } from '@/lib/cli-update'
+import { mergeSeenFailedWorkflowRunIds } from '@/components/shared/workflow-run-utils'
 
 export type PreferencePane =
   | 'general'
@@ -122,6 +123,11 @@ interface UIState {
   workflowRunsModalOpen: boolean
   workflowRunsModalProjectPath: string | null
   workflowRunsModalBranch: string | null
+  /**
+   * GitHub Actions run database IDs already viewed by the user.
+   * Failed-workflow badges only count IDs not in this list.
+   */
+  seenFailedWorkflowRunIds: number[]
   cliUpdateModalOpen: boolean
   cliUpdateModalType: CliUpdateModalType
   cliLoginModalOpen: boolean
@@ -243,6 +249,8 @@ interface UIState {
     projectPath?: string | null,
     branch?: string | null
   ) => void
+  markFailedWorkflowRunsSeen: (runIds: number[]) => void
+  setSeenFailedWorkflowRunIds: (runIds: number[]) => void
   openCliUpdateModal: (type: Exclude<CliUpdateModalType, null>) => void
   closeCliUpdateModal: () => void
   openCliLoginModal: (
@@ -346,6 +354,7 @@ export const useUIStore = create<UIState>()(
       workflowRunsModalOpen: false,
       workflowRunsModalProjectPath: null,
       workflowRunsModalBranch: null,
+      seenFailedWorkflowRunIds: [],
       cliUpdateModalOpen: false,
       cliUpdateModalType: null,
       cliLoginModalOpen: false,
@@ -657,6 +666,31 @@ export const useUIStore = create<UIState>()(
           },
           undefined,
           'setWorkflowRunsModalOpen'
+        ),
+
+      markFailedWorkflowRunsSeen: runIds =>
+        set(
+          state => {
+            if (runIds.length === 0) return state
+            const next = mergeSeenFailedWorkflowRunIds(
+              state.seenFailedWorkflowRunIds,
+              runIds
+            )
+            if (next === state.seenFailedWorkflowRunIds) return state
+            return { seenFailedWorkflowRunIds: next }
+          },
+          undefined,
+          'markFailedWorkflowRunsSeen'
+        ),
+
+      setSeenFailedWorkflowRunIds: runIds =>
+        set(
+          state =>
+            state.seenFailedWorkflowRunIds === runIds
+              ? state
+              : { seenFailedWorkflowRunIds: runIds },
+          undefined,
+          'setSeenFailedWorkflowRunIds'
         ),
 
       openCliUpdateModal: type =>

--- a/src/types/ui-state.ts
+++ b/src/types/ui-state.ts
@@ -144,6 +144,11 @@ export interface UIState {
     string,
     { worktree_id: string; session_id: string }
   >
+  /**
+   * GitHub Actions workflow run database IDs the user has already opened
+   * (failed-run badges only count runs not in this list).
+   */
+  seen_failed_workflow_run_ids?: number[]
   version: number
 }
 
@@ -185,5 +190,6 @@ export const defaultUIState: UIState = {
   browser_bottom_panel_open: {},
   browser_bottom_panel_height: 360,
   github_dashboard_favorite_project_ids: [],
+  seen_failed_workflow_run_ids: [],
   version: 1,
 }


### PR DESCRIPTION
## Summary

- Failed GitHub Actions badges now only count **unread** failures—opening a failed run marks it as seen so it no longer inflates the red badge
- Persists seen workflow run IDs in UI state so the hide-after-seen behavior survives app restarts
- Updates badge tooltips and mobile/worktree counts to reflect unread failed runs only

closes #389

---

Fixes #389