### PR TITLE
feat(chat): add adaptive thinking/effort level

### DIFF
--- a/docs/developer/model-catalog.md
+++ b/docs/developer/model-catalog.md
@@ -51,6 +51,13 @@ Each model can declare at most one reasoning control:
 - Traditional Claude thinking uses `off`, `think`, `megathink`, and
   `ultrathink`. A numeric value such as `16000` defines a custom
   `MAX_THINKING_TOKENS` budget.
+- Jean always injects an `adaptive` option (UI label **Adaptive/Default**) into
+  effort and thinking dropdowns. When selected, Jean omits the thinking/effort
+  parameter so the model uses its default/adaptive depth (e.g. Gemini 3.5 Flash
+  can choose per request). The wire value remains `adaptive`; it is not a catalog
+  default — users opt in explicitly. Models without adaptive support may still
+  pick a high depth when no level is forced — prefer an explicit level for those
+  backends.
 - Omit `reasoning` for models without a control. Set `reasoning` to `null` to
   explicitly remove a bundled capability.
 

--- a/docs/developer/model-catalog.md
+++ b/docs/developer/model-catalog.md
@@ -51,13 +51,13 @@ Each model can declare at most one reasoning control:
 - Traditional Claude thinking uses `off`, `think`, `megathink`, and
   `ultrathink`. A numeric value such as `16000` defines a custom
   `MAX_THINKING_TOKENS` budget.
-- Jean always injects an `adaptive` option (UI label **Adaptive/Default**) into
-  effort and thinking dropdowns. When selected, Jean omits the thinking/effort
-  parameter so the model uses its default/adaptive depth (e.g. Gemini 3.5 Flash
-  can choose per request). The wire value remains `adaptive`; it is not a catalog
-  default — users opt in explicitly. Models without adaptive support may still
-  pick a high depth when no level is forced — prefer an explicit level for those
-  backends.
+- Jean injects an `adaptive` option (UI label **Adaptive/Default**) only for
+  **Gemini** model ids (name contains `gemini`). When selected, Jean omits the
+  thinking/effort parameter so Gemini can use its native adaptive/default depth
+  (e.g. Gemini 3.5 Flash). The wire value remains `adaptive`. Non-Gemini models
+  never show this option. Note: Command Code and Cursor hide the reasoning
+  control entirely, so Adaptive/Default is only visible when a Gemini model is
+  used on a backend that shows effort/thinking (e.g. OpenCode).
 - Omit `reasoning` for models without a control. Set `reasoning` to `null` to
   explicitly remove a bundled capability.
 

--- a/jean-core/src/chat/claude.rs
+++ b/jean-core/src/chat/claude.rs
@@ -544,20 +544,25 @@ fn build_claude_args(
                 );
             }
         }
-        // If Off, don't send any thinking/effort settings (but still send custom profile if present)
+        // Off / Adaptive: omit thinking/effort settings so the model decides
+        // (still send custom profile / other settings if present)
     } else {
         // Traditional thinking levels (Sonnet, Haiku)
         if let Some(level) = thinking_level {
-            let obj = settings_json.get_or_insert_with(|| serde_json::json!({}));
-            if let Some(map) = obj.as_object_mut() {
-                map.insert(
-                    "alwaysThinkingEnabled".to_string(),
-                    serde_json::Value::Bool(level.is_enabled()),
-                );
-            }
+            // Adaptive: omit alwaysThinkingEnabled / MAX_THINKING_TOKENS so
+            // models that support adaptive thinking can choose depth.
+            if !level.omits_thinking_settings() {
+                let obj = settings_json.get_or_insert_with(|| serde_json::json!({}));
+                if let Some(map) = obj.as_object_mut() {
+                    map.insert(
+                        "alwaysThinkingEnabled".to_string(),
+                        serde_json::Value::Bool(level.is_enabled()),
+                    );
+                }
 
-            if let Some(tokens) = level.thinking_tokens() {
-                env_vars.push(("MAX_THINKING_TOKENS".to_string(), tokens.to_string()));
+                if let Some(tokens) = level.thinking_tokens() {
+                    env_vars.push(("MAX_THINKING_TOKENS".to_string(), tokens.to_string()));
+                }
             }
         }
     }

--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -377,7 +377,7 @@ fn codex_reasoning_effort<'a>(effort: &'a EffortLevel, model: Option<&str>) -> O
         )
     );
     match effort {
-        EffortLevel::Off => None,
+        EffortLevel::Off | EffortLevel::Adaptive => None,
         EffortLevel::Minimal => Some("low"),
         // Migrate GPT 5.6 sessions persisted before the Codex-native value was fixed.
         EffortLevel::Ultracode if supports_ultra => Some("ultra"),
@@ -3053,14 +3053,16 @@ pub async fn send_chat_message(
     };
     let run_effort_level = match effective_backend {
         Backend::Cursor | Backend::Commandcode => None,
-        Backend::Pi => effort_level.as_ref().map(|e| match e {
-            EffortLevel::Off => "off",
-            EffortLevel::Minimal => "minimal",
-            EffortLevel::Low => "low",
-            EffortLevel::Medium => "medium",
-            EffortLevel::High => "high",
-            EffortLevel::Xhigh | EffortLevel::Max | EffortLevel::Ultracode => "xhigh",
-            EffortLevel::Other(value) => value.as_str(),
+        Backend::Pi => effort_level.as_ref().and_then(|e| match e {
+            // Adaptive omits the flag so PI can choose its own depth.
+            EffortLevel::Adaptive => None,
+            EffortLevel::Off => Some("off"),
+            EffortLevel::Minimal => Some("minimal"),
+            EffortLevel::Low => Some("low"),
+            EffortLevel::Medium => Some("medium"),
+            EffortLevel::High => Some("high"),
+            EffortLevel::Xhigh | EffortLevel::Max | EffortLevel::Ultracode => Some("xhigh"),
+            EffortLevel::Other(value) => Some(value.as_str()),
         }),
         _ => effort_level.as_ref().and_then(|e| e.effort_value()),
     };
@@ -3845,7 +3847,10 @@ pub async fn send_chat_message(
                         super::types::EffortLevel::Xhigh => Some("xhigh".to_string()),
                         super::types::EffortLevel::Max => Some("xhigh".to_string()),
                         super::types::EffortLevel::Ultracode => Some("xhigh".to_string()),
-                        super::types::EffortLevel::Off => None,
+                        // Off / Adaptive: omit so the model can choose depth
+                        super::types::EffortLevel::Off | super::types::EffortLevel::Adaptive => {
+                            None
+                        }
                         super::types::EffortLevel::Other(value) => Some(value.clone()),
                     });
 
@@ -4647,7 +4652,10 @@ pub async fn send_chat_message(
                         super::types::EffortLevel::Xhigh => Some("xhigh".to_string()),
                         super::types::EffortLevel::Max => Some("max".to_string()),
                         super::types::EffortLevel::Ultracode => Some("max".to_string()),
-                        super::types::EffortLevel::Off => None,
+                        // Off / Adaptive: omit --effort so Grok can choose depth
+                        super::types::EffortLevel::Off | super::types::EffortLevel::Adaptive => {
+                            None
+                        }
                         super::types::EffortLevel::Other(value) => Some(value.clone()),
                     });
 

--- a/jean-core/src/chat/pi.rs
+++ b/jean-core/src/chat/pi.rs
@@ -495,6 +495,8 @@ fn raw_pi_model(model: Option<&str>) -> Option<&str> {
 
 fn pi_thinking_level(effort: Option<&super::types::EffortLevel>) -> Option<&str> {
     match effort {
+        // Adaptive: omit --thinking so PI chooses its own depth.
+        Some(super::types::EffortLevel::Adaptive) => None,
         Some(super::types::EffortLevel::Off) => Some("off"),
         Some(super::types::EffortLevel::Minimal) => Some("minimal"),
         Some(super::types::EffortLevel::Low) => Some("low"),
@@ -1952,6 +1954,7 @@ mod tests {
         use super::super::types::EffortLevel;
 
         assert_eq!(pi_thinking_level(Some(&EffortLevel::Off)), Some("off"));
+        assert_eq!(pi_thinking_level(Some(&EffortLevel::Adaptive)), None);
         assert_eq!(
             pi_thinking_level(Some(&EffortLevel::Minimal)),
             Some("minimal")

--- a/jean-core/src/chat/types.rs
+++ b/jean-core/src/chat/types.rs
@@ -165,6 +165,8 @@ pub enum MessageRole {
 #[derive(Debug, Clone, PartialEq, Default)]
 pub enum ThinkingLevel {
     Off,
+    /// Omit thinking settings so the model can choose its own depth
+    Adaptive,
     Think,
     Megathink,
     #[default]
@@ -189,6 +191,7 @@ impl<'de> Deserialize<'de> for ThinkingLevel {
         let value = String::deserialize(deserializer)?;
         Ok(match value.as_str() {
             "off" => Self::Off,
+            "adaptive" => Self::Adaptive,
             "think" => Self::Think,
             "megathink" => Self::Megathink,
             "ultrathink" => Self::Ultrathink,
@@ -205,6 +208,8 @@ impl<'de> Deserialize<'de> for ThinkingLevel {
 pub enum EffortLevel {
     /// Don't send effort (used when thinking is disabled for mode)
     Off,
+    /// Omit effort so the model chooses its own reasoning depth
+    Adaptive,
     Minimal,
     Low,
     Medium,
@@ -221,7 +226,7 @@ impl Serialize for EffortLevel {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(self.effort_value().unwrap_or("off"))
+        serializer.serialize_str(self.as_str())
     }
 }
 
@@ -233,6 +238,7 @@ impl<'de> Deserialize<'de> for EffortLevel {
         let value = String::deserialize(deserializer)?;
         Ok(match value.as_str() {
             "off" => Self::Off,
+            "adaptive" => Self::Adaptive,
             "minimal" => Self::Minimal,
             "low" => Self::Low,
             "medium" => Self::Medium,
@@ -246,10 +252,28 @@ impl<'de> Deserialize<'de> for EffortLevel {
 }
 
 impl EffortLevel {
-    /// Get the effort value string for CLI --settings JSON
+    /// Stable string form for persistence / wire format
+    pub fn as_str(&self) -> &str {
+        match self {
+            EffortLevel::Off => "off",
+            EffortLevel::Adaptive => "adaptive",
+            EffortLevel::Minimal => "minimal",
+            EffortLevel::Low => "low",
+            EffortLevel::Medium => "medium",
+            EffortLevel::High => "high",
+            EffortLevel::Xhigh => "xhigh",
+            EffortLevel::Max => "max",
+            EffortLevel::Ultracode => "ultracode",
+            EffortLevel::Other(value) => value.as_str(),
+        }
+    }
+
+    /// Get the effort value string for CLI --settings JSON.
+    /// Returns `None` when Jean should omit the effort parameter entirely
+    /// (`Off` disables thinking for a mode; `Adaptive` lets the model decide).
     pub fn effort_value(&self) -> Option<&str> {
         match self {
-            EffortLevel::Off => None,
+            EffortLevel::Off | EffortLevel::Adaptive => None,
             EffortLevel::Minimal => Some("minimal"),
             EffortLevel::Low => Some("low"),
             EffortLevel::Medium => Some("medium"),
@@ -266,6 +290,7 @@ impl ThinkingLevel {
     pub fn thinking_value(&self) -> &str {
         match self {
             Self::Off => "off",
+            Self::Adaptive => "adaptive",
             Self::Think => "think",
             Self::Megathink => "megathink",
             Self::Ultrathink => "ultrathink",
@@ -273,15 +298,22 @@ impl ThinkingLevel {
         }
     }
 
-    /// Whether thinking is enabled for this level
+    /// Whether thinking is enabled for this level.
+    /// `Adaptive` omits thinking settings entirely (model decides), so it is
+    /// not treated as explicitly enabled.
     pub fn is_enabled(&self) -> bool {
-        !matches!(self, ThinkingLevel::Off)
+        !matches!(self, ThinkingLevel::Off | ThinkingLevel::Adaptive)
+    }
+
+    /// Whether Jean should omit thinking settings so the model decides.
+    pub fn omits_thinking_settings(&self) -> bool {
+        matches!(self, ThinkingLevel::Adaptive)
     }
 
     /// Get the MAX_THINKING_TOKENS value for this level
     pub fn thinking_tokens(&self) -> Option<u32> {
         match self {
-            ThinkingLevel::Off => None,
+            ThinkingLevel::Off | ThinkingLevel::Adaptive => None,
             ThinkingLevel::Think => Some(4_000),
             ThinkingLevel::Megathink => Some(10_000),
             ThinkingLevel::Ultrathink => Some(31_999),
@@ -1808,6 +1840,20 @@ mod tests {
     }
 
     #[test]
+    fn effort_level_adaptive_omits_backend_value() {
+        assert_eq!(EffortLevel::Adaptive.effort_value(), None);
+        assert_eq!(EffortLevel::Adaptive.as_str(), "adaptive");
+        assert_eq!(
+            serde_json::to_string(&EffortLevel::Adaptive).unwrap(),
+            "\"adaptive\""
+        );
+        assert_eq!(
+            serde_json::from_str::<EffortLevel>("\"adaptive\"").unwrap(),
+            EffortLevel::Adaptive
+        );
+    }
+
+    #[test]
     fn effort_level_accepts_catalog_defined_values() {
         let effort = serde_json::from_str::<EffortLevel>("\"turbo\"").unwrap();
         assert_eq!(effort.effort_value(), Some("turbo"));
@@ -1825,6 +1871,8 @@ mod tests {
     #[test]
     fn test_thinking_level_is_enabled() {
         assert!(!ThinkingLevel::Off.is_enabled());
+        assert!(!ThinkingLevel::Adaptive.is_enabled());
+        assert!(ThinkingLevel::Adaptive.omits_thinking_settings());
         assert!(ThinkingLevel::Think.is_enabled());
         assert!(ThinkingLevel::Megathink.is_enabled());
         assert!(ThinkingLevel::Ultrathink.is_enabled());
@@ -1833,9 +1881,23 @@ mod tests {
     #[test]
     fn test_thinking_level_tokens() {
         assert_eq!(ThinkingLevel::Off.thinking_tokens(), None);
+        assert_eq!(ThinkingLevel::Adaptive.thinking_tokens(), None);
         assert_eq!(ThinkingLevel::Think.thinking_tokens(), Some(4_000));
         assert_eq!(ThinkingLevel::Megathink.thinking_tokens(), Some(10_000));
         assert_eq!(ThinkingLevel::Ultrathink.thinking_tokens(), Some(31_999));
+    }
+
+    #[test]
+    fn thinking_level_adaptive_roundtrips() {
+        assert_eq!(ThinkingLevel::Adaptive.thinking_value(), "adaptive");
+        assert_eq!(
+            serde_json::to_string(&ThinkingLevel::Adaptive).unwrap(),
+            "\"adaptive\""
+        );
+        assert_eq!(
+            serde_json::from_str::<ThinkingLevel>("\"adaptive\"").unwrap(),
+            ThinkingLevel::Adaptive
+        );
     }
 
     #[test]

--- a/jean-core/src/http_server/dispatch.rs
+++ b/jean-core/src/http_server/dispatch.rs
@@ -1282,6 +1282,14 @@ pub async fn dispatch_command(
             {
                 None => None,
                 Some("off") => Some(crate::chat::types::ThinkingLevel::Off),
+                // Adaptive: omit forced thinking settings. Also map to effort
+                // Adaptive when no explicit effort was provided.
+                Some("adaptive") => {
+                    if effort_level.is_none() {
+                        effort_level = Some(crate::chat::types::EffortLevel::Adaptive);
+                    }
+                    Some(crate::chat::types::ThinkingLevel::Adaptive)
+                }
                 Some("think") => Some(crate::chat::types::ThinkingLevel::Think),
                 Some("megathink") => Some(crate::chat::types::ThinkingLevel::Megathink),
                 Some("ultrathink") => Some(crate::chat::types::ThinkingLevel::Ultrathink),

--- a/src/components/chat/ChatToolbar.tsx
+++ b/src/components/chat/ChatToolbar.tsx
@@ -230,9 +230,10 @@ export const ChatToolbar = memo(function ChatToolbar({
     const values = new Set(
       selectedModelReasoning.levels.map(level => level.value)
     )
-    // Adaptive is always valid: Jean injects it into every effort/thinking
-    // dropdown and omits the forced level on send.
-    values.add('adaptive')
+    // Adaptive/Default is only valid for Gemini models.
+    if (selectedModel?.toLowerCase().includes('gemini')) {
+      values.add('adaptive')
+    }
     if (selectedModelReasoning.type === 'effort') {
       if (!values.has(selectedEffortLevel)) {
         onEffortLevelChange(selectedModelReasoning.default as EffortLevel)
@@ -244,6 +245,7 @@ export const ChatToolbar = memo(function ChatToolbar({
     onEffortLevelChange,
     onThinkingLevelChange,
     selectedEffortLevel,
+    selectedModel,
     selectedModelReasoning,
     selectedThinkingLevel,
   ])
@@ -464,6 +466,7 @@ export const ChatToolbar = memo(function ChatToolbar({
             isDisabled={false}
             providerLocked={providerLocked}
             selectedBackend={selectedBackend}
+            selectedModel={selectedModel}
             selectedProvider={selectedProvider}
             backendModelLabel={backendModelLabel}
             backendModelLabelText={backendModelLabelText}

--- a/src/components/chat/ChatToolbar.tsx
+++ b/src/components/chat/ChatToolbar.tsx
@@ -230,6 +230,9 @@ export const ChatToolbar = memo(function ChatToolbar({
     const values = new Set(
       selectedModelReasoning.levels.map(level => level.value)
     )
+    // Adaptive is always valid: Jean injects it into every effort/thinking
+    // dropdown and omits the forced level on send.
+    values.add('adaptive')
     if (selectedModelReasoning.type === 'effort') {
       if (!values.has(selectedEffortLevel)) {
         onEffortLevelChange(selectedModelReasoning.default as EffortLevel)

--- a/src/components/chat/MessageSettingsBadges.tsx
+++ b/src/components/chat/MessageSettingsBadges.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react'
 import {
+  ADAPTIVE_EFFORT_OPTION,
   EFFORT_LEVEL_OPTIONS,
   PI_EFFORT_LEVEL_OPTIONS,
   THINKING_LEVEL_OPTIONS,
@@ -49,14 +50,20 @@ export const MessageSettingsBadges = memo(function MessageSettingsBadges({
     ? PI_EFFORT_LEVEL_OPTIONS
     : EFFORT_LEVEL_OPTIONS
 
-  const effortLabel = effortLevel
-    ? (effortOptions.find(o => o.value === effortLevel)?.label ?? effortLevel)
-    : null
+  const effortLabel =
+    effortLevel === 'adaptive'
+      ? ADAPTIVE_EFFORT_OPTION.label
+      : effortLevel
+        ? (effortOptions.find(o => o.value === effortLevel)?.label ??
+          effortLevel)
+        : null
 
   const thinkingLabel =
     !usesEffortOnly && thinkingLevel && thinkingLevel !== 'off'
-      ? (THINKING_LEVEL_OPTIONS.find(o => o.value === thinkingLevel)?.label ??
-        thinkingLevel)
+      ? thinkingLevel === 'adaptive'
+        ? ADAPTIVE_EFFORT_OPTION.label
+        : (THINKING_LEVEL_OPTIONS.find(o => o.value === thinkingLevel)
+            ?.label ?? thinkingLevel)
       : null
 
   return (

--- a/src/components/chat/hooks/useClearContextApproval.ts
+++ b/src/components/chat/hooks/useClearContextApproval.ts
@@ -27,6 +27,7 @@ import {
 
 const THINKING_LEVEL_VALUES = new Set<ThinkingLevel>([
   'off',
+  'adaptive',
   'think',
   'megathink',
   'ultrathink',
@@ -43,6 +44,8 @@ function mapCodexReasoningToEffort(
   value: string | null | undefined
 ): EffortLevel | undefined {
   switch (value) {
+    case 'adaptive':
+      return 'adaptive'
     case 'low':
       return 'low'
     case 'medium':

--- a/src/components/chat/hooks/useMessageHandlers.ts
+++ b/src/components/chat/hooks/useMessageHandlers.ts
@@ -202,6 +202,7 @@ interface MessageHandlers {
 
 const THINKING_LEVEL_VALUES = new Set<ThinkingLevel>([
   'off',
+  'adaptive',
   'think',
   'megathink',
   'ultrathink',
@@ -218,6 +219,8 @@ function mapCodexReasoningToEffort(
   value: string | null | undefined
 ): EffortLevel | undefined {
   switch (value) {
+    case 'adaptive':
+      return 'adaptive'
     case 'low':
       return 'low'
     case 'medium':

--- a/src/components/chat/hooks/usePlanApproval.ts
+++ b/src/components/chat/hooks/usePlanApproval.ts
@@ -20,6 +20,7 @@ import type { SessionCardData } from '../session-card-utils'
 
 const THINKING_LEVEL_VALUES = new Set<ThinkingLevel>([
   'off',
+  'adaptive',
   'think',
   'megathink',
   'ultrathink',
@@ -34,6 +35,7 @@ function isThinkingLevel(
 
 const EFFORT_LEVEL_VALUES = new Set<EffortLevel>([
   'off',
+  'adaptive',
   'minimal',
   'low',
   'medium',

--- a/src/components/chat/hooks/usePlanDialogApproval.ts
+++ b/src/components/chat/hooks/usePlanDialogApproval.ts
@@ -23,6 +23,7 @@ import type { CliBackend } from '@/types/preferences'
 
 const THINKING_LEVEL_VALUES = new Set<ThinkingLevel>([
   'off',
+  'adaptive',
   'think',
   'megathink',
   'ultrathink',

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -2227,13 +2227,27 @@ export default function useStreamingEvents({
         case 'thinkingLevel':
           store.setThinkingLevel(
             session_id,
-            value as 'off' | 'think' | 'megathink' | 'ultrathink'
+            value as
+              | 'off'
+              | 'adaptive'
+              | 'think'
+              | 'megathink'
+              | 'ultrathink'
           )
           break
         case 'effortLevel':
           store.setEffortLevel(
             session_id,
-            value as 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra' | 'ultracode'
+            value as
+              | 'off'
+              | 'adaptive'
+              | 'low'
+              | 'medium'
+              | 'high'
+              | 'xhigh'
+              | 'max'
+              | 'ultra'
+              | 'ultracode'
           )
           break
         case 'executionMode':

--- a/src/components/chat/hooks/useWorktreeApproval.ts
+++ b/src/components/chat/hooks/useWorktreeApproval.ts
@@ -34,6 +34,7 @@ import type { CliBackend } from '@/types/preferences'
 
 const THINKING_LEVEL_VALUES = new Set<ThinkingLevel>([
   'off',
+  'adaptive',
   'think',
   'megathink',
   'ultrathink',
@@ -50,6 +51,8 @@ function mapCodexReasoningToEffort(
   value: string | null | undefined
 ): EffortLevel | undefined {
   switch (value) {
+    case 'adaptive':
+      return 'adaptive'
     case 'low':
       return 'low'
     case 'medium':

--- a/src/components/chat/toolbar/DesktopToolbarControls.tsx
+++ b/src/components/chat/toolbar/DesktopToolbarControls.tsx
@@ -207,24 +207,25 @@ export function DesktopToolbarControls({
       (useAdaptiveThinking || isCodex || isPi || isGrok || isKimi))
   const effortLevelOptions =
     modelReasoning?.type === 'effort'
-      ? withAdaptiveEffortOption(modelReasoning.levels)
+      ? withAdaptiveEffortOption(modelReasoning.levels, selectedModel)
       : isPi
-        ? PI_EFFORT_LEVEL_OPTIONS
+        ? withAdaptiveEffortOption(PI_EFFORT_LEVEL_OPTIONS, selectedModel)
         : isCodex
-          ? CODEX_EFFORT_LEVEL_OPTIONS
+          ? withAdaptiveEffortOption(CODEX_EFFORT_LEVEL_OPTIONS, selectedModel)
           : isKimi
-            ? withAdaptiveEffortOption(KIMI_EFFORT_LEVEL_OPTIONS)
+            ? withAdaptiveEffortOption(KIMI_EFFORT_LEVEL_OPTIONS, selectedModel)
             : isGrok
-              ? GROK_EFFORT_LEVEL_OPTIONS
-              : EFFORT_LEVEL_OPTIONS
+              ? withAdaptiveEffortOption(GROK_EFFORT_LEVEL_OPTIONS, selectedModel)
+              : withAdaptiveEffortOption(EFFORT_LEVEL_OPTIONS, selectedModel)
   const thinkingLevelOptions =
     modelReasoning?.type === 'thinking'
-      ? withAdaptiveEffortOption(modelReasoning.levels)
-      : THINKING_LEVEL_OPTIONS
+      ? withAdaptiveEffortOption(modelReasoning.levels, selectedModel)
+      : withAdaptiveEffortOption(THINKING_LEVEL_OPTIONS, selectedModel)
+  const effortOptionValues = new Set(effortLevelOptions.map(o => o.value))
+  const thinkingOptionValues = new Set(thinkingLevelOptions.map(o => o.value))
   const displayedEffortLevel =
     modelReasoning?.type === 'effort'
-      ? selectedEffortLevel === 'adaptive' ||
-        modelReasoning.levels.some(o => o.value === selectedEffortLevel)
+      ? effortOptionValues.has(selectedEffortLevel)
         ? selectedEffortLevel
         : modelReasoning.default
       : isCodex || isPi
@@ -240,10 +241,9 @@ export function DesktopToolbarControls({
     effortLevelOptions.find(o => o.value === displayedEffortLevel)?.label ??
     displayedEffortLevel
   const displayedThinkingLevel =
-    selectedThinkingLevel === 'adaptive'
+    thinkingOptionValues.has(selectedThinkingLevel)
       ? selectedThinkingLevel
-      : modelReasoning?.type === 'thinking' &&
-          !modelReasoning.levels.some(o => o.value === selectedThinkingLevel)
+      : modelReasoning?.type === 'thinking'
         ? modelReasoning.default
         : selectedThinkingLevel
   const displayedThinkingLabel =

--- a/src/components/chat/toolbar/DesktopToolbarControls.tsx
+++ b/src/components/chat/toolbar/DesktopToolbarControls.tsx
@@ -62,6 +62,7 @@ import {
   KIMI_EFFORT_LEVEL_OPTIONS,
   PI_EFFORT_LEVEL_OPTIONS,
   THINKING_LEVEL_OPTIONS,
+  withAdaptiveEffortOption,
 } from '@/components/chat/toolbar/toolbar-options'
 import {
   getPrStatusDisplay,
@@ -206,23 +207,24 @@ export function DesktopToolbarControls({
       (useAdaptiveThinking || isCodex || isPi || isGrok || isKimi))
   const effortLevelOptions =
     modelReasoning?.type === 'effort'
-      ? modelReasoning.levels
+      ? withAdaptiveEffortOption(modelReasoning.levels)
       : isPi
         ? PI_EFFORT_LEVEL_OPTIONS
         : isCodex
           ? CODEX_EFFORT_LEVEL_OPTIONS
           : isKimi
-            ? KIMI_EFFORT_LEVEL_OPTIONS
+            ? withAdaptiveEffortOption(KIMI_EFFORT_LEVEL_OPTIONS)
             : isGrok
               ? GROK_EFFORT_LEVEL_OPTIONS
               : EFFORT_LEVEL_OPTIONS
   const thinkingLevelOptions =
     modelReasoning?.type === 'thinking'
-      ? modelReasoning.levels
+      ? withAdaptiveEffortOption(modelReasoning.levels)
       : THINKING_LEVEL_OPTIONS
   const displayedEffortLevel =
     modelReasoning?.type === 'effort'
-      ? modelReasoning.levels.some(o => o.value === selectedEffortLevel)
+      ? selectedEffortLevel === 'adaptive' ||
+        modelReasoning.levels.some(o => o.value === selectedEffortLevel)
         ? selectedEffortLevel
         : modelReasoning.default
       : isCodex || isPi
@@ -238,10 +240,12 @@ export function DesktopToolbarControls({
     effortLevelOptions.find(o => o.value === displayedEffortLevel)?.label ??
     displayedEffortLevel
   const displayedThinkingLevel =
-    modelReasoning?.type === 'thinking' &&
-    !modelReasoning.levels.some(o => o.value === selectedThinkingLevel)
-      ? modelReasoning.default
-      : selectedThinkingLevel
+    selectedThinkingLevel === 'adaptive'
+      ? selectedThinkingLevel
+      : modelReasoning?.type === 'thinking' &&
+          !modelReasoning.levels.some(o => o.value === selectedThinkingLevel)
+        ? modelReasoning.default
+        : selectedThinkingLevel
   const displayedThinkingLabel =
     thinkingLevelOptions.find(o => o.value === displayedThinkingLevel)?.label ??
     displayedThinkingLevel

--- a/src/components/chat/toolbar/MobileSettingsMenu.test.tsx
+++ b/src/components/chat/toolbar/MobileSettingsMenu.test.tsx
@@ -78,6 +78,7 @@ beforeEach(() => {
 const baseProps = {
   isDisabled: false,
   selectedBackend: 'claude' as const,
+  selectedModel: 'claude-sonnet-4-6',
   selectedProvider: null,
   backendModelLabel: 'Claude · Sonnet',
   backendModelLabelText: 'Claude · Sonnet',

--- a/src/components/chat/toolbar/MobileSettingsMenu.tsx
+++ b/src/components/chat/toolbar/MobileSettingsMenu.tsx
@@ -109,6 +109,7 @@ interface MobileSettingsMenuProps {
   isDisabled: boolean
   providerLocked?: boolean
   selectedBackend: CliBackend
+  selectedModel: string
   selectedProvider: string | null
   backendModelLabel: ReactNode
   backendModelLabelText: string
@@ -163,6 +164,7 @@ interface MobileSettingsMenuProps {
 export function MobileSettingsMenu({
   isDisabled,
   selectedBackend,
+  selectedModel,
   selectedProvider,
   backendModelLabel,
   backendModelLabelText,
@@ -231,24 +233,25 @@ export function MobileSettingsMenu({
       (useAdaptiveThinking || isCodex || isPi || isGrok || isKimi))
   const effortLevelOptions =
     modelReasoning?.type === 'effort'
-      ? withAdaptiveEffortOption(modelReasoning.levels)
+      ? withAdaptiveEffortOption(modelReasoning.levels, selectedModel)
       : isPi
-        ? PI_EFFORT_LEVEL_OPTIONS
+        ? withAdaptiveEffortOption(PI_EFFORT_LEVEL_OPTIONS, selectedModel)
         : isCodex
-          ? CODEX_EFFORT_LEVEL_OPTIONS
+          ? withAdaptiveEffortOption(CODEX_EFFORT_LEVEL_OPTIONS, selectedModel)
           : isKimi
-            ? withAdaptiveEffortOption(KIMI_EFFORT_LEVEL_OPTIONS)
+            ? withAdaptiveEffortOption(KIMI_EFFORT_LEVEL_OPTIONS, selectedModel)
             : isGrok
-              ? GROK_EFFORT_LEVEL_OPTIONS
-              : EFFORT_LEVEL_OPTIONS
+              ? withAdaptiveEffortOption(GROK_EFFORT_LEVEL_OPTIONS, selectedModel)
+              : withAdaptiveEffortOption(EFFORT_LEVEL_OPTIONS, selectedModel)
   const thinkingLevelOptions =
     modelReasoning?.type === 'thinking'
-      ? withAdaptiveEffortOption(modelReasoning.levels)
-      : THINKING_LEVEL_OPTIONS
+      ? withAdaptiveEffortOption(modelReasoning.levels, selectedModel)
+      : withAdaptiveEffortOption(THINKING_LEVEL_OPTIONS, selectedModel)
+  const effortOptionValues = new Set(effortLevelOptions.map(o => o.value))
+  const thinkingOptionValues = new Set(thinkingLevelOptions.map(o => o.value))
   const displayedEffortLevel =
     modelReasoning?.type === 'effort'
-      ? selectedEffortLevel === 'adaptive' ||
-        modelReasoning.levels.some(o => o.value === selectedEffortLevel)
+      ? effortOptionValues.has(selectedEffortLevel)
         ? selectedEffortLevel
         : modelReasoning.default
       : isCodex || isPi
@@ -263,13 +266,11 @@ export function MobileSettingsMenu({
   const displayedEffortLabel =
     effortLevelOptions.find(o => o.value === displayedEffortLevel)?.label ??
     displayedEffortLevel
-  const displayedThinkingLevel =
-    selectedThinkingLevel === 'adaptive'
-      ? selectedThinkingLevel
-      : modelReasoning?.type === 'thinking' &&
-          !modelReasoning.levels.some(o => o.value === selectedThinkingLevel)
-        ? modelReasoning.default
-        : selectedThinkingLevel
+  const displayedThinkingLevel = thinkingOptionValues.has(selectedThinkingLevel)
+    ? selectedThinkingLevel
+    : modelReasoning?.type === 'thinking'
+      ? modelReasoning.default
+      : selectedThinkingLevel
   const displayedThinkingLabel =
     thinkingLevelOptions.find(o => o.value === displayedThinkingLevel)?.label ??
     displayedThinkingLevel

--- a/src/components/chat/toolbar/MobileSettingsMenu.tsx
+++ b/src/components/chat/toolbar/MobileSettingsMenu.tsx
@@ -70,6 +70,7 @@ import {
   KIMI_EFFORT_LEVEL_OPTIONS,
   PI_EFFORT_LEVEL_OPTIONS,
   THINKING_LEVEL_OPTIONS,
+  withAdaptiveEffortOption,
 } from '@/components/chat/toolbar/toolbar-options'
 import {
   getPrStatusDisplay,
@@ -230,23 +231,24 @@ export function MobileSettingsMenu({
       (useAdaptiveThinking || isCodex || isPi || isGrok || isKimi))
   const effortLevelOptions =
     modelReasoning?.type === 'effort'
-      ? modelReasoning.levels
+      ? withAdaptiveEffortOption(modelReasoning.levels)
       : isPi
         ? PI_EFFORT_LEVEL_OPTIONS
         : isCodex
           ? CODEX_EFFORT_LEVEL_OPTIONS
           : isKimi
-            ? KIMI_EFFORT_LEVEL_OPTIONS
+            ? withAdaptiveEffortOption(KIMI_EFFORT_LEVEL_OPTIONS)
             : isGrok
               ? GROK_EFFORT_LEVEL_OPTIONS
               : EFFORT_LEVEL_OPTIONS
   const thinkingLevelOptions =
     modelReasoning?.type === 'thinking'
-      ? modelReasoning.levels
+      ? withAdaptiveEffortOption(modelReasoning.levels)
       : THINKING_LEVEL_OPTIONS
   const displayedEffortLevel =
     modelReasoning?.type === 'effort'
-      ? modelReasoning.levels.some(o => o.value === selectedEffortLevel)
+      ? selectedEffortLevel === 'adaptive' ||
+        modelReasoning.levels.some(o => o.value === selectedEffortLevel)
         ? selectedEffortLevel
         : modelReasoning.default
       : isCodex || isPi
@@ -262,10 +264,12 @@ export function MobileSettingsMenu({
     effortLevelOptions.find(o => o.value === displayedEffortLevel)?.label ??
     displayedEffortLevel
   const displayedThinkingLevel =
-    modelReasoning?.type === 'thinking' &&
-    !modelReasoning.levels.some(o => o.value === selectedThinkingLevel)
-      ? modelReasoning.default
-      : selectedThinkingLevel
+    selectedThinkingLevel === 'adaptive'
+      ? selectedThinkingLevel
+      : modelReasoning?.type === 'thinking' &&
+          !modelReasoning.levels.some(o => o.value === selectedThinkingLevel)
+        ? modelReasoning.default
+        : selectedThinkingLevel
   const displayedThinkingLabel =
     thinkingLevelOptions.find(o => o.value === displayedThinkingLevel)?.label ??
     displayedThinkingLevel

--- a/src/components/chat/toolbar/toolbar-options.test.ts
+++ b/src/components/chat/toolbar/toolbar-options.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import { PI_EFFORT_LEVEL_OPTIONS } from './toolbar-options'
+import {
+  EFFORT_LEVEL_OPTIONS,
+  PI_EFFORT_LEVEL_OPTIONS,
+  THINKING_LEVEL_OPTIONS,
+  withAdaptiveEffortOption,
+} from './toolbar-options'
 
 describe('PI_EFFORT_LEVEL_OPTIONS', () => {
-  it('exposes every PI CLI thinking level in CLI order', () => {
+  it('exposes Adaptive/Default plus every PI CLI thinking level in CLI order', () => {
     expect(PI_EFFORT_LEVEL_OPTIONS.map(option => option.value)).toEqual([
+      'adaptive',
       'off',
       'minimal',
       'low',
@@ -11,5 +17,47 @@ describe('PI_EFFORT_LEVEL_OPTIONS', () => {
       'high',
       'xhigh',
     ])
+  })
+})
+
+describe('Adaptive/Default thinking/effort option', () => {
+  it('includes Adaptive/Default in default effort and thinking dropdowns', () => {
+    expect(EFFORT_LEVEL_OPTIONS.map(option => option.value)).toContain(
+      'adaptive'
+    )
+    expect(THINKING_LEVEL_OPTIONS.map(option => option.value)).toContain(
+      'adaptive'
+    )
+    expect(
+      EFFORT_LEVEL_OPTIONS.find(option => option.value === 'adaptive')?.label
+    ).toBe('Adaptive/Default')
+    expect(
+      THINKING_LEVEL_OPTIONS.find(option => option.value === 'adaptive')?.label
+    ).toBe('Adaptive/Default')
+  })
+
+  it('prepends Adaptive/Default when catalog levels omit it', () => {
+    const levels = withAdaptiveEffortOption([
+      { value: 'medium', label: 'Medium', description: 'Balanced' },
+      { value: 'high', label: 'High', description: 'Deep' },
+    ])
+    expect(levels.map(level => level.value)).toEqual([
+      'adaptive',
+      'medium',
+      'high',
+    ])
+    expect(levels[0]?.label).toBe('Adaptive/Default')
+  })
+
+  it('does not duplicate Adaptive/Default when already present', () => {
+    const levels = withAdaptiveEffortOption([
+      {
+        value: 'adaptive',
+        label: 'Adaptive/Default',
+        description: 'Model default (no forced level)',
+      },
+      { value: 'high', label: 'High', description: 'Deep' },
+    ])
+    expect(levels.map(level => level.value)).toEqual(['adaptive', 'high'])
   })
 })

--- a/src/components/chat/toolbar/toolbar-options.test.ts
+++ b/src/components/chat/toolbar/toolbar-options.test.ts
@@ -7,9 +7,8 @@ import {
 } from './toolbar-options'
 
 describe('PI_EFFORT_LEVEL_OPTIONS', () => {
-  it('exposes Adaptive/Default plus every PI CLI thinking level in CLI order', () => {
+  it('exposes every PI CLI thinking level in CLI order', () => {
     expect(PI_EFFORT_LEVEL_OPTIONS.map(option => option.value)).toEqual([
-      'adaptive',
       'off',
       'minimal',
       'low',
@@ -20,44 +19,48 @@ describe('PI_EFFORT_LEVEL_OPTIONS', () => {
   })
 })
 
-describe('Adaptive/Default thinking/effort option', () => {
-  it('includes Adaptive/Default in default effort and thinking dropdowns', () => {
-    expect(EFFORT_LEVEL_OPTIONS.map(option => option.value)).toContain(
+describe('Adaptive/Default thinking/effort option (Gemini only)', () => {
+  it('does not include Adaptive/Default in default non-Gemini option lists', () => {
+    expect(EFFORT_LEVEL_OPTIONS.map(option => option.value)).not.toContain(
       'adaptive'
     )
-    expect(THINKING_LEVEL_OPTIONS.map(option => option.value)).toContain(
+    expect(THINKING_LEVEL_OPTIONS.map(option => option.value)).not.toContain(
       'adaptive'
     )
-    expect(
-      EFFORT_LEVEL_OPTIONS.find(option => option.value === 'adaptive')?.label
-    ).toBe('Adaptive/Default')
-    expect(
-      THINKING_LEVEL_OPTIONS.find(option => option.value === 'adaptive')?.label
-    ).toBe('Adaptive/Default')
   })
 
-  it('prepends Adaptive/Default when catalog levels omit it', () => {
-    const levels = withAdaptiveEffortOption([
+  it('prepends Adaptive/Default only for Gemini models', () => {
+    const base = [
       { value: 'medium', label: 'Medium', description: 'Balanced' },
       { value: 'high', label: 'High', description: 'Deep' },
-    ])
-    expect(levels.map(level => level.value)).toEqual([
+    ]
+    expect(
+      withAdaptiveEffortOption(base, 'claude-opus-4-8').map(level => level.value)
+    ).toEqual(['medium', 'high'])
+    const geminiLevels = withAdaptiveEffortOption(
+      base,
+      'commandcode/google/gemini-3.5-flash'
+    )
+    expect(geminiLevels.map(level => level.value)).toEqual([
       'adaptive',
       'medium',
       'high',
     ])
-    expect(levels[0]?.label).toBe('Adaptive/Default')
+    expect(geminiLevels[0]?.label).toBe('Adaptive/Default')
   })
 
-  it('does not duplicate Adaptive/Default when already present', () => {
-    const levels = withAdaptiveEffortOption([
-      {
-        value: 'adaptive',
-        label: 'Adaptive/Default',
-        description: 'Model default (no forced level)',
-      },
-      { value: 'high', label: 'High', description: 'Deep' },
-    ])
+  it('does not duplicate Adaptive/Default when already present for Gemini', () => {
+    const levels = withAdaptiveEffortOption(
+      [
+        {
+          value: 'adaptive',
+          label: 'Adaptive/Default',
+          description: 'Model default (no forced level)',
+        },
+        { value: 'high', label: 'High', description: 'Deep' },
+      ],
+      'opencode/google/gemini-3.5-flash'
+    )
     expect(levels.map(level => level.value)).toEqual(['adaptive', 'high'])
   })
 })

--- a/src/components/chat/toolbar/toolbar-options.ts
+++ b/src/components/chat/toolbar/toolbar-options.ts
@@ -109,11 +109,26 @@ export const KIMI_EFFORT_LEVEL_OPTIONS: {
   { value: 'high', label: 'Thinking On', description: 'Enable thinking' },
 ]
 
+export const ADAPTIVE_EFFORT_OPTION: {
+  value: EffortLevel
+  label: string
+  description: string
+} = {
+  value: 'adaptive',
+  label: 'Adaptive/Default',
+  description: 'Model default (no forced level)',
+}
+
 export const THINKING_LEVEL_OPTIONS: {
   value: ThinkingLevel
   label: string
   tokens: string
 }[] = [
+  {
+    value: 'adaptive',
+    label: 'Adaptive/Default',
+    tokens: 'Model default',
+  },
   { value: 'off', label: 'Off', tokens: 'Disabled' },
   { value: 'think', label: 'Think', tokens: '4K' },
   { value: 'megathink', label: 'Megathink', tokens: '10K' },
@@ -125,6 +140,7 @@ export const EFFORT_LEVEL_OPTIONS: {
   label: string
   description: string
 }[] = [
+  ADAPTIVE_EFFORT_OPTION,
   { value: 'low', label: 'Low', description: 'Minimal' },
   { value: 'medium', label: 'Medium', description: 'Moderate' },
   { value: 'high', label: 'High', description: 'Deep' },
@@ -146,6 +162,7 @@ export const PI_EFFORT_LEVEL_OPTIONS: {
   label: string
   description: string
 }[] = [
+  ADAPTIVE_EFFORT_OPTION,
   { value: 'off', label: 'Off', description: 'Disabled' },
   { value: 'minimal', label: 'Minimal', description: 'Minimal' },
   { value: 'low', label: 'Low', description: 'Low' },
@@ -153,6 +170,14 @@ export const PI_EFFORT_LEVEL_OPTIONS: {
   { value: 'high', label: 'High', description: 'High' },
   { value: 'xhigh', label: 'xHigh', description: 'Extra high' },
 ]
+
+/** Prepend Adaptive when catalog/backend levels omit it. */
+export function withAdaptiveEffortOption<
+  T extends { value: string; label: string; description?: string },
+>(levels: T[]): Array<T | typeof ADAPTIVE_EFFORT_OPTION> {
+  if (levels.some(level => level.value === 'adaptive')) return levels
+  return [ADAPTIVE_EFFORT_OPTION, ...levels]
+}
 
 // Grok supports low/medium/high/xhigh/max natively. ultracode is a Jean
 // main-loop concept (xHigh + workflows), not a Grok CLI effort level.

--- a/src/components/chat/toolbar/toolbar-options.ts
+++ b/src/components/chat/toolbar/toolbar-options.ts
@@ -4,6 +4,7 @@ import {
   type ClaudeModel,
 } from '@/types/preferences'
 import type { EffortLevel, ThinkingLevel } from '@/types/chat'
+import { isGeminiModel } from '@/lib/model-utils'
 
 export const MODEL_OPTIONS: { value: ClaudeModel; label: string }[] =
   modelOptions.map(option => ({
@@ -124,11 +125,6 @@ export const THINKING_LEVEL_OPTIONS: {
   label: string
   tokens: string
 }[] = [
-  {
-    value: 'adaptive',
-    label: 'Adaptive/Default',
-    tokens: 'Model default',
-  },
   { value: 'off', label: 'Off', tokens: 'Disabled' },
   { value: 'think', label: 'Think', tokens: '4K' },
   { value: 'megathink', label: 'Megathink', tokens: '10K' },
@@ -140,7 +136,6 @@ export const EFFORT_LEVEL_OPTIONS: {
   label: string
   description: string
 }[] = [
-  ADAPTIVE_EFFORT_OPTION,
   { value: 'low', label: 'Low', description: 'Minimal' },
   { value: 'medium', label: 'Medium', description: 'Moderate' },
   { value: 'high', label: 'High', description: 'Deep' },
@@ -162,7 +157,6 @@ export const PI_EFFORT_LEVEL_OPTIONS: {
   label: string
   description: string
 }[] = [
-  ADAPTIVE_EFFORT_OPTION,
   { value: 'off', label: 'Off', description: 'Disabled' },
   { value: 'minimal', label: 'Minimal', description: 'Minimal' },
   { value: 'low', label: 'Low', description: 'Low' },
@@ -171,10 +165,17 @@ export const PI_EFFORT_LEVEL_OPTIONS: {
   { value: 'xhigh', label: 'xHigh', description: 'Extra high' },
 ]
 
-/** Prepend Adaptive when catalog/backend levels omit it. */
+/**
+ * Prepend Adaptive/Default only for Gemini models (native adaptive thinking
+ * when no level is forced). Non-Gemini levels are returned unchanged.
+ */
 export function withAdaptiveEffortOption<
   T extends { value: string; label: string; description?: string },
->(levels: T[]): Array<T | typeof ADAPTIVE_EFFORT_OPTION> {
+>(
+  levels: T[],
+  model?: string | null
+): Array<T | typeof ADAPTIVE_EFFORT_OPTION> {
+  if (!isGeminiModel(model)) return levels
   if (levels.some(level => level.value === 'adaptive')) return levels
   return [ADAPTIVE_EFFORT_OPTION, ...levels]
 }

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -298,28 +298,34 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
     'codex',
     preferences?.selected_codex_model ?? 'gpt-5.6-sol'
   )
+  const selectedCodexModel = preferences?.selected_codex_model ?? 'gpt-5.6-sol'
   const selectedCodexReasoningOptions = withAdaptiveEffortOption(
     codexReasoning?.type === 'effort'
       ? codexReasoning.levels
-      : codexReasoningOptions
+      : codexReasoningOptions,
+    selectedCodexModel
   )
   const grokReasoning = getCatalogModelReasoning(
     modelCatalog,
     'grok',
     preferences?.selected_grok_model ?? 'grok/grok-4.5'
   )
+  const selectedGrokModel = preferences?.selected_grok_model ?? 'grok/grok-4.5'
   const selectedGrokReasoningOptions = withAdaptiveEffortOption(
     grokReasoning?.type === 'effort'
       ? grokReasoning.levels
-      : grokReasoningOptions
+      : grokReasoningOptions,
+    selectedGrokModel
   )
+  const selectedClaudeModel =
+    preferences?.selected_model ?? 'claude-opus-4-8[1m]'
   const claudeReasoning = getCatalogModelReasoning(
     modelCatalog,
     'claude',
-    preferences?.selected_model ?? 'claude-opus-4-8[1m]'
+    selectedClaudeModel
   )
   const selectedClaudeReasoningOptions = claudeReasoning
-    ? withAdaptiveEffortOption(claudeReasoning.levels)
+    ? withAdaptiveEffortOption(claudeReasoning.levels, selectedClaudeModel)
     : []
   const patchPreferences = usePatchPreferences()
   const isWebAccessView = !isNativeApp()
@@ -1231,7 +1237,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
   const buildReasoning = buildReasoningRaw
     ? {
         ...buildReasoningRaw,
-        levels: withAdaptiveEffortOption(buildReasoningRaw.levels),
+        levels: withAdaptiveEffortOption(buildReasoningRaw.levels, buildModel),
       }
     : null
   const yoloReasoningRaw =
@@ -1251,7 +1257,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
   const yoloReasoning = yoloReasoningRaw
     ? {
         ...yoloReasoningRaw,
-        levels: withAdaptiveEffortOption(yoloReasoningRaw.levels),
+        levels: withAdaptiveEffortOption(yoloReasoningRaw.levels, yoloModel),
       }
     : null
   const piAuthMessage = piAuth?.error

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -143,6 +143,7 @@ import {
   getCatalogModelReasoning,
   useModelCatalog,
 } from '@/services/model-catalog'
+import { withAdaptiveEffortOption } from '@/components/chat/toolbar/toolbar-options'
 import type { AppPreferences } from '@/types/preferences'
 import {
   effortLevelOptions,
@@ -297,24 +298,29 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
     'codex',
     preferences?.selected_codex_model ?? 'gpt-5.6-sol'
   )
-  const selectedCodexReasoningOptions =
+  const selectedCodexReasoningOptions = withAdaptiveEffortOption(
     codexReasoning?.type === 'effort'
       ? codexReasoning.levels
       : codexReasoningOptions
+  )
   const grokReasoning = getCatalogModelReasoning(
     modelCatalog,
     'grok',
     preferences?.selected_grok_model ?? 'grok/grok-4.5'
   )
-  const selectedGrokReasoningOptions =
+  const selectedGrokReasoningOptions = withAdaptiveEffortOption(
     grokReasoning?.type === 'effort'
       ? grokReasoning.levels
       : grokReasoningOptions
+  )
   const claudeReasoning = getCatalogModelReasoning(
     modelCatalog,
     'claude',
     preferences?.selected_model ?? 'claude-opus-4-8[1m]'
   )
+  const selectedClaudeReasoningOptions = claudeReasoning
+    ? withAdaptiveEffortOption(claudeReasoning.levels)
+    : []
   const patchPreferences = usePatchPreferences()
   const isWebAccessView = !isNativeApp()
   const webAccessSoundsEnabled = preferences?.web_access_sounds_enabled ?? true
@@ -1208,7 +1214,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
       preferences,
       piModelOptions
     )
-  const buildReasoning =
+  const buildReasoningRaw =
     getCatalogModelReasoning(modelCatalog, effectiveBuildBackend, buildModel) ??
     (['codex', 'opencode', 'pi', 'grok', 'kimi'].includes(effectiveBuildBackend)
       ? {
@@ -1222,7 +1228,13 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
                 : effortLevelOptions,
         }
       : null)
-  const yoloReasoning =
+  const buildReasoning = buildReasoningRaw
+    ? {
+        ...buildReasoningRaw,
+        levels: withAdaptiveEffortOption(buildReasoningRaw.levels),
+      }
+    : null
+  const yoloReasoningRaw =
     getCatalogModelReasoning(modelCatalog, effectiveYoloBackend, yoloModel) ??
     (['codex', 'opencode', 'pi', 'grok', 'kimi'].includes(effectiveYoloBackend)
       ? {
@@ -1236,6 +1248,12 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
                 : effortLevelOptions,
         }
       : null)
+  const yoloReasoning = yoloReasoningRaw
+    ? {
+        ...yoloReasoningRaw,
+        levels: withAdaptiveEffortOption(yoloReasoningRaw.levels),
+      }
+    : null
   const piAuthMessage = piAuth?.error
 
   const selectedCommandCodeModel =
@@ -2988,7 +3006,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {claudeReasoning.levels.map(option => (
+                    {selectedClaudeReasoningOptions.map(option => (
                       <SelectItem key={option.value} value={option.value}>
                         {option.label}
                       </SelectItem>
@@ -3015,7 +3033,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {claudeReasoning.levels.map(option => (
+                    {selectedClaudeReasoningOptions.map(option => (
                       <SelectItem key={option.value} value={option.value}>
                         {option.label}
                       </SelectItem>

--- a/src/lib/model-utils.test.ts
+++ b/src/lib/model-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   getModelImpliedBackend,
+  isGeminiModel,
   resolveBackend,
   supportsAdaptiveThinking,
 } from './model-utils'
@@ -18,6 +19,21 @@ describe('getModelImpliedBackend', () => {
 
   it('treats raw GPT model ids as Codex', () => {
     expect(getModelImpliedBackend('gpt-5.5')).toBe('codex')
+  })
+})
+
+describe('isGeminiModel', () => {
+  it('detects Gemini model ids across backends', () => {
+    expect(isGeminiModel('commandcode/google/gemini-3.5-flash')).toBe(true)
+    expect(isGeminiModel('cursor/gemini-3.1-pro')).toBe(true)
+    expect(isGeminiModel('opencode/google/gemini-2.5-pro')).toBe(true)
+    expect(isGeminiModel('GEMINI-3.5-flash')).toBe(true)
+  })
+
+  it('rejects non-Gemini models', () => {
+    expect(isGeminiModel('claude-opus-4-8')).toBe(false)
+    expect(isGeminiModel('gpt-5.6-sol')).toBe(false)
+    expect(isGeminiModel(null)).toBe(false)
   })
 })
 

--- a/src/lib/model-utils.ts
+++ b/src/lib/model-utils.ts
@@ -38,6 +38,16 @@ export function getModelImpliedBackend(
 }
 
 /**
+ * Gemini models that support native adaptive thinking when no effort/thinking
+ * level is forced (e.g. Gemini 3.5 Flash). Jean only surfaces Adaptive/Default
+ * for these models.
+ */
+export function isGeminiModel(model: string | null | undefined): boolean {
+  if (!model) return false
+  return model.toLowerCase().includes('gemini')
+}
+
+/**
  * Check if the current model + CLI version combination uses effort levels
  * instead of traditional thinking levels.
  *
@@ -46,6 +56,9 @@ export function getModelImpliedBackend(
  * - CLI version is >= 2.1.32
  *
  * Sonnet models use traditional thinking levels, not effort levels.
+ *
+ * Note: this is Claude "effort mode", not Jean's Gemini-only Adaptive/Default
+ * option (see `isGeminiModel`).
  */
 export function supportsAdaptiveThinking(
   model: string,

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -9,12 +9,14 @@ export type MessageRole = 'user' | 'assistant'
  * Thinking level for Claude responses
  * Controls --settings alwaysThinkingEnabled and MAX_THINKING_TOKENS env var
  * - off: Thinking disabled
+ * - adaptive: Omit thinking settings so the model chooses depth
  * - think: 4K tokens budget
  * - megathink: 10K tokens budget
  * - ultrathink: 32K tokens budget (default)
  */
 export type ThinkingLevel =
   | 'off'
+  | 'adaptive'
   | 'think'
   | 'megathink'
   | 'ultrathink'
@@ -24,6 +26,7 @@ export type ThinkingLevel =
  * Effort level for Opus adaptive thinking
  * Controls --settings {"effort": "<level>"} via CLI
  * Replaces ThinkingLevel when model is Opus (latest) on CLI >= 2.1.32
+ * - adaptive: Omit effort so the model chooses depth (token-efficient for simple prompts)
  * - low: Minimal thinking, skips for simple tasks
  * - medium: Moderate thinking, may skip for very simple queries
  * - high: Deep reasoning (default), almost always thinks
@@ -34,6 +37,7 @@ export type ThinkingLevel =
  */
 export type EffortLevel =
   | 'off'
+  | 'adaptive'
   | 'minimal'
   | 'low'
   | 'medium'

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1728,6 +1728,7 @@ export function getModelFastInfo(
 }
 
 export const thinkingLevelOptions: { value: ThinkingLevel; label: string }[] = [
+  { value: 'adaptive', label: 'Adaptive/Default' },
   { value: 'off', label: 'Off' },
   { value: 'think', label: 'Think (4K)' },
   { value: 'megathink', label: 'Megathink (10K)' },
@@ -1739,6 +1740,11 @@ export const effortLevelOptions: {
   label: string
   description: string
 }[] = [
+  {
+    value: 'adaptive',
+    label: 'Adaptive/Default',
+    description: 'Model default (no forced level)',
+  },
   { value: 'low', label: 'Low', description: 'Minimal Claude Opus effort' },
   {
     value: 'medium',

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1728,7 +1728,6 @@ export function getModelFastInfo(
 }
 
 export const thinkingLevelOptions: { value: ThinkingLevel; label: string }[] = [
-  { value: 'adaptive', label: 'Adaptive/Default' },
   { value: 'off', label: 'Off' },
   { value: 'think', label: 'Think (4K)' },
   { value: 'megathink', label: 'Megathink (10K)' },
@@ -1740,11 +1739,6 @@ export const effortLevelOptions: {
   label: string
   description: string
 }[] = [
-  {
-    value: 'adaptive',
-    label: 'Adaptive/Default',
-    description: 'Model default (no forced level)',
-  },
   { value: 'low', label: 'Low', description: 'Minimal Claude Opus effort' },
   {
     value: 'medium',


### PR DESCRIPTION
## What's Changed

### Features
- Add an Adaptive option for thinking and effort levels so models can choose their own reasoning depth instead of always using a fixed level (fixes #430)

### Improvements
- Show the Adaptive option only for Gemini models that support adaptive reasoning