### PR TITLE
feat(checkpoints): add AI change checkpoints and restore

### DIFF
--- a/docs/developer/ai-checkpoints.md
+++ b/docs/developer/ai-checkpoints.md
@@ -1,0 +1,44 @@
+# AI Change Checkpoints
+
+Jean automatically snapshots each worktree **before** an agent turn starts so users can review AI file changes and restore prior project state (issue #407).
+
+## How it works
+
+1. **Create** — On `send_chat_message`, after the run log starts, Jean captures the full working tree (tracked + untracked, excluding ignored files) as a git commit object via a temporary index. HEAD and the real index are not modified.
+2. **Store** — The commit is referenced at `refs/jean/checkpoints/<id>` (survives `git gc`). Metadata lives in app-data: `ai-checkpoints/{worktree_id}.json`.
+3. **Finalize** — When the run completes or is cancelled, Jean captures an end-of-turn tree and records changed files / line stats.
+4. **Restore** — Users can restore individual files or the entire worktree to the checkpoint’s start tree (`git read-tree -u --reset` + `git clean -fd` for full restore).
+
+## Commands
+
+| Command | Purpose |
+| --- | --- |
+| `list_ai_checkpoints` | List checkpoints for a worktree (newest first) |
+| `get_ai_checkpoint` | Fetch one checkpoint |
+| `get_ai_checkpoint_diff` | Diff `start→end` (`scope: "turn"`) or `start→working tree` (`scope: "current"`) |
+| `restore_ai_checkpoint` | Full worktree restore |
+| `restore_ai_checkpoint_file` | Single-file restore |
+| `delete_ai_checkpoint` | Drop metadata + ref |
+| `finalize_ai_checkpoint` | Manual finalize (auto on run complete) |
+
+All commands are registered in `jean-core/src/http_server/dispatch.rs` (native + web access).
+
+## UI
+
+- **Git Diff modal → Checkpoints tab** (shortcut `4`): history browser, per-file restore, restore-all.
+- **Edited files** row on assistant messages: **Checkpoints** button opens the tab.
+- Diff request may include `worktreeId` / `checkpointId` (`src/types/git-diff.ts`).
+
+## Module map
+
+- Backend: `jean-core/src/projects/checkpoints.rs`
+- Hook: `send_chat_message` create; `RunLogWriter::complete` / `cancel` finalize
+- Run metadata: `RunEntry.checkpoint_id`
+- Frontend: `src/services/checkpoints.ts`, `src/components/chat/CheckpointsTabView.tsx`
+
+## Constraints
+
+- Not a git repo → create fails non-fatally (chat continues).
+- Full restore is destructive for later uncommitted work; confirm in UI.
+- Retention: last 100 checkpoints per worktree (oldest pruned).
+- Empty / no-op turns still create checkpoints (useful as restore points).

--- a/jean-core/src/chat/codex.rs
+++ b/jean-core/src/chat/codex.rs
@@ -6072,6 +6072,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -6129,6 +6130,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -6183,6 +6185,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -6242,6 +6245,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -6303,6 +6307,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -6374,6 +6379,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -6493,6 +6499,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -6550,6 +6557,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -6612,6 +6620,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -6655,6 +6664,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");
@@ -6812,6 +6822,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         let message = parse_codex_run_to_message(&lines, &run).expect("message");

--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -17,7 +17,7 @@ use super::run_log;
 use super::storage::{
     cleanup_combined_context_files, delete_session_data, get_base_index_path, get_data_dir,
     get_index_path, get_session_dir, load_metadata, load_sessions, save_metadata,
-    with_existing_metadata_mut, with_sessions_mut,
+    with_existing_metadata_mut, with_metadata_mut, with_sessions_mut,
 };
 use super::types::{
     AllSessionsEntry, AllSessionsResponse, Backend, ChatMessage, ClaudeContext, EffortLevel,
@@ -2709,7 +2709,10 @@ pub async fn send_chat_message(
                             .magic_prompt_providers
                             .session_naming_provider
                             .clone(),
-                        backend_override: prefs.magic_prompt_backends.session_naming_backend.clone(),
+                        backend_override: prefs
+                            .magic_prompt_backends
+                            .session_naming_backend
+                            .clone(),
                         reasoning_effort: prefs.magic_prompt_efforts.session_naming_effort.clone(),
                     };
 
@@ -2811,9 +2814,8 @@ pub async fn send_chat_message(
     // selected_provider may be a sentinel (__anthropic__/__default__) rather than
     // a real custom profile name — only use it when it looks like a profile id.
     let custom_profile_name = normalize_optional_string(custom_profile_name).or_else(|| {
-        normalize_optional_string(session_selected_provider).filter(|provider| {
-            provider != "__anthropic__" && provider != "__default__"
-        })
+        normalize_optional_string(session_selected_provider)
+            .filter(|provider| provider != "__anthropic__" && provider != "__default__")
     });
 
     // Determine backend from session (or explicit param, or default to claude)
@@ -3012,15 +3014,14 @@ pub async fn send_chat_message(
     } else {
         codex_thread_id
     };
-    let opencode_session_id =
-        if clear_target_resume && effective_backend == Backend::Opencode {
-            log::info!(
-                "[SendChat] OpenCode starting new session for provider handoff session={session_id}"
-            );
-            None
-        } else {
-            opencode_session_id
-        };
+    let opencode_session_id = if clear_target_resume && effective_backend == Backend::Opencode {
+        log::info!(
+            "[SendChat] OpenCode starting new session for provider handoff session={session_id}"
+        );
+        None
+    } else {
+        opencode_session_id
+    };
     let cursor_chat_id = if clear_target_resume && effective_backend == Backend::Cursor {
         None
     } else {
@@ -3086,6 +3087,59 @@ pub async fn send_chat_message(
     let input_file = run_log_writer.input_file_path()?;
     let output_file = run_log_writer.output_file_path()?;
     let run_id = run_log_writer.run_id().to_string();
+
+    // Snapshot the worktree before the agent can modify files so the user can
+    // review AI changes and restore individual files or the whole tree later.
+    // Failures are non-fatal — chat should still proceed.
+    let checkpoint_id = match crate::projects::checkpoints::create_checkpoint(
+        &app,
+        crate::projects::checkpoints::CreateCheckpointArgs {
+            worktree_id: worktree_id.clone(),
+            worktree_path: worktree_path.clone(),
+            session_id: session_id.clone(),
+            run_id: Some(run_id.clone()),
+            user_message_id: Some(user_message_id.clone()),
+            user_message: message.clone(),
+        },
+    ) {
+        Ok(cp) => {
+            let cp_id = cp.id.clone();
+            if let Err(e) = with_metadata_mut(
+                &app,
+                &session_id,
+                &worktree_id,
+                &session_name,
+                session_order,
+                |metadata| {
+                    if let Some(run) = metadata.find_run_mut(&run_id) {
+                        run.checkpoint_id = Some(cp_id.clone());
+                    }
+                    Ok(())
+                },
+            ) {
+                log::warn!("[Checkpoint] failed to attach id to run {run_id}: {e}");
+            }
+            // Emit so clients can show restore affordances immediately.
+            if let Err(e) = app.emit_all(
+                "checkpoint:created",
+                &serde_json::json!({
+                    "worktree_id": worktree_id,
+                    "session_id": session_id,
+                    "run_id": run_id,
+                    "checkpoint_id": cp_id,
+                    "user_message_id": user_message_id,
+                }),
+            ) {
+                log::warn!("[Checkpoint] failed to emit checkpoint:created: {e}");
+            }
+            Some(cp_id)
+        }
+        Err(e) => {
+            log::warn!("[Checkpoint] create failed session={session_id} run={run_id}: {e}");
+            None
+        }
+    };
+    let _ = checkpoint_id;
 
     // Write input file with the effective backend prompt. Hidden handoff context
     // is intentionally not stored as the visible user message in metadata.
@@ -6525,11 +6579,7 @@ pub async fn open_file_in_default_app(
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     std::process::Command::new("open")
                         .args(macos_open_app_args(
-                            "VSCodium",
-                            "vscodium",
-                            &path,
-                            line,
-                            column,
+                            "VSCodium", "vscodium", &path, line, column,
                         ))
                         .spawn()
                 }
@@ -9820,13 +9870,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            macos_open_app_args(
-                "VSCodium",
-                "vscodium",
-                "/tmp/main.ts",
-                Some(10),
-                Some(2)
-            ),
+            macos_open_app_args("VSCodium", "vscodium", "/tmp/main.ts", Some(10), Some(2)),
             vec![
                 "-a".to_string(),
                 "VSCodium".to_string(),

--- a/jean-core/src/chat/detached.rs
+++ b/jean-core/src/chat/detached.rs
@@ -590,9 +590,7 @@ pub fn spawn_detached_claude(
         // already be running under wslhost.exe).
         match child.wait() {
             Ok(status) if !status.success() => {
-                log::warn!(
-                    "WSL launcher exited with status {status} after reporting pid {pid}"
-                );
+                log::warn!("WSL launcher exited with status {status} after reporting pid {pid}");
             }
             Err(e) => log::warn!("Failed to wait for WSL launcher: {e}"),
             _ => {}

--- a/jean-core/src/chat/grok.rs
+++ b/jean-core/src/chat/grok.rs
@@ -5096,6 +5096,7 @@ Ship the feature end-to-end with tests and clear handoff notes for YOLO.
             cursor_chat_id: None,
             grok_session_id: Some("grok-hist-err".to_string()),
             kimi_session_id: None,
+            checkpoint_id: None,
         };
         let message = parse_grok_run_to_message(&lines, &run).unwrap();
         assert!(message.content.contains("Partial reply before failure."));
@@ -5830,6 +5831,7 @@ Ship the feature end-to-end with tests and clear handoff notes for YOLO.
             cursor_chat_id: None,
             grok_session_id: Some("grok-hist-1".to_string()),
             kimi_session_id: None,
+            checkpoint_id: None,
         };
         let message = parse_grok_run_to_message(&lines, &run).unwrap();
         assert_eq!(message.content, "Survived restart");
@@ -5906,6 +5908,7 @@ Ship the feature end-to-end with tests and clear handoff notes for YOLO.
             cursor_chat_id: None,
             grok_session_id: Some("s".to_string()),
             kimi_session_id: None,
+            checkpoint_id: None,
         };
         let message = parse_grok_run_to_message(&lines, &run).unwrap();
         assert_eq!(message.content, "BeforeAfter");

--- a/jean-core/src/chat/handoff.rs
+++ b/jean-core/src/chat/handoff.rs
@@ -476,6 +476,7 @@ mod tests {
                 cursor_chat_id: None,
                 grok_session_id: None,
                 kimi_session_id: None,
+                checkpoint_id: None,
             },
             RunEntry {
                 run_id: "run-2".to_string(),
@@ -501,6 +502,7 @@ mod tests {
                 cursor_chat_id: None,
                 grok_session_id: None,
                 kimi_session_id: None,
+                checkpoint_id: None,
             },
         ];
 
@@ -573,6 +575,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         });
 
         assert_eq!(latest_completed_backend(&metadata), Some(Backend::Claude));
@@ -632,6 +635,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         });
         metadata.runs.push(RunEntry {
             run_id: "run-2".to_string(),
@@ -657,6 +661,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         });
 
         assert_eq!(

--- a/jean-core/src/chat/opencode.rs
+++ b/jean-core/src/chat/opencode.rs
@@ -3674,9 +3674,7 @@ mod tests {
         // A lineage that never reaches a registered subscriber resolves to None.
         let mut orphan_parents = HashMap::new();
         orphan_parents.insert("ses_orphan".to_string(), "ses_unsubscribed".to_string());
-        assert!(
-            resolve_opencode_subscriber(&subscribers, &orphan_parents, "ses_orphan").is_none()
-        );
+        assert!(resolve_opencode_subscriber(&subscribers, &orphan_parents, "ses_orphan").is_none());
 
         // Unknown session with no lineage at all is None.
         assert!(
@@ -3690,11 +3688,17 @@ mod tests {
         // Multi-level chain under the dropped root (the shape resolve tests use).
         parents.insert("ses_child".to_string(), "ses_root".to_string());
         parents.insert("ses_grandchild".to_string(), "ses_child".to_string());
-        parents.insert("ses_great_grandchild".to_string(), "ses_grandchild".to_string());
+        parents.insert(
+            "ses_great_grandchild".to_string(),
+            "ses_grandchild".to_string(),
+        );
         // Sibling branch under the same root.
         parents.insert("ses_other_child".to_string(), "ses_root".to_string());
         // Unrelated tree must survive.
-        parents.insert("ses_unrelated_child".to_string(), "ses_other_root".to_string());
+        parents.insert(
+            "ses_unrelated_child".to_string(),
+            "ses_other_root".to_string(),
+        );
         parents.insert(
             "ses_unrelated_grandchild".to_string(),
             "ses_unrelated_child".to_string(),
@@ -3722,9 +3726,7 @@ mod tests {
             Some("ses_other_root")
         );
         assert_eq!(
-            parents
-                .get("ses_unrelated_grandchild")
-                .map(String::as_str),
+            parents.get("ses_unrelated_grandchild").map(String::as_str),
             Some("ses_unrelated_child")
         );
     }

--- a/jean-core/src/chat/pi.rs
+++ b/jean-core/src/chat/pi.rs
@@ -1790,6 +1790,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         let lines = vec![

--- a/jean-core/src/chat/run_log.rs
+++ b/jean-core/src/chat/run_log.rs
@@ -70,6 +70,8 @@ impl RunLogWriter {
         let run_id = self.run_id.clone();
         let claude_sid = claude_session_id.map(|s| s.to_string());
 
+        let mut checkpoint_id: Option<String> = None;
+
         with_metadata_mut(
             &self.app,
             &self.session_id,
@@ -83,6 +85,7 @@ impl RunLogWriter {
                     run.assistant_message_id = Some(assistant_message_id.to_string());
                     run.claude_session_id = claude_sid.clone();
                     run.usage = usage.clone();
+                    checkpoint_id = run.checkpoint_id.clone();
                 }
 
                 // Update metadata's claude_session_id for resumption
@@ -93,6 +96,21 @@ impl RunLogWriter {
                 Ok(())
             },
         )?;
+
+        // Capture end-of-turn tree + file list for the AI checkpoint.
+        if let Some(cp_id) = checkpoint_id {
+            if let Err(e) = crate::projects::checkpoints::finalize_checkpoint(
+                &self.app,
+                &self.worktree_id,
+                &cp_id,
+            ) {
+                log::warn!(
+                    "[Checkpoint] finalize on complete failed run={} cp={}: {e}",
+                    self.run_id,
+                    cp_id
+                );
+            }
+        }
 
         log::trace!("Run completed: {}", self.run_id);
         Ok(())
@@ -109,6 +127,7 @@ impl RunLogWriter {
         let run_id = self.run_id.clone();
         let asst_id = assistant_message_id.map(|s| s.to_string());
         let claude_sid = claude_session_id.map(|s| s.to_string());
+        let mut checkpoint_id: Option<String> = None;
 
         with_metadata_mut(
             &self.app,
@@ -118,6 +137,7 @@ impl RunLogWriter {
             self.order,
             |metadata| {
                 if let Some(run) = metadata.find_run_mut(&run_id) {
+                    checkpoint_id = run.checkpoint_id.clone();
                     run.status = RunStatus::Cancelled;
                     run.ended_at = Some(now);
                     run.cancelled = true;
@@ -133,6 +153,21 @@ impl RunLogWriter {
                 Ok(())
             },
         )?;
+
+        // Still finalize so the user can review / restore partial AI changes.
+        if let Some(cp_id) = checkpoint_id {
+            if let Err(e) = crate::projects::checkpoints::finalize_checkpoint(
+                &self.app,
+                &self.worktree_id,
+                &cp_id,
+            ) {
+                log::warn!(
+                    "[Checkpoint] finalize on cancel failed run={} cp={}: {e}",
+                    self.run_id,
+                    cp_id
+                );
+            }
+        }
 
         log::trace!("Run cancelled: {}", self.run_id);
         Ok(())
@@ -390,6 +425,7 @@ pub fn start_run(
         cursor_chat_id: None,
         grok_session_id: None,
         kimi_session_id: None,
+        checkpoint_id: None,
     };
 
     with_metadata_mut(
@@ -1521,6 +1557,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         }
     }
 
@@ -2005,6 +2042,7 @@ Move services between instances without downtime.
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         let lines = vec![

--- a/jean-core/src/chat/types.rs
+++ b/jean-core/src/chat/types.rs
@@ -1437,6 +1437,9 @@ pub struct RunEntry {
     /// Kimi Code ACP session ID — persisted per-run for conversation continuity.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kimi_session_id: Option<String>,
+    /// AI change checkpoint id captured before this run (working-tree snapshot).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkpoint_id: Option<String>,
 }
 
 impl RunEntry {
@@ -2228,6 +2231,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         });
 
         let restored = metadata.to_session();
@@ -2270,6 +2274,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         });
 
         assert!(metadata.find_run("run-1").is_some());
@@ -2302,6 +2307,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         };
 
         // Cancelled-with-content now renders user + partial assistant (incl tool calls).
@@ -2355,6 +2361,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         });
         metadata.runs.push(RunEntry {
             run_id: "run-completed".to_string(),
@@ -2380,6 +2387,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         });
 
         // Cancelled partial turn (user + assistant) + completed turn (user + assistant) = 4.
@@ -2423,6 +2431,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         });
 
         assert!(metadata.latest_claude_session_id().is_none());
@@ -2452,6 +2461,7 @@ mod tests {
             cursor_chat_id: None,
             grok_session_id: None,
             kimi_session_id: None,
+            checkpoint_id: None,
         });
 
         assert_eq!(metadata.latest_claude_session_id(), Some("claude-sess-abc"));

--- a/jean-core/src/http_server/dispatch.rs
+++ b/jean-core/src/http_server/dispatch.rs
@@ -3137,6 +3137,88 @@ pub async fn dispatch_command(
             crate::projects::set_worktree_last_opened(app.clone(), worktree_id).await?;
             Ok(Value::Null)
         }
+        "create_ai_checkpoint" => {
+            let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
+            let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
+            let session_id: String = field(&args, "sessionId", "session_id")?;
+            let run_id: Option<String> = field_opt(&args, "runId", "run_id")?;
+            let user_message_id: Option<String> =
+                field_opt(&args, "userMessageId", "user_message_id")?;
+            let user_message: String = field(&args, "userMessage", "user_message")?;
+            let result = crate::projects::create_ai_checkpoint(
+                app.clone(),
+                worktree_id,
+                worktree_path,
+                session_id,
+                run_id,
+                user_message_id,
+                user_message,
+            )
+            .await?;
+            to_value(result)
+        }
+        "list_ai_checkpoints" => {
+            let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
+            let result = crate::projects::list_ai_checkpoints(app.clone(), worktree_id).await?;
+            to_value(result)
+        }
+        "get_ai_checkpoint" => {
+            let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
+            let checkpoint_id: String = field(&args, "checkpointId", "checkpoint_id")?;
+            let result =
+                crate::projects::get_ai_checkpoint(app.clone(), worktree_id, checkpoint_id).await?;
+            to_value(result)
+        }
+        "get_ai_checkpoint_diff" => {
+            let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
+            let checkpoint_id: String = field(&args, "checkpointId", "checkpoint_id")?;
+            let scope: Option<String> = from_field_opt(&args, "scope")?;
+            let result = crate::projects::get_ai_checkpoint_diff(
+                app.clone(),
+                worktree_id,
+                checkpoint_id,
+                scope,
+            )
+            .await?;
+            to_value(result)
+        }
+        "restore_ai_checkpoint" => {
+            let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
+            let checkpoint_id: String = field(&args, "checkpointId", "checkpoint_id")?;
+            let result =
+                crate::projects::restore_ai_checkpoint(app.clone(), worktree_id, checkpoint_id)
+                    .await?;
+            emit_cache_invalidation(app, &["git-status"]);
+            to_value(result)
+        }
+        "restore_ai_checkpoint_file" => {
+            let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
+            let checkpoint_id: String = field(&args, "checkpointId", "checkpoint_id")?;
+            let file_path: String = field(&args, "filePath", "file_path")?;
+            crate::projects::restore_ai_checkpoint_file(
+                app.clone(),
+                worktree_id,
+                checkpoint_id,
+                file_path,
+            )
+            .await?;
+            emit_cache_invalidation(app, &["git-status"]);
+            Ok(Value::Null)
+        }
+        "delete_ai_checkpoint" => {
+            let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
+            let checkpoint_id: String = field(&args, "checkpointId", "checkpoint_id")?;
+            crate::projects::delete_ai_checkpoint(app.clone(), worktree_id, checkpoint_id).await?;
+            Ok(Value::Null)
+        }
+        "finalize_ai_checkpoint" => {
+            let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
+            let checkpoint_id: String = field(&args, "checkpointId", "checkpoint_id")?;
+            let result =
+                crate::projects::finalize_ai_checkpoint(app.clone(), worktree_id, checkpoint_id)
+                    .await?;
+            to_value(result)
+        }
         "git_stash" => {
             let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
             let result = crate::projects::git_stash(worktree_path).await?;

--- a/jean-core/src/projects/checkpoints.rs
+++ b/jean-core/src/projects/checkpoints.rs
@@ -75,6 +75,10 @@ pub struct AiCheckpoint {
     pub finalized_at: Option<u64>,
     /// Commit object capturing the full working tree at snapshot time.
     pub start_commit: String,
+    /// Commit object capturing the real index at snapshot time. Older
+    /// checkpoints omit this and preserve the index that exists at restore.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_index_commit: Option<String>,
     /// Commit object capturing the working tree when the turn finished.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub end_commit: Option<String>,
@@ -210,8 +214,18 @@ fn head_commit(repo_path: &str) -> Option<String> {
     git_output(repo_path, &["rev-parse", "HEAD"], None).ok()
 }
 
-fn checkpoint_ref(id: &str) -> String {
-    format!("refs/jean/checkpoints/{id}")
+#[derive(Clone, Copy)]
+enum CheckpointRefKind {
+    Start,
+    End,
+}
+
+fn checkpoint_ref(id: &str, kind: CheckpointRefKind) -> String {
+    let suffix = match kind {
+        CheckpointRefKind::Start => "start",
+        CheckpointRefKind::End => "end",
+    };
+    format!("refs/jean/checkpoints/{id}/{suffix}")
 }
 
 /// Capture the full working tree (tracked + untracked, excluding ignored) as a
@@ -219,6 +233,14 @@ fn checkpoint_ref(id: &str) -> String {
 ///
 /// Returns the commit SHA.
 pub fn capture_working_tree_commit(repo_path: &str, message: &str) -> Result<String, String> {
+    capture_checkpoint_commits(repo_path, message).map(|(working_commit, _)| working_commit)
+}
+
+/// Capture the working tree and real index as separate commits.
+///
+/// The index commit is a parent of the working-tree commit so the checkpoint
+/// ref keeps both objects reachable.
+fn capture_checkpoint_commits(repo_path: &str, message: &str) -> Result<(String, String), String> {
     let (git_dir, _) = resolve_git_dirs(Path::new(repo_path))
         .ok_or_else(|| format!("Not a git repository: {repo_path}"))?;
 
@@ -230,6 +252,29 @@ pub fn capture_working_tree_commit(repo_path: &str, message: &str) -> Result<Str
     };
 
     let result = (|| {
+        let index_tree = git_output(repo_path, &["write-tree"], None)?;
+        let index_message = format!("{message}:index");
+        let index_commit = if let Some(parent) = head_commit(repo_path) {
+            git_output(
+                repo_path,
+                &[
+                    "commit-tree",
+                    &index_tree,
+                    "-p",
+                    &parent,
+                    "-m",
+                    &index_message,
+                ],
+                None,
+            )?
+        } else {
+            git_output(
+                repo_path,
+                &["commit-tree", &index_tree, "-m", &index_message],
+                None,
+            )?
+        };
+
         // Seed temp index from HEAD when possible, otherwise start empty.
         if has_head(repo_path) {
             git_output(repo_path, &["read-tree", "HEAD"], Some(&index_path))?;
@@ -246,38 +291,45 @@ pub fn capture_working_tree_commit(repo_path: &str, message: &str) -> Result<Str
             return Err("git write-tree returned empty tree hash".to_string());
         }
 
-        // Build a commit object. Parent is HEAD when it exists so the commit
-        // graph stays meaningful for `git log` / tooling.
-        let commit = if let Some(parent) = head_commit(repo_path) {
-            git_output(
-                repo_path,
-                &["commit-tree", &tree, "-p", &parent, "-m", message],
-                None,
-            )?
-        } else {
-            git_output(repo_path, &["commit-tree", &tree, "-m", message], None)?
-        };
+        // Parent the worktree snapshot to the index snapshot, which itself is
+        // parented to HEAD. This keeps both commits reachable from one ref.
+        let commit = git_output(
+            repo_path,
+            &["commit-tree", &tree, "-p", &index_commit, "-m", message],
+            None,
+        )?;
 
         if commit.len() < 7 {
             return Err(format!("Unexpected commit hash: {commit}"));
         }
 
-        Ok(commit)
+        Ok((commit, index_commit))
     })();
 
     cleanup();
     result
 }
 
-fn update_checkpoint_ref(repo_path: &str, id: &str, commit: &str) -> Result<(), String> {
-    let ref_name = checkpoint_ref(id);
+fn update_checkpoint_ref(
+    repo_path: &str,
+    id: &str,
+    kind: CheckpointRefKind,
+    commit: &str,
+) -> Result<(), String> {
+    let ref_name = checkpoint_ref(id, kind);
     git_output(repo_path, &["update-ref", &ref_name, commit], None)?;
     Ok(())
 }
 
-fn delete_checkpoint_ref(repo_path: &str, id: &str) {
-    let ref_name = checkpoint_ref(id);
-    let _ = git_output(repo_path, &["update-ref", "-d", &ref_name], None);
+fn delete_checkpoint_refs(repo_path: &str, id: &str) {
+    for kind in [CheckpointRefKind::Start, CheckpointRefKind::End] {
+        let ref_name = checkpoint_ref(id, kind);
+        let _ = git_output(repo_path, &["update-ref", "-d", &ref_name], None);
+    }
+    // Clean up refs created by versions that stored the start commit directly
+    // at refs/jean/checkpoints/<id>.
+    let legacy_ref = format!("refs/jean/checkpoints/{id}");
+    let _ = git_output(repo_path, &["update-ref", "-d", &legacy_ref], None);
 }
 
 /// Diff two trees/commits (or a commit vs working tree when `to` is None).
@@ -426,8 +478,14 @@ pub fn create_checkpoint(
     let preview = truncate_preview(&args.user_message);
     let message = format!("jean-checkpoint:{id}");
 
-    let start_commit = capture_working_tree_commit(&args.worktree_path, &message)?;
-    update_checkpoint_ref(&args.worktree_path, &id, &start_commit)?;
+    let (start_commit, start_index_commit) =
+        capture_checkpoint_commits(&args.worktree_path, &message)?;
+    update_checkpoint_ref(
+        &args.worktree_path,
+        &id,
+        CheckpointRefKind::Start,
+        &start_commit,
+    )?;
 
     let head = head_commit(&args.worktree_path);
     let created_at = now_secs();
@@ -442,6 +500,7 @@ pub fn create_checkpoint(
         created_at,
         finalized_at: None,
         start_commit,
+        start_index_commit: Some(start_index_commit),
         end_commit: None,
         head_commit: head,
         worktree_path: args.worktree_path,
@@ -459,7 +518,7 @@ pub fn create_checkpoint(
     // Prune oldest beyond retention limit (also drop their refs).
     while store.checkpoints.len() > MAX_CHECKPOINTS_PER_WORKTREE {
         let removed = store.checkpoints.remove(0);
-        delete_checkpoint_ref(&removed.worktree_path, &removed.id);
+        delete_checkpoint_refs(&removed.worktree_path, &removed.id);
     }
 
     save_store(app, &args.worktree_id, &store)?;
@@ -494,7 +553,18 @@ pub fn finalize_checkpoint(
 
     let end_message = format!("jean-checkpoint-end:{checkpoint_id}");
     let end_commit = match capture_working_tree_commit(&checkpoint.worktree_path, &end_message) {
-        Ok(sha) => Some(sha),
+        Ok(sha) => match update_checkpoint_ref(
+            &checkpoint.worktree_path,
+            checkpoint_id,
+            CheckpointRefKind::End,
+            &sha,
+        ) {
+            Ok(()) => Some(sha),
+            Err(e) => {
+                log::warn!("[Checkpoint] failed to protect end tree for {checkpoint_id}: {e}");
+                None
+            }
+        },
         Err(e) => {
             log::warn!("[Checkpoint] failed to capture end tree for {checkpoint_id}: {e}");
             None
@@ -591,7 +661,7 @@ pub fn get_checkpoint_diff(
 
 /// Restore the entire worktree to a checkpoint's start state.
 ///
-/// Resets both the index and working tree to match the checkpoint commit.
+/// Restores the working tree and index snapshots independently.
 /// Untracked files that did not exist in the checkpoint are removed.
 pub fn restore_checkpoint(
     app: &AppHandle,
@@ -608,20 +678,45 @@ pub fn restore_checkpoint(
         .ok_or_else(|| format!("Checkpoint not found: {checkpoint_id}"))?;
 
     let commit = checkpoint.start_commit.clone();
+    let index_commit = checkpoint.start_index_commit.clone();
     let repo = checkpoint.worktree_path.clone();
 
-    // Reset index + worktree to the checkpoint tree.
-    git_output(&repo, &["read-tree", "-u", "--reset", &commit], None)?;
-
-    // Remove untracked files that appeared after the checkpoint.
-    // `-fd` removes untracked files and directories; ignored files stay.
-    let _ = git_output(&repo, &["clean", "-fd"], None);
+    if let Some(index_commit) = index_commit {
+        restore_checkpoint_commits(&repo, &commit, &index_commit)?;
+    } else {
+        // Legacy checkpoints did not capture the original index. Restore the
+        // working tree image, then put the current index back rather than
+        // incorrectly staging every checkpoint difference.
+        let current_index_tree = git_output(&repo, &["write-tree"], None)?;
+        git_output(&repo, &["read-tree", "-u", "--reset", &commit], None)?;
+        let _ = git_output(&repo, &["clean", "-fd"], None);
+        git_output(&repo, &["read-tree", "--reset", &current_index_tree], None)?;
+    }
 
     checkpoint.status = CheckpointStatus::Restored;
     let result = checkpoint.clone();
     save_store(app, worktree_id, &store)?;
     log::info!("[Checkpoint] restored full worktree id={checkpoint_id}");
     Ok(result)
+}
+
+fn restore_checkpoint_commits(
+    repo_path: &str,
+    working_commit: &str,
+    index_commit: &str,
+) -> Result<(), String> {
+    // Populate the worktree from its snapshot, then replace only the index
+    // with its own snapshot to retain the original staged/unstaged boundary.
+    git_output(
+        repo_path,
+        &["read-tree", "-u", "--reset", working_commit],
+        None,
+    )?;
+    // At this point snapshot files are all represented by the temporary
+    // worktree index, so clean removes only files created after capture.
+    let _ = git_output(repo_path, &["clean", "-fd"], None);
+    git_output(repo_path, &["read-tree", "--reset", index_commit], None)?;
+    Ok(())
 }
 
 fn validated_restore_path(repo: &Path, file_path: &Path) -> Result<PathBuf, String> {
@@ -713,7 +808,7 @@ pub fn delete_checkpoint(
         return Err(format!("Checkpoint not found: {checkpoint_id}"));
     };
     let removed = store.checkpoints.remove(idx);
-    delete_checkpoint_ref(&removed.worktree_path, &removed.id);
+    delete_checkpoint_refs(&removed.worktree_path, &removed.id);
     save_store(app, worktree_id, &store)?;
     log::info!("[Checkpoint] deleted id={checkpoint_id}");
     Ok(())
@@ -1018,12 +1113,20 @@ mod tests {
         delete_checkpoint_refs(&repo_str, id);
         assert!(!git_ok(
             &repo_str,
-            &["rev-parse", "--verify", &format!("refs/jean/checkpoints/{id}/start")],
+            &[
+                "rev-parse",
+                "--verify",
+                &format!("refs/jean/checkpoints/{id}/start")
+            ],
             None,
         ));
         assert!(!git_ok(
             &repo_str,
-            &["rev-parse", "--verify", &format!("refs/jean/checkpoints/{id}/end")],
+            &[
+                "rev-parse",
+                "--verify",
+                &format!("refs/jean/checkpoints/{id}/end")
+            ],
             None,
         ));
     }

--- a/jean-core/src/projects/checkpoints.rs
+++ b/jean-core/src/projects/checkpoints.rs
@@ -1,0 +1,1050 @@
+//! AI change checkpoints — snapshot the worktree before an agent turn and
+//! restore files/project state later.
+//!
+//! Snapshots are real git commit objects (via a temporary index) stored under
+//! `refs/jean/checkpoints/<id>` so they survive `git gc` and can be diffed or
+//! restored with ordinary git commands. Metadata lives in Jean's app-data dir.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use tauri::AppHandle;
+use uuid::Uuid;
+
+use crate::platform::wsl_aware_command;
+
+use super::git::resolve_git_dirs;
+use super::git_status::{parse_unified_diff, DiffFile, GitDiff};
+
+/// Max checkpoints retained per worktree (oldest pruned first).
+const MAX_CHECKPOINTS_PER_WORKTREE: usize = 100;
+
+/// Preview length for the triggering user message.
+const MESSAGE_PREVIEW_CHARS: usize = 120;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum CheckpointStatus {
+    /// Snapshot taken; agent may still be running.
+    Open,
+    /// Agent turn finished; file stats captured.
+    Finalized,
+    /// User restored this checkpoint at some point (still restorable).
+    Restored,
+}
+
+impl Default for CheckpointStatus {
+    fn default() -> Self {
+        Self::Open
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckpointFileSummary {
+    pub path: String,
+    /// "added" | "modified" | "deleted" | "renamed"
+    pub status: String,
+    pub additions: u32,
+    pub deletions: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AiCheckpoint {
+    pub id: String,
+    pub worktree_id: String,
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_message_id: Option<String>,
+    /// Truncated user message that triggered the agent turn.
+    pub user_message_preview: String,
+    pub created_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finalized_at: Option<u64>,
+    /// Commit object capturing the full working tree at snapshot time.
+    pub start_commit: String,
+    /// Commit object capturing the working tree when the turn finished.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_commit: Option<String>,
+    /// HEAD commit at snapshot time (may differ from start_commit when there
+    /// were uncommitted changes).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_commit: Option<String>,
+    pub worktree_path: String,
+    #[serde(default)]
+    pub status: CheckpointStatus,
+    #[serde(default)]
+    pub files_changed: Vec<CheckpointFileSummary>,
+    #[serde(default)]
+    pub total_additions: u32,
+    #[serde(default)]
+    pub total_deletions: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct CheckpointStore {
+    checkpoints: Vec<AiCheckpoint>,
+}
+
+// ============================================================================
+// Storage
+// ============================================================================
+
+/// Per-worktree mutexes serialize checkpoint store read-modify-write cycles
+/// without blocking checkpoint writes for unrelated worktrees.
+static CHECKPOINT_STORE_LOCKS: Lazy<Mutex<HashMap<String, Arc<Mutex<()>>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+fn checkpoint_store_lock(worktree_id: &str) -> Arc<Mutex<()>> {
+    let mut locks = CHECKPOINT_STORE_LOCKS.lock().unwrap();
+    locks
+        .entry(worktree_id.to_string())
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
+fn checkpoints_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {e}"))?;
+    let dir = app_data_dir.join("ai-checkpoints");
+    fs::create_dir_all(&dir).map_err(|e| format!("Failed to create checkpoints dir: {e}"))?;
+    Ok(dir)
+}
+
+fn store_path(app: &AppHandle, worktree_id: &str) -> Result<PathBuf, String> {
+    // Sanitize worktree id for filesystem use (UUIDs are fine as-is).
+    let safe: String = worktree_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    Ok(checkpoints_dir(app)?.join(format!("{safe}.json")))
+}
+
+fn load_store(app: &AppHandle, worktree_id: &str) -> Result<CheckpointStore, String> {
+    let path = store_path(app, worktree_id)?;
+    if !path.exists() {
+        return Ok(CheckpointStore::default());
+    }
+    let content =
+        fs::read_to_string(&path).map_err(|e| format!("Failed to read checkpoints: {e}"))?;
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse checkpoints: {e}"))
+}
+
+fn save_store(app: &AppHandle, worktree_id: &str, store: &CheckpointStore) -> Result<(), String> {
+    let path = store_path(app, worktree_id)?;
+    let json = serde_json::to_string_pretty(store)
+        .map_err(|e| format!("Failed to serialize checkpoints: {e}"))?;
+    let tmp = path.with_extension(format!("{}.tmp", Uuid::new_v4()));
+    fs::write(&tmp, json).map_err(|e| format!("Failed to write checkpoints: {e}"))?;
+    fs::rename(&tmp, &path).map_err(|e| format!("Failed to finalize checkpoints: {e}"))?;
+    Ok(())
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn truncate_preview(message: &str) -> String {
+    let trimmed = message.trim();
+    let count = trimmed.chars().count();
+    if count <= MESSAGE_PREVIEW_CHARS {
+        return trimmed.to_string();
+    }
+    let preview: String = trimmed.chars().take(MESSAGE_PREVIEW_CHARS).collect();
+    format!("{preview}…")
+}
+
+// ============================================================================
+// Git helpers
+// ============================================================================
+
+fn git_output(repo_path: &str, args: &[&str], index_file: Option<&Path>) -> Result<String, String> {
+    let mut cmd = wsl_aware_command("git", Some(Path::new(repo_path)));
+    if let Some(index) = index_file {
+        cmd.env("GIT_INDEX_FILE", index);
+    }
+    let output = cmd
+        .args(args)
+        .output()
+        .map_err(|e| format!("Failed to run git {}: {e}", args.first().unwrap_or(&"")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git {} failed: {stderr}", args.join(" ")));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn git_ok(repo_path: &str, args: &[&str], index_file: Option<&Path>) -> bool {
+    git_output(repo_path, args, index_file).is_ok()
+}
+
+fn has_head(repo_path: &str) -> bool {
+    git_ok(repo_path, &["rev-parse", "--verify", "HEAD"], None)
+}
+
+fn head_commit(repo_path: &str) -> Option<String> {
+    git_output(repo_path, &["rev-parse", "HEAD"], None).ok()
+}
+
+fn checkpoint_ref(id: &str) -> String {
+    format!("refs/jean/checkpoints/{id}")
+}
+
+/// Capture the full working tree (tracked + untracked, excluding ignored) as a
+/// commit object without modifying HEAD or the real index.
+///
+/// Returns the commit SHA.
+pub fn capture_working_tree_commit(repo_path: &str, message: &str) -> Result<String, String> {
+    let (git_dir, _) = resolve_git_dirs(Path::new(repo_path))
+        .ok_or_else(|| format!("Not a git repository: {repo_path}"))?;
+
+    let index_path = Path::new(&git_dir).join(format!("jean-checkpoint-index-{}", Uuid::new_v4()));
+
+    // Best-effort cleanup of the temp index on all exit paths.
+    let cleanup = || {
+        let _ = fs::remove_file(&index_path);
+    };
+
+    let result = (|| {
+        // Seed temp index from HEAD when possible, otherwise start empty.
+        if has_head(repo_path) {
+            git_output(repo_path, &["read-tree", "HEAD"], Some(&index_path))?;
+        } else {
+            git_output(repo_path, &["read-tree", "--empty"], Some(&index_path))?;
+        }
+
+        // Stage everything (tracked modifications + untracked files).
+        // `-A` respects .gitignore so build artifacts stay out.
+        git_output(repo_path, &["add", "-A", "--"], Some(&index_path))?;
+
+        let tree = git_output(repo_path, &["write-tree"], Some(&index_path))?;
+        if tree.is_empty() {
+            return Err("git write-tree returned empty tree hash".to_string());
+        }
+
+        // Build a commit object. Parent is HEAD when it exists so the commit
+        // graph stays meaningful for `git log` / tooling.
+        let commit = if let Some(parent) = head_commit(repo_path) {
+            git_output(
+                repo_path,
+                &["commit-tree", &tree, "-p", &parent, "-m", message],
+                None,
+            )?
+        } else {
+            git_output(repo_path, &["commit-tree", &tree, "-m", message], None)?
+        };
+
+        if commit.len() < 7 {
+            return Err(format!("Unexpected commit hash: {commit}"));
+        }
+
+        Ok(commit)
+    })();
+
+    cleanup();
+    result
+}
+
+fn update_checkpoint_ref(repo_path: &str, id: &str, commit: &str) -> Result<(), String> {
+    let ref_name = checkpoint_ref(id);
+    git_output(repo_path, &["update-ref", &ref_name, commit], None)?;
+    Ok(())
+}
+
+fn delete_checkpoint_ref(repo_path: &str, id: &str) {
+    let ref_name = checkpoint_ref(id);
+    let _ = git_output(repo_path, &["update-ref", "-d", &ref_name], None);
+}
+
+/// Diff two trees/commits (or a commit vs working tree when `to` is None).
+fn diff_commits(repo_path: &str, from: &str, to: Option<&str>) -> Result<GitDiff, String> {
+    let mut args = vec!["diff", "--unified=3", from];
+    if let Some(to_ref) = to {
+        args.push(to_ref);
+    }
+
+    let output = wsl_aware_command("git", Some(Path::new(repo_path)))
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to run git diff: {e}"))?;
+
+    // git diff returns exit 1 when there are differences — still success for us.
+    if !output.status.success() && output.status.code() != Some(1) {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Git diff failed: {stderr}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let (files, raw_patch) = parse_unified_diff(&stdout);
+
+    // When diffing against the working tree, also surface untracked files that
+    // are not present in the checkpoint commit. `git diff <commit>` already
+    // includes modifications to tracked files and deletions; untracked files
+    // need the --no-index treatment used elsewhere only when comparing to WD.
+    // For checkpoint→WD we run an extra status pass for untracked-only paths
+    // that aren't already in the diff.
+    let mut files = files;
+    let mut raw_patch = raw_patch;
+    if to.is_none() {
+        let untracked = list_untracked_relative(repo_path);
+        for path in untracked {
+            if files.iter().any(|f| f.path == path) {
+                continue;
+            }
+            // Show as fully-added file via no-index diff when possible.
+            if let Some(file) = untracked_file_diff(repo_path, &path) {
+                if !raw_patch.is_empty() && !raw_patch.ends_with('\n') {
+                    raw_patch.push('\n');
+                }
+                // Reconstruct a minimal raw patch entry for the viewer.
+                raw_patch.push_str(&format!(
+                    "diff --git a/{path} b/{path}\nnew file mode 100644\n--- /dev/null\n+++ b/{path}\n"
+                ));
+                files.push(file);
+            }
+        }
+    }
+
+    let total_additions: u32 = files.iter().map(|f| f.additions).sum();
+    let total_deletions: u32 = files.iter().map(|f| f.deletions).sum();
+
+    Ok(GitDiff {
+        diff_type: "checkpoint".to_string(),
+        base_ref: from.to_string(),
+        target_ref: to.unwrap_or("working directory").to_string(),
+        total_additions,
+        total_deletions,
+        files,
+        raw_patch,
+    })
+}
+
+fn list_untracked_relative(repo_path: &str) -> Vec<String> {
+    let Ok(stdout) = git_output(
+        repo_path,
+        &["ls-files", "--others", "--exclude-standard"],
+        None,
+    ) else {
+        return Vec::new();
+    };
+    stdout
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+fn untracked_file_diff(repo_path: &str, relative_path: &str) -> Option<DiffFile> {
+    let full = Path::new(repo_path).join(relative_path);
+    let content = fs::read_to_string(&full).ok()?;
+    let lines: Vec<&str> = content.lines().collect();
+    let additions = lines.len() as u32;
+    let diff_lines = lines
+        .into_iter()
+        .enumerate()
+        .map(|(i, content)| super::git_status::DiffLine {
+            line_type: "addition".to_string(),
+            content: content.to_string(),
+            old_line_number: None,
+            new_line_number: Some((i + 1) as u32),
+        })
+        .collect();
+    Some(DiffFile {
+        path: relative_path.to_string(),
+        old_path: None,
+        status: "added".to_string(),
+        additions,
+        deletions: 0,
+        is_binary: false,
+        hunks: vec![super::git_status::DiffHunk {
+            header: format!("@@ -0,0 +1,{additions} @@"),
+            old_start: 0,
+            old_lines: 0,
+            new_start: 1,
+            new_lines: additions,
+            lines: diff_lines,
+        }],
+    })
+}
+
+fn file_summaries_from_diff(diff: &GitDiff) -> Vec<CheckpointFileSummary> {
+    diff.files
+        .iter()
+        .map(|f| CheckpointFileSummary {
+            path: f.path.clone(),
+            status: f.status.clone(),
+            additions: f.additions,
+            deletions: f.deletions,
+        })
+        .collect()
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+pub struct CreateCheckpointArgs {
+    pub worktree_id: String,
+    pub worktree_path: String,
+    pub session_id: String,
+    pub run_id: Option<String>,
+    pub user_message_id: Option<String>,
+    pub user_message: String,
+}
+
+/// Create a checkpoint snapshot of the current working tree.
+pub fn create_checkpoint(
+    app: &AppHandle,
+    args: CreateCheckpointArgs,
+) -> Result<AiCheckpoint, String> {
+    let id = Uuid::new_v4().to_string();
+    let preview = truncate_preview(&args.user_message);
+    let message = format!("jean-checkpoint:{id}");
+
+    let start_commit = capture_working_tree_commit(&args.worktree_path, &message)?;
+    update_checkpoint_ref(&args.worktree_path, &id, &start_commit)?;
+
+    let head = head_commit(&args.worktree_path);
+    let created_at = now_secs();
+
+    let checkpoint = AiCheckpoint {
+        id: id.clone(),
+        worktree_id: args.worktree_id.clone(),
+        session_id: args.session_id,
+        run_id: args.run_id,
+        user_message_id: args.user_message_id,
+        user_message_preview: preview,
+        created_at,
+        finalized_at: None,
+        start_commit,
+        end_commit: None,
+        head_commit: head,
+        worktree_path: args.worktree_path,
+        status: CheckpointStatus::Open,
+        files_changed: Vec::new(),
+        total_additions: 0,
+        total_deletions: 0,
+    };
+
+    let store_lock = checkpoint_store_lock(&args.worktree_id);
+    let _store_guard = store_lock.lock().unwrap();
+    let mut store = load_store(app, &args.worktree_id)?;
+    store.checkpoints.push(checkpoint.clone());
+
+    // Prune oldest beyond retention limit (also drop their refs).
+    while store.checkpoints.len() > MAX_CHECKPOINTS_PER_WORKTREE {
+        let removed = store.checkpoints.remove(0);
+        delete_checkpoint_ref(&removed.worktree_path, &removed.id);
+    }
+
+    save_store(app, &args.worktree_id, &store)?;
+    log::info!(
+        "[Checkpoint] created id={id} worktree={} commit={}",
+        args.worktree_id,
+        checkpoint.start_commit
+    );
+    Ok(checkpoint)
+}
+
+/// Finalize a checkpoint after the agent turn completes.
+///
+/// Captures the end tree and records which files changed during the turn.
+pub fn finalize_checkpoint(
+    app: &AppHandle,
+    worktree_id: &str,
+    checkpoint_id: &str,
+) -> Result<AiCheckpoint, String> {
+    let store_lock = checkpoint_store_lock(worktree_id);
+    let _store_guard = store_lock.lock().unwrap();
+    let mut store = load_store(app, worktree_id)?;
+    let checkpoint = store
+        .checkpoints
+        .iter_mut()
+        .find(|c| c.id == checkpoint_id)
+        .ok_or_else(|| format!("Checkpoint not found: {checkpoint_id}"))?;
+
+    if checkpoint.status == CheckpointStatus::Finalized {
+        return Ok(checkpoint.clone());
+    }
+
+    let end_message = format!("jean-checkpoint-end:{checkpoint_id}");
+    let end_commit = match capture_working_tree_commit(&checkpoint.worktree_path, &end_message) {
+        Ok(sha) => Some(sha),
+        Err(e) => {
+            log::warn!("[Checkpoint] failed to capture end tree for {checkpoint_id}: {e}");
+            None
+        }
+    };
+
+    // Diff start → end (or working tree if end capture failed).
+    let diff = diff_commits(
+        &checkpoint.worktree_path,
+        &checkpoint.start_commit,
+        end_commit.as_deref(),
+    )
+    .unwrap_or_else(|e| {
+        log::warn!("[Checkpoint] finalize diff failed for {checkpoint_id}: {e}");
+        GitDiff {
+            diff_type: "checkpoint".to_string(),
+            base_ref: checkpoint.start_commit.clone(),
+            target_ref: "working directory".to_string(),
+            total_additions: 0,
+            total_deletions: 0,
+            files: Vec::new(),
+            raw_patch: String::new(),
+        }
+    });
+
+    checkpoint.end_commit = end_commit;
+    checkpoint.files_changed = file_summaries_from_diff(&diff);
+    checkpoint.total_additions = diff.total_additions;
+    checkpoint.total_deletions = diff.total_deletions;
+    checkpoint.finalized_at = Some(now_secs());
+    checkpoint.status = CheckpointStatus::Finalized;
+
+    let result = checkpoint.clone();
+    save_store(app, worktree_id, &store)?;
+    log::info!(
+        "[Checkpoint] finalized id={checkpoint_id} files={} +{} -{}",
+        result.files_changed.len(),
+        result.total_additions,
+        result.total_deletions
+    );
+    Ok(result)
+}
+
+/// List checkpoints for a worktree (newest first).
+pub fn list_checkpoints(app: &AppHandle, worktree_id: &str) -> Result<Vec<AiCheckpoint>, String> {
+    let mut store = load_store(app, worktree_id)?;
+    store
+        .checkpoints
+        .sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    Ok(store.checkpoints)
+}
+
+/// Get a single checkpoint by id.
+pub fn get_checkpoint(
+    app: &AppHandle,
+    worktree_id: &str,
+    checkpoint_id: &str,
+) -> Result<AiCheckpoint, String> {
+    let store = load_store(app, worktree_id)?;
+    store
+        .checkpoints
+        .into_iter()
+        .find(|c| c.id == checkpoint_id)
+        .ok_or_else(|| format!("Checkpoint not found: {checkpoint_id}"))
+}
+
+/// Diff a checkpoint against the current working tree, or against its end
+/// state (`scope = "turn"` uses start→end when available).
+pub fn get_checkpoint_diff(
+    app: &AppHandle,
+    worktree_id: &str,
+    checkpoint_id: &str,
+    scope: Option<&str>,
+) -> Result<GitDiff, String> {
+    let checkpoint = get_checkpoint(app, worktree_id, checkpoint_id)?;
+    let scope = scope.unwrap_or("current");
+
+    match scope {
+        "turn" => {
+            if let Some(ref end) = checkpoint.end_commit {
+                diff_commits(
+                    &checkpoint.worktree_path,
+                    &checkpoint.start_commit,
+                    Some(end),
+                )
+            } else {
+                // Fall back to start → working tree if not yet finalized.
+                diff_commits(&checkpoint.worktree_path, &checkpoint.start_commit, None)
+            }
+        }
+        _ => diff_commits(&checkpoint.worktree_path, &checkpoint.start_commit, None),
+    }
+}
+
+/// Restore the entire worktree to a checkpoint's start state.
+///
+/// Resets both the index and working tree to match the checkpoint commit.
+/// Untracked files that did not exist in the checkpoint are removed.
+pub fn restore_checkpoint(
+    app: &AppHandle,
+    worktree_id: &str,
+    checkpoint_id: &str,
+) -> Result<AiCheckpoint, String> {
+    let store_lock = checkpoint_store_lock(worktree_id);
+    let _store_guard = store_lock.lock().unwrap();
+    let mut store = load_store(app, worktree_id)?;
+    let checkpoint = store
+        .checkpoints
+        .iter_mut()
+        .find(|c| c.id == checkpoint_id)
+        .ok_or_else(|| format!("Checkpoint not found: {checkpoint_id}"))?;
+
+    let commit = checkpoint.start_commit.clone();
+    let repo = checkpoint.worktree_path.clone();
+
+    // Reset index + worktree to the checkpoint tree.
+    git_output(&repo, &["read-tree", "-u", "--reset", &commit], None)?;
+
+    // Remove untracked files that appeared after the checkpoint.
+    // `-fd` removes untracked files and directories; ignored files stay.
+    let _ = git_output(&repo, &["clean", "-fd"], None);
+
+    checkpoint.status = CheckpointStatus::Restored;
+    let result = checkpoint.clone();
+    save_store(app, worktree_id, &store)?;
+    log::info!("[Checkpoint] restored full worktree id={checkpoint_id}");
+    Ok(result)
+}
+
+fn validated_restore_path(repo: &Path, file_path: &Path) -> Result<PathBuf, String> {
+    if file_path.as_os_str().is_empty()
+        || file_path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(format!(
+            "Invalid checkpoint file path: {}",
+            file_path.display()
+        ));
+    }
+
+    let canonical_repo = repo
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve worktree path: {e}"))?;
+    let target = canonical_repo.join(file_path);
+
+    if target.exists() {
+        let canonical_target = target
+            .canonicalize()
+            .map_err(|e| format!("Failed to resolve checkpoint file path: {e}"))?;
+        if !canonical_target.starts_with(&canonical_repo) {
+            return Err(format!(
+                "Checkpoint file path escapes the worktree: {}",
+                file_path.display()
+            ));
+        }
+    }
+
+    Ok(target)
+}
+
+/// Restore a single file from a checkpoint's start state.
+pub fn restore_checkpoint_file(
+    app: &AppHandle,
+    worktree_id: &str,
+    checkpoint_id: &str,
+    file_path: &str,
+) -> Result<(), String> {
+    let checkpoint = get_checkpoint(app, worktree_id, checkpoint_id)?;
+    let repo = &checkpoint.worktree_path;
+    let commit = &checkpoint.start_commit;
+    let full = validated_restore_path(Path::new(repo), Path::new(file_path))?;
+
+    // Check whether the file existed in the checkpoint tree.
+    let existed = git_ok(
+        repo,
+        &["cat-file", "-e", &format!("{commit}:{file_path}")],
+        None,
+    );
+
+    if existed {
+        git_output(repo, &["checkout", commit, "--", file_path], None)?;
+    } else {
+        // File was created after the checkpoint — remove it.
+        if full.exists() {
+            if full.is_dir() {
+                fs::remove_dir_all(&full)
+                    .map_err(|e| format!("Failed to remove directory {file_path}: {e}"))?;
+            } else {
+                fs::remove_file(&full)
+                    .map_err(|e| format!("Failed to remove file {file_path}: {e}"))?;
+            }
+        }
+        // Unstage if staged.
+        let _ = git_output(
+            repo,
+            &["rm", "-f", "--cached", "--ignore-unmatch", file_path],
+            None,
+        );
+    }
+
+    log::info!("[Checkpoint] restored file={file_path} from checkpoint={checkpoint_id}");
+    Ok(())
+}
+
+/// Delete a checkpoint and its git ref.
+pub fn delete_checkpoint(
+    app: &AppHandle,
+    worktree_id: &str,
+    checkpoint_id: &str,
+) -> Result<(), String> {
+    let store_lock = checkpoint_store_lock(worktree_id);
+    let _store_guard = store_lock.lock().unwrap();
+    let mut store = load_store(app, worktree_id)?;
+    let Some(idx) = store.checkpoints.iter().position(|c| c.id == checkpoint_id) else {
+        return Err(format!("Checkpoint not found: {checkpoint_id}"));
+    };
+    let removed = store.checkpoints.remove(idx);
+    delete_checkpoint_ref(&removed.worktree_path, &removed.id);
+    save_store(app, worktree_id, &store)?;
+    log::info!("[Checkpoint] deleted id={checkpoint_id}");
+    Ok(())
+}
+
+/// Find the most recent open checkpoint for a session/run (used for auto-finalize).
+pub fn find_open_checkpoint_for_run(
+    app: &AppHandle,
+    worktree_id: &str,
+    run_id: &str,
+) -> Result<Option<AiCheckpoint>, String> {
+    let store = load_store(app, worktree_id)?;
+    Ok(store
+        .checkpoints
+        .into_iter()
+        .rev()
+        .find(|c| c.run_id.as_deref() == Some(run_id) && c.status == CheckpointStatus::Open))
+}
+
+// ============================================================================
+// Command wrappers (registered via http_server/dispatch.rs)
+// ============================================================================
+
+pub async fn create_ai_checkpoint(
+    app: AppHandle,
+    worktree_id: String,
+    worktree_path: String,
+    session_id: String,
+    run_id: Option<String>,
+    user_message_id: Option<String>,
+    user_message: String,
+) -> Result<AiCheckpoint, String> {
+    create_checkpoint(
+        &app,
+        CreateCheckpointArgs {
+            worktree_id,
+            worktree_path,
+            session_id,
+            run_id,
+            user_message_id,
+            user_message,
+        },
+    )
+}
+
+pub async fn list_ai_checkpoints(
+    app: AppHandle,
+    worktree_id: String,
+) -> Result<Vec<AiCheckpoint>, String> {
+    list_checkpoints(&app, &worktree_id)
+}
+
+pub async fn get_ai_checkpoint(
+    app: AppHandle,
+    worktree_id: String,
+    checkpoint_id: String,
+) -> Result<AiCheckpoint, String> {
+    get_checkpoint(&app, &worktree_id, &checkpoint_id)
+}
+
+pub async fn get_ai_checkpoint_diff(
+    app: AppHandle,
+    worktree_id: String,
+    checkpoint_id: String,
+    scope: Option<String>,
+) -> Result<GitDiff, String> {
+    get_checkpoint_diff(&app, &worktree_id, &checkpoint_id, scope.as_deref())
+}
+
+pub async fn restore_ai_checkpoint(
+    app: AppHandle,
+    worktree_id: String,
+    checkpoint_id: String,
+) -> Result<AiCheckpoint, String> {
+    restore_checkpoint(&app, &worktree_id, &checkpoint_id)
+}
+
+pub async fn restore_ai_checkpoint_file(
+    app: AppHandle,
+    worktree_id: String,
+    checkpoint_id: String,
+    file_path: String,
+) -> Result<(), String> {
+    restore_checkpoint_file(&app, &worktree_id, &checkpoint_id, &file_path)
+}
+
+pub async fn delete_ai_checkpoint(
+    app: AppHandle,
+    worktree_id: String,
+    checkpoint_id: String,
+) -> Result<(), String> {
+    delete_checkpoint(&app, &worktree_id, &checkpoint_id)
+}
+
+pub async fn finalize_ai_checkpoint(
+    app: AppHandle,
+    worktree_id: String,
+    checkpoint_id: String,
+) -> Result<AiCheckpoint, String> {
+    finalize_checkpoint(&app, &worktree_id, &checkpoint_id)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn run_git(repo: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        run_git(repo, &["init", "--initial-branch", "main"]);
+        run_git(repo, &["config", "user.email", "test@example.com"]);
+        run_git(repo, &["config", "user.name", "Test"]);
+        // Avoid "detected dubious ownership" in some CI sandboxes.
+        run_git(repo, &["config", "core.safecrlf", "false"]);
+        std::fs::write(repo.join("README.md"), "hello\n").unwrap();
+        run_git(repo, &["add", "."]);
+        run_git(repo, &["commit", "-m", "initial"]);
+        dir
+    }
+
+    #[test]
+    fn capture_working_tree_includes_uncommitted_and_untracked() {
+        let dir = init_repo();
+        let repo = dir.path();
+        let repo_str = repo.to_string_lossy().to_string();
+
+        std::fs::write(repo.join("README.md"), "hello world\n").unwrap();
+        std::fs::write(repo.join("new.txt"), "brand new\n").unwrap();
+
+        let commit = capture_working_tree_commit(&repo_str, "test-checkpoint").unwrap();
+        assert_eq!(commit.len(), 40);
+
+        // Working tree and HEAD must be untouched.
+        let head = head_commit(&repo_str).unwrap();
+        assert_ne!(head, commit);
+        let readme = std::fs::read_to_string(repo.join("README.md")).unwrap();
+        assert_eq!(readme, "hello world\n");
+        assert!(repo.join("new.txt").exists());
+
+        // Commit tree must contain both changes.
+        let tree_readme =
+            git_output(&repo_str, &["show", &format!("{commit}:README.md")], None).unwrap();
+        assert_eq!(tree_readme, "hello world");
+        let tree_new =
+            git_output(&repo_str, &["show", &format!("{commit}:new.txt")], None).unwrap();
+        assert_eq!(tree_new, "brand new");
+    }
+
+    #[test]
+    fn restore_file_reverts_modification() {
+        let dir = init_repo();
+        let repo = dir.path();
+        let repo_str = repo.to_string_lossy().to_string();
+
+        let commit = capture_working_tree_commit(&repo_str, "before").unwrap();
+        std::fs::write(repo.join("README.md"), "mutated\n").unwrap();
+
+        // Simulate restore via checkout from commit.
+        git_output(&repo_str, &["checkout", &commit, "--", "README.md"], None).unwrap();
+        let content = std::fs::read_to_string(repo.join("README.md")).unwrap();
+        assert_eq!(content, "hello\n");
+    }
+
+    #[test]
+    fn restore_path_rejects_paths_outside_worktree() {
+        let dir = init_repo();
+        let repo = dir.path();
+
+        assert!(validated_restore_path(repo, Path::new("../outside.txt")).is_err());
+        assert!(validated_restore_path(repo, Path::new("/tmp/outside.txt")).is_err());
+        assert!(validated_restore_path(repo, Path::new("./README.md")).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restore_path_rejects_symlinks_outside_worktree() {
+        use std::os::unix::fs::symlink;
+
+        let dir = init_repo();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), dir.path().join("outside-link")).unwrap();
+
+        assert!(
+            validated_restore_path(dir.path(), Path::new("outside-link")).is_err(),
+            "a symlink resolving outside the worktree must be rejected"
+        );
+    }
+
+    #[test]
+    fn restore_full_tree_removes_new_files() {
+        let dir = init_repo();
+        let repo = dir.path();
+        let repo_str = repo.to_string_lossy().to_string();
+
+        let commit = capture_working_tree_commit(&repo_str, "before").unwrap();
+        std::fs::write(repo.join("README.md"), "mutated\n").unwrap();
+        std::fs::write(repo.join("extra.rs"), "fn x() {}\n").unwrap();
+
+        git_output(&repo_str, &["read-tree", "-u", "--reset", &commit], None).unwrap();
+        let _ = git_output(&repo_str, &["clean", "-fd"], None);
+
+        let content = std::fs::read_to_string(repo.join("README.md")).unwrap();
+        assert_eq!(content, "hello\n");
+        assert!(!repo.join("extra.rs").exists());
+    }
+
+    #[test]
+    fn restore_full_tree_preserves_staged_and_unstaged_states() {
+        let dir = init_repo();
+        let repo = dir.path();
+        let repo_str = repo.to_string_lossy().to_string();
+
+        std::fs::write(repo.join("README.md"), "staged\n").unwrap();
+        run_git(repo, &["add", "README.md"]);
+        std::fs::write(repo.join("README.md"), "unstaged\n").unwrap();
+
+        let (working_commit, index_commit) =
+            capture_checkpoint_commits(&repo_str, "before").unwrap();
+
+        std::fs::write(repo.join("README.md"), "mutated\n").unwrap();
+        run_git(repo, &["add", "README.md"]);
+
+        restore_checkpoint_commits(&repo_str, &working_commit, &index_commit).unwrap();
+
+        let staged = git_output(&repo_str, &["diff", "--cached", "--", "README.md"], None).unwrap();
+        let unstaged = git_output(&repo_str, &["diff", "--", "README.md"], None).unwrap();
+        assert!(staged.contains("+staged"));
+        assert!(unstaged.contains("-staged"));
+        assert!(unstaged.contains("+unstaged"));
+        assert_eq!(
+            std::fs::read_to_string(repo.join("README.md")).unwrap(),
+            "unstaged\n"
+        );
+    }
+
+    #[test]
+    fn diff_detects_turn_changes() {
+        let dir = init_repo();
+        let repo = dir.path();
+        let repo_str = repo.to_string_lossy().to_string();
+
+        let start = capture_working_tree_commit(&repo_str, "start").unwrap();
+        std::fs::write(repo.join("README.md"), "changed by ai\n").unwrap();
+        std::fs::write(repo.join("ai-new.ts"), "export {}\n").unwrap();
+        let end = capture_working_tree_commit(&repo_str, "end").unwrap();
+
+        let diff = diff_commits(&repo_str, &start, Some(&end)).unwrap();
+        assert!(diff.total_additions > 0);
+        let paths: Vec<_> = diff.files.iter().map(|f| f.path.as_str()).collect();
+        assert!(paths.contains(&"README.md") || paths.iter().any(|p| p.contains("README")));
+        assert!(paths.iter().any(|p| p.contains("ai-new")));
+    }
+
+    #[test]
+    fn checkpoint_refs_protect_both_commits_and_are_deleted_together() {
+        let dir = init_repo();
+        let repo_str = dir.path().to_string_lossy().to_string();
+        let id = "checkpoint-id";
+        let start = capture_working_tree_commit(&repo_str, "start").unwrap();
+        let end = capture_working_tree_commit(&repo_str, "end").unwrap();
+
+        update_checkpoint_ref(&repo_str, id, CheckpointRefKind::Start, &start).unwrap();
+        update_checkpoint_ref(&repo_str, id, CheckpointRefKind::End, &end).unwrap();
+
+        assert_eq!(
+            git_output(
+                &repo_str,
+                &["rev-parse", &format!("refs/jean/checkpoints/{id}/start")],
+                None,
+            )
+            .unwrap(),
+            start
+        );
+        assert_eq!(
+            git_output(
+                &repo_str,
+                &["rev-parse", &format!("refs/jean/checkpoints/{id}/end")],
+                None,
+            )
+            .unwrap(),
+            end
+        );
+
+        delete_checkpoint_refs(&repo_str, id);
+        assert!(!git_ok(
+            &repo_str,
+            &["rev-parse", "--verify", &format!("refs/jean/checkpoints/{id}/start")],
+            None,
+        ));
+        assert!(!git_ok(
+            &repo_str,
+            &["rev-parse", "--verify", &format!("refs/jean/checkpoints/{id}/end")],
+            None,
+        ));
+    }
+
+    #[test]
+    fn truncate_preview_respects_char_limit() {
+        let short = truncate_preview("hello");
+        assert_eq!(short, "hello");
+        let long = "x".repeat(200);
+        let preview = truncate_preview(&long);
+        assert!(preview.ends_with('…'));
+        assert!(preview.chars().count() <= MESSAGE_PREVIEW_CHARS + 1);
+    }
+
+    #[test]
+    fn checkpoint_store_lock_is_shared_per_worktree() {
+        let first = checkpoint_store_lock("worktree-a");
+        let second = checkpoint_store_lock("worktree-a");
+        let other = checkpoint_store_lock("worktree-b");
+
+        assert!(std::sync::Arc::ptr_eq(&first, &second));
+        assert!(!std::sync::Arc::ptr_eq(&first, &other));
+    }
+}

--- a/jean-core/src/projects/commands.rs
+++ b/jean-core/src/projects/commands.rs
@@ -6403,12 +6403,8 @@ pub async fn detect_and_link_pr(
                 log::trace!(
                     "Filled missing PR URL for worktree {worktree_id} from PR #{pr_number}"
                 );
-                let _ = save_worktree_pr_link(
-                    &app,
-                    &worktree_id,
-                    response.pr_number,
-                    &response.pr_url,
-                );
+                let _ =
+                    save_worktree_pr_link(&app, &worktree_id, response.pr_number, &response.pr_url);
                 return Ok(Some(response));
             }
             log::trace!(

--- a/jean-core/src/projects/mod.rs
+++ b/jean-core/src/projects/mod.rs
@@ -1,3 +1,4 @@
+pub mod checkpoints;
 mod commands;
 pub mod git;
 pub mod git_log;
@@ -14,6 +15,10 @@ pub mod storage;
 pub mod types;
 
 // Re-export commands for registration in lib.rs
+pub use checkpoints::{
+    create_ai_checkpoint, delete_ai_checkpoint, finalize_ai_checkpoint, get_ai_checkpoint,
+    get_ai_checkpoint_diff, list_ai_checkpoints, restore_ai_checkpoint, restore_ai_checkpoint_file,
+};
 pub use commands::*;
 pub use github_actions::*;
 pub use github_issues::*;

--- a/src/components/chat/CheckpointsTabView.tsx
+++ b/src/components/chat/CheckpointsTabView.tsx
@@ -1,0 +1,609 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  AlertCircle,
+  History,
+  Loader2,
+  RotateCcw,
+  Trash2,
+  FileText,
+  ChevronRight,
+} from 'lucide-react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import {
+  parsePatchFiles,
+  type FileDiffMetadata,
+  type SelectedLineRange,
+} from '@pierre/diffs'
+import {
+  ResizablePanelGroup,
+  ResizablePanel,
+  ResizableHandle,
+} from '@/components/ui/resizable'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { getFilename } from '@/lib/path-utils'
+import { getFileLineStats } from '@/lib/diff-stats'
+import { useTheme } from '@/hooks/use-theme'
+import { usePreferences } from '@/services/preferences'
+import { triggerImmediateGitPoll } from '@/services/git-status'
+import {
+  checkpointQueryKeys,
+  deleteAiCheckpoint,
+  getAiCheckpointDiff,
+  listAiCheckpoints,
+  restoreAiCheckpoint,
+  restoreAiCheckpointFile,
+} from '@/services/checkpoints'
+import { MemoizedFileDiff, getStatusColor } from './MemoizedFileDiff'
+import type { AiCheckpoint } from '@/types/checkpoints'
+import type { GitDiff } from '@/types/git-diff'
+
+const NOOP_LINE_SELECTED = (_range: SelectedLineRange | null) => {}
+const NOOP_REMOVE_COMMENT = (_id: string) => {}
+const EMPTY_ANNOTATIONS: never[] = []
+
+function formatRelativeTime(unixSecs: number): string {
+  const diff = Date.now() - unixSecs * 1000
+  const seconds = Math.floor(diff / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return new Date(unixSecs * 1000).toLocaleDateString()
+}
+
+function statusLabel(status: AiCheckpoint['status']): string {
+  switch (status) {
+    case 'open':
+      return 'In progress'
+    case 'finalized':
+      return 'Ready'
+    case 'restored':
+      return 'Restored'
+    default:
+      return status
+  }
+}
+
+interface FlatFile {
+  key: string
+  fileName: string
+  fileDiff: FileDiffMetadata
+  additions: number
+  deletions: number
+}
+
+interface CheckpointsTabViewProps {
+  worktreeId: string
+  worktreePath: string
+  diffStyle: 'split' | 'unified'
+  /** Pre-select a checkpoint (e.g. from a message restore action). */
+  initialCheckpointId?: string | null
+}
+
+/**
+ * Browse AI change checkpoints for a worktree: view turn diffs, restore
+ * individual files, or restore the entire project to a prior snapshot.
+ */
+export function CheckpointsTabView({
+  worktreeId,
+  worktreePath,
+  diffStyle,
+  initialCheckpointId,
+}: CheckpointsTabViewProps) {
+  const queryClient = useQueryClient()
+  const { theme } = useTheme()
+  const { data: preferences } = usePreferences()
+  const [selectedId, setSelectedId] = useState<string | null>(
+    initialCheckpointId ?? null
+  )
+  const [diff, setDiff] = useState<GitDiff | null>(null)
+  const [diffLoading, setDiffLoading] = useState(false)
+  const [diffError, setDiffError] = useState<string | null>(null)
+  const [selectedFileIndex, setSelectedFileIndex] = useState(0)
+  const [restoreAllTarget, setRestoreAllTarget] = useState<AiCheckpoint | null>(
+    null
+  )
+  const [restoring, setRestoring] = useState(false)
+  const [restoringFile, setRestoringFile] = useState<string | null>(null)
+
+  const resolvedThemeType = useMemo((): 'dark' | 'light' => {
+    if (theme === 'system') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light'
+    }
+    return theme
+  }, [theme])
+
+  const {
+    data: checkpoints = [],
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: checkpointQueryKeys.worktree(worktreeId),
+    queryFn: () => listAiCheckpoints(worktreeId),
+    staleTime: 5_000,
+  })
+
+  useEffect(() => {
+    if (checkpoints.length === 0) {
+      setSelectedId(null)
+      return
+    }
+    if (selectedId && checkpoints.some(c => c.id === selectedId)) return
+    if (
+      initialCheckpointId &&
+      checkpoints.some(c => c.id === initialCheckpointId)
+    ) {
+      setSelectedId(initialCheckpointId)
+      return
+    }
+    setSelectedId(checkpoints[0]?.id ?? null)
+  }, [checkpoints, selectedId, initialCheckpointId])
+
+  const selected = useMemo(
+    () => checkpoints.find(c => c.id === selectedId) ?? null,
+    [checkpoints, selectedId]
+  )
+
+  const loadDiff = useCallback(
+    async (checkpoint: AiCheckpoint) => {
+      setDiffLoading(true)
+      setDiffError(null)
+      setSelectedFileIndex(0)
+      try {
+        const scope =
+          checkpoint.status === 'open' || !checkpoint.endCommit
+            ? 'current'
+            : 'turn'
+        const result = await getAiCheckpointDiff(
+          worktreeId,
+          checkpoint.id,
+          scope
+        )
+        setDiff(result)
+      } catch (e) {
+        setDiff(null)
+        setDiffError(String(e))
+      } finally {
+        setDiffLoading(false)
+      }
+    },
+    [worktreeId]
+  )
+
+  useEffect(() => {
+    if (selected) {
+      void loadDiff(selected)
+    } else {
+      setDiff(null)
+    }
+  }, [selected, loadDiff])
+
+  const flattenedFiles: FlatFile[] = useMemo(() => {
+    if (!diff?.raw_patch) return []
+    try {
+      const parsed = parsePatchFiles(diff.raw_patch)
+      return parsed.flatMap((patch, patchIndex) =>
+        patch.files.map((fileDiff, fileIndex) => {
+          const fileName = fileDiff.name || fileDiff.prevName || 'unknown'
+          const { additions, deletions } = getFileLineStats(
+            fileDiff,
+            diff.files
+          )
+          return {
+            key: `${patchIndex}-${fileIndex}`,
+            fileName,
+            fileDiff,
+            additions,
+            deletions,
+          }
+        })
+      )
+    } catch {
+      return []
+    }
+  }, [diff])
+
+  const selectedFile =
+    flattenedFiles.length > 0
+      ? flattenedFiles[
+          Math.min(selectedFileIndex, flattenedFiles.length - 1)
+        ]
+      : null
+
+  const handleRestoreAll = useCallback(async () => {
+    if (!restoreAllTarget) return
+    setRestoring(true)
+    try {
+      await restoreAiCheckpoint(worktreeId, restoreAllTarget.id)
+      toast.success('Project restored to checkpoint')
+      triggerImmediateGitPoll()
+      await queryClient.invalidateQueries({
+        queryKey: checkpointQueryKeys.worktree(worktreeId),
+      })
+      await loadDiff(restoreAllTarget)
+    } catch (e) {
+      toast.error(`Restore failed: ${e}`)
+    } finally {
+      setRestoring(false)
+      setRestoreAllTarget(null)
+    }
+  }, [restoreAllTarget, worktreeId, queryClient, loadDiff])
+
+  const handleRestoreFile = useCallback(
+    async (filePath: string) => {
+      if (!selected) return
+      setRestoringFile(filePath)
+      try {
+        await restoreAiCheckpointFile(worktreeId, selected.id, filePath)
+        toast.success(`Restored ${getFilename(filePath)}`)
+        triggerImmediateGitPoll()
+        await loadDiff(selected)
+      } catch (e) {
+        toast.error(`Restore failed: ${e}`)
+      } finally {
+        setRestoringFile(null)
+      }
+    },
+    [selected, worktreeId, loadDiff]
+  )
+
+  const handleDelete = useCallback(
+    async (checkpoint: AiCheckpoint) => {
+      try {
+        await deleteAiCheckpoint(worktreeId, checkpoint.id)
+        toast.success('Checkpoint deleted')
+        if (selectedId === checkpoint.id) setSelectedId(null)
+        await queryClient.invalidateQueries({
+          queryKey: checkpointQueryKeys.worktree(worktreeId),
+        })
+      } catch (e) {
+        toast.error(`Delete failed: ${e}`)
+      }
+    },
+    [worktreeId, selectedId, queryClient]
+  )
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading checkpoints…
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+        <AlertCircle className="h-5 w-5 text-destructive" />
+        <span>Failed to load checkpoints</span>
+        <Button size="sm" variant="outline" onClick={() => void refetch()}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  if (checkpoints.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center text-sm text-muted-foreground">
+        <History className="h-8 w-8 opacity-40" />
+        <p className="font-medium text-foreground">No AI checkpoints yet</p>
+        <p className="max-w-sm text-xs">
+          Jean automatically snapshots this worktree before each agent turn so
+          you can review AI changes and restore any previous state.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <ResizablePanelGroup
+        direction="horizontal"
+        className="flex-1 min-h-0 mt-2"
+      >
+        <ResizablePanel defaultSize={28} minSize={18} maxSize={45}>
+          <div className="flex h-full flex-col border-r border-border">
+            <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-xs font-medium text-muted-foreground">
+              <History className="h-3.5 w-3.5" />
+              AI Checkpoints
+              <span className="ml-auto tabular-nums">{checkpoints.length}</span>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {checkpoints.map(cp => {
+                const isActive = cp.id === selectedId
+                const fileCount =
+                  cp.filesChanged.length > 0
+                    ? cp.filesChanged.length
+                    : undefined
+                return (
+                  <button
+                    key={cp.id}
+                    type="button"
+                    onClick={() => setSelectedId(cp.id)}
+                    className={cn(
+                      'flex w-full flex-col gap-1 border-b border-border/50 px-3 py-2.5 text-left transition-colors',
+                      isActive ? 'bg-accent/60' : 'hover:bg-muted/50'
+                    )}
+                  >
+                    <div className="flex items-start gap-2">
+                      <ChevronRight
+                        className={cn(
+                          'mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
+                          isActive && 'rotate-90 text-foreground'
+                        )}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <p className="line-clamp-2 text-xs font-medium leading-snug">
+                          {cp.userMessagePreview || 'Agent turn'}
+                        </p>
+                        <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] text-muted-foreground">
+                          <span>{formatRelativeTime(cp.createdAt)}</span>
+                          <span className="opacity-50">·</span>
+                          <span>{statusLabel(cp.status)}</span>
+                          {fileCount != null && (
+                            <>
+                              <span className="opacity-50">·</span>
+                              <span>
+                                {fileCount} file{fileCount === 1 ? '' : 's'}
+                              </span>
+                            </>
+                          )}
+                          {(cp.totalAdditions > 0 ||
+                            cp.totalDeletions > 0) && (
+                            <>
+                              <span className="text-green-500">
+                                +{cp.totalAdditions}
+                              </span>
+                              <span className="text-red-500">
+                                -{cp.totalDeletions}
+                              </span>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        </ResizablePanel>
+
+        <ResizableHandle withHandle />
+
+        <ResizablePanel defaultSize={72} minSize={40}>
+          <div className="flex h-full min-h-0 flex-col">
+            {selected && (
+              <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-xs font-medium">
+                    {selected.userMessagePreview || 'Agent turn'}
+                  </p>
+                  <p className="text-[10px] text-muted-foreground">
+                    Snapshot {selected.startCommit.slice(0, 7)}
+                    {selected.endCommit
+                      ? ` → ${selected.endCommit.slice(0, 7)}`
+                      : ' → working tree'}
+                    {' · '}
+                    {worktreePath.split('/').pop()}
+                  </p>
+                </div>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-7 gap-1.5 text-xs"
+                      onClick={() => setRestoreAllTarget(selected)}
+                    >
+                      <RotateCcw className="h-3.5 w-3.5" />
+                      Restore all
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Reset the entire worktree to this checkpoint
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 w-7 p-0 text-muted-foreground"
+                      onClick={() => void handleDelete(selected)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Delete checkpoint</TooltipContent>
+                </Tooltip>
+              </div>
+            )}
+
+            {diffLoading ? (
+              <div className="flex flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading diff…
+              </div>
+            ) : diffError ? (
+              <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+                <AlertCircle className="h-5 w-5 text-destructive" />
+                {diffError}
+              </div>
+            ) : flattenedFiles.length === 0 ? (
+              <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+                <FileText className="h-6 w-6 opacity-40" />
+                No file changes in this checkpoint
+              </div>
+            ) : (
+              <ResizablePanelGroup
+                direction="horizontal"
+                className="min-h-0 flex-1"
+              >
+                <ResizablePanel defaultSize={30} minSize={18} maxSize={50}>
+                  <div className="h-full overflow-y-auto border-r border-border">
+                    {flattenedFiles.map((file, idx) => (
+                      <div
+                        key={file.key}
+                        className={cn(
+                          'flex items-center gap-1 border-b border-border/40 px-2 py-1.5 text-xs',
+                          idx === selectedFileIndex
+                            ? 'bg-accent/50'
+                            : 'hover:bg-muted/40'
+                        )}
+                      >
+                        <button
+                          type="button"
+                          className="min-w-0 flex-1 truncate text-left font-mono"
+                          onClick={() => setSelectedFileIndex(idx)}
+                        >
+                          <FileText
+                            className={cn(
+                              'mr-1.5 inline h-3 w-3',
+                              getStatusColor(file.fileDiff.type)
+                            )}
+                          />
+                          {getFilename(file.fileName)}
+                          {(file.additions > 0 || file.deletions > 0) && (
+                            <span className="ml-1.5 font-sans text-[10px] text-muted-foreground">
+                              <span className="text-green-500">
+                                +{file.additions}
+                              </span>
+                              <span className="mx-0.5">/</span>
+                              <span className="text-red-500">
+                                -{file.deletions}
+                              </span>
+                            </span>
+                          )}
+                        </button>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+                              disabled={restoringFile === file.fileName}
+                              onClick={() =>
+                                void handleRestoreFile(file.fileName)
+                              }
+                              aria-label={`Restore ${file.fileName}`}
+                            >
+                              {restoringFile === file.fileName ? (
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                              ) : (
+                                <RotateCcw className="h-3 w-3" />
+                              )}
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            Restore this file from checkpoint
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                    ))}
+                  </div>
+                </ResizablePanel>
+                <ResizableHandle withHandle />
+                <ResizablePanel defaultSize={70} minSize={40}>
+                  <div className="h-full min-w-0 overflow-y-auto">
+                    {selectedFile ? (
+                      <div className="px-2">
+                        <MemoizedFileDiff
+                          key={selectedFile.key}
+                          fileDiff={selectedFile.fileDiff}
+                          fileName={selectedFile.fileName}
+                          annotations={EMPTY_ANNOTATIONS}
+                          selectedLines={null}
+                          themeType={resolvedThemeType}
+                          syntaxThemeDark={
+                            preferences?.syntax_theme_dark ?? 'vitesse-black'
+                          }
+                          syntaxThemeLight={
+                            preferences?.syntax_theme_light ?? 'github-light'
+                          }
+                          diffStyle={diffStyle}
+                          enableLineSelection={false}
+                          onLineSelected={NOOP_LINE_SELECTED}
+                          onRemoveComment={NOOP_REMOVE_COMMENT}
+                        />
+                      </div>
+                    ) : (
+                      <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+                        Select a file
+                      </div>
+                    )}
+                  </div>
+                </ResizablePanel>
+              </ResizablePanelGroup>
+            )}
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+
+      <AlertDialog
+        open={!!restoreAllTarget}
+        onOpenChange={open => !open && setRestoreAllTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Restore entire project?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This resets the worktree to the state before this AI turn. All
+              later uncommitted changes will be lost (including files created
+              after the checkpoint).
+              {restoreAllTarget?.userMessagePreview && (
+                <span className="mt-2 block font-medium text-foreground">
+                  “{restoreAllTarget.userMessagePreview}”
+                </span>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={restoring}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={e => {
+                e.preventDefault()
+                void handleRestoreAll()
+              }}
+              disabled={restoring}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {restoring ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Restoring…
+                </>
+              ) : (
+                'Restore all'
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/src/components/chat/EditedFilesDisplay.tsx
+++ b/src/components/chat/EditedFilesDisplay.tsx
@@ -1,5 +1,6 @@
-import { memo, useMemo, useState } from 'react'
+import { memo, useCallback, useMemo, useState } from 'react'
 import { diffLines } from 'diff'
+import { History } from 'lucide-react'
 import type { ToolCall, ChatMessage } from '@/types/chat'
 import { Badge } from '@/components/ui/badge'
 import { getFilename } from '@/lib/path-utils'
@@ -99,6 +100,14 @@ export const EditedFilesDisplay = memo(function EditedFilesDisplay({
   messageIndex,
 }: EditedFilesDisplayProps) {
   const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null)
+
+  const openCheckpoints = useCallback(() => {
+    window.dispatchEvent(
+      new CustomEvent('open-git-diff', {
+        detail: { type: 'checkpoints' },
+      })
+    )
+  }, [])
 
   const editTools = useMemo(
     () => (toolCalls ?? []).filter(isEditTool),
@@ -213,6 +222,23 @@ export const EditedFilesDisplay = memo(function EditedFilesDisplay({
           </Tooltip>
         )
       })}
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={openCheckpoints}
+            aria-label="Open AI checkpoints"
+            className="inline-flex items-center gap-1 rounded-md border border-border/60 px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <History className="h-3 w-3" />
+            Checkpoints
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          Browse AI checkpoints — view and restore pre-turn snapshots
+        </TooltipContent>
+      </Tooltip>
 
       {selectedFilePath && (
         <MessageDiffModal

--- a/src/components/chat/GitDiffModal.tsx
+++ b/src/components/chat/GitDiffModal.tsx
@@ -16,6 +16,7 @@ import {
   Rows3,
   GitBranch,
   GitCommitHorizontal,
+  History,
   MessageSquarePlus,
   Pencil,
   X,
@@ -83,6 +84,7 @@ import { useUIStore } from '@/store/ui-store'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { usePreferences } from '@/services/preferences'
 import { CommitsTabView } from './CommitsTabView'
+import { CheckpointsTabView } from './CheckpointsTabView'
 import {
   MemoizedFileDiff,
   getStatusColor,
@@ -200,12 +202,13 @@ interface GitDiffModalProps {
 }
 
 type DiffStyle = 'split' | 'unified'
-type DiffType = 'uncommitted' | 'branch' | 'commits'
+type DiffType = 'uncommitted' | 'branch' | 'commits' | 'checkpoints'
 
 const DIFF_TYPE_SHORTCUTS: Record<DiffType, string> = {
   uncommitted: '1',
   branch: '2',
   commits: '3',
+  checkpoints: '4',
 }
 
 const COMMIT_SHORTCUT_LABEL = '⌘↵'
@@ -244,9 +247,11 @@ export function GitDiffModal({
   const [diffStyle, setDiffStyle] = useState<DiffStyle>(
     window.innerWidth < 768 ? 'unified' : 'split'
   )
-  const [activeDiffType, setActiveDiffType] = useState<DiffType>(
-    diffRequest?.type ?? 'uncommitted'
-  )
+  const [activeDiffType, setActiveDiffType] = useState<DiffType>(() => {
+    if (diffRequest?.type === 'checkpoints') return 'checkpoints'
+    if (diffRequest?.type === 'branch') return 'branch'
+    return 'uncommitted'
+  })
   const dialogContentRef = useRef<HTMLDivElement>(null)
   const { theme } = useTheme()
   const isMobile = useIsMobile()
@@ -312,6 +317,9 @@ export function GitDiffModal({
 
   const loadDiff = useCallback(
     async (request: DiffRequest, isRefresh = false) => {
+      if (request.type !== 'uncommitted' && request.type !== 'branch') {
+        return
+      }
       setIsLoading(true)
       setError(null)
       // Only clear diff on initial load, not on refresh
@@ -424,7 +432,7 @@ export function GitDiffModal({
         revertTarget.fileStatus
       )
       // Refresh diff to reflect reverted file (revert only available in diff tabs)
-      if (activeDiffType !== 'commits') {
+      if (activeDiffType === 'uncommitted' || activeDiffType === 'branch') {
         await loadDiff({ ...diffRequest, type: activeDiffType }, true)
       }
     } catch (err) {
@@ -439,8 +447,16 @@ export function GitDiffModal({
 
   useEffect(() => {
     if (diffRequest) {
-      setActiveDiffType(diffRequest.type)
-      loadDiff(diffRequest)
+      const nextType: DiffType =
+        diffRequest.type === 'checkpoints'
+          ? 'checkpoints'
+          : diffRequest.type === 'branch'
+            ? 'branch'
+            : 'uncommitted'
+      setActiveDiffType(nextType)
+      if (nextType !== 'checkpoints') {
+        loadDiff({ ...diffRequest, type: nextType })
+      }
       // Reset to first file when opening/reloading
       setSelectedFileIndex(0)
     } else {
@@ -925,9 +941,8 @@ export function GitDiffModal({
   }, [diffRequest, activeDiffType, loadDiff])
 
   // Show switcher whenever both diff contexts are available, even when counts are zero.
-  const hasUncommitted = uncommittedStats !== undefined
-  const hasBranchDiff = branchStats !== undefined
-  const showSwitcher = hasUncommitted && hasBranchDiff
+  // Always show the tab switcher so Commits / AI Checkpoints remain reachable.
+  const showSwitcher = !!diffRequest
   // Prefer cached stats (from loaded diff) over polling stats for consistency across tab switches
   const uncommittedAdded =
     cachedUncommittedStats?.added ?? uncommittedStats?.added ?? 0
@@ -946,8 +961,8 @@ export function GitDiffModal({
       setSelectedRange(null)
       setShowCommentInput(false)
       useUIStore.getState().clearGitDiffSelectedFiles()
-      // Commits tab manages its own data — only call loadDiff for diff tabs
-      if (type !== 'commits') {
+      // Commits / checkpoints tabs manage their own data — only loadDiff for git tabs
+      if (type !== 'commits' && type !== 'checkpoints') {
         loadDiff({ ...diffRequest, type }, false)
       }
     },
@@ -979,7 +994,9 @@ export function GitDiffModal({
             ? 'branch'
             : e.code === 'Digit3' || e.code === 'Numpad3'
               ? 'commits'
-              : null
+              : e.code === 'Digit4' || e.code === 'Numpad4'
+                ? 'checkpoints'
+                : null
 
       if (!shortcutType) return
 
@@ -1091,6 +1108,22 @@ export function GitDiffModal({
                     <span className="hidden sm:inline">Commits</span>
                     <Kbd className="hidden h-4 min-w-4 px-1 text-[10px] opacity-70 sm:inline-flex">
                       {DIFF_TYPE_SHORTCUTS.commits}
+                    </Kbd>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleSwitchDiffType('checkpoints')}
+                    className={cn(
+                      'flex flex-1 items-center justify-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium transition-colors sm:flex-none sm:shrink-0 sm:px-3',
+                      activeDiffType === 'checkpoints'
+                        ? 'bg-background shadow-sm text-foreground'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    <History className="h-3.5 w-3.5 shrink-0" />
+                    <span className="hidden sm:inline">Checkpoints</span>
+                    <Kbd className="hidden h-4 min-w-4 px-1 text-[10px] opacity-70 sm:inline-flex">
+                      {DIFF_TYPE_SHORTCUTS.checkpoints}
                     </Kbd>
                   </button>
                 </div>
@@ -1217,10 +1250,19 @@ export function GitDiffModal({
                     size="icon"
                     className="h-7 w-7 shrink-0 p-0"
                     onClick={() => {
-                      if (!diffRequest || activeDiffType === 'commits') return
+                      if (
+                        !diffRequest ||
+                        activeDiffType === 'commits' ||
+                        activeDiffType === 'checkpoints'
+                      )
+                        return
                       loadDiff({ ...diffRequest, type: activeDiffType }, true)
                     }}
-                    disabled={isLoading || activeDiffType === 'commits'}
+                    disabled={
+                      isLoading ||
+                      activeDiffType === 'commits' ||
+                      activeDiffType === 'checkpoints'
+                    }
                   >
                     <RefreshCw
                       className={cn('h-4 w-4', isLoading && 'animate-spin')}
@@ -1247,8 +1289,27 @@ export function GitDiffModal({
             />
           )}
 
+          {/* AI Checkpoints tab */}
+          {activeDiffType === 'checkpoints' &&
+            diffRequest?.worktreeId && (
+              <CheckpointsTabView
+                worktreeId={diffRequest.worktreeId}
+                worktreePath={diffRequest.worktreePath}
+                diffStyle={diffStyle}
+                initialCheckpointId={diffRequest.checkpointId}
+              />
+            )}
+          {activeDiffType === 'checkpoints' &&
+            diffRequest &&
+            !diffRequest.worktreeId && (
+              <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+                Worktree id unavailable — open diffs from a worktree session.
+              </div>
+            )}
+
           {/* Diff tabs body (Uncommitted / Branch) */}
-          {activeDiffType !== 'commits' && (
+          {activeDiffType !== 'commits' &&
+            activeDiffType !== 'checkpoints' && (
             <>
               {/* Comment bar - above sidebar and main content */}
               {hasFiles && (

--- a/src/components/chat/hooks/useChatWindowEvents.ts
+++ b/src/components/chat/hooks/useChatWindowEvents.ts
@@ -8,6 +8,7 @@ import { useTerminalStore } from '@/store/terminal-store'
 import { cancelChatMessage } from '@/services/chat'
 import { logger } from '@/lib/logger'
 import type { ContentBlock, QueuedMessage, Session } from '@/types/chat'
+import type { DiffRequest } from '@/types/git-diff'
 
 interface UseChatWindowEventsParams {
   inputRef: RefObject<HTMLTextAreaElement | null>
@@ -25,23 +26,9 @@ interface UseChatWindowEventsParams {
   gitStatus: { base_branch?: string; base_remote?: string } | null | undefined
   setDiffRequest: (
     req:
-      | {
-          type: 'uncommitted' | 'branch'
-          worktreePath: string
-          baseBranch: string
-        }
+      | DiffRequest
       | null
-      | ((
-          prev: {
-            type: 'uncommitted' | 'branch'
-            worktreePath: string
-            baseBranch: string
-          } | null
-        ) => {
-          type: 'uncommitted' | 'branch'
-          worktreePath: string
-          baseBranch: string
-        } | null)
+      | ((prev: DiffRequest | null) => DiffRequest | null)
   ) => void
   // Auto-scroll
   isAtBottom: boolean
@@ -262,6 +249,7 @@ export function useChatWindowEvents({
       const requestedType = (e as CustomEvent).detail?.type as
         | 'uncommitted'
         | 'branch'
+        | 'checkpoints'
         | undefined
 
       setDiffRequest(prev => {
@@ -270,20 +258,29 @@ export function useChatWindowEvents({
           return {
             type: requestedType,
             worktreePath: activeWorktreePath,
+            worktreeId: activeWorktreeId ?? undefined,
             baseBranch,
             baseRemote,
           }
         }
         if (prev) {
           // CMD+G toggle between types
+          const nextType =
+            prev.type === 'uncommitted'
+              ? 'branch'
+              : prev.type === 'branch'
+                ? 'uncommitted'
+                : 'uncommitted'
           return {
             ...prev,
-            type: prev.type === 'uncommitted' ? 'branch' : 'uncommitted',
+            worktreeId: prev.worktreeId ?? activeWorktreeId ?? undefined,
+            type: nextType,
           }
         }
         return {
           type: 'uncommitted',
           worktreePath: activeWorktreePath,
+          worktreeId: activeWorktreeId ?? undefined,
           baseBranch,
           baseRemote,
         }
@@ -293,6 +290,7 @@ export function useChatWindowEvents({
     return () => window.removeEventListener('open-git-diff', handler)
   }, [
     activeWorktreePath,
+    activeWorktreeId,
     gitStatus?.base_branch,
     gitStatus?.base_remote,
     setDiffRequest,

--- a/src/components/dashboard/ProjectCanvasView.diff-request.test.ts
+++ b/src/components/dashboard/ProjectCanvasView.diff-request.test.ts
@@ -5,6 +5,7 @@ import { getCanvasDiffRequest } from './canvas-diff-request'
 describe('getCanvasDiffRequest', () => {
   it('uses the worktree base branch and remote', () => {
     const worktree = {
+      id: 'wt-1',
       path: '/tmp/worktree',
       base_branch: 'release',
       base_remote: 'fork',
@@ -13,6 +14,7 @@ describe('getCanvasDiffRequest', () => {
     expect(getCanvasDiffRequest(worktree, 'main', 'branch')).toEqual({
       type: 'branch',
       worktreePath: '/tmp/worktree',
+      worktreeId: worktree.id,
       baseBranch: 'release',
       baseRemote: 'fork',
     })

--- a/src/components/dashboard/canvas-diff-request.ts
+++ b/src/components/dashboard/canvas-diff-request.ts
@@ -9,6 +9,7 @@ export function getCanvasDiffRequest(
   return {
     type,
     worktreePath: worktree.path,
+    worktreeId: worktree.id,
     baseBranch: worktree.base_branch ?? defaultBranch,
     baseRemote: worktree.base_remote,
   }

--- a/src/services/checkpoints.ts
+++ b/src/services/checkpoints.ts
@@ -1,0 +1,91 @@
+import { invoke } from '@/lib/transport'
+import type {
+  AiCheckpoint,
+  CheckpointDiffScope,
+} from '@/types/checkpoints'
+import type { GitDiff } from '@/types/git-diff'
+
+export const checkpointQueryKeys = {
+  all: ['ai-checkpoints'] as const,
+  worktree: (worktreeId: string) =>
+    [...checkpointQueryKeys.all, worktreeId] as const,
+  detail: (worktreeId: string, checkpointId: string) =>
+    [...checkpointQueryKeys.worktree(worktreeId), checkpointId] as const,
+  diff: (
+    worktreeId: string,
+    checkpointId: string,
+    scope: CheckpointDiffScope = 'current'
+  ) =>
+    [
+      ...checkpointQueryKeys.detail(worktreeId, checkpointId),
+      'diff',
+      scope,
+    ] as const,
+}
+
+export async function listAiCheckpoints(
+  worktreeId: string
+): Promise<AiCheckpoint[]> {
+  return invoke<AiCheckpoint[]>('list_ai_checkpoints', { worktreeId })
+}
+
+export async function getAiCheckpoint(
+  worktreeId: string,
+  checkpointId: string
+): Promise<AiCheckpoint> {
+  return invoke<AiCheckpoint>('get_ai_checkpoint', {
+    worktreeId,
+    checkpointId,
+  })
+}
+
+export async function getAiCheckpointDiff(
+  worktreeId: string,
+  checkpointId: string,
+  scope: CheckpointDiffScope = 'current'
+): Promise<GitDiff> {
+  return invoke<GitDiff>('get_ai_checkpoint_diff', {
+    worktreeId,
+    checkpointId,
+    scope,
+  })
+}
+
+export async function restoreAiCheckpoint(
+  worktreeId: string,
+  checkpointId: string
+): Promise<AiCheckpoint> {
+  return invoke<AiCheckpoint>('restore_ai_checkpoint', {
+    worktreeId,
+    checkpointId,
+  })
+}
+
+export async function restoreAiCheckpointFile(
+  worktreeId: string,
+  checkpointId: string,
+  filePath: string
+): Promise<void> {
+  return invoke('restore_ai_checkpoint_file', {
+    worktreeId,
+    checkpointId,
+    filePath,
+  })
+}
+
+export async function deleteAiCheckpoint(
+  worktreeId: string,
+  checkpointId: string
+): Promise<void> {
+  return invoke('delete_ai_checkpoint', { worktreeId, checkpointId })
+}
+
+export async function finalizeAiCheckpoint(
+  worktreeId: string,
+  checkpointId: string
+): Promise<AiCheckpoint> {
+  return invoke<AiCheckpoint>('finalize_ai_checkpoint', {
+    worktreeId,
+    checkpointId,
+  })
+}

--- a/src/types/checkpoints.ts
+++ b/src/types/checkpoints.ts
@@ -1,0 +1,35 @@
+/**
+ * AI change checkpoints — snapshots of the worktree taken before each agent turn.
+ */
+
+export type CheckpointStatus = 'open' | 'finalized' | 'restored'
+
+export interface CheckpointFileSummary {
+  path: string
+  /** "added" | "modified" | "deleted" | "renamed" */
+  status: string
+  additions: number
+  deletions: number
+}
+
+export interface AiCheckpoint {
+  id: string
+  worktreeId: string
+  sessionId: string
+  runId?: string | null
+  userMessageId?: string | null
+  userMessagePreview: string
+  createdAt: number
+  finalizedAt?: number | null
+  startCommit: string
+  endCommit?: string | null
+  headCommit?: string | null
+  worktreePath: string
+  status: CheckpointStatus
+  filesChanged: CheckpointFileSummary[]
+  totalAdditions: number
+  totalDeletions: number
+}
+
+/** Diff scope for get_ai_checkpoint_diff */
+export type CheckpointDiffScope = 'current' | 'turn'

--- a/src/types/git-diff.ts
+++ b/src/types/git-diff.ts
@@ -93,9 +93,13 @@ export interface GitDiff {
 
 /** Request to open the diff modal */
 export interface DiffRequest {
-  type: 'uncommitted' | 'branch'
+  type: 'uncommitted' | 'branch' | 'checkpoints'
   worktreePath: string
   baseBranch: string
   /** Remote the base branch lives on, when it isn't origin */
   baseRemote?: string
+  /** Worktree id — required for AI checkpoints tab */
+  worktreeId?: string
+  /** Optional checkpoint to pre-select when opening the checkpoints tab */
+  checkpointId?: string
 }


### PR DESCRIPTION
## Summary

- Automatically snapshot each worktree before an AI agent turn so users can review and undo AI file changes (closes #407)
- Capture start/end trees via git commit objects without touching HEAD, with metadata and refs for history
- Support listing, diffing (turn or current), full restore, single-file restore, and delete
- Add Checkpoints tab in the Git Diff modal plus a Checkpoints entry point from assistant edited-files rows
- Document the flow, commands, and constraints for developers

## Breaking Changes

None.

---

Fixes #407