### PR TITLE
fix(keybindings): let Ctrl+T reach terminal on macOS

### DIFF
--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -23,6 +23,7 @@ import { usePreferences } from '@/services/preferences'
 import { logger } from '@/lib/logger'
 import {
   eventToShortcutString,
+  isModKeyEvent,
   DEFAULT_KEYBINDINGS,
   type KeybindingAction,
   type KeybindingsMap,
@@ -823,7 +824,7 @@ export function useMainWindowEventListeners() {
           const digit = digitMatch?.[1] ? parseInt(digitMatch[1], 10) : NaN
 
           if (
-            (e.metaKey || e.ctrlKey) &&
+            isModKeyEvent(e) &&
             !e.shiftKey &&
             !e.altKey &&
             digit >= 1 &&
@@ -861,8 +862,9 @@ export function useMainWindowEventListeners() {
         }
       }
 
-      // CMD/Ctrl+1–9: switch session tabs (when modal open), dashboard tabs, or worktree by index
-      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
+      // Mod+1–9: switch session tabs (when modal open), dashboard tabs, or worktree by index
+      // Use platform mod (Cmd on macOS native, Ctrl elsewhere) so Ctrl+digit reaches terminals.
+      if (isModKeyEvent(e) && !e.shiftKey && !e.altKey) {
         // Use e.code (physical key) since e.key can vary with CMD held on macOS
         const digitMatch = e.code.match(/^Digit(\d)$/)
         const digit = digitMatch?.[1] ? parseInt(digitMatch[1], 10) : NaN

--- a/src/lib/terminal-instances.ts
+++ b/src/lib/terminal-instances.ts
@@ -29,6 +29,7 @@ import { listen } from '@/lib/transport'
 import { queryClient } from '@/lib/query-client'
 import { preferencesQueryKeys } from '@/services/preferences'
 import { isPanelTerminal, useTerminalStore } from '@/store/terminal-store'
+import { isModKeyEvent } from '@/types/keybindings'
 import {
   defaultPreferences,
   type AppPreferences,
@@ -526,6 +527,7 @@ function getThemeFromCss(): ResolvedTerminalTheme {
 }
 
 function shouldLetAppHandleShortcut(event: KeyboardEvent): boolean {
+  // Mod+Shift+Escape: unfocus terminal (platform mod, or either key as escape hatch)
   if (
     (event.metaKey || event.ctrlKey) &&
     event.shiftKey &&
@@ -543,19 +545,22 @@ function shouldLetAppHandleShortcut(event: KeyboardEvent): boolean {
     return false
   }
 
-  if (!event.metaKey) return false
+  // Only the platform primary mod (Cmd on macOS native, Ctrl elsewhere) is
+  // reserved for app shortcuts. Control on macOS native must reach the PTY
+  // (issue #615: Ctrl+T must not open a new terminal tab).
+  if (!isModKeyEvent(event)) return false
   const code = event.code
-  // CMD+` → toggle terminal panel
+  // Mod+` → toggle terminal panel
   if (code === 'Backquote') return true
-  // CMD+T → new terminal tab
+  // Mod+T → new terminal tab
   if (!event.shiftKey && !event.altKey && code === 'KeyT') return true
-  // CMD+W → close terminal tab
+  // Mod+W → close terminal tab
   if (!event.shiftKey && !event.altKey && code === 'KeyW') return true
-  // CMD+1..9 → switch terminal tab
+  // Mod+1..9 → switch terminal tab
   if (!event.shiftKey && !event.altKey && /^Digit[1-9]$/.test(code)) {
     return true
   }
-  // CMD+Alt+Backspace → cancel prompt
+  // Mod+Alt+Backspace → cancel prompt
   return event.altKey && (code === 'Backspace' || code === 'Delete')
 }
 

--- a/src/types/keybindings.test.ts
+++ b/src/types/keybindings.test.ts
@@ -1,9 +1,32 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   DEFAULT_KEYBINDINGS,
   eventToShortcutString,
+  isModKeyEvent,
   KEYBINDING_DEFINITIONS,
 } from '@/types/keybindings'
+
+const environmentMocks = vi.hoisted(() => ({
+  isNativeApp: false,
+}))
+
+const platformMocks = vi.hoisted(() => ({
+  isClientMacOS: false,
+}))
+
+vi.mock('@/lib/environment', () => ({
+  isNativeApp: () => environmentMocks.isNativeApp,
+}))
+
+vi.mock('@/lib/platform', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/platform')>()
+  return {
+    ...actual,
+    get isClientMacOS() {
+      return platformMocks.isClientMacOS
+    },
+  }
+})
 
 function keyboardKey(token: string): { key: string; code: string } {
   if (/^[a-z]$/.test(token)) {
@@ -27,7 +50,19 @@ function keyboardKey(token: string): { key: string; code: string } {
   return result
 }
 
+function setPlatform(options: {
+  isClientMacOS: boolean
+  isNativeApp: boolean
+}) {
+  platformMocks.isClientMacOS = options.isClientMacOS
+  environmentMocks.isNativeApp = options.isNativeApp
+}
+
 describe('eventToShortcutString', () => {
+  afterEach(() => {
+    setPlatform({ isClientMacOS: false, isNativeApp: false })
+  })
+
   it('maps alt-modified letter keys using physical key code', () => {
     const modelEvent = new KeyboardEvent('keydown', {
       key: 'µ',
@@ -67,7 +102,7 @@ describe('eventToShortcutString', () => {
     const deleteEvent = new KeyboardEvent('keydown', {
       key: 'Delete',
       code: 'Delete',
-      metaKey: true,
+      ctrlKey: true,
       altKey: true,
     })
 
@@ -84,7 +119,37 @@ describe('eventToShortcutString', () => {
     expect(eventToShortcutString(altOnlyEvent)).toBeNull()
   })
 
-  it('matches every default mod shortcut with either Command or Control', () => {
+  it('matches every default mod shortcut with the platform mod key (Ctrl on non-mac)', () => {
+    setPlatform({ isClientMacOS: false, isNativeApp: false })
+
+    for (const shortcut of Object.values(DEFAULT_KEYBINDINGS)) {
+      const parts = shortcut.split('+')
+      if (!parts.includes('mod')) continue
+
+      const keyToken = parts.at(-1)
+      if (!keyToken) throw new Error(`Missing key in ${shortcut}`)
+      const key = keyboardKey(keyToken)
+      const modifiers = {
+        shiftKey: parts.includes('shift'),
+        altKey: parts.includes('alt'),
+      }
+
+      expect(
+        eventToShortcutString(
+          new KeyboardEvent('keydown', {
+            ...key,
+            ...modifiers,
+            ctrlKey: true,
+          })
+        ),
+        `Control should match ${shortcut}`
+      ).toBe(shortcut)
+    }
+  })
+
+  it('matches every default mod shortcut with Command on macOS native', () => {
+    setPlatform({ isClientMacOS: true, isNativeApp: true })
+
     for (const shortcut of Object.values(DEFAULT_KEYBINDINGS)) {
       const parts = shortcut.split('+')
       if (!parts.includes('mod')) continue
@@ -107,17 +172,50 @@ describe('eventToShortcutString', () => {
         ),
         `Command should match ${shortcut}`
       ).toBe(shortcut)
-      expect(
-        eventToShortcutString(
-          new KeyboardEvent('keydown', {
-            ...key,
-            ...modifiers,
-            ctrlKey: true,
-          })
-        ),
-        `Control should match ${shortcut}`
-      ).toBe(shortcut)
     }
+  })
+
+  it('does not treat Control as mod on macOS native so Ctrl+T reaches the terminal (issue #615)', () => {
+    setPlatform({ isClientMacOS: true, isNativeApp: true })
+
+    const ctrlT = new KeyboardEvent('keydown', {
+      key: 't',
+      code: 'KeyT',
+      ctrlKey: true,
+    })
+    const cmdT = new KeyboardEvent('keydown', {
+      key: 't',
+      code: 'KeyT',
+      metaKey: true,
+    })
+
+    expect(isModKeyEvent(ctrlT)).toBe(false)
+    expect(eventToShortcutString(ctrlT)).toBeNull()
+
+    expect(isModKeyEvent(cmdT)).toBe(true)
+    expect(eventToShortcutString(cmdT)).toBe('mod+t')
+  })
+
+  it('treats Control as mod on macOS web (browser intercepts Cmd)', () => {
+    setPlatform({ isClientMacOS: true, isNativeApp: false })
+
+    const ctrlT = new KeyboardEvent('keydown', {
+      key: 't',
+      code: 'KeyT',
+      ctrlKey: true,
+    })
+    const cmdT = new KeyboardEvent('keydown', {
+      key: 't',
+      code: 'KeyT',
+      metaKey: true,
+    })
+
+    expect(isModKeyEvent(ctrlT)).toBe(true)
+    expect(eventToShortcutString(ctrlT)).toBe('mod+t')
+
+    // Cmd is not the web mod key; leave unmatched rather than treating as bare "t"
+    expect(isModKeyEvent(cmdT)).toBe(false)
+    expect(eventToShortcutString(cmdT)).toBe('t')
   })
 
   it('keeps the settings definitions aligned with every default shortcut', () => {

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -1,4 +1,5 @@
 // Keybinding action identifiers - extensible for future shortcuts
+import { isNativeApp } from '@/lib/environment'
 import { isClientMacOS } from '@/lib/platform'
 
 export type KeybindingAction =
@@ -470,6 +471,19 @@ export function formatShortcutDisplay(
     .join(' + ')
 }
 
+/**
+ * Primary modifier for "mod" shortcuts.
+ * - macOS native app: Command (metaKey) — Control must pass through to terminals
+ *   (e.g. Ctrl+T) instead of opening a new session (issue #615)
+ * - macOS web: Control (browser intercepts Cmd)
+ * - Windows/Linux: Control
+ */
+export function isModKeyEvent(
+  e: Pick<KeyboardEvent, 'metaKey' | 'ctrlKey'>
+): boolean {
+  return isClientMacOS && isNativeApp() ? e.metaKey : e.ctrlKey
+}
+
 // Helper to parse keyboard event into shortcut string
 export function eventToShortcutString(e: KeyboardEvent): ShortcutString | null {
   // Ignore modifier-only presses
@@ -477,8 +491,15 @@ export function eventToShortcutString(e: KeyboardEvent): ShortcutString | null {
     return null
   }
 
+  // On macOS native, Control chords are not app "mod" shortcuts. Returning null
+  // lets them reach focused terminals (Ctrl+T, Ctrl+R, …) instead of matching
+  // mod+t / mod+r / etc. Issue #615.
+  if (isClientMacOS && isNativeApp() && e.ctrlKey && !e.metaKey) {
+    return null
+  }
+
   const parts: string[] = []
-  if (e.metaKey || e.ctrlKey) parts.push('mod')
+  if (isModKeyEvent(e)) parts.push('mod')
   if (e.shiftKey) parts.push('shift')
   if (e.altKey) parts.push('alt')
 


### PR DESCRIPTION
## Summary

- On macOS native, only Command is treated as the platform `mod` key so Control chords (e.g. Ctrl+T) reach the focused terminal instead of app shortcuts
- New terminal tab (`mod+t`) and related shortcuts remain on Cmd; Ctrl is no longer treated as an equivalent mod key in the native app
- Adds tests covering macOS native vs web mod-key behavior for issue #615

fixes #615

---

Fixes #615