### PR TITLE
fix(chat): keep mobile session settings open after picks

### DIFF
--- a/src/components/chat/ChatToolbar.tsx
+++ b/src/components/chat/ChatToolbar.tsx
@@ -155,6 +155,9 @@ export const ChatToolbar = memo(function ChatToolbar({
   const [mcpDropdownOpen, setMcpDropdownOpen] = useState(false)
   const [mobileBackendModelPickerOpen, setMobileBackendModelPickerOpen] =
     useState(false)
+  // Bumped after a mobile model pick so MobileSettingsMenu opens effort/thinking
+  // without forcing the user to reopen the gear (issue #574).
+  const [openReasoningSheetSignal, setOpenReasoningSheetSignal] = useState(0)
   const isMobile = useIsMobile()
   const [revertConfirmOpen, setRevertConfirmOpen] = useState(false)
 
@@ -344,6 +347,14 @@ export const ChatToolbar = memo(function ChatToolbar({
     [onEffortLevelChange]
   )
 
+  const handleAfterMobileModelSelect = useCallback(() => {
+    // Defer so selectedBackend/model props refresh before the reasoning sheet
+    // decides effort vs thinking options.
+    requestAnimationFrame(() => {
+      setOpenReasoningSheetSignal(n => n + 1)
+    })
+  }, [])
+
   const handlePullClick = useCallback(async () => {
     if (!activeWorktreePath || !worktreeId) return
     await performGitPull({
@@ -485,6 +496,7 @@ export const ChatToolbar = memo(function ChatToolbar({
             handleProviderChange={handleProviderChange}
             handleEffortLevelChange={handleEffortLevelChange}
             handleThinkingLevelChange={handleThinkingLevelChange}
+            openReasoningSheetSignal={openReasoningSheetSignal}
             loadedIssueContexts={loadedIssueContexts}
             loadedPRContexts={loadedPRContexts}
             loadedSecurityContexts={loadedSecurityContexts}
@@ -527,6 +539,7 @@ export const ChatToolbar = memo(function ChatToolbar({
               customCliProfiles={customCliProfiles}
               onModelChange={handleModelChange}
               onBackendModelChange={onBackendModelChange}
+              onAfterModelSelect={handleAfterMobileModelSelect}
             />
           )}
 

--- a/src/components/chat/toolbar/BackendModelPickerContent.tsx
+++ b/src/components/chat/toolbar/BackendModelPickerContent.tsx
@@ -58,6 +58,8 @@ interface BackendModelPickerContentProps {
   onModelChange: (model: string) => void
   onBackendModelChange: (backend: CliBackend, model: string) => void
   onRequestClose: () => void
+  /** Called after a model is applied and the picker has been asked to close. */
+  onAfterSelect?: (backend: CliBackend, model: string) => void
   defaultModelOption?: { value: string; label: string }
   searchPlaceholder?: string
   className?: string
@@ -76,6 +78,7 @@ export function BackendModelPickerContent({
   onModelChange,
   onBackendModelChange,
   onRequestClose,
+  onAfterSelect,
   defaultModelOption,
   searchPlaceholder,
   className,
@@ -364,10 +367,12 @@ export function BackendModelPickerContent({
         onBackendModelChange(backend, resolved)
       }
       onRequestClose()
+      onAfterSelect?.(backend, resolved)
     },
     [
       isFastRemembered,
       modelCatalog,
+      onAfterSelect,
       onBackendModelChange,
       onModelChange,
       onRequestClose,
@@ -418,11 +423,13 @@ export function BackendModelPickerContent({
       onBackendModelChange(activeBackend, fastInfo.fastModel)
     }
     onRequestClose()
+    onAfterSelect?.(activeBackend, fastInfo.fastModel)
     return true
   }, [
     activeBackend,
     highlightedOption,
     modelCatalog,
+    onAfterSelect,
     onBackendModelChange,
     onModelChange,
     onRequestClose,

--- a/src/components/chat/toolbar/MobileBackendModelPickerSheet.tsx
+++ b/src/components/chat/toolbar/MobileBackendModelPickerSheet.tsx
@@ -22,6 +22,8 @@ interface MobileBackendModelPickerSheetProps {
   customCliProfiles: CustomCliProfile[]
   onModelChange: (model: string) => void
   onBackendModelChange: (backend: CliBackend, model: string) => void
+  /** Fired after a model is selected (picker already closed). */
+  onAfterModelSelect?: (backend: CliBackend, model: string) => void
 }
 
 export function MobileBackendModelPickerSheet({
@@ -36,6 +38,7 @@ export function MobileBackendModelPickerSheet({
   customCliProfiles,
   onModelChange,
   onBackendModelChange,
+  onAfterModelSelect,
 }: MobileBackendModelPickerSheetProps) {
   const isMobile = useIsMobile()
 
@@ -71,6 +74,7 @@ export function MobileBackendModelPickerSheet({
           onModelChange={onModelChange}
           onBackendModelChange={onBackendModelChange}
           onRequestClose={() => onOpenChange(false)}
+          onAfterSelect={onAfterModelSelect}
           className="min-h-0"
           commandListClassName="!max-h-none min-h-0 flex-1 overflow-y-auto pb-[calc(env(safe-area-inset-bottom)+0.5rem)]"
         />

--- a/src/components/chat/toolbar/MobileSettingsMenu.test.tsx
+++ b/src/components/chat/toolbar/MobileSettingsMenu.test.tsx
@@ -13,16 +13,19 @@ interface PortInfo {
   host?: string | null
 }
 
-const usePortsMock = vi.fn(() => ({ data: [] as PortInfo[] }))
-const useWorktreeMock = vi.fn(() => ({
-  data: {
-    id: 'worktree-1',
-    path: '/repo/worktree',
-    branch: 'feature',
-    project_id: 'project-1',
-    base_branch: 'main',
-  },
-}))
+const { usePortsMock, useWorktreeMock } = vi.hoisted(() => {
+  const usePortsMock = vi.fn(() => ({ data: [] as PortInfo[] }))
+  const useWorktreeMock = vi.fn(() => ({
+    data: {
+      id: 'worktree-1',
+      path: '/repo/worktree',
+      branch: 'feature',
+      project_id: 'project-1',
+      base_branch: 'main',
+    },
+  }))
+  return { usePortsMock, useWorktreeMock }
+})
 
 vi.mock('@/services/projects', async importOriginal => {
   const actual = await importOriginal<typeof ProjectsService>()
@@ -54,6 +57,11 @@ beforeEach(() => {
       project_id: 'project-1',
       base_branch: 'main',
     },
+  })
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: 1280,
   })
   vi.stubGlobal(
     'matchMedia',
@@ -623,5 +631,133 @@ describe('MobileSettingsMenu', () => {
     await user.click(screen.getByText('Effort'))
 
     expect(screen.getAllByText('Ultracode').length).toBeGreaterThan(0)
+  })
+
+  it('keeps the gear menu open when selecting an effort from the submenu', async () => {
+    const user = userEvent.setup()
+    const handleEffortLevelChange = vi.fn()
+    // Force non-mobile so Effort uses the submenu (not bottom sheet).
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 1280,
+    })
+
+    render(
+      <MobileSettingsMenu
+        {...baseProps}
+        useAdaptiveThinking
+        handleEffortLevelChange={handleEffortLevelChange}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /settings/i }))
+    await user.click(screen.getByText('Effort'))
+    const highItem = screen
+      .getAllByRole('menuitemradio', { name: /high/i })
+      .find(item => item.textContent?.startsWith('High'))
+    expect(highItem).toBeDefined()
+    if (!highItem) return
+    fireEvent.click(highItem)
+
+    expect(handleEffortLevelChange).toHaveBeenCalledWith('high')
+    // Menu should remain open so further settings can be changed without reopening.
+    expect(screen.getByText('Model')).toBeInTheDocument()
+    expect(screen.getByText('Effort')).toBeInTheDocument()
+  })
+
+  it('auto-opens the effort sheet when openReasoningSheetSignal bumps', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 390,
+    })
+
+    const { rerender } = render(
+      <MobileSettingsMenu
+        {...baseProps}
+        useAdaptiveThinking
+        openReasoningSheetSignal={0}
+      />
+    )
+
+    expect(
+      screen.queryByRole('dialog', { name: 'Select effort' })
+    ).not.toBeInTheDocument()
+
+    rerender(
+      <MobileSettingsMenu
+        {...baseProps}
+        useAdaptiveThinking
+        openReasoningSheetSignal={1}
+      />
+    )
+
+    expect(
+      await screen.findByRole('dialog', { name: 'Select effort' })
+    ).toBeInTheDocument()
+  })
+
+  it('auto-opens the thinking sheet for non-effort backends when signal bumps', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 390,
+    })
+
+    const { rerender } = render(
+      <MobileSettingsMenu
+        {...baseProps}
+        useAdaptiveThinking={false}
+        isCodex={false}
+        selectedBackend="claude"
+        openReasoningSheetSignal={0}
+      />
+    )
+
+    rerender(
+      <MobileSettingsMenu
+        {...baseProps}
+        useAdaptiveThinking={false}
+        isCodex={false}
+        selectedBackend="claude"
+        openReasoningSheetSignal={1}
+      />
+    )
+
+    expect(
+      await screen.findByRole('dialog', { name: 'Select thinking' })
+    ).toBeInTheDocument()
+  })
+
+  it('does not open a reasoning sheet when signal bumps for commandcode', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 390,
+    })
+
+    const { rerender } = render(
+      <MobileSettingsMenu
+        {...baseProps}
+        selectedBackend="commandcode"
+        useAdaptiveThinking={false}
+        isCodex={false}
+        openReasoningSheetSignal={0}
+      />
+    )
+
+    rerender(
+      <MobileSettingsMenu
+        {...baseProps}
+        selectedBackend="commandcode"
+        useAdaptiveThinking={false}
+        isCodex={false}
+        openReasoningSheetSignal={1}
+      />
+    )
+
+    expect(
+      screen.queryByRole('dialog', { name: 'Select effort' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('dialog', { name: 'Select thinking' })
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/components/chat/toolbar/MobileSettingsMenu.tsx
+++ b/src/components/chat/toolbar/MobileSettingsMenu.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useState, type ReactNode } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
 import {
   Brain,
   Check,
@@ -127,6 +134,11 @@ interface MobileSettingsMenuProps {
   handleProviderChange: (value: string) => void
   handleEffortLevelChange: (value: string) => void
   handleThinkingLevelChange: (value: string) => void
+  /**
+   * Bump this after a mobile model pick so the reasoning (effort/thinking)
+   * sheet opens without reopening the gear menu (issue #574).
+   */
+  openReasoningSheetSignal?: number
 
   loadedIssueContexts: LoadedIssueContext[]
   loadedPRContexts: LoadedPullRequestContext[]
@@ -181,6 +193,7 @@ export function MobileSettingsMenu({
   handleProviderChange,
   handleEffortLevelChange,
   handleThinkingLevelChange,
+  openReasoningSheetSignal = 0,
   loadedIssueContexts,
   loadedPRContexts,
   loadedSecurityContexts,
@@ -283,9 +296,15 @@ export function MobileSettingsMenu({
   const queryClient = useQueryClient()
   const [menuOpen, setMenuOpen] = useState(false)
   const [effortSheetOpen, setEffortSheetOpen] = useState(false)
+  const [thinkingSheetOpen, setThinkingSheetOpen] = useState(false)
   const [mcpSheetOpen, setMcpSheetOpen] = useState(false)
   const [scriptsSheetOpen, setScriptsSheetOpen] = useState(false)
   const [resumeCommand, setResumeCommand] = useState<string | null>(null)
+  // Keep radio/checkbox selections from dismissing the gear menu so users can
+  // chain model/effort/provider/MCP changes without reopening (issue #574).
+  const keepMenuOpenOnSelect = useCallback((event: Event) => {
+    event.preventDefault()
+  }, [])
   const providerDisplayName = getProviderDisplayName(
     selectedProvider,
     selectedBackend
@@ -323,6 +342,11 @@ export function MobileSettingsMenu({
     requestAnimationFrame(() => setEffortSheetOpen(true))
   }
 
+  const openThinkingPicker = () => {
+    setMenuOpen(false)
+    requestAnimationFrame(() => setThinkingSheetOpen(true))
+  }
+
   const openMcpPicker = () => {
     setMenuOpen(false)
     requestAnimationFrame(() => setMcpSheetOpen(true))
@@ -332,6 +356,24 @@ export function MobileSettingsMenu({
     setMenuOpen(false)
     requestAnimationFrame(() => setScriptsSheetOpen(true))
   }
+
+  // After mobile model selection, auto-open effort/thinking so users don't
+  // have to reopen the settings cog (issue #574).
+  const lastReasoningSheetSignalRef = useRef(0)
+  useEffect(() => {
+    if (!openReasoningSheetSignal) return
+    if (openReasoningSheetSignal === lastReasoningSheetSignalRef.current) return
+    lastReasoningSheetSignalRef.current = openReasoningSheetSignal
+    if (hideReasoningControl) return
+    setMenuOpen(false)
+    if (usesEffortControl) {
+      setThinkingSheetOpen(false)
+      requestAnimationFrame(() => setEffortSheetOpen(true))
+    } else {
+      setEffortSheetOpen(false)
+      requestAnimationFrame(() => setThinkingSheetOpen(true))
+    }
+  }, [openReasoningSheetSignal, hideReasoningControl, usesEffortControl])
 
   const getActiveResumeCommand = useCallback(() => {
     if (!worktreeId) return null
@@ -489,7 +531,10 @@ export function MobileSettingsMenu({
                     value={selectedProvider ?? '__anthropic__'}
                     onValueChange={handleProviderChange}
                   >
-                    <DropdownMenuRadioItem value="__anthropic__">
+                    <DropdownMenuRadioItem
+                      value="__anthropic__"
+                      onSelect={keepMenuOpenOnSelect}
+                    >
                       Anthropic
                     </DropdownMenuRadioItem>
                     <DropdownMenuSeparator />
@@ -500,6 +545,7 @@ export function MobileSettingsMenu({
                       <DropdownMenuRadioItem
                         key={profile.name}
                         value={profile.name}
+                        onSelect={keepMenuOpenOnSelect}
                       >
                         {profile.name}
                       </DropdownMenuRadioItem>
@@ -510,7 +556,10 @@ export function MobileSettingsMenu({
                     value={selectedProvider ?? '__default__'}
                     onValueChange={handleProviderChange}
                   >
-                    <DropdownMenuRadioItem value="__default__">
+                    <DropdownMenuRadioItem
+                      value="__default__"
+                      onSelect={keepMenuOpenOnSelect}
+                    >
                       Default (OpenAI)
                     </DropdownMenuRadioItem>
                     <DropdownMenuSeparator />
@@ -521,6 +570,7 @@ export function MobileSettingsMenu({
                       <DropdownMenuRadioItem
                         key={profile.name}
                         value={profile.name}
+                        onSelect={keepMenuOpenOnSelect}
                       >
                         {profile.name}
                       </DropdownMenuRadioItem>
@@ -572,6 +622,7 @@ export function MobileSettingsMenu({
                     <DropdownMenuRadioItem
                       key={option.value}
                       value={option.value}
+                      onSelect={keepMenuOpenOnSelect}
                     >
                       {option.label}
                       <span className="ml-auto pl-4 text-xs text-muted-foreground">
@@ -582,6 +633,15 @@ export function MobileSettingsMenu({
                 </DropdownMenuRadioGroup>
               </DropdownMenuSubContent>
             </DropdownMenuSub>
+          ) : isMobile ? (
+            <DropdownMenuItem onSelect={openThinkingPicker}>
+              <Brain className="h-4 w-4 text-muted-foreground" />
+              <span>Thinking</span>
+              <span className="ml-auto w-16 text-right text-xs text-muted-foreground">
+                {displayedThinkingLabel}
+              </span>
+              <ChevronRight className="ml-2 h-4 w-4 shrink-0 text-foreground" />
+            </DropdownMenuItem>
           ) : (
             <DropdownMenuSub>
               <DropdownMenuSubTrigger className="[&>svg:last-child]:!ml-2">
@@ -600,6 +660,7 @@ export function MobileSettingsMenu({
                     <DropdownMenuRadioItem
                       key={option.value}
                       value={option.value}
+                      onSelect={keepMenuOpenOnSelect}
                     >
                       {option.label}
                       <span className="ml-auto pl-4 text-xs text-muted-foreground">
@@ -674,6 +735,7 @@ export function MobileSettingsMenu({
                               enabledMcpServers.includes(key)
                             }
                             onCheckedChange={() => onToggleMcpServer(key)}
+                            onSelect={keepMenuOpenOnSelect}
                             disabled={server.disabled}
                             className={
                               server.disabled ? 'opacity-50' : undefined
@@ -1099,6 +1161,53 @@ export function MobileSettingsMenu({
                     <span className="block text-xs text-muted-foreground">
                       {option.description}
                     </span>
+                  </span>
+                  {selected && <Check className="h-4 w-4 shrink-0" />}
+                </button>
+              )
+            })}
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={thinkingSheetOpen} onOpenChange={setThinkingSheetOpen}>
+        <SheetContent
+          side="bottom"
+          className="max-h-[75svh] overflow-hidden rounded-t-xl p-0"
+          showCloseButton={false}
+        >
+          <SheetHeader className="shrink-0 border-b px-4 py-3 text-left">
+            <SheetTitle>Select thinking</SheetTitle>
+            <SheetDescription>
+              Choose how much thinking the model should use.
+            </SheetDescription>
+          </SheetHeader>
+          <div className="overflow-y-auto px-2 pb-[calc(env(safe-area-inset-bottom)+0.5rem)]">
+            {thinkingLevelOptions.map(option => {
+              const selected = option.value === displayedThinkingLevel
+              const detail =
+                'tokens' in option ? option.tokens : option.description
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={cn(
+                    'flex min-h-12 w-full items-center gap-3 rounded-lg px-3 text-left active:bg-accent',
+                    selected && 'bg-accent'
+                  )}
+                  aria-pressed={selected}
+                  onClick={() => {
+                    handleThinkingLevelChange(option.value)
+                    setThinkingSheetOpen(false)
+                  }}
+                >
+                  <span className="flex-1">
+                    <span className="block font-medium">{option.label}</span>
+                    {detail ? (
+                      <span className="block text-xs text-muted-foreground">
+                        {detail}
+                      </span>
+                    ) : null}
                   </span>
                   {selected && <Check className="h-4 w-4 shrink-0" />}
                 </button>


### PR DESCRIPTION
## Summary

- Keep the session settings cog menu open on mobile after selecting nested options like effort, so users can change multiple settings without reopening the menu
- After picking a model from the mobile model sheet, automatically open the effort/thinking picker for a smoother model + reasoning flow
- Add coverage for menu persistence and auto-open reasoning sheet behavior

fixes #574

---

Fixes #574