### PR TITLE
feat(chat): inject session refs into context via MCP

### DIFF
--- a/jean-core/src/http_server/dispatch.rs
+++ b/jean-core/src/http_server/dispatch.rs
@@ -1037,6 +1037,26 @@ pub async fn dispatch_command(
                     .await?;
             to_value(result)
         }
+        "attach_session_reference" => {
+            let target_session_id: String =
+                field(&args, "targetSessionId", "target_session_id")?;
+            let source_session_id: String =
+                field(&args, "sourceSessionId", "source_session_id")?;
+            let session_name: String = field(&args, "sessionName", "session_name")?;
+            let project_name: String = field(&args, "projectName", "project_name")?;
+            let worktree_name: String = field(&args, "worktreeName", "worktree_name")?;
+            let result = crate::projects::attach_session_reference(
+                app.clone(),
+                target_session_id,
+                source_session_id,
+                session_name,
+                project_name,
+                worktree_name,
+            )
+            .await?;
+            emit_cache_invalidation(app, &["contexts"]);
+            to_value(result)
+        }
 
         // =====================================================================
         // Chat Sessions
@@ -1505,9 +1525,15 @@ pub async fn dispatch_command(
         "generate_context_from_session" => {
             let worktree_path: String = field(&args, "worktreePath", "worktree_path")?;
             let worktree_id: String = field(&args, "worktreeId", "worktree_id")?;
-            let session_id: String = field(&args, "sessionId", "session_id")?;
+            // Frontend sends sourceSessionId; accept sessionId as a fallback alias.
+            let source_session_id: String = field(&args, "sourceSessionId", "source_session_id")
+                .or_else(|_| field(&args, "sessionId", "session_id"))?;
             let project_name: String = field(&args, "projectName", "project_name")?;
-            let custom_prompt: Option<String> = field_opt(&args, "magicPrompt", "magic_prompt")?;
+            let custom_prompt: Option<String> = match field_opt(&args, "customPrompt", "custom_prompt")?
+            {
+                Some(v) => Some(v),
+                None => field_opt(&args, "magicPrompt", "magic_prompt")?,
+            };
             let model: Option<String> = from_field_opt(&args, "model")?;
             let custom_profile_name: Option<String> =
                 field_opt(&args, "customProfileName", "custom_profile_name")?;
@@ -1517,7 +1543,7 @@ pub async fn dispatch_command(
                 app.clone(),
                 worktree_path,
                 worktree_id,
-                session_id,
+                source_session_id,
                 project_name,
                 custom_prompt,
                 model,

--- a/jean-core/src/projects/saved_contexts.rs
+++ b/jean-core/src/projects/saved_contexts.rs
@@ -10,6 +10,33 @@ pub struct AttachedSavedContext {
     pub created_at: u64,
 }
 
+/// Slug used when attaching a lightweight session reference to another session.
+pub fn session_reference_slug(source_session_id: &str) -> String {
+    format!("session-ref-{source_session_id}")
+}
+
+/// Build the MCP-pointer prompt attached when injecting a session into context.
+///
+/// Intentionally does **not** embed message history — the agent should use
+/// Jean MCP `read_session_messages` to fetch only what it needs.
+pub fn build_session_reference_content(
+    source_session_id: &str,
+    session_name: &str,
+    project_name: &str,
+    worktree_name: &str,
+) -> String {
+    format!(
+        r#"# Session: {session_name}
+
+The user has requested to take a look at session `{source_session_id}` (name: "{session_name}", project: {project_name}, worktree: {worktree_name}).
+
+Use the Jean MCP tool `read_session_messages` with `sessionId` set to `{source_session_id}` to fetch the most recent messages from the user and agent (start with a small `limit`, e.g. 2–10; results are most recent first). If you need more context to understand what the user is looking for, you may fetch additional messages from the history. Do **not** consume the entire session at once.
+
+You may also use `get_session_status` with the same `sessionId` if you need run state for that session.
+"#
+    )
+}
+
 /// Attach a saved context to a session by copying it to the session-specific location.
 ///
 /// Storage location: `app-data/session-context/{session_id}-context-{slug}.md`
@@ -245,4 +272,131 @@ pub fn cleanup_saved_contexts_for_session(
         }
     }
     Ok(())
+}
+
+/// Inject a lightweight session reference into another session's context.
+///
+/// Writes a small markdown context file with an MCP pointer prompt (no message
+/// dump) to `session-context/{target_session_id}-context-session-ref-{source}.md`.
+pub async fn attach_session_reference(
+    app: tauri::AppHandle,
+    target_session_id: String,
+    source_session_id: String,
+    session_name: String,
+    project_name: String,
+    worktree_name: String,
+) -> Result<AttachedSavedContext, String> {
+    if target_session_id == source_session_id {
+        return Err("Cannot inject a session into itself".to_string());
+    }
+    if source_session_id.trim().is_empty() {
+        return Err("Source session id is required".to_string());
+    }
+
+    let slug = session_reference_slug(&source_session_id);
+    let content = build_session_reference_content(
+        &source_session_id,
+        &session_name,
+        &project_name,
+        &worktree_name,
+    );
+    let name = Some(format!("Session: {session_name}"));
+
+    log::trace!(
+        "Attaching session reference '{source_session_id}' to session {target_session_id}"
+    );
+
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {e}"))?;
+
+    let saved_contexts_dir = app_data_dir.join("session-context");
+    std::fs::create_dir_all(&saved_contexts_dir)
+        .map_err(|e| format!("Failed to create session-context directory: {e}"))?;
+
+    let dest_file = saved_contexts_dir.join(format!("{target_session_id}-context-{slug}.md"));
+
+    // Already attached — return existing metadata without rewriting.
+    if dest_file.exists() {
+        let metadata = std::fs::metadata(&dest_file)
+            .map_err(|e| format!("Failed to get file metadata: {e}"))?;
+        let size = metadata.len();
+        let created_at = metadata
+            .created()
+            .or_else(|_| metadata.modified())
+            .map_err(|e| format!("Failed to get file time: {e}"))?
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| format!("Failed to convert time: {e}"))?
+            .as_secs();
+        log::trace!(
+            "Session reference '{source_session_id}' already attached to {target_session_id}"
+        );
+        return Ok(AttachedSavedContext {
+            slug,
+            name,
+            size,
+            created_at,
+        });
+    }
+
+    std::fs::write(&dest_file, &content)
+        .map_err(|e| format!("Failed to write session reference file: {e}"))?;
+
+    let metadata =
+        std::fs::metadata(&dest_file).map_err(|e| format!("Failed to get file metadata: {e}"))?;
+    let size = metadata.len();
+    let created_at = metadata
+        .created()
+        .or_else(|_| metadata.modified())
+        .map_err(|e| format!("Failed to get file time: {e}"))?
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| format!("Failed to convert time: {e}"))?
+        .as_secs();
+
+    log::trace!(
+        "Attached session reference '{source_session_id}' to session {target_session_id}"
+    );
+
+    Ok(AttachedSavedContext {
+        slug,
+        name,
+        size,
+        created_at,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_reference_slug_is_stable() {
+        assert_eq!(
+            session_reference_slug("abc-123"),
+            "session-ref-abc-123"
+        );
+    }
+
+    #[test]
+    fn session_reference_content_points_at_mcp_not_full_history() {
+        let content = build_session_reference_content(
+            "sess-42",
+            "Fix login bug",
+            "jean",
+            "issue-596",
+        );
+
+        assert!(content.contains("# Session: Fix login bug"));
+        assert!(content.contains("`sess-42`"));
+        assert!(content.contains("read_session_messages"));
+        assert!(content.contains("sessionId"));
+        assert!(content.contains("get_session_status"));
+        assert!(content.contains("Do **not** consume the entire session at once"));
+        // Must not embed fabricated conversation content
+        assert!(!content.contains("User:"));
+        assert!(!content.contains("Assistant:"));
+        assert!(content.contains("project: jean"));
+        assert!(content.contains("worktree: issue-596"));
+    }
 }

--- a/src/components/chat/hooks/useMagicCommands.ts
+++ b/src/components/chat/hooks/useMagicCommands.ts
@@ -150,6 +150,8 @@ export function useMagicCommands({
           handlers.handleSaveContext()
           break
         case 'load-context':
+        case 'inject-session':
+          // Inject Session opens Load Context on the Contexts tab (Sessions list)
           handlers.handleLoadContext()
           break
         case 'linked-projects':

--- a/src/components/magic/ContextsTab.tsx
+++ b/src/components/magic/ContextsTab.tsx
@@ -43,6 +43,7 @@ interface ContextsTabProps {
   onRenameKeyDown: (e: React.KeyboardEvent, filename: string) => void
   onDeleteContext: (e: React.MouseEvent, context: SavedContext) => void
   onSessionClick: (sessionWithContext: SessionWithContext) => void
+  onGenerateSessionContext?: (sessionWithContext: SessionWithContext) => void
 }
 
 export function ContextsTab({
@@ -78,6 +79,7 @@ export function ContextsTab({
   onRenameKeyDown,
   onDeleteContext,
   onSessionClick,
+  onGenerateSessionContext,
 }: ContextsTabProps) {
   const isEmpty =
     !hasContexts && !hasSessions && !hasAttachedContexts && !isLoading && !error
@@ -143,7 +145,8 @@ export function ContextsTab({
             No saved contexts or sessions available.
             <br />
             <span className="text-sm">
-              Use &quot;Save Context&quot; to save a conversation summary.
+              Use &quot;Save Context&quot; for a summary, or inject another
+              session as an MCP pointer from this tab.
             </span>
           </div>
         ) : (
@@ -179,11 +182,15 @@ export function ContextsTab({
               </>
             )}
 
-            {/* Sessions Section - narrow list style */}
+            {/* Sessions Section — inject lightweight MCP pointer (not full history) */}
             {hasSessions && (
               <>
                 <div className="px-3 py-2 text-xs font-medium text-muted-foreground bg-muted/30 mt-2">
-                  Generate from Session
+                  Sessions
+                </div>
+                <div className="px-3 pb-1 text-[11px] text-muted-foreground">
+                  Click to inject an MCP pointer (agent fetches messages on
+                  demand). File icon generates a full AI summary instead.
                 </div>
                 {filteredEntries.map(entry => {
                   const entryElement = (
@@ -192,6 +199,7 @@ export function ContextsTab({
                       entry={entry}
                       generatingSessionId={generatingSessionId}
                       onSessionClick={onSessionClick}
+                      onGenerateSessionContext={onGenerateSessionContext}
                       selectedIndex={selectedIndex}
                       sessionStartIndex={sessionStartIndex}
                       setSelectedIndex={setSelectedIndex}

--- a/src/components/magic/LoadContextItems.tsx
+++ b/src/components/magic/LoadContextItems.tsx
@@ -1,6 +1,7 @@
 import {
   CircleDot,
   Eye,
+  FileText,
   FolderOpen,
   GitPullRequest,
   Loader2,
@@ -37,6 +38,7 @@ export interface SessionWithContext {
   session: Session
   worktreeId: string
   worktreePath: string
+  worktreeName: string
   projectName: string
 }
 
@@ -1090,6 +1092,7 @@ interface SessionGroupProps {
   entry: AllSessionsEntry
   generatingSessionId: string | null
   onSessionClick: (sessionWithContext: SessionWithContext) => void
+  onGenerateSessionContext?: (sessionWithContext: SessionWithContext) => void
   selectedIndex: number
   sessionStartIndex: number
   setSelectedIndex: (index: number) => void
@@ -1099,6 +1102,7 @@ export function SessionGroup({
   entry,
   generatingSessionId,
   onSessionClick,
+  onGenerateSessionContext,
   selectedIndex,
   sessionStartIndex,
   setSelectedIndex,
@@ -1119,44 +1123,77 @@ export function SessionGroup({
           const isDisabled = !hasMessages || generatingSessionId !== null
           const isGenerating = generatingSessionId === session.id
           const flatIndex = sessionStartIndex + idx
+          const sessionWithContext: SessionWithContext = {
+            session,
+            worktreeId: entry.worktree_id,
+            worktreePath: entry.worktree_path,
+            worktreeName: entry.worktree_name,
+            projectName: entry.project_name,
+          }
 
           return (
-            <button
+            <div
               key={session.id}
               data-load-item-index={flatIndex}
               className={cn(
                 'w-full flex items-start gap-3 px-3 py-2 text-left transition-colors',
-                'hover:bg-accent focus:outline-none',
+                'hover:bg-accent',
                 flatIndex === selectedIndex && 'bg-accent',
-                isDisabled && 'opacity-50 cursor-not-allowed'
+                isDisabled && 'opacity-50'
               )}
-              onClick={() =>
-                onSessionClick({
-                  session,
-                  worktreeId: entry.worktree_id,
-                  worktreePath: entry.worktree_path,
-                  projectName: entry.project_name,
-                })
-              }
               onMouseEnter={() => setSelectedIndex(flatIndex)}
-              disabled={isDisabled}
             >
-              {isGenerating ? (
-                <Loader2 className="h-4 w-4 mt-0.5 animate-spin text-muted-foreground flex-shrink-0" />
-              ) : (
-                <MessageSquare className="h-4 w-4 mt-0.5 text-muted-foreground flex-shrink-0" />
+              <button
+                type="button"
+                className={cn(
+                  'flex flex-1 items-start gap-3 min-w-0 text-left focus:outline-none',
+                  isDisabled && 'cursor-not-allowed'
+                )}
+                onClick={() => onSessionClick(sessionWithContext)}
+                disabled={isDisabled}
+                title="Inject session as MCP context pointer"
+              >
+                {isGenerating ? (
+                  <Loader2 className="h-4 w-4 mt-0.5 animate-spin text-muted-foreground flex-shrink-0" />
+                ) : (
+                  <MessageSquare className="h-4 w-4 mt-0.5 text-muted-foreground flex-shrink-0" />
+                )}
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium truncate">
+                    {session.name}
+                  </div>
+                  <div className="text-xs text-muted-foreground mt-0.5">
+                    {hasMessages
+                      ? `${session.messages.length} messages · inject pointer`
+                      : 'No messages'}
+                  </div>
+                </div>
+              </button>
+              {onGenerateSessionContext && hasMessages && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className={cn(
+                        'p-1 rounded hover:bg-background/80 text-muted-foreground hover:text-foreground flex-shrink-0 mt-0.5',
+                        isDisabled && 'cursor-not-allowed opacity-50'
+                      )}
+                      onClick={e => {
+                        e.stopPropagation()
+                        onGenerateSessionContext(sessionWithContext)
+                      }}
+                      disabled={isDisabled}
+                      aria-label="Generate full context summary"
+                    >
+                      <FileText className="h-3.5 w-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="left">
+                    Generate full context summary (AI)
+                  </TooltipContent>
+                </Tooltip>
               )}
-              <div className="flex-1 min-w-0">
-                <div className="text-sm font-medium truncate">
-                  {session.name}
-                </div>
-                <div className="text-xs text-muted-foreground mt-0.5">
-                  {hasMessages
-                    ? `${session.messages.length} messages`
-                    : 'No messages'}
-                </div>
-              </div>
-            </button>
+            </div>
           )
         })}
       </div>

--- a/src/components/magic/LoadContextModal.tsx
+++ b/src/components/magic/LoadContextModal.tsx
@@ -511,6 +511,7 @@ export function LoadContextModal({
               onRenameKeyDown={handlers.handleRenameKeyDown}
               onDeleteContext={handlers.handleDeleteContext}
               onSessionClick={handlers.handleSessionClick}
+              onGenerateSessionContext={handlers.handleGenerateSessionContext}
             />
           )}
         </div>

--- a/src/components/magic/MagicModal.test.tsx
+++ b/src/components/magic/MagicModal.test.tsx
@@ -636,6 +636,14 @@ describe('MagicModal manual PR link', () => {
     ).toBeInTheDocument()
   })
 
+  it('shows the inject session magic command', () => {
+    render(<MagicModal />)
+
+    expect(
+      screen.getByRole('button', { name: /inject session/i })
+    ).toBeInTheDocument()
+  })
+
   it('starts commit and push actions directly with loading notifications when chat is active', async () => {
     const user = userEvent.setup()
     mocks.activeWorktreePath = '/repo/worktree'

--- a/src/components/magic/MagicModal.tsx
+++ b/src/components/magic/MagicModal.tsx
@@ -126,6 +126,7 @@ import { resolveMcpConfigForSend } from '@/services/mcp'
 type MagicOption =
   | 'save-context'
   | 'load-context'
+  | 'inject-session'
   | 'linked-projects'
   | 'fork-session'
   | 'commit'
@@ -250,6 +251,12 @@ function buildMagicColumns(hasOpenPr: boolean): MagicColumns {
           key: 'L',
         },
         {
+          id: 'inject-session',
+          label: 'Inject Session',
+          icon: MessageSquare,
+          key: 'J',
+        },
+        {
           id: 'linked-projects',
           label: 'Linked Projects',
           icon: Link2,
@@ -372,6 +379,7 @@ function buildMagicColumns(hasOpenPr: boolean): MagicColumns {
 const KEY_TO_OPTION: Record<string, MagicOption> = {
   s: 'save-context',
   l: 'load-context',
+  j: 'inject-session',
   k: 'linked-projects',
   w: 'fork-session',
   c: 'commit',

--- a/src/components/magic/hooks/useLoadContextData.ts
+++ b/src/components/magic/hooks/useLoadContextData.ts
@@ -280,15 +280,19 @@ export function useLoadContextData({
     )
   }, [contextsData, searchQuery, attachedSavedContexts])
 
-  // Filter sessions (exclude current session, apply search, group by project/worktree)
+  // Filter sessions (exclude current session + already-injected refs, apply search)
   const filteredEntries = useMemo(() => {
     if (!allSessionsData?.entries) return []
+
+    const attachedSlugs = new Set(attachedSavedContexts?.map(c => c.slug) ?? [])
 
     return allSessionsData.entries
       .map(entry => {
         const filteredSessions = entry.sessions
           .filter(s => s.messages.length > 0)
           .filter(s => s.id !== activeSessionId)
+          // Hide sessions already injected as session-ref-* attached contexts
+          .filter(s => !attachedSlugs.has(`session-ref-${s.id}`))
           .filter(s => {
             if (!searchQuery) return true
             const query = searchQuery.toLowerCase()
@@ -303,7 +307,7 @@ export function useLoadContextData({
         return { ...entry, sessions: filteredSessions }
       })
       .filter(entry => entry.sessions.length > 0)
-  }, [allSessionsData, searchQuery, activeSessionId])
+  }, [allSessionsData, searchQuery, activeSessionId, attachedSavedContexts])
 
   // Filter Linear issues locally, merge with search results, exclude already loaded ones
   const filteredLinearIssues = useMemo(() => {

--- a/src/components/magic/hooks/useLoadContextHandlers.ts
+++ b/src/components/magic/hooks/useLoadContextHandlers.ts
@@ -13,6 +13,7 @@ import {
   removeAdvisoryContext,
   getAdvisoryContextContent,
   attachSavedContext,
+  attachSessionReference,
   removeSavedContext,
   getSavedContextContent,
 } from '@/services/github'
@@ -752,7 +753,56 @@ export function useLoadContextHandlers({
     [handleRenameSubmit]
   )
 
+  /** Inject a lightweight MCP pointer for a session (no full history dump). */
   const handleSessionClick = useCallback(
+    async (sessionWithContext: SessionWithContext) => {
+      const {
+        session,
+        projectName: sessionProjectName,
+        worktreeName: sessionWorktreeName,
+      } = sessionWithContext
+
+      if (!activeSessionId) {
+        toast.error('No active session')
+        return
+      }
+
+      if (session.id === activeSessionId) {
+        toast.error('Cannot inject the current session into itself')
+        return
+      }
+
+      setGeneratingSessionId(session.id)
+      const toastId = toast.loading(
+        `Injecting session "${session.name || session.id}"...`
+      )
+
+      try {
+        await attachSessionReference(
+          activeSessionId,
+          session.id,
+          session.name || session.id,
+          sessionProjectName,
+          sessionWorktreeName
+        )
+        await refetchAttachedContexts()
+        toast.success(
+          `Session "${session.name || session.id}" injected as context`,
+          { id: toastId }
+        )
+        onClearSearch()
+      } catch (err) {
+        console.error('Failed to inject session:', err)
+        toast.error(`Failed to inject session: ${err}`, { id: toastId })
+      } finally {
+        setGeneratingSessionId(null)
+      }
+    },
+    [activeSessionId, refetchAttachedContexts, onClearSearch]
+  )
+
+  /** Optional: AI-summarize a session into a permanent saved context and attach it. */
+  const handleGenerateSessionContext = useCallback(
     async (sessionWithContext: SessionWithContext) => {
       const {
         session,
@@ -887,5 +937,6 @@ export function useLoadContextHandlers({
     handleRenameSubmit,
     handleRenameKeyDown,
     handleSessionClick,
+    handleGenerateSessionContext,
   }
 }

--- a/src/components/magic/hooks/useLoadContextKeyboard.ts
+++ b/src/components/magic/hooks/useLoadContextKeyboard.ts
@@ -254,6 +254,7 @@ export function useLoadContextKeyboard({
                       session,
                       worktreeId: entry.worktree_id,
                       worktreePath: entry.worktree_path,
+                      worktreeName: entry.worktree_name,
                       projectName: entry.project_name,
                     })
                   }

--- a/src/services/github.test.ts
+++ b/src/services/github.test.ts
@@ -11,9 +11,11 @@ vi.mock('./projects', () => ({
 }))
 
 import {
+  attachSessionReference,
   getAdvisoryContextContent,
   isGhAuthError,
   isUnsupportedGitHubRepoError,
+  sessionReferenceSlug,
 } from './github'
 
 describe('GitHub service error classification', () => {
@@ -66,6 +68,41 @@ describe('github advisory context service', () => {
       ghsaId: 'GHSA-892v-qq52-xprh',
       projectPath: '/repo/worktree',
       worktreeId: 'wt-1',
+    })
+  })
+})
+
+describe('session reference injection', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset()
+  })
+
+  it('builds stable session-ref slugs', () => {
+    expect(sessionReferenceSlug('abc-123')).toBe('session-ref-abc-123')
+  })
+
+  it('invokes attach_session_reference with camelCase args', async () => {
+    mockInvoke.mockResolvedValueOnce({
+      slug: 'session-ref-src-1',
+      name: 'Session: Fix login',
+      size: 100,
+      createdAt: 1,
+    })
+
+    await attachSessionReference(
+      'target-session',
+      'src-1',
+      'Fix login',
+      'jean',
+      'issue-596'
+    )
+
+    expect(mockInvoke).toHaveBeenCalledWith('attach_session_reference', {
+      targetSessionId: 'target-session',
+      sourceSessionId: 'src-1',
+      sessionName: 'Fix login',
+      projectName: 'jean',
+      worktreeName: 'issue-596',
     })
   })
 })

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1386,6 +1386,31 @@ export async function attachSavedContext(
 }
 
 /**
+ * Inject a lightweight session reference (MCP pointer prompt) into another session.
+ * Does not dump full message history — the agent uses Jean MCP to fetch on demand.
+ */
+export async function attachSessionReference(
+  targetSessionId: string,
+  sourceSessionId: string,
+  sessionName: string,
+  projectName: string,
+  worktreeName: string
+): Promise<AttachedSavedContext> {
+  return invoke<AttachedSavedContext>('attach_session_reference', {
+    targetSessionId,
+    sourceSessionId,
+    sessionName,
+    projectName,
+    worktreeName,
+  })
+}
+
+/** Stable slug for a session-reference attachment (must match Rust `session_reference_slug`). */
+export function sessionReferenceSlug(sourceSessionId: string): string {
+  return `session-ref-${sourceSessionId}`
+}
+
+/**
  * Remove an attached saved context from a session
  */
 export async function removeSavedContext(


### PR DESCRIPTION
## Summary

- Add a lightweight **Inject Session** flow so you can attach another session to the current one without dumping full message history
- Session refs are small context files that point the agent at Jean MCP (`read_session_messages` / `get_session_status`) to fetch only what it needs
- Expose injection from the Load Context **Sessions** tab, plus a magic command (`inject-session`)
- Wire `attach_session_reference` for native and web access, with tests for slug/prompt stability and invoke args

closes #596

---

Fixes #596