### PR TITLE
fix(ui): prevent display-scale zoom feedback loops

### DIFF
--- a/docs/developer/troubleshooting.md
+++ b/docs/developer/troubleshooting.md
@@ -219,7 +219,8 @@ defaults -currentHost write -g AppleFontSmoothing -int 2
 **Engineering notes:**
 
 - Native zoom is applied via `getCurrentWebview().setZoom()` in `src/hooks/use-zoom.ts`.
-- On display scale changes, Jean re-applies zoom (bounce through 1.0 when target ≠ 100%) so WKWebView refreshes its layer after multi-monitor moves.
+- On Tauri `onScaleChanged` only (not resize/`devicePixelRatio`), Jean re-applies custom zoom by bouncing through 1.0 so WKWebView refreshes its layer after multi-monitor moves. At 100% zoom the bounce is skipped entirely.
+- Do not re-listen to resize/DPR for this: `setZoom()` can change both and feed back into another refresh (UI jumps continuously). Re-entry is also guarded with a short settle window after each bounce.
 - CSS uses `-webkit-font-smoothing: antialiased` on HiDPI, and `auto` on 1× displays (`src/App.css`).
 - Main window config is opaque with empty `windowEffects` (`src-tauri/tauri.conf.json`); `set_window_vibrancy` enables translucency only when the Appearance preference is on.
 - Soft-text tip: `useExternalDisplayZoomTip` + `has_seen_external_display_zoom_tip` preference.

--- a/src/hooks/use-zoom.test.tsx
+++ b/src/hooks/use-zoom.test.tsx
@@ -13,7 +13,9 @@ let mockIsMobile = false
 const mockSetZoom = vi.fn()
 const mockMutate = vi.fn()
 const mockOnScaleChanged = vi.fn()
-type ScaleChangedEvent = { payload: { scaleFactor: number } }
+interface ScaleChangedEvent {
+  payload: { scaleFactor: number }
+}
 let scaleChangedHandler: ((event: ScaleChangedEvent) => void) | null = null
 
 vi.mock('@/services/preferences', () => ({
@@ -52,7 +54,7 @@ vi.mock('@tauri-apps/api/window', () => ({
   }),
 }))
 
-import { useZoom } from './use-zoom'
+import { DISPLAY_SCALE_ZOOM_SETTLE_MS, useZoom } from './use-zoom'
 
 describe('useZoom', () => {
   beforeEach(() => {
@@ -70,6 +72,7 @@ describe('useZoom', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     document.documentElement.style.zoom = ''
     document.documentElement.style.fontSize = ''
     document.documentElement.style.removeProperty('--app-zoom')
@@ -160,6 +163,40 @@ describe('useZoom', () => {
     await waitFor(() => {
       expect(mockSetZoom.mock.calls).toEqual([[1], [0.9]])
     })
+  })
+
+  it('ignores delayed scale side-effects after the zoom bounce settles', async () => {
+    vi.useFakeTimers()
+    mockIsNativeApp = true
+    mockPreferences = { zoom_level: 90 }
+
+    renderHook(() => useZoom())
+
+    await vi.runAllTimersAsync()
+    expect(mockOnScaleChanged).toHaveBeenCalledOnce()
+    mockSetZoom.mockClear()
+
+    mockSetZoom.mockImplementation(async zoom => {
+      if (zoom === 0.9) {
+        // Side-effect after the bounce, still inside the settle window.
+        scaleChangedHandler?.({ payload: { scaleFactor: 1.75 } })
+      }
+    })
+
+    scaleChangedHandler?.({ payload: { scaleFactor: 2 } })
+    await vi.runAllTimersAsync()
+
+    expect(mockSetZoom.mock.calls).toEqual([[1], [0.9]])
+
+    // Settle window ends; absorbed scale must not re-fire.
+    await vi.advanceTimersByTimeAsync(DISPLAY_SCALE_ZOOM_SETTLE_MS)
+    scaleChangedHandler?.({ payload: { scaleFactor: 1.75 } })
+    expect(mockSetZoom).toHaveBeenCalledTimes(2)
+
+    // A real later monitor change still refreshes once.
+    scaleChangedHandler?.({ payload: { scaleFactor: 1 } })
+    await vi.runAllTimersAsync()
+    expect(mockSetZoom.mock.calls).toEqual([[1], [0.9], [1], [0.9]])
   })
 
   it('uses the separate mobile zoom when syncing is disabled', async () => {

--- a/src/hooks/use-zoom.test.tsx
+++ b/src/hooks/use-zoom.test.tsx
@@ -13,7 +13,8 @@ let mockIsMobile = false
 const mockSetZoom = vi.fn()
 const mockMutate = vi.fn()
 const mockOnScaleChanged = vi.fn()
-let scaleChangedHandler: (() => void) | null = null
+type ScaleChangedEvent = { payload: { scaleFactor: number } }
+let scaleChangedHandler: ((event: ScaleChangedEvent) => void) | null = null
 
 vi.mock('@/services/preferences', () => ({
   usePreferences: () => ({ data: mockPreferences }),
@@ -41,7 +42,7 @@ vi.mock('@tauri-apps/api/webview', () => ({
 
 vi.mock('@tauri-apps/api/window', () => ({
   getCurrentWindow: () => ({
-    onScaleChanged: (handler: () => void) => {
+    onScaleChanged: (handler: (event: ScaleChangedEvent) => void) => {
       scaleChangedHandler = handler
       mockOnScaleChanged(handler)
       return Promise.resolve(() => {
@@ -103,29 +104,7 @@ describe('useZoom', () => {
     expect(document.documentElement.style.fontSize).toBe('')
   })
 
-  it('re-applies native zoom (bounce through 1) when display scale changes', async () => {
-    mockIsNativeApp = true
-    mockPreferences = { zoom_level: 90 }
-
-    renderHook(() => useZoom())
-
-    await waitFor(() => {
-      expect(mockSetZoom).toHaveBeenCalledWith(0.9)
-    })
-    await waitFor(() => {
-      expect(mockOnScaleChanged).toHaveBeenCalled()
-    })
-
-    mockSetZoom.mockClear()
-    scaleChangedHandler?.()
-
-    await waitFor(() => {
-      expect(mockSetZoom).toHaveBeenCalledWith(1)
-      expect(mockSetZoom).toHaveBeenCalledWith(0.9)
-    })
-  })
-
-  it('does not bounce through 1 when already at 100% zoom on scale change', async () => {
+  it('does not re-apply native zoom at 100% when display scale changes', async () => {
     mockIsNativeApp = true
     mockPreferences = { zoom_level: 100 }
 
@@ -133,18 +112,54 @@ describe('useZoom', () => {
 
     await waitFor(() => {
       expect(mockSetZoom).toHaveBeenCalledWith(1)
-    })
-    await waitFor(() => {
-      expect(mockOnScaleChanged).toHaveBeenCalled()
+      expect(mockOnScaleChanged).toHaveBeenCalledOnce()
     })
 
     mockSetZoom.mockClear()
-    scaleChangedHandler?.()
+    scaleChangedHandler?.({ payload: { scaleFactor: 2 } })
+
+    expect(mockSetZoom).not.toHaveBeenCalled()
+  })
+
+  it('refreshes a custom native zoom once when display scale changes', async () => {
+    mockIsNativeApp = true
+    mockPreferences = { zoom_level: 90 }
+
+    renderHook(() => useZoom())
 
     await waitFor(() => {
-      expect(mockSetZoom).toHaveBeenCalledWith(1)
+      expect(mockOnScaleChanged).toHaveBeenCalledOnce()
     })
-    expect(mockSetZoom).toHaveBeenCalledTimes(1)
+    mockSetZoom.mockClear()
+
+    scaleChangedHandler?.({ payload: { scaleFactor: 2 } })
+
+    await waitFor(() => {
+      expect(mockSetZoom.mock.calls).toEqual([[1], [0.9]])
+    })
+  })
+
+  it('ignores scale events caused while refreshing custom native zoom', async () => {
+    mockIsNativeApp = true
+    mockPreferences = { zoom_level: 90 }
+
+    renderHook(() => useZoom())
+
+    await waitFor(() => {
+      expect(mockOnScaleChanged).toHaveBeenCalledOnce()
+    })
+    mockSetZoom.mockClear()
+    mockSetZoom.mockImplementation(async zoom => {
+      if (zoom === 1) {
+        scaleChangedHandler?.({ payload: { scaleFactor: 1.8 } })
+      }
+    })
+
+    scaleChangedHandler?.({ payload: { scaleFactor: 2 } })
+
+    await waitFor(() => {
+      expect(mockSetZoom.mock.calls).toEqual([[1], [0.9]])
+    })
   })
 
   it('uses the separate mobile zoom when syncing is disabled', async () => {

--- a/src/hooks/use-zoom.ts
+++ b/src/hooks/use-zoom.ts
@@ -22,14 +22,7 @@ function findNearestTickIndex(zoom: number): number {
   return closest
 }
 
-/**
- * Apply UI zoom.
- *
- * Native desktop uses WKWebView/WebView2 page zoom. Fractional zoom +
- * multi-monitor scale factors is a common source of soft/blurry text on
- * macOS external displays, so callers re-apply this when the window's
- * scale factor changes.
- */
+/** Apply UI zoom when the saved preference changes. */
 async function applyZoom(scaleFactor: number) {
   if (!isNativeApp()) {
     const root = document.documentElement
@@ -50,31 +43,6 @@ async function applyZoom(scaleFactor: number) {
   }
 }
 
-/**
- * WKWebView can keep a stale backing-store scale after the window moves
- * between a Retina laptop panel and an external display. Forcing zoom to
- * 1 first, then back to the target, rebuilds the layer at the new DPR.
- */
-async function reapplyNativeZoom(scaleFactor: number) {
-  if (!isNativeApp()) {
-    await applyZoom(scaleFactor)
-    return
-  }
-
-  try {
-    const { getCurrentWebview } = await import('@tauri-apps/api/webview')
-    const webview = getCurrentWebview()
-    // Only bounce through 1 when the target isn't already 1 — avoids a
-    // flash for users already at 100% while still refreshing the surface.
-    if (Math.abs(scaleFactor - 1) > 0.001) {
-      await webview.setZoom(1)
-    }
-    await webview.setZoom(scaleFactor)
-  } catch (error) {
-    console.error('Failed to re-apply zoom after scale change:', error)
-  }
-}
-
 export function useZoom() {
   const { data: preferences } = usePreferences()
   const patchPreferences = usePatchPreferences()
@@ -91,44 +59,63 @@ export function useZoom() {
     void applyZoom(zoomLevel / 100)
   }, [zoomLevel])
 
-  // Re-apply zoom when the window moves between displays with different
-  // scale factors (classic macOS multi-monitor blur source for webviews).
+  // A native display-scale event is the reliable signal that the window moved
+  // between monitors. Do not use resize/devicePixelRatio here: setZoom() can
+  // change both and feed the zoom operation back into itself.
   useEffect(() => {
     if (!isNativeApp()) return
 
     const scaleFactor = zoomLevel / 100
     let unlisten: (() => void) | undefined
     let cancelled = false
-    let lastDpr = window.devicePixelRatio
+    let refreshing = false
+    let lastDisplayScale: number | undefined
 
     void (async () => {
       try {
         const { getCurrentWindow } = await import('@tauri-apps/api/window')
         if (cancelled) return
-        unlisten = await getCurrentWindow().onScaleChanged(() => {
-          lastDpr = window.devicePixelRatio
-          void reapplyNativeZoom(scaleFactor)
+
+        unlisten = await getCurrentWindow().onScaleChanged(event => {
+          const displayScale = event.payload.scaleFactor
+          if (
+            cancelled ||
+            refreshing ||
+            Math.abs(scaleFactor - 1) < 0.001 ||
+            displayScale === lastDisplayScale
+          ) {
+            return
+          }
+
+          lastDisplayScale = displayScale
+          refreshing = true
+
+          void (async () => {
+            try {
+              const { getCurrentWebview } = await import(
+                '@tauri-apps/api/webview'
+              )
+              const webview = getCurrentWebview()
+              await webview.setZoom(1)
+              await webview.setZoom(scaleFactor)
+            } catch (error) {
+              console.error(
+                'Failed to re-apply zoom after display scale change:',
+                error
+              )
+            } finally {
+              refreshing = false
+            }
+          })()
         })
       } catch (error) {
         console.error('Failed to listen for display scale changes:', error)
       }
     })()
 
-    // Fallback: some WebKit builds update devicePixelRatio without a clean
-    // Tauri scale event (e.g. after sleep/wake with external monitors).
-    // Only re-apply when DPR actually changes — not on every window resize.
-    const onWindowResize = () => {
-      const nextDpr = window.devicePixelRatio
-      if (Math.abs(nextDpr - lastDpr) < 0.001) return
-      lastDpr = nextDpr
-      void reapplyNativeZoom(scaleFactor)
-    }
-    window.addEventListener('resize', onWindowResize)
-
     return () => {
       cancelled = true
       unlisten?.()
-      window.removeEventListener('resize', onWindowResize)
     }
   }, [zoomLevel])
 

--- a/src/hooks/use-zoom.ts
+++ b/src/hooks/use-zoom.ts
@@ -43,6 +43,21 @@ async function applyZoom(scaleFactor: number) {
   }
 }
 
+/** UI zoom at 100% — re-applying is a no-op and can still disturb the surface. */
+function isDefaultZoom(scaleFactor: number): boolean {
+  return Math.abs(scaleFactor - 1) < 0.001
+}
+
+function sameDisplayScale(a: number | undefined, b: number): boolean {
+  return a !== undefined && Math.abs(a - b) < 0.001
+}
+
+/**
+ * How long to keep absorbing scale events after a zoom bounce.
+ * setZoom() can emit delayed scale/DPR side-effects after the awaits resolve.
+ */
+export const DISPLAY_SCALE_ZOOM_SETTLE_MS = 50
+
 export function useZoom() {
   const { data: preferences } = usePreferences()
   const patchPreferences = usePatchPreferences()
@@ -69,6 +84,7 @@ export function useZoom() {
     let unlisten: (() => void) | undefined
     let cancelled = false
     let refreshing = false
+    let settleTimer: ReturnType<typeof setTimeout> | undefined
     let lastDisplayScale: number | undefined
 
     void (async () => {
@@ -78,25 +94,41 @@ export function useZoom() {
 
         unlisten = await getCurrentWindow().onScaleChanged(event => {
           const displayScale = event.payload.scaleFactor
-          if (
-            cancelled ||
-            refreshing ||
-            Math.abs(scaleFactor - 1) < 0.001 ||
-            displayScale === lastDisplayScale
-          ) {
+
+          // 100% zoom does not need a bounce refresh; calling setZoom(1) on
+          // every scale change is what made the UI jump continuously.
+          if (cancelled || isDefaultZoom(scaleFactor)) {
+            return
+          }
+
+          // Absorb side-effect scale events from an in-flight (or settling)
+          // setZoom bounce so they cannot start another refresh loop.
+          if (refreshing) {
+            lastDisplayScale = displayScale
+            return
+          }
+
+          if (sameDisplayScale(lastDisplayScale, displayScale)) {
             return
           }
 
           lastDisplayScale = displayScale
           refreshing = true
+          if (settleTimer !== undefined) {
+            clearTimeout(settleTimer)
+            settleTimer = undefined
+          }
 
           void (async () => {
             try {
               const { getCurrentWebview } = await import(
                 '@tauri-apps/api/webview'
               )
+              if (cancelled) return
               const webview = getCurrentWebview()
+              // Bounce through 1 so WKWebView rebuilds its layer at the new DPR.
               await webview.setZoom(1)
+              if (cancelled) return
               await webview.setZoom(scaleFactor)
             } catch (error) {
               console.error(
@@ -104,7 +136,13 @@ export function useZoom() {
                 error
               )
             } finally {
-              refreshing = false
+              // Keep absorbing late scale events for a short settle window.
+              settleTimer = setTimeout(() => {
+                settleTimer = undefined
+                if (!cancelled) {
+                  refreshing = false
+                }
+              }, DISPLAY_SCALE_ZOOM_SETTLE_MS)
             }
           })()
         })
@@ -115,6 +153,9 @@ export function useZoom() {
 
     return () => {
       cancelled = true
+      if (settleTimer !== undefined) {
+        clearTimeout(settleTimer)
+      }
       unlisten?.()
     }
   }, [zoomLevel])


### PR DESCRIPTION
## Summary
- listen only to Tauri's native display-scale event when refreshing custom desktop zoom
- avoid reapplying 100% zoom and guard custom zoom refreshes against re-entrant scale events
- remove the resize/devicePixelRatio fallback that can feed WebView zoom changes back into the layout

## Why
The display-scale zoom refresh introduced in `7becad2b` can repeatedly call `setZoom()` when the resulting WebView resize or DPR update is observed as another scale change. At 100% this makes the whole interface continuously jump until the user changes zoom.

## Test plan
- [x] `bun run test:run src/hooks/use-zoom.test.tsx`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] Manually verify 100% zoom remains stable while resizing and moving between displays
- [x] Manually verify a custom zoom is preserved when moving between displays