### PR TITLE
fix(ui): store zoom levels in client-local storage

### DIFF
--- a/docs/developer/troubleshooting.md
+++ b/docs/developer/troubleshooting.md
@@ -218,6 +218,7 @@ defaults -currentHost write -g AppleFontSmoothing -int 2
 
 **Engineering notes:**
 
+- Zoom is **client-local** (`src/lib/client-zoom.ts` + `localStorage` key `jean-client-zoom`), not shared server preferences. Remote Jean clients and the host shell keep independent zoom levels (issue #622). Server `zoom_level` fields are a one-time seed only.
 - Native zoom is applied via `getCurrentWebview().setZoom()` in `src/hooks/use-zoom.ts`.
 - On Tauri `onScaleChanged` only (not resize/`devicePixelRatio`), Jean re-applies custom zoom by bouncing through 1.0 so WKWebView refreshes its layer after multi-monitor moves. At 100% zoom the bounce is skipped entirely.
 - Do not re-listen to resize/DPR for this: `setZoom()` can change both and feed back into another refresh (UI jumps continuously). Re-entry is also guarded with a short settle window after each bounce.

--- a/src/components/preferences/panes/AppearancePane.tsx
+++ b/src/components/preferences/panes/AppearancePane.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Label } from '@/components/ui/label'
 import { Slider } from '@/components/ui/slider'
 import { Switch } from '@/components/ui/switch'
@@ -21,7 +21,6 @@ import {
   terminalBackgroundOptions,
   FONT_SIZE_DEFAULT,
   FONT_WEIGHT_DEFAULT,
-  ZOOM_LEVEL_DEFAULT,
   uiFontScaleTicks,
   chatFontScaleTicks,
   zoomLevelTicks,
@@ -36,6 +35,7 @@ import { invoke } from '@/lib/transport'
 import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
 import { isValidHex } from '@/lib/terminal-theme'
+import { useClientZoom } from '@/lib/client-zoom'
 import { SettingsSection } from '../SettingsSection'
 
 const InlineField: React.FC<{
@@ -82,11 +82,30 @@ export const AppearancePane: React.FC = () => {
   const patchPreferences = usePatchPreferences()
   const [isVibrancyPending, setIsVibrancyPending] = useState(false)
 
-  // Zoom uses commit-only saving to avoid flickering the webview during drag.
-  // localZoom tracks slider position, preferences are saved only on release.
-  const desktopZoom = preferences?.zoom_level ?? ZOOM_LEVEL_DEFAULT
-  const savedMobileZoom = preferences?.mobile_zoom_level ?? ZOOM_LEVEL_DEFAULT
-  const syncZoomLevels = preferences?.sync_zoom_levels ?? true
+  // Zoom is client-local (issue #622) — not written to shared AppPreferences.
+  // Commit-only slider updates avoid flickering the webview during drag.
+  const zoomSeed = useMemo(
+    () =>
+      preferences
+        ? {
+            zoom_level: preferences.zoom_level,
+            mobile_zoom_level: preferences.mobile_zoom_level,
+            sync_zoom_levels: preferences.sync_zoom_levels,
+          }
+        : null,
+    [
+      preferences?.zoom_level,
+      preferences?.mobile_zoom_level,
+      preferences?.sync_zoom_levels,
+      preferences == null,
+    ]
+  )
+  const {
+    zoom_level: desktopZoom,
+    mobile_zoom_level: savedMobileZoom,
+    sync_zoom_levels: syncZoomLevels,
+    updateZoom,
+  } = useClientZoom(zoomSeed)
   const [localDesktopZoom, setLocalDesktopZoom] = useState<number | null>(null)
   const [localMobileZoom, setLocalMobileZoom] = useState<number | null>(null)
   const desktopZoomValue = localDesktopZoom ?? desktopZoom
@@ -115,17 +134,17 @@ export const AppearancePane: React.FC = () => {
     (target: 'desktop' | 'mobile', value: number) => {
       if (target === 'desktop') {
         setLocalDesktopZoom(null)
-        patchPreferences.mutate(
+        updateZoom(
           syncZoomLevels
             ? { zoom_level: value, mobile_zoom_level: value }
             : { zoom_level: value }
         )
       } else {
         setLocalMobileZoom(null)
-        patchPreferences.mutate({ mobile_zoom_level: value })
+        updateZoom({ mobile_zoom_level: value })
       }
     },
-    [patchPreferences, syncZoomLevels]
+    [syncZoomLevels, updateZoom]
   )
 
   const handleSyncZoomLevelsChange = useCallback(
@@ -133,12 +152,12 @@ export const AppearancePane: React.FC = () => {
       const shouldSync = checked === true
       setLocalDesktopZoom(null)
       setLocalMobileZoom(null)
-      patchPreferences.mutate({
+      updateZoom({
         sync_zoom_levels: shouldSync,
         mobile_zoom_level: desktopZoom,
       })
     },
-    [desktopZoom, patchPreferences]
+    [desktopZoom, updateZoom]
   )
 
   const handleFontChange = useCallback(
@@ -547,7 +566,6 @@ export const AppearancePane: React.FC = () => {
               id="sync-zoom-levels"
               checked={syncZoomLevels}
               onCheckedChange={handleSyncZoomLevelsChange}
-              disabled={patchPreferences.isPending}
             />
             <Label
               htmlFor="sync-zoom-levels"
@@ -559,14 +577,13 @@ export const AppearancePane: React.FC = () => {
 
           <ScalingField
             label="Desktop zoom level"
-            description="Adjust the interface size on desktop screens"
+            description="Adjust the interface size on this device (not shared with remote clients)"
           >
             <Slider
               ticks={zoomLevelTicks}
               value={desktopZoomValue}
               onValueChange={setLocalDesktopZoom}
               onValueCommit={value => handleZoomCommit('desktop', value)}
-              disabled={patchPreferences.isPending}
             />
             <p className="text-xs text-muted-foreground">
               You can change the zoom level with {modKey} +/- and reset to the
@@ -580,7 +597,7 @@ export const AppearancePane: React.FC = () => {
             description={
               syncZoomLevels
                 ? 'Synced with the desktop zoom level'
-                : 'Adjust the interface size on mobile screens'
+                : 'Adjust the interface size on this device (not shared with remote clients)'
             }
           >
             <Slider
@@ -588,7 +605,7 @@ export const AppearancePane: React.FC = () => {
               value={mobileZoomValue}
               onValueChange={setLocalMobileZoom}
               onValueCommit={value => handleZoomCommit('mobile', value)}
-              disabled={syncZoomLevels || patchPreferences.isPending}
+              disabled={syncZoomLevels}
             />
           </ScalingField>
         </div>

--- a/src/hooks/use-external-display-zoom-tip.ts
+++ b/src/hooks/use-external-display-zoom-tip.ts
@@ -1,8 +1,8 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { toast } from 'sonner'
 import { usePreferences, usePatchPreferences } from '@/services/preferences'
 import { isNativeApp } from '@/lib/environment'
-import { ZOOM_LEVEL_DEFAULT } from '@/types/preferences'
+import { useClientZoom } from '@/lib/client-zoom'
 
 export const EXTERNAL_DISPLAY_ZOOM_TIP_TOAST_ID = 'external-display-zoom-tip'
 
@@ -34,7 +34,24 @@ export function useExternalDisplayZoomTip() {
   const patchPreferences = usePatchPreferences()
   const shownRef = useRef(false)
 
-  const zoomLevel = preferences?.zoom_level ?? ZOOM_LEVEL_DEFAULT
+  const zoomSeed = useMemo(
+    () =>
+      preferences
+        ? {
+            zoom_level: preferences.zoom_level,
+            mobile_zoom_level: preferences.mobile_zoom_level,
+            sync_zoom_levels: preferences.sync_zoom_levels,
+          }
+        : null,
+    [
+      preferences?.zoom_level,
+      preferences?.mobile_zoom_level,
+      preferences?.sync_zoom_levels,
+      preferences == null,
+    ]
+  )
+  const { zoom_level: zoomLevel, sync_zoom_levels: syncZoomLevels, updateZoom } =
+    useClientZoom(zoomSeed)
   const hasSeenTip = preferences?.has_seen_external_display_zoom_tip ?? false
 
   useEffect(() => {
@@ -46,13 +63,12 @@ export function useExternalDisplayZoomTip() {
     }
 
     const setZoomTo100 = () => {
-      patchPreferences.mutate({
+      // Zoom is client-local; only the tip dismissal is shared preferences.
+      updateZoom({
         zoom_level: 100,
-        ...(preferences.sync_zoom_levels !== false
-          ? { mobile_zoom_level: 100 }
-          : {}),
-        has_seen_external_display_zoom_tip: true,
+        ...(syncZoomLevels ? { mobile_zoom_level: 100 } : {}),
       })
+      patchPreferences.mutate({ has_seen_external_display_zoom_tip: true })
     }
 
     const evaluate = () => {
@@ -136,5 +152,12 @@ export function useExternalDisplayZoomTip() {
       unlisten?.()
       window.removeEventListener('resize', onResize)
     }
-  }, [hasSeenTip, patchPreferences, preferences, zoomLevel])
+  }, [
+    hasSeenTip,
+    patchPreferences,
+    preferences,
+    syncZoomLevels,
+    updateZoom,
+    zoomLevel,
+  ])
 }

--- a/src/hooks/use-zoom.test.tsx
+++ b/src/hooks/use-zoom.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearClientZoomForTests, writeClientZoom } from '@/lib/client-zoom'
 
 let mockPreferences:
   | {
@@ -11,7 +12,6 @@ let mockPreferences:
 let mockIsNativeApp = false
 let mockIsMobile = false
 const mockSetZoom = vi.fn()
-const mockMutate = vi.fn()
 const mockOnScaleChanged = vi.fn()
 interface ScaleChangedEvent {
   payload: { scaleFactor: number }
@@ -20,7 +20,7 @@ let scaleChangedHandler: ((event: ScaleChangedEvent) => void) | null = null
 
 vi.mock('@/services/preferences', () => ({
   usePreferences: () => ({ data: mockPreferences }),
-  usePatchPreferences: () => ({ mutate: mockMutate }),
+  usePatchPreferences: () => ({ mutate: vi.fn() }),
 }))
 
 vi.mock('@/hooks/use-mobile', () => ({
@@ -39,10 +39,31 @@ vi.mock('@/lib/platform', () => ({
 }))
 
 vi.mock('@tauri-apps/api/webview', () => ({
-  getCurrentWebview: () => ({ setZoom: mockSetZoom }),
+  getCurrentWebview: () => ({
+    setZoom: (...args: unknown[]) => mockSetZoom(...args),
+  }),
 }))
 
 vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    onScaleChanged: (handler: (event: ScaleChangedEvent) => void) => {
+      scaleChangedHandler = handler
+      mockOnScaleChanged(handler)
+      return Promise.resolve(() => {
+        scaleChangedHandler = null
+      })
+    },
+  }),
+}))
+
+// Ensure dynamic imports hit the same mocks (vitest isolates some ESM paths).
+vi.mock('@tauri-apps/api/webview.js', () => ({
+  getCurrentWebview: () => ({
+    setZoom: (...args: unknown[]) => mockSetZoom(...args),
+  }),
+}))
+
+vi.mock('@tauri-apps/api/window.js', () => ({
   getCurrentWindow: () => ({
     onScaleChanged: (handler: (event: ScaleChangedEvent) => void) => {
       scaleChangedHandler = handler
@@ -58,12 +79,12 @@ import { DISPLAY_SCALE_ZOOM_SETTLE_MS, useZoom } from './use-zoom'
 
 describe('useZoom', () => {
   beforeEach(() => {
+    clearClientZoomForTests()
     mockPreferences = { zoom_level: 125 }
     mockIsNativeApp = false
     mockIsMobile = false
     mockSetZoom.mockReset()
     mockSetZoom.mockResolvedValue(undefined)
-    mockMutate.mockReset()
     mockOnScaleChanged.mockReset()
     scaleChangedHandler = null
     document.documentElement.style.zoom = ''
@@ -73,6 +94,7 @@ describe('useZoom', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    clearClientZoomForTests()
     document.documentElement.style.zoom = ''
     document.documentElement.style.fontSize = ''
     document.documentElement.style.removeProperty('--app-zoom')
@@ -229,7 +251,7 @@ describe('useZoom', () => {
     })
   })
 
-  it('uses the Mac client modifier when connected to a non-Mac server', () => {
+  it('uses the Mac client modifier when connected to a non-Mac server', async () => {
     mockIsNativeApp = true
     mockPreferences = {
       zoom_level: 125,
@@ -238,27 +260,54 @@ describe('useZoom', () => {
     }
     renderHook(() => useZoom())
 
+    await waitFor(() => {
+      expect(mockSetZoom).toHaveBeenCalledWith(1.25)
+    })
+
     document.dispatchEvent(
       new KeyboardEvent('keydown', { key: '+', metaKey: true, bubbles: true })
     )
 
-    expect(mockMutate).toHaveBeenCalledWith({
-      zoom_level: 150,
-      mobile_zoom_level: 150,
+    await waitFor(() => {
+      expect(mockSetZoom).toHaveBeenCalledWith(1.5)
     })
   })
 
-  it('uses Control for zoom in a Mac web client', () => {
+  it('uses Control for zoom in a Mac web client', async () => {
     mockPreferences = { zoom_level: 125 }
     renderHook(() => useZoom())
+
+    await waitFor(() => {
+      expect(
+        document.documentElement.style.getPropertyValue('--app-zoom')
+      ).toBe('1.25')
+    })
 
     document.dispatchEvent(
       new KeyboardEvent('keydown', { key: '+', ctrlKey: true, bubbles: true })
     )
 
-    expect(mockMutate).toHaveBeenCalledWith({
+    await waitFor(() => {
+      expect(
+        document.documentElement.style.getPropertyValue('--app-zoom')
+      ).toBe('1.5')
+    })
+  })
+
+  it('keeps client zoom when server preferences change after seed', async () => {
+    writeClientZoom({
       zoom_level: 150,
       mobile_zoom_level: 150,
+      sync_zoom_levels: true,
+    })
+    mockPreferences = { zoom_level: 90 }
+
+    renderHook(() => useZoom())
+
+    await waitFor(() => {
+      expect(
+        document.documentElement.style.getPropertyValue('--app-zoom')
+      ).toBe('1.5')
     })
   })
 })

--- a/src/hooks/use-zoom.ts
+++ b/src/hooks/use-zoom.ts
@@ -1,9 +1,10 @@
-import { useEffect } from 'react'
-import { usePreferences, usePatchPreferences } from '@/services/preferences'
+import { useEffect, useMemo } from 'react'
+import { usePreferences } from '@/services/preferences'
 import { isNativeApp } from '@/lib/environment'
 import { ZOOM_LEVEL_DEFAULT, zoomLevelTicks } from '@/types/preferences'
 import { isClientMacOS } from '@/lib/platform'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { useClientZoom } from '@/lib/client-zoom'
 
 const tickValues = zoomLevelTicks.map(t => t.value)
 
@@ -60,16 +61,39 @@ export const DISPLAY_SCALE_ZOOM_SETTLE_MS = 50
 
 export function useZoom() {
   const { data: preferences } = usePreferences()
-  const patchPreferences = usePatchPreferences()
   const isMobile = useIsMobile()
-  const syncZoomLevels = preferences?.sync_zoom_levels ?? true
-  const desktopZoom = preferences?.zoom_level ?? ZOOM_LEVEL_DEFAULT
-  const zoomLevel =
-    isMobile && !syncZoomLevels
-      ? (preferences?.mobile_zoom_level ?? ZOOM_LEVEL_DEFAULT)
-      : desktopZoom
 
-  // Apply zoom when preferences change
+  // Zoom is client-local (localStorage) so remote Jean clients and the host
+  // shell do not overwrite each other via shared AppPreferences (issue #622).
+  const zoomSeed = useMemo(
+    () =>
+      preferences
+        ? {
+            zoom_level: preferences.zoom_level,
+            mobile_zoom_level: preferences.mobile_zoom_level,
+            sync_zoom_levels: preferences.sync_zoom_levels,
+          }
+        : null,
+    [
+      preferences?.zoom_level,
+      preferences?.mobile_zoom_level,
+      preferences?.sync_zoom_levels,
+      // preferences identity when still loading → null seed
+      preferences == null,
+    ]
+  )
+
+  const {
+    zoom_level: desktopZoom,
+    mobile_zoom_level: mobileZoom,
+    sync_zoom_levels: syncZoomLevels,
+    updateZoom,
+  } = useClientZoom(zoomSeed)
+
+  const zoomLevel =
+    isMobile && !syncZoomLevels ? mobileZoom : desktopZoom
+
+  // Apply zoom when client-local zoom changes
   useEffect(() => {
     void applyZoom(zoomLevel / 100)
   }, [zoomLevel])
@@ -186,22 +210,23 @@ export function useZoom() {
         newZoom = tickValues[prevIndex] ?? currentZoom
       }
 
-      if (newZoom !== currentZoom && preferences) {
-        if (syncZoomLevels) {
-          patchPreferences.mutate({
-            zoom_level: newZoom,
-            mobile_zoom_level: newZoom,
-          })
-        } else if (isMobile) {
-          patchPreferences.mutate({ mobile_zoom_level: newZoom })
-        } else {
-          patchPreferences.mutate({ zoom_level: newZoom })
-        }
+      if (newZoom === currentZoom) return
+
+      // Always persist on this client only — never patch shared AppPreferences.
+      if (syncZoomLevels) {
+        updateZoom({
+          zoom_level: newZoom,
+          mobile_zoom_level: newZoom,
+        })
+      } else if (isMobile) {
+        updateZoom({ mobile_zoom_level: newZoom })
+      } else {
+        updateZoom({ zoom_level: newZoom })
       }
     }
 
     document.addEventListener('keydown', handleKeyDown, { capture: true })
     return () =>
       document.removeEventListener('keydown', handleKeyDown, { capture: true })
-  }, [isMobile, patchPreferences, preferences, syncZoomLevels, zoomLevel])
+  }, [isMobile, syncZoomLevels, updateZoom, zoomLevel])
 }

--- a/src/lib/client-zoom.test.ts
+++ b/src/lib/client-zoom.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  CLIENT_ZOOM_STORAGE_KEY,
+  clearClientZoomForTests,
+  clampZoomLevel,
+  defaultClientZoomSettings,
+  readClientZoom,
+  resolveClientZoom,
+  writeClientZoom,
+} from './client-zoom'
+
+describe('client-zoom', () => {
+  beforeEach(() => {
+    clearClientZoomForTests()
+    vi.mocked(window.localStorage.getItem).mockReset()
+    vi.mocked(window.localStorage.setItem).mockReset()
+    vi.mocked(window.localStorage.removeItem).mockReset()
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    clearClientZoomForTests()
+  })
+
+  it('clamps zoom to the supported range', () => {
+    expect(clampZoomLevel(10)).toBe(50)
+    expect(clampZoomLevel(300)).toBe(200)
+    expect(clampZoomLevel(125.4)).toBe(125)
+    expect(clampZoomLevel(Number.NaN)).toBe(100)
+  })
+
+  it('writes and reads client-local zoom without shared backend state', () => {
+    expect(readClientZoom()).toBeNull()
+
+    const written = writeClientZoom({
+      zoom_level: 125,
+      mobile_zoom_level: 150,
+      sync_zoom_levels: false,
+    })
+
+    expect(written).toEqual({
+      zoom_level: 125,
+      mobile_zoom_level: 150,
+      sync_zoom_levels: false,
+    })
+    expect(readClientZoom()).toEqual(written)
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      CLIENT_ZOOM_STORAGE_KEY,
+      expect.stringContaining('"zoom_level":125')
+    )
+  })
+
+  it('seeds from server preferences only when client has no stored zoom', () => {
+    const seeded = resolveClientZoom({
+      zoom_level: 90,
+      mobile_zoom_level: 110,
+      sync_zoom_levels: false,
+    })
+    expect(seeded).toEqual({
+      zoom_level: 90,
+      mobile_zoom_level: 110,
+      sync_zoom_levels: false,
+    })
+
+    // Later server preference broadcasts must not overwrite client zoom.
+    const again = resolveClientZoom({
+      zoom_level: 200,
+      mobile_zoom_level: 200,
+      sync_zoom_levels: true,
+    })
+    expect(again).toEqual(seeded)
+  })
+
+  it('falls back to defaults when no seed is available', () => {
+    expect(resolveClientZoom(null)).toEqual(defaultClientZoomSettings())
+  })
+
+  it('partial updates merge with existing client settings', () => {
+    writeClientZoom({
+      zoom_level: 100,
+      mobile_zoom_level: 150,
+      sync_zoom_levels: false,
+    })
+    expect(writeClientZoom({ zoom_level: 125 })).toEqual({
+      zoom_level: 125,
+      mobile_zoom_level: 150,
+      sync_zoom_levels: false,
+    })
+  })
+})

--- a/src/lib/client-zoom.ts
+++ b/src/lib/client-zoom.ts
@@ -1,0 +1,201 @@
+/**
+ * Client-local zoom settings.
+ *
+ * Zoom is a display concern (DPI, monitor, remote vs local shell) and must not
+ * live in shared server preferences — otherwise native Jean and remote Jean
+ * clients overwrite each other (issue #622).
+ *
+ * Server `zoom_level` / `mobile_zoom_level` / `sync_zoom_levels` remain only as
+ * a one-time seed for clients that have never stored a local value.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ZOOM_LEVEL_DEFAULT } from '@/types/preferences'
+
+export const CLIENT_ZOOM_STORAGE_KEY = 'jean-client-zoom'
+export const CLIENT_ZOOM_CHANGED_EVENT = 'jean-client-zoom-changed'
+
+export const ZOOM_LEVEL_MIN = 50
+export const ZOOM_LEVEL_MAX = 200
+
+export interface ClientZoomSettings {
+  zoom_level: number
+  mobile_zoom_level: number
+  sync_zoom_levels: boolean
+}
+
+export interface ClientZoomSeed {
+  zoom_level?: number
+  mobile_zoom_level?: number
+  sync_zoom_levels?: boolean
+}
+
+/** In-memory cache so updates work even if localStorage is unavailable/mocked. */
+let memoryCache: ClientZoomSettings | null = null
+
+export function clampZoomLevel(value: number): number {
+  if (!Number.isFinite(value)) return ZOOM_LEVEL_DEFAULT
+  return Math.min(ZOOM_LEVEL_MAX, Math.max(ZOOM_LEVEL_MIN, Math.round(value)))
+}
+
+export function defaultClientZoomSettings(): ClientZoomSettings {
+  return {
+    zoom_level: ZOOM_LEVEL_DEFAULT,
+    mobile_zoom_level: ZOOM_LEVEL_DEFAULT,
+    sync_zoom_levels: true,
+  }
+}
+
+function normalizeSettings(input: ClientZoomSeed): ClientZoomSettings {
+  const defaults = defaultClientZoomSettings()
+  const zoom = clampZoomLevel(input.zoom_level ?? defaults.zoom_level)
+  return {
+    zoom_level: zoom,
+    mobile_zoom_level: clampZoomLevel(
+      input.mobile_zoom_level ?? input.zoom_level ?? defaults.mobile_zoom_level
+    ),
+    sync_zoom_levels: input.sync_zoom_levels ?? defaults.sync_zoom_levels,
+  }
+}
+
+function parseStored(raw: string | null): ClientZoomSettings | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as ClientZoomSeed
+    if (typeof parsed !== 'object' || parsed == null) return null
+    return normalizeSettings(parsed)
+  } catch {
+    return null
+  }
+}
+
+function readStorage(): ClientZoomSettings | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return parseStored(window.localStorage.getItem(CLIENT_ZOOM_STORAGE_KEY))
+  } catch {
+    return null
+  }
+}
+
+function writeStorage(settings: ClientZoomSettings): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(
+      CLIENT_ZOOM_STORAGE_KEY,
+      JSON.stringify(settings)
+    )
+  } catch {
+    // Quota / private mode — memory cache still works for the session.
+  }
+}
+
+function notifyChanged(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new Event(CLIENT_ZOOM_CHANGED_EVENT))
+}
+
+/** Read client zoom (memory first, then localStorage). */
+export function readClientZoom(): ClientZoomSettings | null {
+  if (memoryCache) return memoryCache
+  const stored = readStorage()
+  if (stored) {
+    memoryCache = stored
+    return stored
+  }
+  return null
+}
+
+/**
+ * Persist a partial zoom update on this client only (never the shared backend).
+ */
+export function writeClientZoom(
+  patch: Partial<ClientZoomSettings>
+): ClientZoomSettings {
+  const current = readClientZoom() ?? defaultClientZoomSettings()
+  const next = normalizeSettings({ ...current, ...patch })
+  memoryCache = next
+  writeStorage(next)
+  notifyChanged()
+  return next
+}
+
+/**
+ * Resolve zoom for this client. Prefer existing client storage; otherwise seed
+ * from server preferences once and persist so later preference broadcasts do
+ * not overwrite an independent remote/local zoom.
+ */
+export function resolveClientZoom(seed?: ClientZoomSeed | null): ClientZoomSettings {
+  const existing = readClientZoom()
+  if (existing) return existing
+
+  const resolved = normalizeSettings(seed ?? defaultClientZoomSettings())
+  memoryCache = resolved
+  writeStorage(resolved)
+  // Do not notify on first seed — callers already hold the resolved value.
+  return resolved
+}
+
+/** Test helper: clear memory + storage. */
+export function clearClientZoomForTests(): void {
+  memoryCache = null
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.removeItem(CLIENT_ZOOM_STORAGE_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * React hook for client-local zoom. Seeds from server preferences once when
+ * this client has no stored zoom yet.
+ */
+export function useClientZoom(seed?: ClientZoomSeed | null) {
+  const [settings, setSettings] = useState<ClientZoomSettings>(() => {
+    const existing = readClientZoom()
+    if (existing) return existing
+    // If preferences already hydrated on first render (common in tests and
+    // warm caches), seed immediately so we do not flash default 100% zoom.
+    if (seed != null) return resolveClientZoom(seed)
+    return defaultClientZoomSettings()
+  })
+  const seededRef = useRef(readClientZoom() !== null)
+
+  // Seed once from server preferences when local storage is empty.
+  useEffect(() => {
+    if (seededRef.current) return
+    // Wait until seed is available so we don't lock in defaults before prefs load.
+    if (seed == null) return
+    const resolved = resolveClientZoom(seed)
+    seededRef.current = true
+    setSettings(resolved)
+  }, [seed])
+
+  // Sync across components (and tabs when localStorage works).
+  useEffect(() => {
+    const syncFromStore = () => {
+      const next = readClientZoom()
+      if (next) setSettings(next)
+    }
+    window.addEventListener(CLIENT_ZOOM_CHANGED_EVENT, syncFromStore)
+    window.addEventListener('storage', syncFromStore)
+    return () => {
+      window.removeEventListener(CLIENT_ZOOM_CHANGED_EVENT, syncFromStore)
+      window.removeEventListener('storage', syncFromStore)
+    }
+  }, [])
+
+  const updateZoom = useCallback((patch: Partial<ClientZoomSettings>) => {
+    const next = writeClientZoom(patch)
+    setSettings(next)
+    return next
+  }, [])
+
+  return {
+    zoom_level: settings.zoom_level,
+    mobile_zoom_level: settings.mobile_zoom_level,
+    sync_zoom_levels: settings.sync_zoom_levels,
+    updateZoom,
+  }
+}

--- a/src/services/preferences.test.ts
+++ b/src/services/preferences.test.ts
@@ -1287,8 +1287,23 @@ describe('preferences service', () => {
   })
 
   describe('AppearancePane scaling', () => {
-    it('syncs desktop and mobile scaling by default', async () => {
+    it(
+      'stores desktop/mobile zoom on this client only (not shared prefs)',
+      async () => {
       const { invoke } = await import('@/lib/transport')
+      const {
+        clearClientZoomForTests,
+        readClientZoom,
+        writeClientZoom,
+      } = await import('@/lib/client-zoom')
+      clearClientZoomForTests()
+      // Seed client zoom so the pane does not depend on async prefs hydrate.
+      writeClientZoom({
+        zoom_level: ZOOM_LEVEL_DEFAULT,
+        mobile_zoom_level: ZOOM_LEVEL_DEFAULT,
+        sync_zoom_levels: true,
+      })
+
       let storedPreferences = { ...defaultPreferences }
       vi.mocked(invoke).mockImplementation(async (command, args) => {
         if (command === 'load_preferences') return storedPreferences
@@ -1319,31 +1334,45 @@ describe('preferences service', () => {
         'data-disabled'
       )
 
+      const patchCallsBefore = vi
+        .mocked(invoke)
+        .mock.calls.filter(([command]) => command === 'patch_preferences')
+        .length
+
       await user.click(syncCheckbox)
 
       await waitFor(() => {
-        expect(invoke).toHaveBeenCalledWith('patch_preferences', {
-          patch: {
-            sync_zoom_levels: false,
-            mobile_zoom_level: ZOOM_LEVEL_DEFAULT,
-          },
-        })
         expect(syncCheckbox).not.toBeChecked()
-        expect(screen.getAllByRole('slider').at(-1)).not.toHaveAttribute(
-          'data-disabled'
-        )
+        expect(readClientZoom()?.sync_zoom_levels).toBe(false)
       })
+      expect(screen.getAllByRole('slider').at(-1)).not.toHaveAttribute(
+        'data-disabled'
+      )
+
+      // Zoom must not be written to shared server preferences (issue #622).
+      const patchCallsAfterSync = vi
+        .mocked(invoke)
+        .mock.calls.filter(([command]) => command === 'patch_preferences')
+      expect(patchCallsAfterSync).toHaveLength(patchCallsBefore)
 
       const mobileSlider = screen.getAllByRole('slider').at(-1)
-      mobileSlider?.focus()
+      expect(mobileSlider).toBeTruthy()
+      mobileSlider!.focus()
       await user.keyboard('{ArrowRight}')
 
       await waitFor(() => {
-        expect(invoke).toHaveBeenCalledWith('patch_preferences', {
-          patch: { mobile_zoom_level: 110 },
-        })
+        expect(readClientZoom()?.mobile_zoom_level).toBe(110)
       })
-    })
+      expect(
+        vi
+          .mocked(invoke)
+          .mock.calls.filter(([command]) => command === 'patch_preferences')
+      ).toHaveLength(patchCallsBefore)
+
+      clearClientZoomForTests()
+    },
+      15_000
+    )
   })
 
   describe('AppearancePane finished session animation', () => {

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1235,8 +1235,11 @@ export interface AppPreferences {
   /** One-time tip: soft text on 1× displays when zoom ≠ 100% (default false = not dismissed) */
   has_seen_external_display_zoom_tip?: boolean
   chrome_enabled: boolean // Enable browser automation via Chrome extension
+  /** @deprecated Client-local only (issue #622). Kept for one-time seed/migration. */
   zoom_level: number // Desktop zoom level percentage (50-200, default 100)
+  /** @deprecated Client-local only (issue #622). Kept for one-time seed/migration. */
   mobile_zoom_level?: number // Mobile zoom level percentage (50-200, default 100)
+  /** @deprecated Client-local only (issue #622). Kept for one-time seed/migration. */
   sync_zoom_levels?: boolean // Keep desktop and mobile zoom levels in sync (default true)
   custom_cli_profiles: CustomCliProfile[] // Custom CLI settings profiles (e.g., OpenRouter, MiniMax)
   default_provider: string | null // Default Claude provider profile name (null = Anthropic direct)


### PR DESCRIPTION
## Summary

- Store desktop/mobile zoom and sync preference in client-local storage instead of shared server preferences so host and remote Jean clients keep independent zoom levels
- Seed client zoom once from existing server preference values for migration, without writing zoom changes back to AppPreferences
- Update Appearance settings copy and troubleshooting notes to document per-device zoom behavior

fixes #622

---

Fixes #622