### PR TITLE
fix(ui): dismiss stuck overlays on remote disconnect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,6 +105,7 @@ import {
 } from './lib/remote-connections'
 import { RemoteConnectionRecovery } from './components/remote/RemoteConnectionRecovery'
 import { getStartupOnboardingAction } from './lib/startup-onboarding'
+import { dismissTransientUi } from './lib/dismiss-transient-ui'
 
 interface AutoFixStoppedEvent {
   projectId: string
@@ -842,10 +843,17 @@ function App() {
 
   // Browser mode: only open WebSocket after preload + listener registration.
   // This lets us replay buffered server events before live events start arriving.
+  // Native remote clients keep the shell and show RemoteConnectionRecovery —
+  // dismiss open overlays so they cannot trap pointer events (issue #623).
+  // Pure web-access reloads so in-memory UI state is rebuilt cleanly.
   useEffect(() => {
-    if (!webBackend || isNativeApp()) return
+    if (!webBackend) return
 
     return onEstablishedWsDisconnect(() => {
+      if (isNativeApp()) {
+        dismissTransientUi()
+        return
+      }
       logger.info('WebSocket disconnected, reloading web app')
       captureWebReloadState()
       window.location.reload()

--- a/src/App.web-reload-regression.test.ts
+++ b/src/App.web-reload-regression.test.ts
@@ -19,4 +19,16 @@ describe('web reload recovery UI', () => {
     expect(source).toContain('QuitConfirmationDialog')
     expect(source).not.toContain('WebReloadingOverlay')
   })
+
+  it('dismisses stuck overlays on native remote disconnect instead of reloading', () => {
+    // Native remote keeps the shell + recovery UI; pure web still reloads.
+    expect(source).toContain('dismissTransientUi()')
+    expect(source).toMatch(
+      /if \(isNativeApp\(\)\) \{\s*dismissTransientUi\(\)/
+    )
+    // Must not skip the disconnect listener entirely for native clients.
+    expect(source).not.toMatch(
+      /if \(!webBackend \|\| isNativeApp\(\)\) return/
+    )
+  })
 })

--- a/src/components/remote/RemoteConnectionRecovery.test.tsx
+++ b/src/components/remote/RemoteConnectionRecovery.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RemoteConnectionRecovery } from './RemoteConnectionRecovery'
+
+const dismissTransientUi = vi.fn()
+
+vi.mock('@/lib/dismiss-transient-ui', () => ({
+  dismissTransientUi: () => dismissTransientUi(),
+}))
+
+vi.mock('@/lib/remote-connections', () => ({
+  LOCAL_CONNECTION_ID: 'local',
+  markConnectionSwitch: vi.fn(),
+  selectConnection: vi.fn(),
+}))
+
+describe('RemoteConnectionRecovery', () => {
+  beforeEach(() => {
+    dismissTransientUi.mockClear()
+  })
+
+  it('dismisses open overlays on mount so recovery stays interactive', () => {
+    render(
+      <RemoteConnectionRecovery
+        connection={{
+          id: 'remote-1',
+          name: 'Lab',
+          url: 'https://lab.example',
+          token: 'tok',
+        }}
+        error="Connection to the selected Jean server was lost."
+      />
+    )
+
+    expect(dismissTransientUi).toHaveBeenCalledOnce()
+    expect(screen.getByRole('heading', { name: /Couldn't connect to Lab/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Switch to Local' })
+    ).toBeInTheDocument()
+  })
+
+  it('uses a z-index above dialogs and menus', () => {
+    const { container } = render(
+      <RemoteConnectionRecovery
+        connection={{
+          id: 'remote-1',
+          name: 'Lab',
+          url: 'https://lab.example',
+          token: 'tok',
+        }}
+        error="lost"
+      />
+    )
+
+    const root = container.firstElementChild as HTMLElement
+    expect(root.className).toContain('z-[100]')
+  })
+})

--- a/src/components/remote/RemoteConnectionRecovery.tsx
+++ b/src/components/remote/RemoteConnectionRecovery.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { ServerOff } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -6,6 +7,7 @@ import {
   selectConnection,
   type RemoteConnection,
 } from '@/lib/remote-connections'
+import { dismissTransientUi } from '@/lib/dismiss-transient-ui'
 
 function reloadPage() {
   window.location.reload()
@@ -18,8 +20,15 @@ export function RemoteConnectionRecovery({
   connection: RemoteConnection
   error: string
 }) {
+  // Drop open context menus / settings / dialogs so they cannot sit above
+  // this surface or leave body pointer-events locked (issue #623).
+  useEffect(() => {
+    dismissTransientUi()
+  }, [])
+
   return (
-    <div className="fixed inset-x-0 bottom-0 top-8 z-[55] flex items-center justify-center bg-background">
+    // z-[100] sits above dialogs (70) and menus/popovers (80).
+    <div className="fixed inset-x-0 bottom-0 top-8 z-[100] flex items-center justify-center bg-background">
       <div className="mx-4 w-full max-w-md rounded-lg border bg-card p-6 shadow-lg">
         <div className="flex items-center gap-2">
           <ServerOff className="size-5 text-destructive" />

--- a/src/components/remote/RemoteConnectionsDialog.tsx
+++ b/src/components/remote/RemoteConnectionsDialog.tsx
@@ -37,6 +37,7 @@ import {
   useRemoteConnections,
   type RemoteConnection,
 } from '@/lib/remote-connections'
+import { DISMISS_TRANSIENT_UI_EVENT } from '@/lib/dismiss-transient-ui'
 import {
   checkRemoteVersionCompatibility,
   fetchRemoteServerInfo,
@@ -191,6 +192,17 @@ export function RemoteConnectionsDialog({
     return () =>
       window.removeEventListener('open-remote-connections', handleOpen)
   }, [connections])
+
+  // Close when remote connection recovery dismisses transient UI (#623).
+  useEffect(() => {
+    const handleDismiss = () => {
+      setOpen(false)
+      setEditingId(null)
+    }
+    window.addEventListener(DISMISS_TRANSIENT_UI_EVENT, handleDismiss)
+    return () =>
+      window.removeEventListener(DISMISS_TRANSIENT_UI_EVENT, handleDismiss)
+  }, [])
 
   useEffect(() => {
     if (!open || !installing || !native) return
@@ -449,7 +461,11 @@ export function RemoteConnectionsDialog({
           )}
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-md">
+      {/* Above RemoteConnectionRecovery (z-100) so Edit connection works while offline. */}
+      <DialogContent
+        className="sm:max-w-md z-[110]"
+        overlayClassName="z-[110]"
+      >
         <DialogHeader>
           <DialogTitle>Jean connections</DialogTitle>
           <DialogDescription>

--- a/src/lib/dismiss-transient-ui.test.ts
+++ b/src/lib/dismiss-transient-ui.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useUIStore } from '@/store/ui-store'
+import { useProjectsStore } from '@/store/projects-store'
+import { useBrowserStore } from '@/store/browser-store'
+import {
+  DISMISS_TRANSIENT_UI_EVENT,
+  dismissTransientUi,
+} from './dismiss-transient-ui'
+
+describe('dismissTransientUi', () => {
+  beforeEach(() => {
+    useUIStore.setState({
+      commandPaletteOpen: false,
+      preferencesOpen: false,
+      preferencesPane: null,
+      onboardingOpen: false,
+      magicModalOpen: false,
+      sessionChatModalOpen: false,
+      sessionChatModalWorktreeId: null,
+      githubDashboardOpen: false,
+      viewingFilePath: null,
+      updateModalVersion: null,
+      remotePickerOpen: false,
+      remotePickerRepoPath: null,
+    })
+    useProjectsStore.setState({
+      projectSettingsDialogOpen: false,
+      projectSettingsProjectId: null,
+      projectSettingsInitialPane: null,
+      addProjectDialogOpen: false,
+      gitInitModalOpen: false,
+      cloneModalOpen: false,
+      jeanConfigWizardOpen: false,
+    })
+    useBrowserStore.setState({ modalOpen: {} })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('closes store-managed dialogs and modals', () => {
+    useUIStore.setState({
+      commandPaletteOpen: true,
+      preferencesOpen: true,
+      preferencesPane: 'general',
+      onboardingOpen: true,
+      magicModalOpen: true,
+      sessionChatModalOpen: true,
+      sessionChatModalWorktreeId: 'wt-1',
+      githubDashboardOpen: true,
+      viewingFilePath: '/tmp/a.ts',
+      updateModalVersion: '1.2.3',
+    })
+    useProjectsStore.getState().openProjectSettings('proj-1', 'general')
+    useProjectsStore.getState().setAddProjectDialogOpen(true)
+    useBrowserStore.setState({ modalOpen: { 'wt-1': true } })
+
+    dismissTransientUi()
+
+    const ui = useUIStore.getState()
+    expect(ui.commandPaletteOpen).toBe(false)
+    expect(ui.preferencesOpen).toBe(false)
+    expect(ui.preferencesPane).toBeNull()
+    expect(ui.onboardingOpen).toBe(false)
+    expect(ui.magicModalOpen).toBe(false)
+    expect(ui.sessionChatModalOpen).toBe(false)
+    expect(ui.sessionChatModalWorktreeId).toBeNull()
+    expect(ui.githubDashboardOpen).toBe(false)
+    expect(ui.viewingFilePath).toBeNull()
+    expect(ui.updateModalVersion).toBeNull()
+
+    const projects = useProjectsStore.getState()
+    expect(projects.projectSettingsDialogOpen).toBe(false)
+    expect(projects.addProjectDialogOpen).toBe(false)
+
+    expect(useBrowserStore.getState().modalOpen['wt-1']).toBe(false)
+  })
+
+  it('dispatches dismiss event for local-state overlays', () => {
+    const listener = vi.fn()
+    window.addEventListener(DISMISS_TRANSIENT_UI_EVENT, listener)
+
+    dismissTransientUi()
+
+    expect(listener).toHaveBeenCalledOnce()
+    window.removeEventListener(DISMISS_TRANSIENT_UI_EVENT, listener)
+  })
+
+  it('dispatches Escape so uncontrolled Radix menus can close', () => {
+    const keydown = vi.fn()
+    document.addEventListener('keydown', keydown)
+
+    dismissTransientUi()
+
+    expect(keydown).toHaveBeenCalled()
+    const escapeCalls = keydown.mock.calls.filter(
+      ([event]) => (event as KeyboardEvent).key === 'Escape'
+    )
+    expect(escapeCalls.length).toBeGreaterThan(0)
+
+    document.removeEventListener('keydown', keydown)
+  })
+
+  it('clears body pointer-events lock after dismiss when no overlay remains', async () => {
+    document.body.style.pointerEvents = 'none'
+    document.body.setAttribute('data-scroll-locked', '1')
+
+    dismissTransientUi()
+
+    await new Promise(resolve => setTimeout(resolve, 60))
+
+    expect(document.body.style.pointerEvents).toBe('')
+    expect(document.body.hasAttribute('data-scroll-locked')).toBe(false)
+  })
+})

--- a/src/lib/dismiss-transient-ui.ts
+++ b/src/lib/dismiss-transient-ui.ts
@@ -1,0 +1,149 @@
+/**
+ * Dismiss open overlays when the remote/WebSocket connection is lost.
+ *
+ * Open Radix dialogs, menus, and popovers sit above recovery UI (or leave
+ * body pointer-events locked) so Retry / Switch to Local become unusable
+ * until Jean is restarted (issue #623).
+ */
+
+import { useUIStore } from '@/store/ui-store'
+import { useProjectsStore } from '@/store/projects-store'
+import { useBrowserStore } from '@/store/browser-store'
+
+/** Fired so locally-managed overlays (e.g. RemoteConnectionsDialog) can close. */
+export const DISMISS_TRANSIENT_UI_EVENT = 'jean:dismiss-transient-ui'
+
+/**
+ * Close store-driven modals/dialogs and ask uncontrolled Radix layers to
+ * dismiss (Escape). Safe to call repeatedly; no-ops when nothing is open.
+ */
+export function dismissTransientUi(): void {
+  // Batch-close every store flag that mounts a dialog, sheet, or modal.
+  // Leave shell chrome (sidebars, file browser pane) alone — recovery covers
+  // the viewport; navigation state is restored on reconnect/reload.
+  useUIStore.setState({
+    commandPaletteOpen: false,
+    preferencesOpen: false,
+    preferencesPane: null,
+    commitModalOpen: false,
+    // Setup wizard is a Dialog with body pointer-events lock; keep recovery usable.
+    onboardingOpen: false,
+    openInModalOpen: false,
+    remotePickerOpen: false,
+    remotePickerRepoPath: null,
+    loadContextModalOpen: false,
+    linkedProjectsModalOpen: false,
+    magicModalOpen: false,
+    resolveConflictsDialogOpen: false,
+    newWorktreeModalOpen: false,
+    newWorktreeModalDefaultTab: null,
+    releaseNotesModalOpen: false,
+    updatePrModalOpen: false,
+    reviewCommentsModalOpen: false,
+    workflowRunsModalOpen: false,
+    workflowRunsModalProjectPath: null,
+    workflowRunsModalBranch: null,
+    cliUpdateModalOpen: false,
+    cliUpdateModalType: null,
+    cliLoginModalOpen: false,
+    cliLoginModalType: null,
+    cliLoginModalCommand: null,
+    cliLoginModalCommandArgs: null,
+    cliLoginModalAction: 'login',
+    sessionChatModalOpen: false,
+    sessionChatModalWorktreeId: null,
+    newSessionModeTarget: null,
+    gitDiffModalOpen: false,
+    planDialogOpen: false,
+    contextViewerOpen: false,
+    featureTourOpen: false,
+    jeanMcpIntroOpen: false,
+    chatSearchOpen: false,
+    githubDashboardOpen: false,
+    viewingFilePath: null,
+    // App update prompt is non-critical during connection recovery.
+    updateModalVersion: null,
+  })
+
+  // Clear remote picker callback held outside store state.
+  useUIStore.getState().closeRemotePicker()
+
+  const projects = useProjectsStore.getState()
+  if (projects.projectSettingsDialogOpen) projects.closeProjectSettings()
+  if (projects.addProjectDialogOpen) projects.setAddProjectDialogOpen(false)
+  if (projects.gitInitModalOpen) projects.closeGitInitModal()
+  if (projects.cloneModalOpen) projects.closeCloneModal()
+  if (projects.jeanConfigWizardOpen) projects.closeJeanConfigWizard()
+
+  // Close any open browser modal drawers (portal/fixed layers).
+  const browser = useBrowserStore.getState()
+  const modalOpen = browser.modalOpen
+  const openModalIds = Object.keys(modalOpen).filter(id => modalOpen[id])
+  if (openModalIds.length > 0) {
+    const nextModal = { ...modalOpen }
+    for (const id of openModalIds) nextModal[id] = false
+    useBrowserStore.setState({ modalOpen: nextModal })
+  }
+
+  // Uncontrolled Radix ContextMenu / DropdownMenu / Select / Popover layers.
+  dispatchEscapeToDismissFloatingLayers()
+
+  // Local-state dialogs (RemoteConnectionsDialog, etc.)
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(DISMISS_TRANSIENT_UI_EVENT))
+  }
+
+  // Safety net: clear scroll/pointer locks if a dialog unmount races the
+  // recovery overlay (Radix RemoveScroll can leave body pointer-events:none).
+  scheduleBodyLockCleanup()
+}
+
+function dispatchEscapeToDismissFloatingLayers(): void {
+  if (typeof document === 'undefined') return
+
+  const target = document.activeElement ?? document.body
+  const eventInit: KeyboardEventInit = {
+    key: 'Escape',
+    code: 'Escape',
+    keyCode: 27,
+    which: 27,
+    bubbles: true,
+    cancelable: true,
+  }
+
+  target.dispatchEvent(new KeyboardEvent('keydown', eventInit))
+  document.dispatchEvent(new KeyboardEvent('keydown', eventInit))
+}
+
+function scheduleBodyLockCleanup(): void {
+  if (typeof document === 'undefined') return
+
+  const clear = () => {
+    // Only clear when no dialog/sheet overlay remains mounted.
+    const hasBlockingOverlay = document.querySelector(
+      '[data-slot="dialog-overlay"], [data-slot="sheet-overlay"], [data-slot="alert-dialog-overlay"]'
+    )
+    if (hasBlockingOverlay) return
+
+    if (document.body.style.pointerEvents === 'none') {
+      document.body.style.pointerEvents = ''
+    }
+    if (document.body.hasAttribute('data-scroll-locked')) {
+      document.body.removeAttribute('data-scroll-locked')
+    }
+    // Radix RemoveScroll sometimes sets these on <html> as well.
+    if (document.documentElement.style.pointerEvents === 'none') {
+      document.documentElement.style.pointerEvents = ''
+    }
+  }
+
+  // After React flushes closed dialog unmounts.
+  queueMicrotask(clear)
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(() => {
+      clear()
+      requestAnimationFrame(clear)
+    })
+  }
+  setTimeout(clear, 50)
+}


### PR DESCRIPTION
## Summary

- Dismiss open dialogs, menus, and other transient overlays when a remote Jean connection drops so they cannot trap pointer events or block recovery UI
- Raise remote connection recovery above stuck layers and close store/local-state overlays on disconnect and recovery mount
- Keep pure web-access reload behavior; native remote clients dismiss overlays instead of reloading

fixes #623

---

Fixes #623