### PR TITLE
fix(transport): prefer remote native-open over ssh:// remap

### DIFF
--- a/src/lib/environment.test.ts
+++ b/src/lib/environment.test.ts
@@ -78,6 +78,26 @@ describe('environment detection', () => {
     expect(canOpenInEditor()).toBe(true)
   })
 
+  it('prefers host-native open over local ssh:// remap when remote allows it', () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: { invoke: vi.fn() },
+    })
+    const remote = addRemoteConnection({
+      name: 'WSL Jean',
+      url: 'http://127.0.0.1:3456',
+      token: 'test-token',
+    })
+    selectConnection(remote.id)
+    setNativeOpenAllowed(true)
+
+    expect(isLocalBackend()).toBe(false)
+    expect(canOpenNativeApps()).toBe(true)
+    // ssh:// local remap is disabled when the backend can open apps itself
+    expect(canOpenRemoteEditorLocally()).toBe(false)
+    expect(canOpenInEditor()).toBe(true)
+  })
+
   it('treats WebSocket connection as browser backend', () => {
     setWsConnected(true)
 

--- a/src/lib/environment.ts
+++ b/src/lib/environment.ts
@@ -46,10 +46,13 @@ export const canOpenNativeApps = (): boolean =>
 
 /**
  * Native desktop shell connected to a remote Jean can open remote paths in the
- * local Zed CLI via `ssh://` (see `prepareRemoteEditorOpenArgs`).
+ * local Zed CLI via `ssh://` when the remote cannot open apps itself
+ * (see `prepareRemoteEditorOpenArgs` and transport invoke routing).
  */
 export const canOpenRemoteEditorLocally = (): boolean =>
-  isNativeApp() && getActiveRemoteConnection() !== null
+  isNativeApp() &&
+  getActiveRemoteConnection() !== null &&
+  !isNativeOpenAllowed()
 
 /**
  * Show Open in Editor: full host-native open, or remote Jean + local Zed CLI.

--- a/src/lib/remote-editor.test.ts
+++ b/src/lib/remote-editor.test.ts
@@ -44,6 +44,35 @@ describe('resolveRemoteSshEndpoint', () => {
       )
     ).toBeNull()
   })
+
+  it('does not fall back to loopback Web Access hostnames', () => {
+    expect(
+      resolveRemoteSshEndpoint(
+        baseConnection({ url: 'http://127.0.0.1:3456', sshHost: undefined })
+      )
+    ).toBeNull()
+    expect(
+      resolveRemoteSshEndpoint(
+        baseConnection({ url: 'http://localhost:3456', sshHost: '' })
+      )
+    ).toBeNull()
+    expect(
+      resolveRemoteSshEndpoint(
+        baseConnection({ url: 'http://[::1]:3456', sshHost: undefined })
+      )
+    ).toBeNull()
+  })
+
+  it('rejects explicit loopback SSH hosts', () => {
+    expect(
+      resolveRemoteSshEndpoint(
+        baseConnection({ sshHost: '127.0.0.1', sshUser: 'ubuntu' })
+      )
+    ).toBeNull()
+    expect(
+      resolveRemoteSshEndpoint(baseConnection({ sshHost: 'localhost' }))
+    ).toBeNull()
+  })
 })
 
 describe('buildZedSshTarget', () => {
@@ -147,5 +176,15 @@ describe('prepareRemoteEditorOpenArgs', () => {
         baseConnection({ url: 'bad', sshHost: undefined })
       )
     ).toThrow(/SSH/)
+  })
+
+  it('errors when only a loopback host is available (e.g. WSL on 127.0.0.1)', () => {
+    expect(() =>
+      prepareRemoteEditorOpenArgs(
+        'open_worktree_in_editor',
+        { worktreePath: '/home/user/project', editor: 'zed' },
+        baseConnection({ url: 'http://127.0.0.1:3456', sshHost: undefined })
+      )
+    ).toThrow(/Configure SSH/)
   })
 })

--- a/src/lib/remote-editor.ts
+++ b/src/lib/remote-editor.ts
@@ -7,12 +7,27 @@ export interface RemoteSshEndpoint {
   port?: number
 }
 
+/** Loopback hosts are never a useful SSH target for the *client* machine. */
+function isLoopbackHost(host: string): boolean {
+  const h = host.trim().toLowerCase()
+  return (
+    h === 'localhost' ||
+    h === '127.0.0.1' ||
+    h === '::1' ||
+    h === '[::1]' ||
+    h === '0.0.0.0' ||
+    h === '::'
+  )
+}
+
 /**
  * Resolve SSH connection details for opening remote filesystem paths in a
  * local editor CLI (Zed: `zed ssh://user@host/path`).
  *
  * Prefers explicit SSH fields on the connection; falls back to the Web Access
- * URL hostname when `sshHost` is unset.
+ * URL hostname when `sshHost` is unset. Loopback hostnames are rejected —
+ * they cannot be a meaningful SSH target for the client (e.g. Windows Jean
+ * connected to WSL Jean on 127.0.0.1 has no sshd on the Windows loopback).
  */
 export function resolveRemoteSshEndpoint(
   connection: RemoteConnection
@@ -27,6 +42,10 @@ export function resolveRemoteSshEndpoint(
     }
   }
   if (!host) return null
+
+  // Loopback is never a useful client-side SSH target (e.g. Windows Jean →
+  // WSL Jean on 127.0.0.1 has no sshd on the Windows loopback).
+  if (isLoopbackHost(host)) return null
 
   const user = connection.sshUser?.trim() || undefined
   const port =

--- a/src/lib/transport.test.ts
+++ b/src/lib/transport.test.ts
@@ -52,6 +52,7 @@ async function loadTransportModule() {
   vi.resetModules()
   vi.doMock('./environment', () => ({
     isNativeApp: () => false,
+    isNativeOpenAllowed: () => false,
     setWsConnected: setWsConnectedMock,
     setWebAccessEnabled: vi.fn(),
   }))
@@ -64,6 +65,7 @@ async function loadNativeTransportModule(
   vi.resetModules()
   vi.doMock('./environment', () => ({
     isNativeApp: () => true,
+    isNativeOpenAllowed: () => false,
     setWsConnected: setWsConnectedMock,
     setWebAccessEnabled: vi.fn(),
   }))
@@ -81,11 +83,14 @@ async function loadRemoteNativeTransportModule(
     sshHost?: string
     sshPort?: number
   },
-  tauriInvoke?: ReturnType<typeof vi.fn>
+  tauriInvoke?: ReturnType<typeof vi.fn>,
+  options?: { nativeOpenAllowed?: boolean }
 ) {
   vi.resetModules()
+  const nativeOpenAllowed = options?.nativeOpenAllowed ?? false
   vi.doMock('./environment', () => ({
     isNativeApp: () => true,
+    isNativeOpenAllowed: () => nativeOpenAllowed,
     setWsConnected: setWsConnectedMock,
     setWebAccessEnabled: vi.fn(),
   }))
@@ -265,6 +270,43 @@ describe('transport bootstrap', () => {
       worktreePath: 'ssh://ubuntu@192.168.1.50/home/ubuntu/jean/app/feature',
       editor: 'zed',
     })
+  })
+
+  it('prefers backend native-open over ssh:// remap when the remote allows it', async () => {
+    // WSL/--allow-native-open headless: editor must go through WebSocket
+    // dispatch (same as Finder/Terminal), not local Windows-side ssh://.
+    const tauriInvoke = vi.fn().mockResolvedValue(undefined)
+    const transport = await loadRemoteNativeTransportModule(
+      {
+        id: 'remote-1',
+        name: 'WSL Jean',
+        url: 'http://127.0.0.1:3456',
+        token: 'secret',
+      },
+      tauriInvoke,
+      { nativeOpenAllowed: true }
+    )
+
+    transport.connectTransport()
+    await waitFor(() => expect(MockWebSocket.instances.length).toBe(1))
+    await flushAsync()
+    const ws = getWs(0)
+
+    const request = transport.invoke('open_worktree_in_editor', {
+      worktreePath: '/home/ubuntu/jean/app/feature',
+      editor: 'zed',
+    })
+    await waitFor(() =>
+      expect(ws.send).toHaveBeenCalledWith(
+        expect.stringContaining('"command":"open_worktree_in_editor"')
+      )
+    )
+    // Resolve the pending WS invoke so it does not leak.
+    const sent = JSON.parse(String(ws.send.mock.calls.at(-1)?.[0]))
+    ws.receive({ type: 'response', id: sent.id, data: null })
+    await request
+
+    expect(tauriInvoke).not.toHaveBeenCalled()
   })
 
   it('rejects non-Zed remote editor opens with a clear error', async () => {

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -7,7 +7,12 @@
  */
 
 import { useSyncExternalStore } from 'react'
-import { isNativeApp, setWebAccessEnabled, setWsConnected } from './environment'
+import {
+  isNativeApp,
+  isNativeOpenAllowed,
+  setWebAccessEnabled,
+  setWsConnected,
+} from './environment'
 import { generateId } from './uuid'
 import { isServerWindows } from './platform'
 import { getActiveRemoteConnection } from './remote-connections'
@@ -232,9 +237,11 @@ export async function invoke<T>(
     return null as T
   }
 
-  // Native app + remote Jean: open remote paths in local Zed via ssh://.
-  // Must stay on the local Tauri shell (not the remote WebSocket dispatch).
-  if (isNativeApp() && usesWebSocketBackend()) {
+  // Native app + remote Jean: open remote paths in local Zed via ssh://
+  // when the remote host cannot launch apps itself. Prefer the backend's
+  // native-open path when available (e.g. headless on WSL, --allow-native-open)
+  // so we don't bypass the WSL launcher with a broken Windows-side ssh:// remap.
+  if (isNativeApp() && usesWebSocketBackend() && !isNativeOpenAllowed()) {
     const remote = getActiveRemoteConnection()
     if (remote) {
       const remapped = prepareRemoteEditorOpenArgs(command, args, remote)


### PR DESCRIPTION
## Summary

- Prefer the remote backend’s native-open path for editor opens when the host reports `nativeOpenAllowed` (e.g. headless Jean on WSL), instead of remapping to a local Windows `ssh://` Zed launch
- Keep the local `ssh://` remap only as a fallback for remotes that cannot open apps themselves
- Stop treating loopback Web Access hostnames (`127.0.0.1`, `localhost`, `::1`) as SSH targets, so users get a clear config error instead of a guaranteed connection failure
- Align `canOpenRemoteEditorLocally()` with the same native-open preference and add coverage for the WSL/remote-desktop case

fixes #632

---

Fixes #632