### PR TITLE
fix(chat): truncate UTF-8 strings on char boundaries

### DIFF
--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -7452,16 +7452,26 @@ fn execute_summarization_claude(
 
     // Parse the JSON response
     serde_json::from_str(&text_content).map_err(|e| {
-        let preview = if text_content.len() > 200 {
-            format!("{}...", &text_content[..200])
-        } else {
-            text_content.to_string()
-        };
+        // Truncate by chars so a recoverable parse error never panics on
+        // multi-byte UTF-8 (byte index 200 may fall inside a character).
+        let preview = truncate_error_preview(&text_content, 200);
         log::error!(
             "Failed to parse JSON response: {e}, content preview: {preview}, full stdout: {stdout}"
         );
         format!("Failed to parse structured response: {e}")
     })
+}
+
+/// Build a short log preview of content that failed JSON parsing.
+/// Always safe for multi-byte UTF-8; never panics on a mid-character boundary.
+pub(crate) fn truncate_error_preview(text: &str, max_chars: usize) -> String {
+    let mut iter = text.chars();
+    let preview: String = iter.by_ref().take(max_chars).collect();
+    if iter.next().is_some() {
+        format!("{preview}...")
+    } else {
+        preview
+    }
 }
 
 /// Generate a context summary from a session's messages in the background
@@ -10820,5 +10830,28 @@ my-disabled: /usr/bin/disabled (STDIO) - disabled";
             opencode.opencode_session_id.as_deref(),
             Some("opencode-session")
         );
+    }
+
+    #[test]
+    fn truncate_error_preview_handles_non_ascii_without_panic() {
+        // Multi-byte chars; previously `&text[..200]` paniced mid-character.
+        let text = "日".repeat(100); // 300 bytes, 100 chars
+        let preview = truncate_error_preview(&text, 200);
+        // Cap is by char count here (200), so full text fits and no ellipsis.
+        assert_eq!(preview, text);
+        assert!(!preview.ends_with("..."));
+
+        let long = "日".repeat(250);
+        let preview = truncate_error_preview(&long, 200);
+        assert!(preview.ends_with("..."));
+        assert_eq!(preview.chars().count(), 200 + 3); // 200 chars + "..."
+        assert!(preview.is_char_boundary(preview.len() - 3));
+    }
+
+    #[test]
+    fn truncate_error_preview_ascii_adds_ellipsis_when_long() {
+        let text = "a".repeat(250);
+        let preview = truncate_error_preview(&text, 200);
+        assert_eq!(preview, format!("{}...", "a".repeat(200)));
     }
 }

--- a/jean-core/src/chat/naming.rs
+++ b/jean-core/src/chat/naming.rs
@@ -998,9 +998,11 @@ fn validate_branch_name(name: &str) -> Result<String, String> {
 
     let sanitized = sanitized.trim_matches('-').to_string();
 
-    // Enforce length limit
+    // Enforce length limit on a UTF-8 char boundary (byte index 50 may land
+    // inside a multi-byte character for non-ASCII branch names).
     let final_name = if sanitized.len() > 50 {
-        sanitized[..50].to_string()
+        let end = sanitized.floor_char_boundary(50);
+        sanitized[..end].to_string()
     } else {
         sanitized
     };
@@ -1294,5 +1296,25 @@ mod tests {
             .expect("required array");
         assert!(required.iter().any(|v| v.as_str() == Some("session_name")));
         assert!(required.iter().any(|v| v.as_str() == Some("branch_name")));
+    }
+
+    #[test]
+    fn validate_branch_name_truncates_non_ascii_without_panic() {
+        // Multi-byte chars (each "日" is 3 bytes). Byte index 50 lands mid-character
+        // and previously panicked with "byte index 50 is not a char boundary".
+        let long_jp = "日".repeat(30); // 90 bytes
+        let result = validate_branch_name(&long_jp).unwrap();
+        assert!(!result.is_empty());
+        assert!(result.len() <= 50);
+        assert!(result.is_char_boundary(result.len()));
+        assert!(result.chars().all(|c| c == '日'));
+    }
+
+    #[test]
+    fn validate_branch_name_ascii_still_capped_at_50() {
+        let long = "a".repeat(80);
+        let result = validate_branch_name(&long).unwrap();
+        assert_eq!(result.len(), 50);
+        assert_eq!(result, "a".repeat(50));
     }
 }

--- a/jean-core/src/projects/github_issues.rs
+++ b/jean-core/src/projects/github_issues.rs
@@ -392,9 +392,11 @@ pub fn slugify_issue_title(title: &str) -> String {
         .collect::<Vec<_>>()
         .join("-");
 
-    // Limit total length
+    // Limit total length on a UTF-8 char boundary (byte index 40 may land
+    // inside a multi-byte character for non-ASCII titles, e.g. Japanese).
     if slug.len() > 40 {
-        slug[..40].trim_end_matches('-').to_string()
+        let end = slug.floor_char_boundary(40);
+        slug[..end].trim_end_matches('-').to_string()
     } else {
         slug
     }
@@ -2479,7 +2481,12 @@ pub fn generate_branch_name_from_advisory(ghsa_id: &str, summary: &str) -> Strin
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join("-");
-    let slug = if slug.len() > 40 { &slug[..40] } else { &slug };
+    // Truncate on a UTF-8 char boundary so multi-byte summaries never panic.
+    let slug = if slug.len() > 40 {
+        &slug[..slug.floor_char_boundary(40)]
+    } else {
+        &slug
+    };
     let slug = slug.trim_end_matches('-');
     // Use short GHSA ID (remove "GHSA-" prefix for branch name brevity)
     let ghsa_short = ghsa_id.strip_prefix("GHSA-").unwrap_or(ghsa_id);
@@ -3236,6 +3243,19 @@ mod tests {
     }
 
     #[test]
+    fn test_slugify_issue_title_non_ascii_does_not_panic() {
+        // 15 Japanese chars → 45 bytes after lowercasing; byte 40 lands inside a char.
+        // Previously paniced with "byte index 40 is not a char boundary".
+        let title = "日本語のタイトルを持つ課題の例";
+        let slug = slugify_issue_title(title);
+        assert!(!slug.is_empty());
+        assert!(slug.len() <= 40);
+        assert!(slug.is_char_boundary(slug.len()));
+        // Every retained character should still be valid UTF-8 (no partial sequences).
+        assert!(std::str::from_utf8(slug.as_bytes()).is_ok());
+    }
+
+    #[test]
     fn test_generate_branch_name_from_issue() {
         assert_eq!(
             generate_branch_name_from_issue(123, "Fix the login bug"),
@@ -3245,6 +3265,17 @@ mod tests {
             generate_branch_name_from_issue(42, "Add new feature"),
             "issue-42-add-new-feature"
         );
+    }
+
+    #[test]
+    fn test_generate_branch_name_from_issue_non_ascii() {
+        let branch =
+            generate_branch_name_from_issue(629, "日本語のタイトルを持つ課題の例と追加の文字");
+        assert!(branch.starts_with("issue-629-"));
+        assert!(branch.is_char_boundary(branch.len()));
+        // Prefix is ASCII; slug portion must stay within the 40-byte cap.
+        let slug = branch.strip_prefix("issue-629-").unwrap();
+        assert!(slug.len() <= 40);
     }
 
     #[test]
@@ -3299,6 +3330,19 @@ mod tests {
         );
         assert!(result.starts_with("advisory-jg7v-5cqg-jvmf-"));
         assert!(result.contains("prototype"));
+    }
+
+    #[test]
+    fn test_generate_branch_name_from_advisory_non_ascii() {
+        let result = generate_branch_name_from_advisory(
+            "GHSA-jg7v-5cqg-jvmf",
+            "日本語のセキュリティアドバイザリ概要の非常に長いタイトル例",
+        );
+        assert!(result.starts_with("advisory-jg7v-5cqg-jvmf-"));
+        assert!(result.is_char_boundary(result.len()));
+        let slug = result.strip_prefix("advisory-jg7v-5cqg-jvmf-").unwrap();
+        assert!(slug.len() <= 40);
+        assert!(!slug.ends_with('-'));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix panics when truncating non-ASCII (e.g. Japanese) strings at fixed byte indexes in issue/advisory slug generation, branch-name sanitization, and JSON error previews
- Truncate on UTF-8 character boundaries (`floor_char_boundary` / char-based preview) so multi-byte text no longer lands mid-character
- Add regression tests covering non-ASCII and ASCII truncation paths

fixes #629

---

Fixes #629