### PR TITLE
fix(file-browser): stop infinite re-render when files undefined

### DIFF
--- a/src/components/file-browser/FileBrowserSidebar.test.tsx
+++ b/src/components/file-browser/FileBrowserSidebar.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@/test/test-utils'
+import { FileBrowserSidebar } from './FileBrowserSidebar'
+import type * as FilesService from '@/services/files'
+import type * as ProjectsService from '@/services/projects'
+
+/**
+ * Regression for #628: when useWorktreeFiles returns undefined data
+ * (query disabled / loading), defaulting with inline `= []` produced a new
+ * array identity every render. Combined with the search auto-expand effect
+ * that always called setExpanded(new Set(...)), that caused React error #185
+ * (maximum update depth exceeded).
+ */
+vi.mock('@/services/files', async () => {
+  const actual = await vi.importActual<typeof FilesService>('@/services/files')
+  return {
+    ...actual,
+    // Keep data undefined forever — the crash path when rootPath is null
+    // (query enabled: false) or cache is cold while switching projects.
+    useWorktreeFiles: () => ({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+    }),
+  }
+})
+
+vi.mock('@/services/projects', async () => {
+  const actual = await vi.importActual<typeof ProjectsService>(
+    '@/services/projects'
+  )
+  return {
+    ...actual,
+    useWorktree: () => ({ data: undefined }),
+    useProjects: () => ({ data: [] }),
+  }
+})
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}))
+
+describe('FileBrowserSidebar', () => {
+  it('does not infinite-loop when worktree files data is undefined', () => {
+    // If the #185 loop regressed, React would throw during render/effect.
+    render(<FileBrowserSidebar />)
+
+    expect(screen.getByTestId('file-browser-sidebar')).toBeTruthy()
+    expect(
+      screen.getByText('Select a project or worktree to browse files.')
+    ).toBeTruthy()
+  })
+})

--- a/src/components/file-browser/FileBrowserSidebar.tsx
+++ b/src/components/file-browser/FileBrowserSidebar.tsx
@@ -36,6 +36,7 @@ import { useWorktree, useProjects } from '@/services/projects'
 import { fileQueryKeys, useWorktreeFiles } from '@/services/files'
 import { getExtensionColor } from '@/lib/file-colors'
 import { getFilename, joinPaths } from '@/lib/path-utils'
+import type { WorktreeFile } from '@/types/chat'
 import { isFolder } from '@/types/projects'
 import { useIsMobile } from '@/hooks/use-mobile'
 import {
@@ -44,6 +45,23 @@ import {
   pathsToExpandForMatches,
   type FileTreeNode,
 } from './build-file-tree'
+
+/**
+ * Stable empty list for useWorktreeFiles while data is undefined.
+ * Inline `= []` creates a new array every render; when that identity is an
+ * effect dependency, setState in the effect causes React error #185
+ * (maximum update depth exceeded). See issue #628.
+ */
+const EMPTY_WORKTREE_FILES: WorktreeFile[] = []
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a === b) return true
+  if (a.size !== b.size) return false
+  for (const value of a) {
+    if (!b.has(value)) return false
+  }
+  return true
+}
 
 interface FileBrowserSidebarProps {
   className?: string
@@ -104,7 +122,7 @@ export function FileBrowserSidebar({
 
   const { rootPath, label } = useFileBrowserRootPath()
   const {
-    data: files = [],
+    data: files = EMPTY_WORKTREE_FILES,
     isLoading,
     isFetching,
     isError,
@@ -128,7 +146,7 @@ export function FileBrowserSidebar({
 
   // Reset expansion when root path changes
   useEffect(() => {
-    setExpanded(new Set())
+    setExpanded(prev => (prev.size === 0 ? prev : new Set()))
     userExpandedRef.current = new Set()
     setSelectedPath(null)
     setSearch('')
@@ -138,10 +156,12 @@ export function FileBrowserSidebar({
   useEffect(() => {
     const q = search.trim()
     if (!q) {
-      setExpanded(new Set(userExpandedRef.current ?? []))
+      const restored = new Set(userExpandedRef.current ?? [])
+      setExpanded(prev => (setsEqual(prev, restored) ? prev : restored))
       return
     }
-    setExpanded(pathsToExpandForMatches(files, q))
+    const next = pathsToExpandForMatches(files, q)
+    setExpanded(prev => (setsEqual(prev, next) ? prev : next))
   }, [search, files])
 
   const tree = useMemo(() => buildFileTree(files), [files])


### PR DESCRIPTION
## Summary

- Fix React error #185 (maximum update depth exceeded) that crashed the app when the file browser sidebar was open and the user switched projects (fixes #628)
- Use a stable empty array default while worktree files are loading or unavailable, and skip no-op `setExpanded` updates when expanded paths are unchanged
- Add a regression test covering the undefined-files crash path

## Breaking Changes

None.

---

Fixes #628