### PR TITLE
fix(codex): always allow YOLO promote on command approvals

### DIFF
--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -8779,16 +8779,42 @@ pub fn approve_codex_command(
     send_codex_response(rpc_id, serde_json::json!({ "decision": decision }))
 }
 
-pub fn respond_codex_command_approval(
-    session_id: String,
-    rpc_id: u64,
-    response: serde_json::Value,
-) -> Result<(), String> {
+/// Strip Jean-only YOLO promote flags from a command-approval response and
+/// return whether mid-turn auto-approve should be enabled for the session.
+///
+/// Codex may omit `acceptForSession` from `availableDecisions` (unknown
+/// commands often only allow `accept` + `cancel`). Jean still lets the user
+/// promote the session to YOLO; the frontend then sends `decision: "accept"`
+/// plus `promoteToYolo: true` so residual prompts are auto-accepted (#626).
+pub(crate) fn prepare_codex_command_approval_response(
+    response: &mut serde_json::Value,
+) -> bool {
+    let promote_to_yolo = response
+        .as_object_mut()
+        .and_then(|obj| {
+            obj.remove("promoteToYolo")
+                .or_else(|| obj.remove("promote_to_yolo"))
+        })
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
     let is_accept_for_session = response
         .get("decision")
         .and_then(|d| d.as_str())
         .is_some_and(|d| d == "acceptForSession");
-    if is_accept_for_session {
+
+    promote_to_yolo || is_accept_for_session
+}
+
+pub fn respond_codex_command_approval(
+    session_id: String,
+    rpc_id: u64,
+    mut response: serde_json::Value,
+) -> Result<(), String> {
+    if prepare_codex_command_approval_response(&mut response) {
+        // Approve (yolo) / acceptForSession: auto-accept residual sandbox/command
+        // prompts for the rest of this session without waiting for the next turn
+        // (issue #328 / #626).
         super::registry::set_codex_yolo_auto_approve(&session_id, true);
     }
     send_codex_response(rpc_id, response)
@@ -9890,6 +9916,30 @@ mod tests {
         assert_eq!(event.session_id, "session-1");
         assert_eq!(event.worktree_id, "worktree-1");
         assert_eq!(event.error, "rate limit reached");
+    }
+
+    #[test]
+    fn prepare_codex_command_approval_promotes_yolo_without_accept_for_session() {
+        let mut response = serde_json::json!({
+            "decision": "accept",
+            "promoteToYolo": true,
+        });
+        assert!(prepare_codex_command_approval_response(&mut response));
+        // Jean-only flag must be stripped before forwarding to Codex.
+        assert!(response.get("promoteToYolo").is_none());
+        assert_eq!(response.get("decision").and_then(|d| d.as_str()), Some("accept"));
+    }
+
+    #[test]
+    fn prepare_codex_command_approval_accept_for_session_promotes() {
+        let mut response = serde_json::json!({ "decision": "acceptForSession" });
+        assert!(prepare_codex_command_approval_response(&mut response));
+    }
+
+    #[test]
+    fn prepare_codex_command_approval_plain_accept_does_not_promote() {
+        let mut response = serde_json::json!({ "decision": "accept" });
+        assert!(!prepare_codex_command_approval_response(&mut response));
     }
 
     fn naming_test_worktree(branch: &str, base_branch: Option<&str>) -> Worktree {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -467,7 +467,20 @@ function App() {
               reviewingUpdates[session.id] = true
               statusOverrideUpdates[session.id] = 'review'
             }
-            if (session.waiting_for_input) {
+            // Mid-turn Codex/Claude approvals keep waiting_for_input true while
+            // the turn is still running. Also treat pending approval queues as
+            // waiting so remote reconnects keep indicators (issue #626).
+            const hasPendingMidTurnApproval =
+              (session.pending_codex_command_approval_requests?.length ?? 0) >
+                0 ||
+              (session.pending_codex_permission_requests?.length ?? 0) > 0 ||
+              (session.pending_codex_user_input_requests?.length ?? 0) > 0 ||
+              (session.pending_codex_mcp_elicitation_requests?.length ?? 0) >
+                0 ||
+              (session.pending_codex_dynamic_tool_call_requests?.length ?? 0) >
+                0 ||
+              (session.pending_permission_denials?.length ?? 0) > 0
+            if (session.waiting_for_input || hasPendingMidTurnApproval) {
               waitingUpdates[session.id] = true
             }
           }
@@ -485,8 +498,10 @@ function App() {
           }
         }
         // Clear stale waiting/reviewing state for sessions actively running a turn.
-        // The server persists these flags from the previous turn's completion;
-        // if a new turn is in-flight they're stale and would show approve buttons.
+        // The server may still have previous-turn waiting flags on disk; a new
+        // turn without pending approvals should not show approve buttons.
+        // Keep waiting when the running turn itself is paused on mid-turn
+        // approvals (Codex command/permission prompts — issue #626).
         if (data.runningSessions?.length) {
           const runningSessionIds = new Set(data.runningSessions)
           for (const sessionId of data.runningSessions) {
@@ -502,14 +517,11 @@ function App() {
               ([sessionId]) => !runningSessionIds.has(sessionId)
             )
           )
-          const filteredWaitingUpdates = Object.fromEntries(
-            Object.entries(waitingUpdates).filter(
-              ([sessionId]) => !runningSessionIds.has(sessionId)
-            )
-          )
+          // waitingUpdates already includes mid-turn pending approvals; do not
+          // strip those for running sessions.
           storeUpdates.reviewingSessions = filteredReviewingUpdates
           storeUpdates.sessionStatusOverrides = filteredStatusOverrideUpdates
-          storeUpdates.waitingForInputSessionIds = filteredWaitingUpdates
+          storeUpdates.waitingForInputSessionIds = waitingUpdates
         } else {
           storeUpdates.reviewingSessions = reviewingUpdates
           storeUpdates.sessionStatusOverrides = statusOverrideUpdates

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -105,6 +105,7 @@ import { cn } from '@/lib/utils'
 import { PermissionApproval } from './PermissionApproval'
 import { AskUserQuestion } from './AskUserQuestion'
 import { CodexCommandApprovalRequestCard } from './CodexCommandApprovalRequest'
+import { resolveCodexYoloDecision } from './codex-command-approval-utils'
 import { CodexPermissionsRequest } from './CodexPermissionsRequest'
 import { CodexMcpElicitationRequest as CodexMcpElicitationRequestCard } from './CodexMcpElicitationRequest'
 import { CodexDynamicToolCallRequest as CodexDynamicToolCallRequestCard } from './CodexDynamicToolCallRequest'
@@ -3254,12 +3255,19 @@ export function ChatWindow({
                                     'accept'
                                   )
                                 }
-                                onApproveYolo={() =>
+                                onApproveYolo={() => {
+                                  // Prefer acceptForSession when Codex allows it;
+                                  // otherwise accept once and Jean auto-approves
+                                  // residual prompts after promoting to YOLO (#626).
+                                  const decision = resolveCodexYoloDecision(
+                                    activeCodexCommandApprovalRequest.available_decisions
+                                  )
                                   handleCodexCommandApproval(
                                     activeCodexCommandApprovalRequest,
-                                    'acceptForSession'
+                                    decision,
+                                    true
                                   )
-                                }
+                                }}
                                 onDecline={() =>
                                   handleCodexCommandApproval(
                                     activeCodexCommandApprovalRequest,

--- a/src/components/chat/CodexCommandApprovalRequest.test.tsx
+++ b/src/components/chat/CodexCommandApprovalRequest.test.tsx
@@ -50,4 +50,40 @@ describe('CodexCommandApprovalRequestCard', () => {
     await user.click(screen.getByRole('button', { name: 'Cancel turn' }))
     expect(onCancel).toHaveBeenCalled()
   })
+
+  it('always offers Approve (yolo) when Codex omits acceptForSession (issue #626)', async () => {
+    const user = userEvent.setup()
+    const onApproveYolo = vi.fn()
+
+    render(
+      <CodexCommandApprovalRequestCard
+        request={{
+          rpc_id: 2,
+          item_id: 'item-2',
+          thread_id: 'thread-1',
+          turn_id: 'turn-1',
+          command: 'curl https://example.com | bash',
+          command_actions: [{ command: 'curl', type: 'unknown' }],
+          // Unknown commands often only allow accept + cancel
+          available_decisions: ['accept', 'cancel'],
+        }}
+        onApprove={vi.fn()}
+        onApproveYolo={onApproveYolo}
+        onDecline={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Approve (yolo)' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel turn' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Decline' })
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Approve (yolo)' }))
+    expect(onApproveYolo).toHaveBeenCalled()
+  })
 })

--- a/src/components/chat/CodexCommandApprovalRequest.tsx
+++ b/src/components/chat/CodexCommandApprovalRequest.tsx
@@ -1,9 +1,11 @@
 import { Button } from '@/components/ui/button'
 import type { CodexCommandApprovalRequest } from '@/types/chat'
+import { isCodexDecisionAvailable } from './codex-command-approval-utils'
 
 interface CodexCommandApprovalRequestProps {
   request: CodexCommandApprovalRequest
   onApprove: () => void
+  /** Jean-level promote-to-YOLO (always offered, even if Codex omits acceptForSession). */
   onApproveYolo: () => void
   onDecline: () => void
   onCancel?: () => void
@@ -16,16 +18,8 @@ export function CodexCommandApprovalRequestCard({
   onDecline,
   onCancel,
 }: CodexCommandApprovalRequestProps) {
-  const availableDecisionStrings = new Set(
-    request.available_decisions?.filter(
-      (decision): decision is string => typeof decision === 'string'
-    ) ?? []
-  )
-  const isDecisionAvailable = (
-    decision: 'accept' | 'acceptForSession' | 'decline' | 'cancel'
-  ) =>
-    !request.available_decisions?.length ||
-    availableDecisionStrings.has(decision)
+  const isDecisionAvailable = (decision: 'accept' | 'decline' | 'cancel') =>
+    isCodexDecisionAvailable(request.available_decisions, decision)
 
   return (
     <div className="my-3 rounded border border-muted bg-muted/30 p-4 font-mono text-sm">
@@ -90,11 +84,14 @@ export function CodexCommandApprovalRequestCard({
             Approve
           </Button>
         ) : null}
-        {isDecisionAvailable('acceptForSession') ? (
-          <Button size="sm" variant="destructive" onClick={onApproveYolo}>
-            Approve (yolo)
-          </Button>
-        ) : null}
+        {/*
+          Always offer Jean-level YOLO promote. Codex may omit acceptForSession
+          for unknown commands (issue #626); Jean still switches the session to
+          yolo and auto-accepts residual mid-turn prompts.
+        */}
+        <Button size="sm" variant="destructive" onClick={onApproveYolo}>
+          Approve (yolo)
+        </Button>
         {isDecisionAvailable('decline') ? (
           <Button size="sm" variant="secondary" onClick={onDecline}>
             Decline

--- a/src/components/chat/codex-command-approval-utils.test.ts
+++ b/src/components/chat/codex-command-approval-utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isCodexDecisionAvailable,
+  normalizeCodexAvailableDecisions,
+  resolveCodexYoloDecision,
+} from './codex-command-approval-utils'
+
+describe('codex-command-approval-utils', () => {
+  it('treats missing availableDecisions as all decisions available', () => {
+    expect(isCodexDecisionAvailable(null, 'acceptForSession')).toBe(true)
+    expect(isCodexDecisionAvailable(undefined, 'acceptForSession')).toBe(true)
+    expect(isCodexDecisionAvailable([], 'acceptForSession')).toBe(true)
+  })
+
+  it('hides acceptForSession when Codex only offers accept/cancel', () => {
+    const available = ['accept', 'cancel']
+    expect(isCodexDecisionAvailable(available, 'accept')).toBe(true)
+    expect(isCodexDecisionAvailable(available, 'cancel')).toBe(true)
+    expect(isCodexDecisionAvailable(available, 'acceptForSession')).toBe(false)
+    expect(isCodexDecisionAvailable(available, 'decline')).toBe(false)
+  })
+
+  it('normalizes object-form decision keys', () => {
+    const decisions = normalizeCodexAvailableDecisions([
+      'accept',
+      { acceptWithExecpolicyAmendment: { execpolicy_amendment: ['git'] } },
+    ])
+    expect(decisions.has('accept')).toBe(true)
+    expect(decisions.has('acceptWithExecpolicyAmendment')).toBe(true)
+  })
+
+  it('resolves YOLO to acceptForSession when available, else accept', () => {
+    expect(resolveCodexYoloDecision(null)).toBe('acceptForSession')
+    expect(resolveCodexYoloDecision(['accept', 'acceptForSession', 'cancel'])).toBe(
+      'acceptForSession'
+    )
+    expect(resolveCodexYoloDecision(['accept', 'cancel'])).toBe('accept')
+  })
+})

--- a/src/components/chat/codex-command-approval-utils.ts
+++ b/src/components/chat/codex-command-approval-utils.ts
@@ -1,0 +1,63 @@
+/**
+ * Helpers for Codex command-approval UI and YOLO promotion.
+ *
+ * Codex sometimes restricts `availableDecisions` (e.g. only `accept` + `cancel`
+ * for unknown shell commands). Jean still always offers a session-level YOLO
+ * promote action: accept the current prompt, switch the Jean session to yolo,
+ * and auto-approve residual Codex sandbox prompts mid-turn.
+ */
+
+export type CodexCommandDecision =
+  | 'accept'
+  | 'acceptForSession'
+  | 'decline'
+  | 'cancel'
+
+/** Normalize available_decisions entries into string decision ids. */
+export function normalizeCodexAvailableDecisions(
+  availableDecisions: unknown[] | null | undefined
+): Set<string> {
+  if (!availableDecisions?.length) return new Set()
+
+  const decisions = new Set<string>()
+  for (const entry of availableDecisions) {
+    if (typeof entry === 'string') {
+      decisions.add(entry)
+      continue
+    }
+    if (entry && typeof entry === 'object') {
+      // Object-form decisions: { acceptWithExecpolicyAmendment: ... } etc.
+      const keys = Object.keys(entry as Record<string, unknown>)
+      for (const key of keys) {
+        decisions.add(key)
+      }
+    }
+  }
+  return decisions
+}
+
+/**
+ * Whether a Codex-native decision should be offered in the UI.
+ * Empty/missing availableDecisions means all decisions are available.
+ */
+export function isCodexDecisionAvailable(
+  availableDecisions: unknown[] | null | undefined,
+  decision: CodexCommandDecision
+): boolean {
+  if (!availableDecisions?.length) return true
+  return normalizeCodexAvailableDecisions(availableDecisions).has(decision)
+}
+
+/**
+ * Decision sent to Codex when the user clicks Jean's Approve (yolo).
+ * Prefer acceptForSession when Codex allows it; otherwise fall back to accept
+ * and rely on Jean's mid-turn auto-approve flag.
+ */
+export function resolveCodexYoloDecision(
+  availableDecisions: unknown[] | null | undefined
+): 'accept' | 'acceptForSession' {
+  if (isCodexDecisionAvailable(availableDecisions, 'acceptForSession')) {
+    return 'acceptForSession'
+  }
+  return 'accept'
+}

--- a/src/components/chat/hooks/useMessageHandlers.ts
+++ b/src/components/chat/hooks/useMessageHandlers.ts
@@ -172,7 +172,9 @@ interface MessageHandlers {
   ) => void
   handleCodexCommandApproval: (
     request: CodexCommandApprovalRequest,
-    decision: 'accept' | 'acceptForSession' | 'decline' | 'cancel'
+    decision: 'accept' | 'acceptForSession' | 'decline' | 'cancel',
+    /** When true, promote Jean session to YOLO and auto-approve residual Codex prompts. */
+    promoteToYolo?: boolean
   ) => void
   handleCodexPermissionRequestDecline: (request: CodexPermissionRequest) => void
   handleCodexUserInputAnswer: (
@@ -2863,7 +2865,8 @@ export function useMessageHandlers({
   const handleCodexCommandApproval = useCallback(
     (
       request: CodexCommandApprovalRequest,
-      decision: 'accept' | 'acceptForSession' | 'decline' | 'cancel'
+      decision: 'accept' | 'acceptForSession' | 'decline' | 'cancel',
+      promoteToYolo = false
     ) => {
       const sessionId = activeSessionIdRef.current
       const worktreeId = activeWorktreeIdRef.current
@@ -2879,7 +2882,11 @@ export function useMessageHandlers({
       )
       store.setWaitingForInput(sessionId, false)
 
-      if (decision === 'acceptForSession') {
+      // Jean-level YOLO promote: switch session mode even when Codex only allows
+      // a one-shot "accept" (availableDecisions without acceptForSession — #626).
+      const shouldPromoteToYolo =
+        promoteToYolo || decision === 'acceptForSession'
+      if (shouldPromoteToYolo) {
         store.setExecutionMode(sessionId, 'yolo')
         invoke('broadcast_session_setting', {
           sessionId,
@@ -2906,7 +2913,12 @@ export function useMessageHandlers({
       invoke('respond_codex_command_approval', {
         sessionId,
         rpcId: request.rpc_id,
-        response: { decision },
+        response: {
+          decision,
+          // Backend strips this before forwarding to Codex, and uses it to set
+          // the mid-turn auto-approve flag even when decision is plain "accept".
+          promoteToYolo: shouldPromoteToYolo,
+        },
       })
         .then(() =>
           persistCodexPendingState(sessionId, worktreeId, worktreePath)

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -24,7 +24,10 @@ import {
   upsertCodexUserInputRequest,
 } from '@/types/chat'
 import { playNotificationSound } from '@/lib/sounds'
-import { notifyIfBackground } from '@/lib/session-notifications'
+import {
+  notifyIfBackground,
+  notifySessionNeedsAttention,
+} from '@/lib/session-notifications'
 import { findPlanFilePath } from '@/components/chat/tool-call-utils'
 import { generateId } from '@/lib/uuid'
 import {
@@ -302,9 +305,15 @@ export default function useStreamingEvents({
     const cancelledRunIds = new Map<string, Set<string>>()
     const cancelledUntaggedSessionIds = new Set<string>()
 
-    // Fire a native OS banner (background-only) for a session lifecycle event,
-    // gated by the desktop_notifications_enabled preference. Body = session name.
-    const notifySession = (sessionId: string, title: string): void => {
+    // Fire a native OS banner for a session lifecycle event, gated by the
+    // desktop_notifications_enabled preference. Body = session name.
+    // Waiting-for-input uses notifySessionNeedsAttention so approvals still
+    // notify when Jean is focused on a different session (issue #626).
+    const notifySession = (
+      sessionId: string,
+      title: string,
+      kind: 'waiting' | 'lifecycle' = 'lifecycle'
+    ): void => {
       const prefs = queryClient.getQueryData<AppPreferences>(
         preferencesQueryKeys.preferences()
       )
@@ -312,7 +321,11 @@ export default function useStreamingEvents({
       const name = queryClient.getQueryData<Session>(
         chatQueryKeys.session(sessionId)
       )?.name
-      notifyIfBackground(title, name)
+      if (kind === 'waiting') {
+        notifySessionNeedsAttention(sessionId, title, name)
+      } else {
+        notifyIfBackground(title, name)
+      }
     }
 
     // Play the configured waiting sound (settings preview + chat:done share this).
@@ -778,7 +791,7 @@ export default function useStreamingEvents({
       setPendingCodexMcpElicitationRequests(sessionId, next)
       setWaitingForInput(sessionId, true)
       playWaitingSound()
-      notifySession(sessionId, 'Needs your input')
+      notifySession(sessionId, 'Needs your input', 'waiting')
       persistCodexPendingState(sessionId, worktreeId, {
         pendingCodexMcpElicitationRequests: next,
       })
@@ -797,7 +810,7 @@ export default function useStreamingEvents({
         setPendingCodexPermissionRequests(session_id, next)
         setWaitingForInput(session_id, true)
         playWaitingSound()
-        notifySession(session_id, 'Needs your input')
+        notifySession(session_id, 'Needs your input', 'waiting')
         persistCodexPendingState(session_id, worktree_id, {
           pendingCodexPermissionRequests: next,
         })
@@ -819,7 +832,7 @@ export default function useStreamingEvents({
           setPendingCodexCommandApprovalRequests(session_id, next)
           setWaitingForInput(session_id, true)
           playWaitingSound()
-          notifySession(session_id, 'Needs your input')
+          notifySession(session_id, 'Needs your input', 'waiting')
           persistCodexPendingState(session_id, worktree_id, {
             pendingCodexCommandApprovalRequests: next,
           })
@@ -856,7 +869,7 @@ export default function useStreamingEvents({
         if (next === current) return
 
         playWaitingSound()
-        notifySession(session_id, 'Needs your input')
+        notifySession(session_id, 'Needs your input', 'waiting')
         persistCodexPendingState(session_id, worktree_id, {
           pendingCodexUserInputRequests: next,
         })
@@ -904,7 +917,7 @@ export default function useStreamingEvents({
           setPendingCodexDynamicToolCallRequests(session_id, next)
           setWaitingForInput(session_id, true)
           playWaitingSound()
-          notifySession(session_id, 'Needs your input')
+          notifySession(session_id, 'Needs your input', 'waiting')
           persistCodexPendingState(session_id, worktree_id, {
             pendingCodexDynamicToolCallRequests: next,
           })
@@ -1188,7 +1201,7 @@ export default function useStreamingEvents({
 
           // Play waiting sound
           playWaitingSound()
-          notifySession(sessionId, 'Needs your input')
+          notifySession(sessionId, 'Needs your input', 'waiting')
         }
       } else if (event.payload.waiting_for_plan) {
         // Codex/Opencode plan-mode run completed with content — enter plan-waiting state.
@@ -1351,7 +1364,7 @@ export default function useStreamingEvents({
 
         // Play waiting sound
         playWaitingSound()
-        notifySession(sessionId, 'Needs your input')
+        notifySession(sessionId, 'Needs your input', 'waiting')
       } else {
         // No blocking tools — add optimistic message FIRST, then batch-clear state.
         // This eliminates the flicker gap where neither streaming nor persisted content is visible.
@@ -1445,7 +1458,7 @@ export default function useStreamingEvents({
           }
 
           playWaitingSound()
-          notifySession(sessionId, 'Needs your input')
+          notifySession(sessionId, 'Needs your input', 'waiting')
         } else {
           // 2. Update last_run_status + session state in caches so UI reflects immediately.
           // CRITICAL: Include waiting_for_input/is_reviewing so

--- a/src/components/unread/unread-utils.test.ts
+++ b/src/components/unread/unread-utils.test.ts
@@ -40,4 +40,23 @@ describe('isUnreadSession', () => {
       )
     ).toBe(true)
   })
+
+  it('treats pending Codex command approvals as unread even without waiting_for_input (issue #626)', () => {
+    expect(
+      isUnreadSession(
+        session({
+          waiting_for_input: false,
+          pending_codex_command_approval_requests: [
+            {
+              rpc_id: 1,
+              item_id: 'item-1',
+              thread_id: 'thread-1',
+              turn_id: 'turn-1',
+              command: 'npm test',
+            },
+          ],
+        })
+      )
+    ).toBe(true)
+  })
 })

--- a/src/components/unread/unread-utils.ts
+++ b/src/components/unread/unread-utils.ts
@@ -2,6 +2,18 @@ import type { Session } from '@/types/chat'
 
 export const FINISHED_UNREAD_STATUSES = ['completed', 'cancelled', 'crashed']
 
+/** True when the session has a mid-turn approval/input queue pending. */
+export function hasPendingSessionApproval(session: Session): boolean {
+  return (
+    (session.pending_codex_command_approval_requests?.length ?? 0) > 0 ||
+    (session.pending_codex_permission_requests?.length ?? 0) > 0 ||
+    (session.pending_codex_user_input_requests?.length ?? 0) > 0 ||
+    (session.pending_codex_mcp_elicitation_requests?.length ?? 0) > 0 ||
+    (session.pending_codex_dynamic_tool_call_requests?.length ?? 0) > 0 ||
+    (session.pending_permission_denials?.length ?? 0) > 0
+  )
+}
+
 /** Check if a session counts as "unread" — has unseen activity */
 export function isUnreadSession(session: Session): boolean {
   if (session.archived_at) return false
@@ -9,7 +21,10 @@ export function isUnreadSession(session: Session): boolean {
   const hasFinishedRun =
     session.last_run_status &&
     FINISHED_UNREAD_STATUSES.includes(session.last_run_status)
-  const isWaiting = session.waiting_for_input
+  // Mid-turn Codex approvals set waiting_for_input, but also count pending
+  // queues so reconnect/remote clients still surface them (issue #626).
+  const isWaiting =
+    session.waiting_for_input || hasPendingSessionApproval(session)
   const isReviewing = session.is_reviewing
   const hasReviewResults = !!session.review_results
 

--- a/src/lib/session-notifications.test.ts
+++ b/src/lib/session-notifications.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const invoke = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@/lib/transport', () => ({
+  invoke: (...args: unknown[]) => invoke(...args),
+}))
+
+vi.mock('@/lib/environment', () => ({
+  isNativeApp: () => true,
+}))
+
+vi.mock('@/store/chat-store', () => ({
+  useChatStore: {
+    getState: () => chatState,
+  },
+}))
+
+vi.mock('@/store/ui-store', () => ({
+  useUIStore: {
+    getState: () => uiState,
+  },
+}))
+
+let chatState: {
+  activeWorktreeId: string | null
+  activeSessionIds: Record<string, string>
+  sessionWorktreeMap: Record<string, string>
+}
+
+let uiState: {
+  sessionChatModalOpen: boolean
+  sessionChatModalWorktreeId: string | null
+}
+
+describe('session-notifications', () => {
+  beforeEach(() => {
+    invoke.mockClear()
+    chatState = {
+      activeWorktreeId: 'wt-other',
+      activeSessionIds: { 'wt-1': 'session-1', 'wt-other': 'session-other' },
+      sessionWorktreeMap: { 'session-1': 'wt-1', 'session-other': 'wt-other' },
+    }
+    uiState = {
+      sessionChatModalOpen: false,
+      sessionChatModalWorktreeId: null,
+    }
+    // Focused window by default
+    Object.defineProperty(document, 'hasFocus', {
+      configurable: true,
+      value: () => true,
+    })
+  })
+
+  it('notifies when focused on a different session (issue #626)', async () => {
+    const { notifySessionNeedsAttention } = await import(
+      './session-notifications'
+    )
+    notifySessionNeedsAttention('session-1', 'Needs your input', 'My session')
+    expect(invoke).toHaveBeenCalledWith('send_native_notification', {
+      title: 'Needs your input',
+      body: 'My session',
+    })
+  })
+
+  it('skips OS banner when the session is actively viewed and window focused', async () => {
+    chatState.activeWorktreeId = 'wt-1'
+    const { notifySessionNeedsAttention } = await import(
+      './session-notifications'
+    )
+    notifySessionNeedsAttention('session-1', 'Needs your input', 'My session')
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('notifies when window is unfocused even if session is active', async () => {
+    chatState.activeWorktreeId = 'wt-1'
+    Object.defineProperty(document, 'hasFocus', {
+      configurable: true,
+      value: () => false,
+    })
+    const { notifySessionNeedsAttention } = await import(
+      './session-notifications'
+    )
+    notifySessionNeedsAttention('session-1', 'Needs your input', 'My session')
+    expect(invoke).toHaveBeenCalledWith('send_native_notification', {
+      title: 'Needs your input',
+      body: 'My session',
+    })
+  })
+})

--- a/src/lib/session-notifications.ts
+++ b/src/lib/session-notifications.ts
@@ -1,11 +1,17 @@
 /**
  * Native desktop notifications for session lifecycle events.
- * Fires an OS banner only when Jean is in the background — when the window is
- * focused the existing notification sound already covers the event.
+ *
+ * - When Jean is unfocused: always fire an OS banner (if enabled).
+ * - When Jean is focused on a *different* session/view: also fire an OS banner
+ *   so mid-turn Codex/Claude approvals aren't silent (issue #626).
+ * - When Jean is focused on the session that needs input: skip the banner —
+ *   the in-app UI + optional waiting sound already cover it.
  */
 
 import { invoke } from '@/lib/transport'
 import { isNativeApp } from './environment'
+import { useChatStore } from '@/store/chat-store'
+import { useUIStore } from '@/store/ui-store'
 
 /**
  * Fire a native OS banner only when the app is unfocused.
@@ -14,6 +20,53 @@ import { isNativeApp } from './environment'
 export function notifyIfBackground(title: string, body?: string): void {
   if (!isNativeApp()) return
   if (document.hasFocus()) return // sound already covers the focused case
+  void invoke('send_native_notification', { title, body }).catch(
+    () => undefined
+  )
+}
+
+/** Whether the given session is currently open in the full chat view or modal. */
+export function isSessionCurrentlyViewed(sessionId: string): boolean {
+  const {
+    activeWorktreeId,
+    activeSessionIds,
+    sessionWorktreeMap,
+  } = useChatStore.getState()
+  const worktreeId = sessionWorktreeMap[sessionId]
+  if (!worktreeId) return false
+
+  const isActiveSession = activeSessionIds[worktreeId] === sessionId
+  if (!isActiveSession) return false
+
+  if (activeWorktreeId === worktreeId) return true
+
+  const { sessionChatModalOpen, sessionChatModalWorktreeId } =
+    useUIStore.getState()
+  return sessionChatModalOpen && sessionChatModalWorktreeId === worktreeId
+}
+
+/**
+ * Notify the user that a session needs attention (approval/input).
+ *
+ * Fires a native OS banner when:
+ * - the window is unfocused, OR
+ * - the window is focused but the user is not viewing this session
+ *
+ * Always pairs with playWaitingSound in callers for the focused-on-session case.
+ */
+export function notifySessionNeedsAttention(
+  sessionId: string,
+  title: string,
+  body?: string
+): void {
+  if (!isNativeApp()) return
+
+  const viewingThisSession = isSessionCurrentlyViewed(sessionId)
+  if (document.hasFocus() && viewingThisSession) {
+    // User can already see the approval UI; sound (if configured) is enough.
+    return
+  }
+
   void invoke('send_native_notification', { title, body }).catch(
     () => undefined
   )


### PR DESCRIPTION
## Summary

- Always offer **Approve (yolo)** on Codex command approvals, even when Codex omits `acceptForSession` from `availableDecisions` (unknown commands often only allow `accept` + `cancel`)
- Accept once with a Jean-only `promoteToYolo` flag so residual mid-turn prompts auto-approve after YOLO promote
- Keep waiting-for-input indicators for mid-turn Codex approval queues across reconnects and running turns
- Fire native “needs your input” notifications when Jean is focused on a different session (not only when the app is unfocused)

## Breaking Changes

None.

---

Fixes #624