### PR TITLE
fix(terminal): floor login PTY size so TUI CLIs stay usable

### DIFF
--- a/jean-core/src/terminal/pty.rs
+++ b/jean-core/src/terminal/pty.rs
@@ -16,6 +16,29 @@ fn get_user_shell() -> String {
     crate::platform::get_default_shell()
 }
 
+/// Normalize PTY cols/rows before openpty/spawn.
+///
+/// - Degenerate sizes (< 2) become 80×24 (portable_pty asserts on 0).
+/// - Command PTYs floor at 80×24 so interactive TUI CLIs get a usable viewport
+///   even when the frontend fit ran during a dialog zoom-in (issue #624).
+pub(crate) fn effective_pty_size(cols: u16, rows: u16, is_command: bool) -> (u16, u16) {
+    let cols = if cols < 2 {
+        80
+    } else if is_command {
+        cols.max(80)
+    } else {
+        cols
+    };
+    let rows = if rows < 2 {
+        24
+    } else if is_command {
+        rows.max(24)
+    } else {
+        rows
+    };
+    (cols, rows)
+}
+
 fn is_windows_batch_file(path: &str) -> bool {
     std::path::Path::new(path)
         .extension()
@@ -127,9 +150,12 @@ pub fn spawn_terminal(
 
     let pty_system = native_pty_system();
 
-    // Guard against degenerate dimensions that crash portable_pty
-    let cols = if cols == 0 { 80 } else { cols };
-    let rows = if rows == 0 { 24 } else { rows };
+    // Guard against degenerate dimensions that crash portable_pty.
+    // Command PTYs (CLI login TUI apps) also floor at 80×24 — a tiny first
+    // fit during dialog animation leaves tools like `opencode auth login`
+    // stuck after "Add credential" (issue #624).
+    let is_command = command.as_ref().is_some_and(|c| !c.is_empty());
+    let (cols, rows) = effective_pty_size(cols, rows, is_command);
     log::info!("spawn_terminal {terminal_id}: effective size={cols}x{rows}");
 
     // Create PTY pair
@@ -561,9 +587,19 @@ pub fn kill_all_terminals() -> usize {
 mod tests {
     #[cfg(unix)]
     use super::build_unix_shell_command;
-    use super::is_windows_batch_file;
+    use super::{effective_pty_size, is_windows_batch_file};
     #[cfg(unix)]
     use super::{terminal_utf8_locale_overrides, ParentLocale};
+
+    #[test]
+    fn effective_pty_size_clamps_degenerate_and_command_floors() {
+        assert_eq!(effective_pty_size(0, 0, false), (80, 24));
+        assert_eq!(effective_pty_size(1, 1, false), (80, 24));
+        assert_eq!(effective_pty_size(40, 10, false), (40, 10));
+        // Command/login PTYs always get a TUI-usable floor (issue #624).
+        assert_eq!(effective_pty_size(12, 5, true), (80, 24));
+        assert_eq!(effective_pty_size(100, 40, true), (100, 40));
+    }
 
     #[cfg(unix)]
     #[test]

--- a/src/components/chat/StandaloneTerminalSurface.test.tsx
+++ b/src/components/chat/StandaloneTerminalSurface.test.tsx
@@ -34,6 +34,8 @@ vi.mock('@/lib/terminal-instances', () => ({
   focusTerminal: vi.fn(),
 }))
 
+let mockContentRect = { width: 640, height: 360 }
+
 class ResizeObserverMock {
   private readonly callback: ResizeObserverCallback
 
@@ -42,17 +44,18 @@ class ResizeObserverMock {
   }
 
   observe = (target: Element) => {
+    const { width, height } = mockContentRect
     this.callback(
       [
         {
           target,
           contentRect: {
-            width: 640,
-            height: 360,
+            width,
+            height,
             top: 0,
             left: 0,
-            bottom: 360,
-            right: 640,
+            bottom: height,
+            right: width,
             x: 0,
             y: 0,
             toJSON: () => ({}),
@@ -73,6 +76,7 @@ class ResizeObserverMock {
 describe('StandaloneTerminalSurface', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockContentRect = { width: 640, height: 360 }
     isNativeApp.mockReturnValue(false)
     window.ResizeObserver =
       ResizeObserverMock as unknown as typeof ResizeObserver
@@ -106,5 +110,22 @@ describe('StandaloneTerminalSurface', () => {
     )
 
     expect(screen.queryByTestId('terminal-extra-keys-bar')).toBeNull()
+  })
+
+  it('does not start the login PTY while the container is still tiny (issue #624)', async () => {
+    mockContentRect = { width: 40, height: 20 }
+
+    render(
+      <StandaloneTerminalSurface
+        terminalId="login-term-tiny"
+        command="opencode"
+        commandArgs={['auth', 'login']}
+        className="h-[300px]"
+      />
+    )
+
+    // ResizeObserver fired with sub-minimum size — must not spawn yet.
+    await new Promise(r => setTimeout(r, 30))
+    expect(initTerminal).not.toHaveBeenCalled()
   })
 })

--- a/src/components/chat/StandaloneTerminalSurface.tsx
+++ b/src/components/chat/StandaloneTerminalSurface.tsx
@@ -11,6 +11,8 @@ import { useTerminalBackgroundColor } from '@/hooks/useTerminalThemeSync'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useVisualViewportBottomInset } from '@/hooks/useVisualViewportBottomInset'
 import { isNativeApp } from '@/lib/environment'
+import { isLoginTerminalContainerReady } from '@/lib/terminal-dimensions'
+import { focusTerminal } from '@/lib/terminal-instances'
 import { cn } from '@/lib/utils'
 import { TerminalArrowGesture } from './TerminalArrowGesture'
 import { TerminalExtraKeysBar } from './TerminalExtraKeysBar'
@@ -54,7 +56,7 @@ export function StandaloneTerminalSurface({
   const keyboardInset = useVisualViewportBottomInset(rootRef, showExtraKeys)
   const terminalBg = useTerminalBackgroundColor()
 
-  const { initTerminal, fit } = useTerminal({
+  const { initTerminal, fit, focus } = useTerminal({
     terminalId,
     worktreeId,
     worktreePath,
@@ -63,6 +65,8 @@ export function StandaloneTerminalSurface({
   })
 
   // ResizeObserver owns init + fit; disconnect on container change / unmount.
+  // Wait for a minimum size so login TUI CLIs (OpenCode auth, etc.) are not
+  // spawned during dialog zoom with a tiny PTY (issue #624).
   useEffect(() => {
     if (!container) return
 
@@ -75,6 +79,9 @@ export function StandaloneTerminalSurface({
       }
 
       if (!initialized.current) {
+        if (!isLoginTerminalContainerReady(width, height)) {
+          return
+        }
         initialized.current = true
         void initTerminal(container)
         return
@@ -115,6 +122,10 @@ export function StandaloneTerminalSurface({
         backgroundColor: terminalBg,
         // Lift the extra-keys bar (and shrink the emulator) above the soft keyboard.
         paddingBottom: keyboardInset > 0 ? keyboardInset : undefined,
+      }}
+      onMouseDown={() => {
+        focus()
+        focusTerminal(terminalId)
       }}
     >
       {/* Pad chrome sits above the emulator so long-press arrows never cover text. */}

--- a/src/components/onboarding/CliSetupComponents.test.tsx
+++ b/src/components/onboarding/CliSetupComponents.test.tsx
@@ -100,6 +100,9 @@ describe('AuthLoginState completion', () => {
       'data-terminal-id',
       'cursor-login-test'
     )
+    expect(
+      screen.getByText(/provider list may take a few seconds/i)
+    ).toBeTruthy()
   })
 
   it('only advances once when completion is clicked repeatedly', () => {

--- a/src/components/onboarding/CliSetupComponents.tsx
+++ b/src/components/onboarding/CliSetupComponents.tsx
@@ -510,13 +510,19 @@ export function AuthLoginState({
           {action === 'install' ? 'installation' : 'authentication'}
           {' process below.'}
         </p>
+        {action === 'login' && (
+          <p className="text-xs text-muted-foreground mt-2">
+            Click the terminal, then use ↑/↓ and Enter to choose options. The
+            provider list may take a few seconds to appear.
+          </p>
+        )}
       </div>
 
       <StandaloneTerminalSurface
         terminalId={terminalId}
         command={command}
         commandArgs={commandArgs}
-        className="h-[min(50dvh,380px)] sm:h-[360px]"
+        className="h-[min(50dvh,380px)] min-h-[200px] sm:h-[360px]"
       />
 
       {exitStatus && (

--- a/src/lib/terminal-dimensions.test.ts
+++ b/src/lib/terminal-dimensions.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isLoginTerminalContainerReady,
+  LOGIN_TERMINAL_MIN_HEIGHT_PX,
+  LOGIN_TERMINAL_MIN_WIDTH_PX,
+  resolveSafeTerminalDimensions,
+  SAFE_TERMINAL_MIN_COLS,
+  SAFE_TERMINAL_MIN_ROWS,
+} from './terminal-dimensions'
+
+describe('resolveSafeTerminalDimensions', () => {
+  it('clamps degenerate sizes to the safe floor', () => {
+    expect(resolveSafeTerminalDimensions(0, 0)).toEqual({
+      cols: SAFE_TERMINAL_MIN_COLS,
+      rows: SAFE_TERMINAL_MIN_ROWS,
+    })
+    expect(resolveSafeTerminalDimensions(1, 1)).toEqual({
+      cols: SAFE_TERMINAL_MIN_COLS,
+      rows: SAFE_TERMINAL_MIN_ROWS,
+    })
+  })
+
+  it('keeps larger interactive panel sizes as-is when not a command PTY', () => {
+    expect(resolveSafeTerminalDimensions(120, 40)).toEqual({
+      cols: 120,
+      rows: 40,
+    })
+    // Small but non-degenerate panel (no command) — preserve fit result
+    expect(resolveSafeTerminalDimensions(40, 10)).toEqual({
+      cols: 40,
+      rows: 10,
+    })
+  })
+
+  it('floors command/login PTYs at 80x24 so TUI prompts stay usable', () => {
+    // Dialog zoom-in often yields a handful of cols before layout settles
+    expect(
+      resolveSafeTerminalDimensions(12, 5, { forCommand: true })
+    ).toEqual({
+      cols: SAFE_TERMINAL_MIN_COLS,
+      rows: SAFE_TERMINAL_MIN_ROWS,
+    })
+    expect(
+      resolveSafeTerminalDimensions(100, 30, { forCommand: true })
+    ).toEqual({
+      cols: 100,
+      rows: 30,
+    })
+  })
+})
+
+describe('isLoginTerminalContainerReady', () => {
+  it('rejects empty or sub-minimum containers', () => {
+    expect(isLoginTerminalContainerReady(0, 0)).toBe(false)
+    expect(isLoginTerminalContainerReady(100, 400)).toBe(false)
+    expect(isLoginTerminalContainerReady(400, 50)).toBe(false)
+  })
+
+  it('accepts containers that meet the login TUI minimum', () => {
+    expect(
+      isLoginTerminalContainerReady(
+        LOGIN_TERMINAL_MIN_WIDTH_PX,
+        LOGIN_TERMINAL_MIN_HEIGHT_PX
+      )
+    ).toBe(true)
+    expect(isLoginTerminalContainerReady(640, 360)).toBe(true)
+  })
+})

--- a/src/lib/terminal-dimensions.ts
+++ b/src/lib/terminal-dimensions.ts
@@ -1,0 +1,64 @@
+/**
+ * Terminal dimension helpers for embedded PTYs.
+ *
+ * Interactive TUI CLIs (OpenCode `auth login`, clack prompts, etc.) mis-render
+ * or appear frozen when the PTY starts at near-zero cols/rows — common while a
+ * dialog is still animating open. These helpers enforce safe floors and a
+ * minimum container size before spawning command PTYs.
+ */
+
+/** Absolute floor used when the emulator reports a degenerate size. */
+export const SAFE_TERMINAL_MIN_COLS = 80
+export const SAFE_TERMINAL_MIN_ROWS = 24
+
+/**
+ * Minimum container CSS pixels before a one-shot login/install PTY is started.
+ * Below this, fit() often yields only a handful of cols during dialog zoom-in
+ * (issue #624: OpenCode auth stuck on "Add credential").
+ *
+ * Kept low enough for narrow mobile dialogs, high enough to skip mid-animation
+ * sizes (often tens of px).
+ */
+export const LOGIN_TERMINAL_MIN_WIDTH_PX = 200
+export const LOGIN_TERMINAL_MIN_HEIGHT_PX = 120
+
+/**
+ * Resolve PTY cols/rows from an emulator's reported size.
+ *
+ * Degenerate sizes (< 2) crash portable_pty. Sizes that are merely "small"
+ * still break interactive TUI apps — for command PTYs we therefore floor at
+ * 80×24 so OpenCode/clack prompts get a usable viewport even if fit ran early.
+ */
+export function resolveSafeTerminalDimensions(
+  rawCols: number,
+  rawRows: number,
+  options?: { forCommand?: boolean }
+): { cols: number; rows: number } {
+  const forCommand = options?.forCommand === true
+
+  let cols = Number.isFinite(rawCols) ? Math.floor(rawCols) : 0
+  let rows = Number.isFinite(rawRows) ? Math.floor(rawRows) : 0
+
+  if (cols < 2) cols = SAFE_TERMINAL_MIN_COLS
+  if (rows < 2) rows = SAFE_TERMINAL_MIN_ROWS
+
+  if (forCommand) {
+    cols = Math.max(cols, SAFE_TERMINAL_MIN_COLS)
+    rows = Math.max(rows, SAFE_TERMINAL_MIN_ROWS)
+  }
+
+  return { cols, rows }
+}
+
+/** True when a login/install terminal container is large enough to start a TUI. */
+export function isLoginTerminalContainerReady(
+  width: number,
+  height: number
+): boolean {
+  return (
+    Number.isFinite(width) &&
+    Number.isFinite(height) &&
+    width >= LOGIN_TERMINAL_MIN_WIDTH_PX &&
+    height >= LOGIN_TERMINAL_MIN_HEIGHT_PX
+  )
+}

--- a/src/lib/terminal-instances.ts
+++ b/src/lib/terminal-instances.ts
@@ -45,6 +45,7 @@ import {
   type ResolvedTerminalTheme,
 } from '@/lib/terminal-theme'
 import { isArrowGestureActive } from '@/lib/terminal-arrow-gesture'
+import { resolveSafeTerminalDimensions } from '@/lib/terminal-dimensions'
 
 type TerminalRenderer = 'xterm' | 'ghostty-web'
 type EmbeddedTerminal = XtermTerminal | GhosttyWebTerminal
@@ -199,7 +200,10 @@ function scheduleAppearanceResize(instance: PersistentTerminal): void {
     instance.appearanceResizeTimer = null
     if (!instance.terminal || !instance.fitAddon) return
     instance.fitAddon.fit()
-    const { cols, rows } = getSafeTerminalDimensions(instance.terminal)
+    const forCommand = instance.command != null && instance.command.length > 0
+    const { cols, rows } = getSafeTerminalDimensions(instance.terminal, {
+      forCommand,
+    })
     if (!instance.initialized) return
     invoke('terminal_resize', {
       terminalId: instance.terminalId,
@@ -209,15 +213,14 @@ function scheduleAppearanceResize(instance: PersistentTerminal): void {
   }, 120)
 }
 
-function getSafeTerminalDimensions(terminal: EmbeddedTerminal): {
+function getSafeTerminalDimensions(
+  terminal: EmbeddedTerminal,
+  options?: { forCommand?: boolean }
+): {
   cols: number
   rows: number
 } {
-  const rawCols = terminal.cols
-  const rawRows = terminal.rows
-  const rows = rawRows < 2 ? 24 : rawRows
-  const cols = rawCols < 2 ? 80 : rawCols
-  return { cols, rows }
+  return resolveSafeTerminalDimensions(terminal.cols, terminal.rows, options)
 }
 
 function disableGhosttyScrollbar(instance: PersistentTerminal): void {
@@ -1071,11 +1074,15 @@ export async function attachToContainer(
     fitAddon.fit()
     // Enforce minimum dimensions — degenerate sizes (e.g. rows=0 during dialog
     // animation) cause portable_pty to crash with an internal assertion failure.
+    // Command PTYs (CLI login) also floor at 80×24 so TUI prompts like
+    // `opencode auth login` are not started mid-zoom with a handful of cols
+    // (issue #624).
+    const forCommand = command != null && command.length > 0
     const rawCols = terminal.cols
     const rawRows = terminal.rows
-    const { cols, rows } = getSafeTerminalDimensions(terminal)
+    const { cols, rows } = getSafeTerminalDimensions(terminal, { forCommand })
     console.log(
-      `[terminal-instances] attachToContainer ${terminalId}: fit=${rawCols}x${rawRows} → used=${cols}x${rows}, initialized=${instance.initialized}, container=${container.clientWidth}x${container.clientHeight}`
+      `[terminal-instances] attachToContainer ${terminalId}: fit=${rawCols}x${rawRows} → used=${cols}x${rows}, initialized=${instance.initialized}, container=${container.clientWidth}x${container.clientHeight}, forCommand=${forCommand}`
     )
 
     if (!(await waitForTerminalReady(terminalId, instance))) return
@@ -1117,6 +1124,12 @@ export async function attachToContainer(
       if (!isCurrentInstance(terminalId, instance)) return
 
       instance.initialized = true
+
+      // Dialog zoom / flex layout often settles a frame after first attach.
+      // Re-fit and SIGWINCH so interactive TUI CLIs pick up the final size.
+      if (forCommand) {
+        scheduleCommandTerminalSettleResize(terminalId, instance)
+      }
     } else {
       // Already initialized - just resize
       await invoke('terminal_resize', { terminalId, cols, rows }).catch(
@@ -1125,6 +1138,39 @@ export async function attachToContainer(
     }
 
     terminal.focus()
+  })
+}
+
+/**
+ * After a command PTY starts, re-measure once layout has settled and push a
+ * resize to the backend. Fixes OpenCode/clack prompts that read TTY size at
+ * startup when the first fit ran during dialog animation (issue #624).
+ */
+function scheduleCommandTerminalSettleResize(
+  terminalId: string,
+  instance: PersistentTerminal
+): void {
+  const run = () => {
+    if (!isCurrentInstance(terminalId, instance)) return
+    if (!instance.terminal || !instance.fitAddon) return
+    instance.fitAddon.fit()
+    const { cols, rows } = getSafeTerminalDimensions(instance.terminal, {
+      forCommand: true,
+    })
+    invoke('terminal_resize', { terminalId, cols, rows }).catch(console.error)
+    try {
+      instance.terminal.focus()
+    } catch {
+      // ignore — terminal may be mid-dispose
+    }
+  }
+
+  // Two rAFs + short timeout covers dialog zoom-in and flex reflow.
+  scheduleAnimationFrame(() => {
+    scheduleAnimationFrame(() => {
+      setTimeout(run, 50)
+      setTimeout(run, 250)
+    })
   })
 }
 
@@ -1192,7 +1238,10 @@ export function fitTerminal(terminalId: string): void {
   if (!instance || !instance.fitAddon || !instance.terminal) return
 
   instance.fitAddon.fit()
-  const { cols, rows } = getSafeTerminalDimensions(instance.terminal)
+  const forCommand = instance.command != null && instance.command.length > 0
+  const { cols, rows } = getSafeTerminalDimensions(instance.terminal, {
+    forCommand,
+  })
   invoke('terminal_resize', { terminalId, cols, rows }).catch(console.error)
 }
 


### PR DESCRIPTION
## Summary

- Floor command/login PTY sizes at 80×24 so interactive TUI CLIs stay usable when the first fit runs during dialog zoom or a tiny layout
- Delay spawning login terminals until the container is large enough, then re-fit after layout settles so tools like OpenCode auth pick up a real viewport
- Improve CLI login UX with a minimum terminal height, focus-on-click, and guidance for arrow-key provider selection
- Add unit and component coverage for PTY sizing, container readiness, and deferred init

fixes #624

---

Fixes #626