### PR TITLE
fix(git): emit raw UTF-8 paths for non-ASCII names

### DIFF
--- a/jean-core/src/projects/checkpoints.rs
+++ b/jean-core/src/projects/checkpoints.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 use crate::platform::wsl_aware_command;
 
 use super::git::resolve_git_dirs;
-use super::git_status::{parse_unified_diff, DiffFile, GitDiff};
+use super::git_status::{parse_unified_diff, DiffFile, GitDiff, GIT_NO_QUOTE_PATH_ARGS};
 
 /// Max checkpoints retained per worktree (oldest pruned first).
 const MAX_CHECKPOINTS_PER_WORKTREE: usize = 100;
@@ -346,7 +346,10 @@ fn delete_checkpoint_refs(repo_path: &str, id: &str) {
 
 /// Diff two trees/commits (or a commit vs working tree when `to` is None).
 fn diff_commits(repo_path: &str, from: &str, to: Option<&str>) -> Result<GitDiff, String> {
-    let mut args = vec!["diff", "--unified=3", from];
+    // Emit raw UTF-8 paths so frontend patch parsers work with non-ASCII names (#631).
+    let mut args = Vec::with_capacity(6);
+    args.extend_from_slice(GIT_NO_QUOTE_PATH_ARGS);
+    args.extend_from_slice(&["diff", "--unified=3", from]);
     if let Some(to_ref) = to {
         args.push(to_ref);
     }
@@ -408,9 +411,16 @@ fn diff_commits(repo_path: &str, from: &str, to: Option<&str>) -> Result<GitDiff
 }
 
 fn list_untracked_relative(repo_path: &str) -> Vec<String> {
+    // Raw UTF-8 paths — see GIT_NO_QUOTE_PATH_ARGS / #631.
     let Ok(stdout) = git_output(
         repo_path,
-        &["ls-files", "--others", "--exclude-standard"],
+        &[
+            "-c",
+            "core.quotePath=false",
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+        ],
         None,
     ) else {
         return Vec::new();

--- a/jean-core/src/projects/commands.rs
+++ b/jean-core/src/projects/commands.rs
@@ -1143,6 +1143,7 @@ pub async fn get_worktree_diff(
     let base_remote = worktree.base_remote.clone();
     let base_branch = worktree.base_branch.unwrap_or(project_default_branch);
     let has_head = git_has_head(&worktree.path);
+    // -c core.quotePath=false so non-ASCII paths are raw UTF-8 (issue #631).
     let mut args = match diff_type.as_str() {
         "uncommitted" => {
             let diff_base = if has_head {
@@ -1151,12 +1152,16 @@ pub async fn get_worktree_diff(
                 "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
             };
             vec![
+                "-c".to_string(),
+                "core.quotePath=false".to_string(),
                 "diff".to_string(),
                 diff_base.to_string(),
                 "--unified=3".to_string(),
             ]
         }
         "branch" => vec![
+            "-c".to_string(),
+            "core.quotePath=false".to_string(),
             "diff".to_string(),
             "--unified=3".to_string(),
             format!(
@@ -6028,9 +6033,10 @@ pub async fn get_review_prompt(
         return Err(format!("Git log failed: {stderr}"));
     };
 
-    // Get uncommitted changes (staged + unstaged for tracked files)
+    // Get uncommitted changes (staged + unstaged for tracked files).
+    // core.quotePath=false: raw UTF-8 paths for non-ASCII names (#631).
     let uncommitted_output = wsl_aware_command("git", Some(Path::new(&worktree_path)))
-        .args(["diff", "HEAD"])
+        .args(["-c", "core.quotePath=false", "diff", "HEAD"])
         .output()
         .map_err(|e| format!("Failed to run git diff HEAD: {e}"))?;
 
@@ -6040,9 +6046,15 @@ pub async fn get_review_prompt(
         String::new() // Not an error if no uncommitted changes
     };
 
-    // Get list of untracked files
+    // Get list of untracked files (raw UTF-8 paths — #631)
     let untracked_output = wsl_aware_command("git", Some(Path::new(&worktree_path)))
-        .args(["ls-files", "--others", "--exclude-standard"])
+        .args([
+            "-c",
+            "core.quotePath=false",
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+        ])
         .output()
         .map_err(|e| format!("Failed to list untracked files: {e}"))?;
 
@@ -9789,9 +9801,10 @@ pub async fn run_review_with_ai(
     // Get commit history (non-fatal — same reason)
     let commits = get_branch_commits(&worktree_path, &target_branch, "HEAD").unwrap_or_default();
 
-    // Get uncommitted changes (staged + unstaged for tracked files)
+    // Get uncommitted changes (staged + unstaged for tracked files).
+    // core.quotePath=false: raw UTF-8 paths for non-ASCII names (#631).
     let uncommitted_output = wsl_aware_command("git", Some(Path::new(&worktree_path)))
-        .args(["diff", "HEAD"])
+        .args(["-c", "core.quotePath=false", "diff", "HEAD"])
         .output()
         .map_err(|e| format!("Failed to get uncommitted diff: {e}"))?;
 
@@ -9802,9 +9815,15 @@ pub async fn run_review_with_ai(
         String::new()
     };
 
-    // Get untracked files
+    // Get untracked files (raw UTF-8 paths — #631)
     let untracked_output = wsl_aware_command("git", Some(Path::new(&worktree_path)))
-        .args(["ls-files", "--others", "--exclude-standard"])
+        .args([
+            "-c",
+            "core.quotePath=false",
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+        ])
         .output()
         .map_err(|e| format!("Failed to list untracked files: {e}"))?;
 

--- a/jean-core/src/projects/git_log.rs
+++ b/jean-core/src/projects/git_log.rs
@@ -2,7 +2,7 @@ use crate::platform::wsl_aware_command;
 use serde::Serialize;
 use std::path::Path;
 
-use super::git_status::{parse_unified_diff, GitDiff};
+use super::git_status::{parse_unified_diff, GitDiff, GIT_NO_QUOTE_PATH_ARGS};
 
 /// Metadata for a single commit
 #[derive(Debug, Clone, Serialize)]
@@ -156,7 +156,9 @@ pub fn get_commit_diff(repo_path: &str, commit_sha: &str) -> Result<GitDiff, Str
     let parent_ref = format!("{commit_sha}^");
     let range = format!("{parent_ref}..{commit_sha}");
 
+    // Emit raw UTF-8 paths so frontend patch parsers work with non-ASCII names (#631).
     let output = wsl_aware_command("git", Some(Path::new(repo_path)))
+        .args(GIT_NO_QUOTE_PATH_ARGS)
         .args(["diff", "--unified=3", &range])
         .output()
         .map_err(|e| format!("Failed to run git diff: {e}"))?;
@@ -166,6 +168,7 @@ pub fn get_commit_diff(repo_path: &str, commit_sha: &str) -> Result<GitDiff, Str
     } else {
         // Might be root commit — try diff-tree
         let fallback = wsl_aware_command("git", Some(Path::new(repo_path)))
+            .args(GIT_NO_QUOTE_PATH_ARGS)
             .args(["diff-tree", "-p", "--unified=3", "--root", commit_sha])
             .output()
             .map_err(|e| format!("Failed to run git diff-tree: {e}"))?;
@@ -191,4 +194,67 @@ pub fn get_commit_diff(repo_path: &str, commit_sha: &str) -> Result<GitDiff, Str
         files,
         raw_patch,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::wsl_aware_command;
+    use std::path::Path;
+
+    fn run_test_git(repo: &Path, args: &[&str]) {
+        let output = wsl_aware_command("git", Some(repo))
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn commit_diff_handles_non_ascii_filename() {
+        // Regression for #631: commit diffs must surface non-ASCII paths, not
+        // empty "No file changes" from quoted path parse failures.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path();
+        run_test_git(repo, &["init"]);
+        run_test_git(repo, &["config", "core.quotePath", "true"]);
+        run_test_git(repo, &["config", "user.email", "test@example.com"]);
+        run_test_git(repo, &["config", "user.name", "Test"]);
+
+        let filename = "日本語ファイル名.md";
+        std::fs::write(repo.join("seed.txt"), "seed\n").expect("seed");
+        run_test_git(repo, &["add", "."]);
+        run_test_git(repo, &["commit", "-m", "seed"]);
+
+        std::fs::write(repo.join(filename), "content\n").expect("write non-ascii");
+        run_test_git(repo, &["add", "."]);
+        run_test_git(repo, &["commit", "-m", "add japanese file"]);
+
+        let sha = {
+            let output = wsl_aware_command("git", Some(repo))
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .expect("rev-parse");
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        };
+
+        let diff = get_commit_diff(repo.to_str().unwrap(), &sha).expect("commit diff");
+        assert_eq!(diff.files.len(), 1, "files: {:?}", diff.files);
+        assert_eq!(diff.files[0].path, filename);
+        assert!(
+            diff.raw_patch.contains(filename),
+            "raw_patch should contain unquoted UTF-8 path:\n{}",
+            diff.raw_patch
+        );
+        assert!(
+            !diff.raw_patch.contains(r"\346"),
+            "raw_patch must not use octal-escaped paths:\n{}",
+            diff.raw_patch
+        );
+    }
 }

--- a/jean-core/src/projects/git_status.rs
+++ b/jean-core/src/projects/git_status.rs
@@ -209,8 +209,9 @@ fn get_uncommitted_diff_stats(repo_path: &str) -> (u32, u32) {
     }
 
     // 3. Get stats for untracked (new) files
-    // List all untracked files
+    // List all untracked files (raw UTF-8 paths — see GIT_NO_QUOTE_PATH_ARGS / #631)
     let untracked_output = wsl_aware_command("git", Some(Path::new(repo_path)))
+        .args(GIT_NO_QUOTE_PATH_ARGS)
         .args(["ls-files", "--others", "--exclude-standard"])
         .output();
 
@@ -243,8 +244,9 @@ fn get_uncommitted_diff_stats(repo_path: &str) -> (u32, u32) {
 fn get_untracked_files_raw_patch(repo_path: &str) -> String {
     let mut raw_patch = String::new();
 
-    // List all untracked files
+    // List all untracked files (raw UTF-8 paths — see GIT_NO_QUOTE_PATH_ARGS / #631)
     let output = wsl_aware_command("git", Some(Path::new(repo_path)))
+        .args(GIT_NO_QUOTE_PATH_ARGS)
         .args(["ls-files", "--others", "--exclude-standard"])
         .output();
 
@@ -292,8 +294,9 @@ fn get_untracked_files_raw_patch(repo_path: &str) -> String {
 fn get_untracked_files_diff(repo_path: &str) -> Vec<DiffFile> {
     let mut untracked_files: Vec<DiffFile> = Vec::new();
 
-    // List all untracked files
+    // List all untracked files (raw UTF-8 paths — see GIT_NO_QUOTE_PATH_ARGS / #631)
     let output = wsl_aware_command("git", Some(Path::new(repo_path)))
+        .args(GIT_NO_QUOTE_PATH_ARGS)
         .args(["ls-files", "--others", "--exclude-standard"])
         .output();
 
@@ -506,6 +509,189 @@ pub struct GitDiff {
     pub raw_patch: String,
 }
 
+/// Git `-c` args that force raw UTF-8 paths instead of C-quoted octal escapes.
+///
+/// With the default `core.quotePath=true`, paths containing bytes ≥ 0x80 are emitted
+/// as `"a/\346\227\245..."` which breaks `@pierre/diffs` (frontend) and our own
+/// `parse_unified_diff` header parser. Command-line `-c` overrides any user/global
+/// config. See issue #631.
+pub const GIT_NO_QUOTE_PATH_ARGS: &[&str] = &["-c", "core.quotePath=false"];
+
+/// Decode a git C-style escaped string (content between the surrounding quotes).
+/// Handles `\\`, `\"`, `\n`, `\t`, `\r`, and octal byte escapes like `\346` (UTF-8).
+fn unescape_git_c_style(escaped: &str) -> String {
+    let bytes = escaped.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 1 < bytes.len() {
+            match bytes[i + 1] {
+                b'n' => {
+                    out.push(b'\n');
+                    i += 2;
+                }
+                b't' => {
+                    out.push(b'\t');
+                    i += 2;
+                }
+                b'r' => {
+                    out.push(b'\r');
+                    i += 2;
+                }
+                b'a' => {
+                    out.push(0x07);
+                    i += 2;
+                }
+                b'b' => {
+                    out.push(0x08);
+                    i += 2;
+                }
+                b'f' => {
+                    out.push(0x0c);
+                    i += 2;
+                }
+                b'v' => {
+                    out.push(0x0b);
+                    i += 2;
+                }
+                b'\\' => {
+                    out.push(b'\\');
+                    i += 2;
+                }
+                b'"' => {
+                    out.push(b'"');
+                    i += 2;
+                }
+                d0 if (b'0'..=b'7').contains(&d0) => {
+                    let mut val: u8 = d0 - b'0';
+                    i += 2;
+                    let mut count = 1;
+                    while count < 3 && i < bytes.len() && (b'0'..=b'7').contains(&bytes[i]) {
+                        val = val.wrapping_mul(8).wrapping_add(bytes[i] - b'0');
+                        i += 1;
+                        count += 1;
+                    }
+                    out.push(val);
+                }
+                other => {
+                    out.push(other);
+                    i += 2;
+                }
+            }
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Unquote a git path token: strips surrounding double-quotes and C-unescapes,
+/// or returns the token as-is when unquoted.
+fn unquote_git_path(token: &str) -> String {
+    let token = token.trim();
+    if token.len() >= 2 && token.starts_with('"') && token.ends_with('"') {
+        unescape_git_c_style(&token[1..token.len() - 1])
+    } else {
+        token.to_string()
+    }
+}
+
+/// Strip a leading `a/` or `b/` prefix from a diff path (after unquoting).
+fn strip_diff_ab_prefix(path: &str) -> &str {
+    path.strip_prefix("a/")
+        .or_else(|| path.strip_prefix("b/"))
+        .unwrap_or(path)
+}
+
+/// Extract a C-quoted token (`"..."` with escapes) from the start of `s`.
+/// Returns `(token_including_quotes, remainder)`.
+fn take_quoted_token(s: &str) -> Option<(&str, &str)> {
+    let s = s.trim_start();
+    if !s.starts_with('"') {
+        return None;
+    }
+    let bytes = s.as_bytes();
+    let mut i = 1;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            i += 1;
+            if i >= bytes.len() {
+                break;
+            }
+            // Skip the escaped sequence. Octal escapes are 1–3 digits.
+            if (b'0'..=b'7').contains(&bytes[i]) {
+                let mut count = 0;
+                while count < 3 && i < bytes.len() && (b'0'..=b'7').contains(&bytes[i]) {
+                    i += 1;
+                    count += 1;
+                }
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+        if bytes[i] == b'"' {
+            return Some((&s[..=i], &s[i + 1..]));
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Parse `diff --git a/<old> b/<new>` into the new-side path (without `a/`/`b/`).
+///
+/// Handles:
+/// - C-quoted paths from `core.quotePath=true` (octal-escaped non-ASCII)
+/// - Unquoted paths that contain spaces (`a/file with spaces.txt b/file with spaces.txt`)
+/// - Renames where old and new paths differ
+fn parse_diff_git_new_path(line: &str) -> String {
+    let rest = line.strip_prefix("diff --git ").unwrap_or(line).trim();
+
+    // Quoted form: diff --git "a/..." "b/..."
+    if rest.starts_with('"') {
+        if let Some((a_tok, after_a)) = take_quoted_token(rest) {
+            if let Some((b_tok, _)) = take_quoted_token(after_a.trim_start()) {
+                let b = unquote_git_path(b_tok);
+                return strip_diff_ab_prefix(&b).to_string();
+            }
+            // Only one quoted token — fall back to a-side
+            let a = unquote_git_path(a_tok);
+            return strip_diff_ab_prefix(&a).to_string();
+        }
+    }
+
+    // Unquoted form: `a/<path> b/<path>` where path may contain spaces.
+    // Prefer an equal-path split (common for modifications).
+    if let Some(after_a) = rest.strip_prefix("a/") {
+        let mut search_at = 0;
+        while let Some(rel) = after_a[search_at..].find(" b/") {
+            let idx = search_at + rel;
+            let a_path = &after_a[..idx];
+            let b_path = &after_a[idx + 3..];
+            if a_path == b_path {
+                return a_path.to_string();
+            }
+            search_at = idx + 1;
+        }
+        // Rename / different paths: first " b/" is the separator (best-effort).
+        if let Some(idx) = after_a.find(" b/") {
+            return after_a[idx + 3..].to_string();
+        }
+        return after_a.to_string();
+    }
+
+    // Legacy fallback for unexpected shapes
+    let parts: Vec<&str> = rest.split_whitespace().collect();
+    if parts.len() >= 2 {
+        strip_diff_ab_prefix(parts[parts.len() - 1]).to_string()
+    } else if parts.len() == 1 {
+        strip_diff_ab_prefix(parts[0]).to_string()
+    } else {
+        "unknown".to_string()
+    }
+}
+
 /// Parse a hunk header like "@@ -1,5 +1,7 @@" or "@@ -0,0 +1,10 @@"
 fn parse_hunk_header(header: &str) -> Option<(u32, u32, u32, u32)> {
     // Format: @@ -old_start,old_lines +new_start,new_lines @@
@@ -553,13 +739,8 @@ pub fn parse_unified_diff(raw_output: &str) -> (Vec<DiffFile>, String) {
                 files.push(file);
             }
 
-            // Parse file paths from "diff --git a/path b/path"
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            let path = if parts.len() >= 4 {
-                parts[3].trim_start_matches("b/").to_string()
-            } else {
-                "unknown".to_string()
-            };
+            // Parse file paths from "diff --git a/path b/path" (quoted or unquoted)
+            let path = parse_diff_git_new_path(line);
 
             current_file = Some(DiffFile {
                 path,
@@ -578,14 +759,14 @@ pub fn parse_unified_diff(raw_output: &str) -> (Vec<DiffFile>, String) {
             if let Some(ref mut file) = current_file {
                 file.status = "deleted".to_string();
             }
-        } else if line.starts_with("rename from ") {
+        } else if let Some(rest) = line.strip_prefix("rename from ") {
             if let Some(ref mut file) = current_file {
-                file.old_path = Some(line.trim_start_matches("rename from ").to_string());
+                file.old_path = Some(unquote_git_path(rest));
                 file.status = "renamed".to_string();
             }
-        } else if line.starts_with("rename to ") {
+        } else if let Some(rest) = line.strip_prefix("rename to ") {
             if let Some(ref mut file) = current_file {
-                file.path = line.trim_start_matches("rename to ").to_string();
+                file.path = unquote_git_path(rest);
             }
         } else if line.starts_with("Binary files") {
             if let Some(ref mut file) = current_file {
@@ -698,7 +879,10 @@ pub fn get_git_diff(
         _ => return Err(format!("Invalid diff_type: {diff_type}")),
     };
 
+    // Emit raw UTF-8 paths so frontend patch parsers and parse_unified_diff work
+    // with non-ASCII file names (issue #631).
     let output = wsl_aware_command("git", Some(Path::new(repo_path)))
+        .args(GIT_NO_QUOTE_PATH_ARGS)
         .args(&args)
         .output()
         .map_err(|e| format!("Failed to run git diff: {e}"))?;
@@ -1130,5 +1314,135 @@ mod tests {
         assert!(diff
             .raw_patch
             .contains("diff --git a/hello.txt b/hello.txt"));
+    }
+
+    #[test]
+    fn unescape_git_c_style_decodes_octal_utf8() {
+        // "日本語" in UTF-8 as git octal escapes
+        let escaped = r"\346\227\245\346\234\254\350\252\236.md";
+        assert_eq!(unescape_git_c_style(escaped), "日本語.md");
+    }
+
+    #[test]
+    fn unquote_git_path_handles_quoted_and_plain() {
+        // \346\227\245 is UTF-8 for 日
+        assert_eq!(unquote_git_path(r#""a/\346\227\245.md""#), "a/日.md");
+        assert_eq!(unquote_git_path("a/plain.txt"), "a/plain.txt");
+        assert_eq!(
+            unquote_git_path("\"path with \\\"quote\\\"\""),
+            "path with \"quote\""
+        );
+    }
+
+    #[test]
+    fn parse_diff_git_new_path_handles_quoted_non_ascii() {
+        let line = r#"diff --git "a/\346\227\245\346\234\254\350\252\236.md" "b/\346\227\245\346\234\254\350\252\236.md""#;
+        assert_eq!(parse_diff_git_new_path(line), "日本語.md");
+    }
+
+    #[test]
+    fn parse_diff_git_new_path_handles_spaces() {
+        let line = "diff --git a/file with spaces.txt b/file with spaces.txt";
+        assert_eq!(parse_diff_git_new_path(line), "file with spaces.txt");
+    }
+
+    #[test]
+    fn parse_diff_git_new_path_handles_simple_ascii() {
+        let line = "diff --git a/src/main.rs b/src/main.rs";
+        assert_eq!(parse_diff_git_new_path(line), "src/main.rs");
+    }
+
+    #[test]
+    fn parse_unified_diff_quoted_non_ascii_path() {
+        // Simulate default git core.quotePath=true output for a Japanese filename
+        let patch = concat!(
+            r#"diff --git "a/\346\227\245\346\234\254\350\252\236.md" "b/\346\227\245\346\234\254\350\252\236.md""#,
+            "\n",
+            "new file mode 100644\n",
+            "index 0000000..45b983b\n",
+            r#"--- /dev/null"#,
+            "\n",
+            r#"+++ "b/\346\227\245\346\234\254\350\252\236.md""#,
+            "\n",
+            "@@ -0,0 +1 @@\n",
+            "+hello\n",
+        );
+        let (files, _) = parse_unified_diff(patch);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "日本語.md");
+        assert_eq!(files[0].status, "added");
+        assert_eq!(files[0].additions, 1);
+    }
+
+    #[test]
+    fn parse_unified_diff_path_with_spaces() {
+        let patch = concat!(
+            "diff --git a/file with spaces.txt b/file with spaces.txt\n",
+            "index 1234567..89abcde 100644\n",
+            "--- a/file with spaces.txt\n",
+            "+++ b/file with spaces.txt\n",
+            "@@ -1 +1 @@\n",
+            "-old\n",
+            "+new\n",
+        );
+        let (files, _) = parse_unified_diff(patch);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "file with spaces.txt");
+        assert_eq!(files[0].additions, 1);
+        assert_eq!(files[0].deletions, 1);
+    }
+
+    #[test]
+    fn uncommitted_diff_handles_non_ascii_filename() {
+        // Regression for #631: default core.quotePath must not break diffs.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path();
+        run_test_git(repo, &["init"]);
+        // Explicitly leave quotePath at default (true). Do not set it false.
+        run_test_git(repo, &["config", "core.quotePath", "true"]);
+        run_test_git(repo, &["config", "user.email", "test@example.com"]);
+        run_test_git(repo, &["config", "user.name", "Test"]);
+
+        let filename = "日本語ファイル名.md";
+        std::fs::write(repo.join(filename), "line one\n").expect("write non-ascii file");
+        run_test_git(repo, &["add", "."]);
+        run_test_git(repo, &["commit", "-m", "add japanese file"]);
+        std::fs::write(repo.join(filename), "line one\nline two\n").expect("modify file");
+
+        let diff = get_git_diff(repo.to_str().unwrap(), "uncommitted", None, None)
+            .expect("diff with non-ascii path should succeed");
+
+        assert_eq!(diff.files.len(), 1, "expected one changed file, got: {:?}", diff.files);
+        assert_eq!(diff.files[0].path, filename);
+        assert!(
+            diff.raw_patch.contains(filename),
+            "raw_patch should contain unquoted UTF-8 path, got:\n{}",
+            diff.raw_patch
+        );
+        assert!(
+            !diff.raw_patch.contains(r"\346"),
+            "raw_patch must not use octal-escaped paths:\n{}",
+            diff.raw_patch
+        );
+        assert!(diff.total_additions >= 1);
+    }
+
+    #[test]
+    fn uncommitted_diff_handles_untracked_non_ascii_filename() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path();
+        run_test_git(repo, &["init"]);
+        run_test_git(repo, &["config", "core.quotePath", "true"]);
+
+        let filename = "日本語ファイル名.md";
+        std::fs::write(repo.join(filename), "new content\n").expect("write");
+
+        let diff = get_git_diff(repo.to_str().unwrap(), "uncommitted", None, None)
+            .expect("untracked non-ascii diff should work");
+
+        assert_eq!(diff.files.len(), 1);
+        assert_eq!(diff.files[0].path, filename);
+        assert_eq!(diff.files[0].status, "untracked");
+        assert!(diff.raw_patch.contains(filename));
     }
 }


### PR DESCRIPTION
## Summary

- Force `core.quotePath=false` on git diff/ls-files paths so non-ASCII filenames are emitted as raw UTF-8 instead of octal-escaped quoted strings
- Apply the same no-quote path args across worktree diffs, commit diffs, checkpoints, review prompts, and untracked file listing
- Add regression tests covering non-ASCII and space-containing filenames so frontend patch parsers no longer show empty “No file changes” for those files

## Related

Issue #631 (non-ASCII path handling in git diffs)

---

Fixes #635