### PR TITLE
fix(projects): refresh replaced avatar images

### DIFF
--- a/jean-core/src/projects/commands.rs
+++ b/jean-core/src/projects/commands.rs
@@ -13363,6 +13363,15 @@ pub async fn set_project_avatar(_app: AppHandle, _project_id: String) -> Result<
     Err("Project avatar file selection is only available in the desktop app".to_string())
 }
 
+fn project_avatar_destination_name(project_id: &str, extension: &str) -> String {
+    format!("{project_id}-{}.{}", Uuid::new_v4(), extension)
+}
+
+fn is_project_avatar_file(file_name: &str, project_id: &str) -> bool {
+    file_name.starts_with(&format!("{project_id}."))
+        || file_name.starts_with(&format!("{project_id}-"))
+}
+
 pub async fn set_project_avatar_from_path(
     app: AppHandle,
     project_id: String,
@@ -13374,13 +13383,15 @@ pub async fn set_project_avatar_from_path(
         .unwrap_or("png")
         .to_lowercase();
     let avatars_dir = get_avatars_dir(&app)?;
-    let destination_name = format!("{project_id}.{extension}");
+    let destination_name = project_avatar_destination_name(&project_id, &extension);
     let destination_path = avatars_dir.join(&destination_name);
 
-    for extension in ["png", "jpg", "jpeg", "webp", "gif"] {
-        let old_file = avatars_dir.join(format!("{project_id}.{extension}"));
-        if old_file.exists() {
-            let _ = std::fs::remove_file(old_file);
+    if let Ok(entries) = std::fs::read_dir(&avatars_dir) {
+        for entry in entries.flatten() {
+            let file_name = entry.file_name();
+            if is_project_avatar_file(&file_name.to_string_lossy(), &project_id) {
+                let _ = std::fs::remove_file(entry.path());
+            }
         }
     }
 
@@ -14320,6 +14331,17 @@ mod tests {
         attach_default_avatar(&mut project);
 
         assert_eq!(project.default_avatar_path, None);
+    }
+
+    #[test]
+    fn project_avatar_replacements_get_a_fresh_file_name() {
+        let first = project_avatar_destination_name("project-1", "png");
+        let second = project_avatar_destination_name("project-1", "png");
+
+        assert_ne!(first, second);
+        assert!(is_project_avatar_file(&first, "project-1"));
+        assert!(is_project_avatar_file("project-1.png", "project-1"));
+        assert!(!is_project_avatar_file(&first, "project-10"));
     }
 
     #[test]

--- a/src/components/projects/panes/GeneralPane.test.tsx
+++ b/src/components/projects/panes/GeneralPane.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@/test/test-utils'
+import type { Project } from '@/types/projects'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GeneralPane } from './GeneralPane'
+
+const mocks = vi.hoisted(() => ({
+  projects: [] as Project[],
+}))
+
+vi.mock('@/lib/transport', () => ({
+  convertFileSrc: (path: string) => `file://${path}`,
+  convertProjectFileSrc: (path: string) => `project://${path}`,
+}))
+
+vi.mock('@/services/projects', () => ({
+  useProjects: () => ({ data: mocks.projects }),
+  useProjectBranches: () => ({ data: [], isLoading: false, error: null }),
+  useUpdateProjectSettings: () => ({ mutate: vi.fn(), isPending: false }),
+  useAppDataDir: () => ({ data: '/app-data' }),
+  useSetProjectAvatar: () => ({ mutate: vi.fn(), isPending: false }),
+  useRemoveProjectAvatar: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('@/services/preferences', () => ({
+  usePreferences: () => ({ data: { custom_cli_profiles: [] } }),
+}))
+
+vi.mock('@/hooks/useInstalledBackends', () => ({
+  useInstalledBackends: () => ({ installedBackends: [] }),
+}))
+
+function project(avatarPath: string): Project {
+  return {
+    id: 'project-1',
+    name: 'Jean',
+    path: '/projects/jean',
+    default_branch: 'main',
+    added_at: 1,
+    order: 0,
+    avatar_path: avatarPath,
+  }
+}
+
+describe('GeneralPane project avatar', () => {
+  beforeEach(() => {
+    mocks.projects = [project('avatars/project-1-old.png')]
+  })
+
+  it('reloads the avatar when a replacement keeps the same persisted path', () => {
+    const { rerender } = render(
+      <GeneralPane projectId="project-1" projectPath="/projects/jean" />
+    )
+    const firstSrc = screen
+      .getByRole('img', { name: 'Jean' })
+      .getAttribute('src')
+
+    mocks.projects = [project('avatars/project-1-new.png')]
+    rerender(<GeneralPane projectId="project-1" projectPath="/projects/jean" />)
+
+    expect(screen.getByRole('img', { name: 'Jean' })).not.toHaveAttribute(
+      'src',
+      firstSrc
+    )
+  })
+})


### PR DESCRIPTION
## Fixes
Replacing an avatar image didn't work, even after removing the old one

## Summary
- store each imported project avatar under a fresh UUID-based filename
- remove legacy and previous avatar files before copying the replacement
- add frontend and Rust regression coverage for avatar replacement caching

## Testing
- `bun --bun node_modules/vitest/vitest.mjs run src/components/projects/panes/GeneralPane.test.tsx`
- `cargo test --manifest-path jean-core/Cargo.toml project_avatar_replacements_get_a_fresh_file_name`
- `bun run typecheck`
- `bun run lint`