### PR TITLE
fix(backends): list installed CLIs in pickers; gate login at send

### DIFF
--- a/jean-core/src/claude_cli/commands.rs
+++ b/jean-core/src/claude_cli/commands.rs
@@ -1167,6 +1167,25 @@ async fn refresh_claude_access_token(
     Ok(next_oauth.access_token)
 }
 
+/// True when Claude can run via env API key (no OAuth login required).
+fn claude_env_api_key_present() -> bool {
+    std::env::var_os("ANTHROPIC_API_KEY")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+}
+
+/// Fallback auth signals when `claude auth status` is false or unavailable.
+/// Covers keychain/credentials.json OAuth tokens and ANTHROPIC_API_KEY.
+fn claude_credentials_or_env_authenticated() -> bool {
+    if claude_env_api_key_present() {
+        return true;
+    }
+    match load_claude_credentials() {
+        Ok((_, creds)) => credentials_have_access_token(&creds),
+        Err(_) => false,
+    }
+}
+
 /// Check if Claude CLI is authenticated by running a simple query
 pub async fn check_claude_cli_auth(app: AppHandle) -> Result<ClaudeAuthStatus, String> {
     log::trace!("Checking Claude CLI authentication status");
@@ -1211,16 +1230,50 @@ pub async fn check_claude_cli_auth(app: AppHandle) -> Result<ClaudeAuthStatus, S
             .ok()
             .and_then(|v| v.get("loggedIn")?.as_bool())
             .unwrap_or(false);
+        if logged_in {
+            return Ok(ClaudeAuthStatus {
+                authenticated: true,
+                error: None,
+            });
+        }
+        // `auth status` can false-negative while credentials/API key still work
+        // (custom providers, credential store vs CLI status desync). Fall back.
+        if claude_credentials_or_env_authenticated() {
+            log::trace!(
+                "Claude auth status reported loggedOut; treating as authenticated via credentials/env"
+            );
+            return Ok(ClaudeAuthStatus {
+                authenticated: true,
+                error: None,
+            });
+        }
         Ok(ClaudeAuthStatus {
-            authenticated: logged_in,
-            error: if logged_in { None } else { Some(stdout) },
+            authenticated: false,
+            error: Some(if stdout.is_empty() {
+                "Not authenticated".to_string()
+            } else {
+                stdout
+            }),
         })
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         log::warn!("Claude CLI auth check failed: {stderr}");
+        if claude_credentials_or_env_authenticated() {
+            log::trace!(
+                "Claude auth status command failed; treating as authenticated via credentials/env"
+            );
+            return Ok(ClaudeAuthStatus {
+                authenticated: true,
+                error: None,
+            });
+        }
         Ok(ClaudeAuthStatus {
             authenticated: false,
-            error: Some(stderr),
+            error: Some(if stderr.is_empty() {
+                "Not authenticated".to_string()
+            } else {
+                stderr
+            }),
         })
     }
 }
@@ -1489,6 +1542,22 @@ mod tests {
             ..Default::default()
         });
         assert!(credentials_have_access_token(&credentials));
+    }
+
+    #[test]
+    fn claude_env_api_key_present_when_non_empty() {
+        // SAFETY: test-only env mutation in a single-threaded unit test.
+        unsafe {
+            std::env::remove_var("ANTHROPIC_API_KEY");
+        }
+        assert!(!claude_env_api_key_present());
+        unsafe {
+            std::env::set_var("ANTHROPIC_API_KEY", "sk-test");
+        }
+        assert!(claude_env_api_key_present());
+        unsafe {
+            std::env::remove_var("ANTHROPIC_API_KEY");
+        }
     }
 
     #[test]

--- a/src/components/chat/hooks/useMessageSending.test.tsx
+++ b/src/components/chat/hooks/useMessageSending.test.tsx
@@ -13,22 +13,36 @@ import {
 import type { ExecutionMode, Session } from '@/types/chat'
 import type * as ChatService from '@/services/chat'
 
-const { mockInvoke, mockInstalledBackends } = vi.hoisted(() => ({
-  mockInvoke: vi.fn().mockResolvedValue(undefined),
-  mockInstalledBackends: {
-    installedBackends: [
-      'claude',
-      'codex',
-      'opencode',
-      'cursor',
-      'pi',
-      'commandcode',
-      'grok',
-      'kimi',
-    ] as string[],
-    isLoading: false,
-  },
-}))
+const { mockInvoke, mockInstalledBackends, mockBackendAuthStatuses } =
+  vi.hoisted(() => ({
+    mockInvoke: vi.fn().mockResolvedValue(undefined),
+    mockInstalledBackends: {
+      installedBackends: [
+        'claude',
+        'codex',
+        'opencode',
+        'cursor',
+        'pi',
+        'commandcode',
+        'grok',
+        'kimi',
+      ] as string[],
+      isLoading: false,
+    },
+    mockBackendAuthStatuses: {
+      authByBackend: {
+        claude: true,
+        codex: true,
+        opencode: true,
+        cursor: true,
+        pi: true,
+        commandcode: true,
+        grok: true,
+        kimi: true,
+      } as Record<string, boolean | undefined>,
+      isLoading: false,
+    },
+  }))
 
 vi.mock('@/lib/transport', () => ({
   invoke: mockInvoke,
@@ -36,6 +50,15 @@ vi.mock('@/lib/transport', () => ({
 
 vi.mock('@/hooks/useInstalledBackends', () => ({
   useInstalledBackends: () => mockInstalledBackends,
+  useBackendAuthStatuses: () => mockBackendAuthStatuses,
+  isBackendUsable: (
+    installed: boolean | undefined,
+    authenticated: boolean | undefined
+  ) => {
+    if (!installed) return false
+    if (authenticated === undefined) return true
+    return authenticated
+  },
 }))
 
 vi.mock('sonner', () => ({
@@ -167,6 +190,17 @@ function resetInstalledBackendsMock() {
     'kimi',
   ]
   mockInstalledBackends.isLoading = false
+  mockBackendAuthStatuses.authByBackend = {
+    claude: true,
+    codex: true,
+    opencode: true,
+    cursor: true,
+    pi: true,
+    commandcode: true,
+    grok: true,
+    kimi: true,
+  }
+  mockBackendAuthStatuses.isLoading = false
 }
 
 describe('useMessageSending Codex /goal', () => {
@@ -197,7 +231,7 @@ describe('useMessageSending Codex /goal', () => {
     })
   })
 
-  it('blocks send when the selected backend is not authenticated', async () => {
+  it('blocks send when the selected backend is not installed', async () => {
     mockInstalledBackends.installedBackends = ['claude']
     const { result, sendMessage } = renderUseMessageSending({
       inputValue: 'hello',
@@ -211,7 +245,31 @@ describe('useMessageSending Codex /goal', () => {
     })
 
     expect(handleCliAuthError).toHaveBeenCalledWith(
-      expect.stringContaining('codex'),
+      'codex is not installed',
+      'codex'
+    )
+    expect(sendMessage.mutate).not.toHaveBeenCalled()
+  })
+
+  it('blocks send when the selected backend is installed but not authenticated', async () => {
+    mockInstalledBackends.installedBackends = ['claude', 'codex']
+    mockBackendAuthStatuses.authByBackend = {
+      ...mockBackendAuthStatuses.authByBackend,
+      codex: false,
+    }
+    const { result, sendMessage } = renderUseMessageSending({
+      inputValue: 'hello',
+      selectedBackend: 'codex',
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent)
+    })
+
+    expect(handleCliAuthError).toHaveBeenCalledWith(
+      'codex is not authenticated',
       'codex'
     )
     expect(sendMessage.mutate).not.toHaveBeenCalled()

--- a/src/components/chat/hooks/useMessageSending.ts
+++ b/src/components/chat/hooks/useMessageSending.ts
@@ -38,7 +38,11 @@ import {
   isBackendAutoSteerEnabled,
   isSteerCapableBackend,
 } from '@/lib/backend-auto-steer'
-import { useInstalledBackends } from '@/hooks/useInstalledBackends'
+import {
+  isBackendUsable,
+  useBackendAuthStatuses,
+  useInstalledBackends,
+} from '@/hooks/useInstalledBackends'
 
 interface UseMessageSendingParams {
   activeSessionId: string | null | undefined
@@ -114,9 +118,10 @@ export function useMessageSending({
   clearInputDraft,
   clearChatInputState,
 }: UseMessageSendingParams) {
-  // Installed + authenticated backends only — block send when not logged in.
+  // Installed backends for availability; auth map for login gate at send time.
   const { installedBackends, isLoading: backendsLoading } =
     useInstalledBackends()
+  const { authByBackend, isLoading: authLoading } = useBackendAuthStatuses()
 
   // Helper to resolve custom CLI profile name for the active provider.
   // Claude: custom_cli_profiles; Codex: custom_codex_providers (same wire field).
@@ -356,17 +361,28 @@ export function useMessageSending({
         return
       }
 
-      // Block using a model for a backend the user isn't logged into.
-      // Wait for status/auth to resolve so we don't flash false blocks on load.
+      // Block send when the selected backend is not installed, or when auth is
+      // known-unauthenticated. Wait for probes so we don't flash false blocks.
+      // Pickers list all installed backends (issue #627/#649); login is gated here.
+      // Skip the OAuth auth gate when a custom provider/API-key profile is active
+      // — those sessions authenticate via profile credentials, not CLI login.
+      const sendBackend = selectedBackendRef.current
+      const provider = selectedProviderRef.current
+      const usingCustomProvider =
+        !!provider &&
+        provider !== '__anthropic__' &&
+        provider !== '__default__'
+      if (!backendsLoading && !installedBackends.includes(sendBackend)) {
+        handleCliAuthError(`${sendBackend} is not installed`, sendBackend)
+        return
+      }
       if (
+        !usingCustomProvider &&
         !backendsLoading &&
-        !installedBackends.includes(selectedBackendRef.current)
+        !authLoading &&
+        !isBackendUsable(true, authByBackend[sendBackend])
       ) {
-        const unauthenticatedBackend = selectedBackendRef.current
-        handleCliAuthError(
-          `${unauthenticatedBackend} is not authenticated`,
-          unauthenticatedBackend
-        )
+        handleCliAuthError(`${sendBackend} is not authenticated`, sendBackend)
         return
       }
 
@@ -625,6 +641,8 @@ export function useMessageSending({
       activeSessionId,
       activeWorktreeId,
       activeWorktreePath,
+      authByBackend,
+      authLoading,
       backendsLoading,
       clearInputDraft,
       clearChatInputState,

--- a/src/components/preferences/panes/GeneralPane.structure.test.ts
+++ b/src/components/preferences/panes/GeneralPane.structure.test.ts
@@ -92,6 +92,26 @@ describe('GeneralPane settings structure', () => {
     expect(grokSection).not.toContain('grokCliQueryKeys.auth()')
   })
 
+  // Regression #627/#649: default backend picker must list installed CLIs even
+  // when auth probes return false (login is gated at send time instead).
+  it('filters default backend options by install status only, not auth', () => {
+    const source = readFileSync(
+      'src/components/preferences/panes/GeneralPane.tsx',
+      'utf8'
+    )
+
+    expect(source).toContain('const claudeInstalled = !!cliStatus?.installed')
+    expect(source).toContain('const codexInstalled = !!codexStatus?.installed')
+    expect(source).toContain(
+      'const opencodeInstalled = !!opencodeStatus?.installed'
+    )
+    expect(source).not.toMatch(
+      /claudeInstalled\s*=\s*!!cliStatus\?\.installed\s*&&\s*!!claudeAuth\?\.authenticated/
+    )
+    expect(source).not.toContain('claudeUsable')
+    expect(source).toContain('installedBackendOptions.map(option =>')
+  })
+
   it('renders build and yolo reasoning overrides from model capabilities', () => {
     const source = readFileSync(
       'src/components/preferences/panes/GeneralPane.tsx',

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -1016,75 +1016,75 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
     }
   }
 
-  // Default backend: only installed AND authenticated backends are selectable.
+  // Default backend: show all installed CLIs (issue #627/#649). Auth is enforced
+  // at send time / backend settings — hiding unauthenticated backends made Claude
+  // (and others) disappear from Defaults when auth probes were false-negative.
   const stored = preferences?.default_backend ?? 'claude'
-  const claudeUsable = !!cliStatus?.installed && !!claudeAuth?.authenticated
-  const codexUsable = !!codexStatus?.installed && !!codexAuth?.authenticated
-  const opencodeUsable =
-    !!opencodeStatus?.installed && !!opencodeAuth?.authenticated
-  const cursorUsable = !!cursorStatus?.installed && !!cursorAuth?.authenticated
-  const piUsable = !!piStatus?.installed && !!piAuth?.authenticated
-  const commandcodeUsable =
-    !!commandcodeStatus?.installed && !!commandcodeAuth?.authenticated
-  const grokUsable = !!grokStatus?.installed && !!grokAuth?.authenticated
-  const kimiUsable = !!kimiStatus?.installed && !!kimiAuth?.authenticated
+  const claudeInstalled = !!cliStatus?.installed
+  const codexInstalled = !!codexStatus?.installed
+  const opencodeInstalled = !!opencodeStatus?.installed
+  const cursorInstalled = !!cursorStatus?.installed
+  const piInstalled = !!piStatus?.installed
+  const commandcodeInstalled = !!commandcodeStatus?.installed
+  const grokInstalled = !!grokStatus?.installed
+  const kimiInstalled = !!kimiStatus?.installed
   const installedBackendOptions = useMemo(
     () =>
       backendOptions.filter(option =>
         option.value === 'claude'
-          ? claudeUsable
+          ? claudeInstalled
           : option.value === 'codex'
-            ? codexUsable
+            ? codexInstalled
             : option.value === 'opencode'
-              ? opencodeUsable
+              ? opencodeInstalled
               : option.value === 'cursor'
-                ? cursorUsable
+                ? cursorInstalled
                 : option.value === 'pi'
-                  ? piUsable
+                  ? piInstalled
                   : option.value === 'commandcode'
-                    ? commandcodeUsable
+                    ? commandcodeInstalled
                     : option.value === 'grok'
-                      ? grokUsable
+                      ? grokInstalled
                       : option.value === 'kimi'
-                        ? kimiUsable
+                        ? kimiInstalled
                         : false
       ),
     [
-      claudeUsable,
-      codexUsable,
-      opencodeUsable,
-      cursorUsable,
-      piUsable,
-      commandcodeUsable,
-      grokUsable,
-      kimiUsable,
+      claudeInstalled,
+      codexInstalled,
+      opencodeInstalled,
+      cursorInstalled,
+      piInstalled,
+      commandcodeInstalled,
+      grokInstalled,
+      kimiInstalled,
     ]
   )
 
   const effectiveBackend = useMemo(() => {
-    const usable: Record<string, boolean | undefined> = {
-      claude: claudeUsable,
-      codex: codexUsable,
-      opencode: opencodeUsable,
-      cursor: cursorUsable,
-      pi: piUsable,
-      commandcode: commandcodeUsable,
-      grok: grokUsable,
-      kimi: kimiUsable,
+    const installed: Record<string, boolean | undefined> = {
+      claude: claudeInstalled,
+      codex: codexInstalled,
+      opencode: opencodeInstalled,
+      cursor: cursorInstalled,
+      pi: piInstalled,
+      commandcode: commandcodeInstalled,
+      grok: grokInstalled,
+      kimi: kimiInstalled,
     }
-    if (usable[stored]) return stored
+    if (installed[stored]) return stored
     const first = installedBackendOptions[0]
     return first?.value ?? stored
   }, [
     stored,
-    claudeUsable,
-    codexUsable,
-    opencodeUsable,
-    cursorUsable,
-    piUsable,
-    commandcodeUsable,
-    grokUsable,
-    kimiUsable,
+    claudeInstalled,
+    codexInstalled,
+    opencodeInstalled,
+    cursorInstalled,
+    piInstalled,
+    commandcodeInstalled,
+    grokInstalled,
+    kimiInstalled,
     installedBackendOptions,
   ])
 

--- a/src/components/projects/panes/GeneralPane.tsx
+++ b/src/components/projects/panes/GeneralPane.tsx
@@ -95,7 +95,7 @@ export function GeneralPane({
 
   const { data: preferences } = usePreferences()
   const profiles = preferences?.custom_cli_profiles ?? []
-  // Only show backends the user is logged into (installed + authenticated).
+  // Show all installed backends (auth is checked at send time / backend settings).
   const { installedBackends } = useInstalledBackends()
   const installedBackendsSet = useMemo(
     () => new Set(installedBackends),

--- a/src/hooks/useInstalledBackends.test.ts
+++ b/src/hooks/useInstalledBackends.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import {
   isBackendUsable,
+  useBackendAuthStatuses,
   useInstalledBackends,
 } from '@/hooks/useInstalledBackends'
 import type { CliBackend } from '@/types/preferences'
@@ -91,7 +92,7 @@ describe('useInstalledBackends', () => {
     }
   })
 
-  it('excludes installed backends that are not authenticated', () => {
+  it('includes installed backends even when not authenticated (issue #627/#649)', () => {
     status.claude.installed = true
     auth.claude.authenticated = false
     status.codex.installed = true
@@ -99,27 +100,53 @@ describe('useInstalledBackends', () => {
 
     const { result } = renderHook(() => useInstalledBackends())
 
-    expect(result.current.installedBackends).toEqual(['codex'])
+    expect(result.current.installedBackends).toEqual(['claude', 'codex'])
     expect(result.current.isLoading).toBe(false)
   })
 
-  it('includes all backends that are both installed and authenticated', () => {
+  it('includes all installed backends regardless of auth', () => {
     status.claude.installed = true
     auth.claude.authenticated = true
     status.opencode.installed = true
     auth.opencode.authenticated = true
     status.cursor.installed = true
-    // cursor not authenticated
+    // cursor not authenticated — still listed
 
     const { result } = renderHook(() => useInstalledBackends())
 
-    expect(result.current.installedBackends).toEqual(['claude', 'opencode'])
+    expect(result.current.installedBackends).toEqual([
+      'claude',
+      'opencode',
+      'cursor',
+    ])
   })
 
-  it('returns empty when nothing is ready', () => {
-    status.claude.installed = true
-    // not authenticated
+  it('returns empty when nothing is installed', () => {
+    status.claude.installed = false
     const { result } = renderHook(() => useInstalledBackends())
     expect(result.current.installedBackends).toEqual([])
+  })
+})
+
+describe('useBackendAuthStatuses', () => {
+  beforeEach(() => {
+    for (const backend of BACKENDS) {
+      status[backend].installed = false
+      auth[backend].authenticated = false
+    }
+  })
+
+  it('reports auth only for installed backends', () => {
+    status.claude.installed = true
+    auth.claude.authenticated = false
+    status.opencode.installed = true
+    auth.opencode.authenticated = true
+
+    const { result } = renderHook(() => useBackendAuthStatuses())
+
+    expect(result.current.authByBackend.claude).toBe(false)
+    expect(result.current.authByBackend.opencode).toBe(true)
+    expect(result.current.authByBackend.codex).toBeUndefined()
+    expect(result.current.isLoading).toBe(false)
   })
 })

--- a/src/hooks/useInstalledBackends.ts
+++ b/src/hooks/useInstalledBackends.ts
@@ -16,26 +16,83 @@ import { useKimiCliStatus, useKimiCliAuth } from '@/services/kimi-cli'
 import type { CliBackend } from '@/types/preferences'
 
 /**
- * Backend is usable for chat/models when installed and not known-unauthenticated.
+ * Backend is usable for chat/sends when installed and not known-unauthenticated.
  * While auth is still loading (`authenticated` undefined), treat as usable so the
- * picker doesn't flash empty; once auth resolves to false, exclude it.
+ * picker/send path doesn't flash empty or false blocks; once auth resolves to
+ * false, exclude it from "usable" lists.
  */
 export function isBackendUsable(
   installed: boolean | undefined,
   authenticated: boolean | undefined
 ): boolean {
   if (!installed) return false
-  // Auth not resolved yet — keep visible; send path waits on isLoading.
+  // Auth not resolved yet — keep usable so picker doesn't flash empty
   if (authenticated === undefined) return true
   return authenticated
 }
 
 /**
- * Returns backends whose CLIs are installed AND authenticated (or still checking).
- * Use this to filter backend/model selection UI so users can't pick backends
- * they aren't logged into (or that aren't installed).
+ * Returns backends whose CLIs are currently installed.
+ *
+ * Use this to filter backend/model selection UI so users can pick any installed
+ * backend (including ones that still need login). Auth is checked at send time
+ * and shown in backend settings — hiding unauthenticated backends made defaults
+ * and model pickers look broken when auth probes false-negative (issue #627/#649).
  */
 export function useInstalledBackends(options?: { enabled?: boolean }) {
+  const enabled = options?.enabled ?? true
+  const claude = useClaudeCliStatus({ enabled })
+  const codex = useCodexCliStatus({ enabled })
+  const opencode = useOpencodeCliStatus({ enabled })
+  const cursor = useCursorCliStatus({ enabled })
+  const pi = usePiCliStatus({ enabled })
+  const commandcode = useCommandCodeCliStatus({ enabled })
+  const grok = useGrokCliStatus({ enabled })
+  const kimi = useKimiCliStatus({ enabled })
+
+  const installedBackends = useMemo(() => {
+    const backends: CliBackend[] = []
+    if (claude.data?.installed) backends.push('claude')
+    if (codex.data?.installed) backends.push('codex')
+    if (opencode.data?.installed) backends.push('opencode')
+    if (cursor.data?.installed) backends.push('cursor')
+    if (pi.data?.installed) backends.push('pi')
+    if (commandcode.data?.installed) backends.push('commandcode')
+    if (grok.data?.installed) backends.push('grok')
+    if (kimi.data?.installed) backends.push('kimi')
+    return backends
+  }, [
+    claude.data?.installed,
+    codex.data?.installed,
+    opencode.data?.installed,
+    cursor.data?.installed,
+    pi.data?.installed,
+    commandcode.data?.installed,
+    grok.data?.installed,
+    kimi.data?.installed,
+  ])
+
+  const isLoading =
+    claude.isLoading ||
+    codex.isLoading ||
+    opencode.isLoading ||
+    cursor.isLoading ||
+    pi.isLoading ||
+    commandcode.isLoading ||
+    grok.isLoading ||
+    kimi.isLoading
+
+  return {
+    installedBackends,
+    isLoading,
+  }
+}
+
+/**
+ * Auth status per installed backend. `undefined` means still loading / not probed.
+ * Prefer this (plus `isBackendUsable`) when you need login-aware send gates.
+ */
+export function useBackendAuthStatuses(options?: { enabled?: boolean }) {
   const enabled = options?.enabled ?? true
   const claude = useClaudeCliStatus({ enabled })
   const codex = useCodexCliStatus({ enabled })
@@ -71,39 +128,26 @@ export function useInstalledBackends(options?: { enabled?: boolean }) {
     enabled: enabled && !!kimi.data?.installed,
   })
 
-  const installedBackends = useMemo(() => {
-    const backends: CliBackend[] = []
-    if (
-      isBackendUsable(claude.data?.installed, claudeAuth.data?.authenticated)
-    )
-      backends.push('claude')
-    if (isBackendUsable(codex.data?.installed, codexAuth.data?.authenticated))
-      backends.push('codex')
-    if (
-      isBackendUsable(
-        opencode.data?.installed,
-        opencodeAuth.data?.authenticated
-      )
-    )
-      backends.push('opencode')
-    if (
-      isBackendUsable(cursor.data?.installed, cursorAuth.data?.authenticated)
-    )
-      backends.push('cursor')
-    if (isBackendUsable(pi.data?.installed, piAuth.data?.authenticated))
-      backends.push('pi')
-    if (
-      isBackendUsable(
-        commandcode.data?.installed,
-        commandcodeAuth.data?.authenticated
-      )
-    )
-      backends.push('commandcode')
-    if (isBackendUsable(grok.data?.installed, grokAuth.data?.authenticated))
-      backends.push('grok')
-    if (isBackendUsable(kimi.data?.installed, kimiAuth.data?.authenticated))
-      backends.push('kimi')
-    return backends
+  const authByBackend = useMemo(() => {
+    const map: Partial<Record<CliBackend, boolean | undefined>> = {
+      claude: claude.data?.installed
+        ? claudeAuth.data?.authenticated
+        : undefined,
+      codex: codex.data?.installed ? codexAuth.data?.authenticated : undefined,
+      opencode: opencode.data?.installed
+        ? opencodeAuth.data?.authenticated
+        : undefined,
+      cursor: cursor.data?.installed
+        ? cursorAuth.data?.authenticated
+        : undefined,
+      pi: pi.data?.installed ? piAuth.data?.authenticated : undefined,
+      commandcode: commandcode.data?.installed
+        ? commandcodeAuth.data?.authenticated
+        : undefined,
+      grok: grok.data?.installed ? grokAuth.data?.authenticated : undefined,
+      kimi: kimi.data?.installed ? kimiAuth.data?.authenticated : undefined,
+    }
+    return map
   }, [
     claude.data?.installed,
     claudeAuth.data?.authenticated,
@@ -133,7 +177,6 @@ export function useInstalledBackends(options?: { enabled?: boolean }) {
     grok.isLoading ||
     kimi.isLoading
 
-  // Auth queries are only enabled when installed; count their loading too.
   const isAuthLoading =
     (!!claude.data?.installed && claudeAuth.isLoading) ||
     (!!codex.data?.installed && codexAuth.isLoading) ||
@@ -145,7 +188,7 @@ export function useInstalledBackends(options?: { enabled?: boolean }) {
     (!!kimi.data?.installed && kimiAuth.isLoading)
 
   return {
-    installedBackends,
+    authByBackend,
     isLoading: isStatusLoading || isAuthLoading,
   }
 }


### PR DESCRIPTION
## Summary
- Show all installed backends in default/backend pickers instead of only authenticated ones, so users can select Claude, Codex, Cursor, and other installed CLIs even before login
- Gate authentication at send time: block sends for uninstalled or unauthenticated backends and prompt login when needed
- Harden Claude auth detection with credentials/env API key fallback when `claude auth status` false-negatives

## Breaking Changes
None

fixes #649

---

Fixes #649