### PR TITLE
feat(ui): move file browser toggle into content headers

### DIFF
--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -14,6 +14,7 @@ import {
   Archive,
   ChevronDown,
   Copy,
+  FolderTree,
   GitBranchPlus,
   GitPullRequestArrow,
   Maximize2,
@@ -206,6 +207,8 @@ export function SessionChatModal({
   const isTouch = useIsTouchDevice()
   const zenMode = useUIStore(state => state.zenMode)
   const toggleZenMode = useUIStore(state => state.toggleZenMode)
+  const fileBrowserVisible = useUIStore(state => state.fileBrowserVisible)
+  const toggleFileBrowser = useUIStore(state => state.toggleFileBrowser)
   const isModalTerminalOpen = useTerminalStore(
     state => state.modalTerminalOpen[worktreeId] ?? false
   )
@@ -294,6 +297,10 @@ export function SessionChatModal({
   )
   const runShortcut = formatShortcutDisplay(
     preferences?.keybindings?.execute_run ?? DEFAULT_KEYBINDINGS.execute_run
+  )
+  const fileBrowserShortcut = formatShortcutDisplay(
+    preferences?.keybindings?.toggle_file_browser ??
+      DEFAULT_KEYBINDINGS.toggle_file_browser
   )
   // Horizontal scroll on session tabs
   const modalTabScrollRef = useRef<HTMLDivElement>(null)
@@ -1127,6 +1134,34 @@ export function SessionChatModal({
                 )}
               >
                 <div className="flex items-center gap-2 min-w-0">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        onClick={toggleFileBrowser}
+                        variant="ghost"
+                        size="icon"
+                        className={cn(
+                          'h-6 w-6 shrink-0 text-foreground/70 hover:text-foreground',
+                          fileBrowserVisible && 'text-foreground bg-muted/50'
+                        )}
+                        aria-pressed={fileBrowserVisible}
+                        aria-label={
+                          fileBrowserVisible
+                            ? 'Hide file browser'
+                            : 'Show file browser'
+                        }
+                        data-testid="toggle-file-browser"
+                      >
+                        <FolderTree className="size-3.5" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {fileBrowserVisible ? 'Hide' : 'Show'} File Browser{' '}
+                      <kbd className="ml-1 text-[0.625rem] opacity-60">
+                        {fileBrowserShortcut}
+                      </kbd>
+                    </TooltipContent>
+                  </Tooltip>
                   <h2 className="text-sm font-medium min-w-0 flex-1 truncate">
                     {project && !isMobile && (
                       <span className="text-muted-foreground font-normal">

--- a/src/components/dashboard/ProjectCanvasView.tsx
+++ b/src/components/dashboard/ProjectCanvasView.tsx
@@ -44,6 +44,7 @@ import {
   ExternalLink,
   Folder,
   FolderOpen,
+  FolderTree,
   Home,
   Terminal,
   Trash2,
@@ -171,6 +172,11 @@ import {
 import { TerminalStatusIndicator } from '@/hooks/useWorktreeTerminalStatus'
 import { usePreferences } from '@/services/preferences'
 import { DEFAULT_KEYBINDINGS, formatShortcutDisplay } from '@/types/keybindings'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { CloseWorktreeDialog } from '@/components/chat/CloseWorktreeDialog'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { hasBackendTransport } from '@/lib/environment'
@@ -901,6 +907,8 @@ function WorktreeSectionHeader({
 
 export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
   const { data: preferences } = usePreferences()
+  const fileBrowserVisible = useUIStore(state => state.fileBrowserVisible)
+  const toggleFileBrowser = useUIStore(state => state.toggleFileBrowser)
   const worktreeSortMode = useProjectsStore(
     state =>
       state.projectCanvasSettings[projectId]?.worktreeSortMode ?? 'created'
@@ -3049,6 +3057,37 @@ export function ProjectCanvasView({ projectId }: ProjectCanvasViewProps) {
           <div className="relative grid grid-cols-[auto_1fr_auto] items-center gap-4 px-4 py-2 sm:py-3 border-b border-border/30 sm:min-h-[61px]">
             <div className="flex flex-col shrink-0">
               <div className="flex items-center gap-2">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      onClick={toggleFileBrowser}
+                      variant="ghost"
+                      size="icon"
+                      className={cn(
+                        'h-6 w-6 shrink-0 text-foreground/70 hover:text-foreground',
+                        fileBrowserVisible && 'text-foreground bg-muted/50'
+                      )}
+                      aria-pressed={fileBrowserVisible}
+                      aria-label={
+                        fileBrowserVisible
+                          ? 'Hide file browser'
+                          : 'Show file browser'
+                      }
+                      data-testid="toggle-file-browser"
+                    >
+                      <FolderTree className="size-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {fileBrowserVisible ? 'Hide' : 'Show'} File Browser{' '}
+                    <kbd className="ml-1 text-[0.625rem] opacity-60">
+                      {formatShortcutDisplay(
+                        preferences?.keybindings?.toggle_file_browser ??
+                          DEFAULT_KEYBINDINGS.toggle_file_browser
+                      )}
+                    </kbd>
+                  </TooltipContent>
+                </Tooltip>
                 <h2 className="truncate text-lg font-semibold">
                   {project.name}
                 </h2>

--- a/src/components/titlebar/TitleBar.tsx
+++ b/src/components/titlebar/TitleBar.tsx
@@ -13,7 +13,6 @@ import { useCommandContext } from '@/lib/commands'
 import {
   ArrowUpCircle,
   Download,
-  FolderTree,
   Github,
   Heart,
   Minimize2,
@@ -53,8 +52,6 @@ export function TitleBar({
 }: TitleBarProps) {
   const leftSidebarVisible = useUIStore(state => state.leftSidebarVisible)
   const toggleLeftSidebar = useUIStore(state => state.toggleLeftSidebar)
-  const fileBrowserVisible = useUIStore(state => state.fileBrowserVisible)
-  const toggleFileBrowser = useUIStore(state => state.toggleFileBrowser)
   const zenMode = useUIStore(state => state.zenMode)
   const toggleZenMode = useUIStore(state => state.toggleZenMode)
   const commandContext = useCommandContext()
@@ -66,10 +63,6 @@ export function TitleBar({
   const sidebarShortcut = formatShortcutDisplay(
     (preferences?.keybindings?.toggle_left_sidebar ||
       DEFAULT_KEYBINDINGS.toggle_left_sidebar) as string
-  )
-  const fileBrowserShortcut = formatShortcutDisplay(
-    (preferences?.keybindings?.toggle_file_browser ||
-      DEFAULT_KEYBINDINGS.toggle_file_browser) as string
   )
   const native = isNativeApp()
 
@@ -129,34 +122,6 @@ export function TitleBar({
                 {leftSidebarVisible ? 'Hide' : 'Show'} Left Sidebar{' '}
                 <kbd className="ml-1 text-[0.625rem] opacity-60">
                   {sidebarShortcut}
-                </kbd>
-              </TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  onClick={toggleFileBrowser}
-                  variant="ghost"
-                  size="icon"
-                  className={cn(
-                    'h-6 w-6 rounded-none text-foreground/70 hover:text-foreground',
-                    fileBrowserVisible && 'text-foreground bg-muted/50'
-                  )}
-                  aria-pressed={fileBrowserVisible}
-                  aria-label={
-                    fileBrowserVisible
-                      ? 'Hide file browser'
-                      : 'Show file browser'
-                  }
-                  data-testid="toggle-file-browser"
-                >
-                  <FolderTree className="size-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {fileBrowserVisible ? 'Hide' : 'Show'} File Browser{' '}
-                <kbd className="ml-1 text-[0.625rem] opacity-60">
-                  {fileBrowserShortcut}
                 </kbd>
               </TooltipContent>
             </Tooltip>


### PR DESCRIPTION
Moves the file browser toggle out of the global title bar and into the headers of the views it actually applies to.

- Removed the toggle from `TitleBar` (left sidebar / settings / GitHub / sponsor buttons unchanged).
- Added it to the project canvas header, before the project name.
- Added it to the session modal header, before the project name breadcrumb.

The file browser panel opens on the left edge, so a left-most toggle matches the direction it expands. Both buttons keep the same icon, tooltip with keybinding hint, `aria-pressed` state, and `data-testid`. The keyboard shortcut and the app menu item continue to work everywhere, including zen mode where the headers are hidden.

Verified with `npm run typecheck`, `eslint` on the changed files, and the dashboard and session modal test suites.
