### PR TITLE
fix(files): open files in view mode by default

### DIFF
--- a/src/components/chat/FileContentModal.tsx
+++ b/src/components/chat/FileContentModal.tsx
@@ -158,8 +158,6 @@ export function FileContentModal({ filePath, onClose }: FileContentModalProps) {
       if (signal.cancelled) return
       setContent(fileContent)
       setEditedContent(fileContent)
-      // Open in edit mode by default (matches mobile file browser)
-      setIsEditing(true)
     } catch (err) {
       if (signal.cancelled) return
       setError(err instanceof Error ? err.message : String(err))


### PR DESCRIPTION
Clicking a file in the file browser opened it directly in the Pierre editor, which makes accidental edits easy and adds an editor load for what is usually just a read.

`FileContentModal` now leaves `isEditing` at its initial `false` after loading content, so the file renders in the syntax-highlighted read-only view. The `Edit` button in the modal header switches to the editor exactly as before, and saving, discarding, and "Open in Editor" are unchanged.

This applies everywhere the modal is used: the desktop file browser sidebar, the mobile file browser, and file links in tool calls.
