### PR TITLE
Fix: Prevent premature "Response lost" crash status during active sends in Web UI

### DIFF
--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -99,19 +99,7 @@ When specifying subagent_type for Task tool calls, always use the fully qualifie
 static BACKEND_QUEUE_DRAINING: Lazy<Mutex<HashSet<String>>> =
     Lazy::new(|| Mutex::new(HashSet::new()));
 
-/// Sessions with a `send_chat_message` call currently in flight.
-///
-/// The registry-based "actively managed" guard only catches duplicates after a
-/// process/turn is registered, leaving a window where two concurrent sends
-/// (frontend queue processor vs backend queue drain vs another client) both
-/// pass the check and spawn duplicate runs. This claim is taken atomically at
-/// `send_chat_message` entry and held for the whole call — unless cancel
-/// releases it early so a follow-up send is not stuck (#329).
-///
-/// Values are generation tokens so an early cancel release cannot be clobbered
-/// by a later `Drop` from the cancelled claim after a new claim was acquired.
-static ACTIVE_SENDS: Lazy<Mutex<HashMap<String, u64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
-static SEND_CLAIM_GENERATION: AtomicU64 = AtomicU64::new(1);
+use super::registry::{has_active_send, release_active_send, SendClaim};
 
 /// Whether a session has no prior user messages for auto-naming purposes.
 ///
@@ -145,53 +133,8 @@ fn should_auto_name_branch(worktree: Option<&Worktree>) -> bool {
         .unwrap_or(true)
 }
 
-/// RAII claim on a session's send slot — released on drop (any return path).
-struct SendClaim {
-    session_id: String,
-    generation: u64,
-}
-
-impl SendClaim {
-    fn try_acquire(session_id: &str) -> Option<Self> {
-        let mut active = ACTIVE_SENDS.lock().unwrap();
-        if active.contains_key(session_id) {
-            return None;
-        }
-        let generation = SEND_CLAIM_GENERATION.fetch_add(1, Ordering::Relaxed);
-        active.insert(session_id.to_string(), generation);
-        Some(Self {
-            session_id: session_id.to_string(),
-            generation,
-        })
-    }
-}
-
-impl Drop for SendClaim {
-    fn drop(&mut self) {
-        let mut active = ACTIVE_SENDS.lock().unwrap();
-        // Only clear if we still own the slot — cancel may have released early
-        // and a newer send may already hold a different generation.
-        if active.get(&self.session_id) == Some(&self.generation) {
-            active.remove(&self.session_id);
-        }
-    }
-}
-
-/// Release the in-flight send claim for a session after cancel so a follow-up
-/// prompt is not rejected with "Session already has an active request" while
-/// the cancelled worker finishes teardown (#329).
-fn release_active_send(session_id: &str) {
-    if ACTIVE_SENDS.lock().unwrap().remove(session_id).is_some() {
-        log::info!("[SendChat] released active send claim after cancel session={session_id}");
-    }
-}
-
-fn has_active_send(session_id: &str) -> bool {
-    ACTIVE_SENDS.lock().unwrap().contains_key(session_id)
-}
-
 fn should_forward_cancel_request(session_id: &str) -> bool {
-    has_active_send(session_id) || super::registry::is_session_actively_managed(session_id)
+    super::registry::is_session_actively_managed(session_id)
 }
 
 fn clear_stale_pending_cancel_before_send(session_id: &str) {

--- a/jean-core/src/chat/registry.rs
+++ b/jean-core/src/chat/registry.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -51,6 +51,64 @@ static CODEX_YOLO_AUTO_APPROVE: Lazy<Mutex<HashSet<String>>> =
 /// Sessions in PROCESS_REGISTRY whose process is fully detached (survives Jean
 /// quitting). Claude CLI and host-backed Pi/Grok/Kimi runs are detached.
 static DETACHED_SESSIONS: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+
+/// Sessions with a `send_chat_message` call currently in flight.
+///
+/// The registry-based "actively managed" guard only catches duplicates after a
+/// process/turn is registered, leaving a window where two concurrent sends
+/// (frontend queue processor vs backend queue drain vs another client) both
+/// pass the check and spawn duplicate runs. This claim is taken atomically at
+/// `send_chat_message` entry and held for the whole call — unless cancel
+/// releases it early so a follow-up send is not stuck (#329).
+///
+/// Values are generation tokens so an early cancel release cannot be clobbered
+/// by a later `Drop` from the cancelled claim after a new claim was acquired.
+static ACTIVE_SENDS: Lazy<Mutex<HashMap<String, u64>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+static SEND_CLAIM_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+/// RAII claim on a session's send slot — released on drop (any return path).
+pub struct SendClaim {
+    session_id: String,
+    generation: u64,
+}
+
+impl SendClaim {
+    pub fn try_acquire(session_id: &str) -> Option<Self> {
+        let mut active = lock_recover(&ACTIVE_SENDS, "ACTIVE_SENDS");
+        if active.contains_key(session_id) {
+            return None;
+        }
+        let generation = SEND_CLAIM_GENERATION.fetch_add(1, Ordering::Relaxed);
+        active.insert(session_id.to_string(), generation);
+        Some(Self {
+            session_id: session_id.to_string(),
+            generation,
+        })
+    }
+}
+
+impl Drop for SendClaim {
+    fn drop(&mut self) {
+        let mut active = lock_recover(&ACTIVE_SENDS, "ACTIVE_SENDS");
+        if active.get(&self.session_id) == Some(&self.generation) {
+            active.remove(&self.session_id);
+        }
+    }
+}
+
+/// Release the in-flight send claim for a session after cancel so a follow-up
+/// prompt is not rejected with "Session already has an active request" while
+/// the cancelled worker finishes teardown (#329).
+pub fn release_active_send(session_id: &str) {
+    if lock_recover(&ACTIVE_SENDS, "ACTIVE_SENDS").remove(session_id).is_some() {
+        log::info!("[SendChat] released active send claim after cancel session={session_id}");
+    }
+}
+
+pub fn has_active_send(session_id: &str) -> bool {
+    lock_recover(&ACTIVE_SENDS, "ACTIVE_SENDS").contains_key(session_id)
+}
 
 fn lock_recover<'a, T>(mutex: &'a Mutex<T>, name: &str) -> std::sync::MutexGuard<'a, T> {
     match mutex.lock() {
@@ -460,7 +518,7 @@ pub fn get_running_sessions() -> Vec<String> {
     sessions
 }
 
-/// Get all session IDs that are actively managed (running process, cancel flag, or codex turn).
+/// Get all session IDs that are actively managed (running process, cancel flag, codex turn, or active send).
 /// Used by recover_incomplete_runs to skip sessions that don't need recovery.
 pub fn get_actively_managed_sessions() -> HashSet<String> {
     let mut sessions: HashSet<String> = lock_recover(&PROCESS_REGISTRY, "PROCESS_REGISTRY")
@@ -473,6 +531,7 @@ pub fn get_actively_managed_sessions() -> HashSet<String> {
             .keys()
             .cloned(),
     );
+    sessions.extend(lock_recover(&ACTIVE_SENDS, "ACTIVE_SENDS").keys().cloned());
     sessions
 }
 
@@ -497,12 +556,13 @@ pub fn has_nonsurvivable_running_sessions() -> bool {
         .any(|session_id| !detached.contains(session_id))
 }
 
-/// Check if a specific session is actively managed (has a running process, cancel flag, or codex turn).
+/// Check if a specific session is actively managed (has a running process, cancel flag, codex turn, or active send).
 /// Used by resume_session to avoid starting a duplicate tail.
 pub fn is_session_actively_managed(session_id: &str) -> bool {
     lock_recover(&PROCESS_REGISTRY, "PROCESS_REGISTRY").contains_key(session_id)
         || lock_recover(&CANCEL_FLAGS, "CANCEL_FLAGS").contains_key(session_id)
         || lock_recover(&CODEX_TURN_REGISTRY, "CODEX_TURN_REGISTRY").contains_key(session_id)
+        || lock_recover(&ACTIVE_SENDS, "ACTIVE_SENDS").contains_key(session_id)
 }
 
 #[cfg(test)]
@@ -517,6 +577,7 @@ mod tests {
         lock_recover(&PENDING_CANCELS, "PENDING_CANCELS").clear();
         lock_recover(&CANCEL_FLAGS, "CANCEL_FLAGS").clear();
         lock_recover(&CODEX_TURN_REGISTRY, "CODEX_TURN_REGISTRY").clear();
+        lock_recover(&ACTIVE_SENDS, "ACTIVE_SENDS").clear();
     }
 
     #[test]
@@ -544,6 +605,26 @@ mod tests {
                 "opencode-session".to_string()
             ]
         );
+
+        clear_registries();
+    }
+
+    #[test]
+    fn send_claim_marks_session_as_actively_managed() {
+        let _guard = lock_recover(&TEST_LOCK, "TEST_LOCK");
+        clear_registries();
+
+        let session_id = "send-claim-session";
+        assert!(!is_session_actively_managed(session_id));
+        assert!(!get_actively_managed_sessions().contains(session_id));
+
+        let claim = SendClaim::try_acquire(session_id).expect("acquire claim");
+        assert!(is_session_actively_managed(session_id));
+        assert!(get_actively_managed_sessions().contains(session_id));
+
+        drop(claim);
+        assert!(!is_session_actively_managed(session_id));
+        assert!(!get_actively_managed_sessions().contains(session_id));
 
         clear_registries();
     }


### PR DESCRIPTION
## Summary

This PR fixes a bug where active, in-flight chat runs were prematurely marked as `Crashed` in `metadata.json` on disk when accessed via Web UI / Web Access, resulting in the error message:

> `*Response lost - Jean was closed before receiving a response.*`

## Root Cause

1. **Missing `ACTIVE_SENDS` in Session Registry**:
   When a Web UI client connects, reloads, or polls, it calls `check_resumable_sessions` (or `get_session`), which invokes `recover_incomplete_runs` in `jean-core`.
   `recover_incomplete_runs` inspects all sessions with `run.status == RunStatus::Running` and skips any session included in `get_actively_managed_sessions()`.
   Previously, `get_actively_managed_sessions()` in `registry.rs` checked `PROCESS_REGISTRY`, `CANCEL_FLAGS`, and `CODEX_TURN_REGISTRY`, but **did NOT check `ACTIVE_SENDS`** (the in-flight `send_chat_message` claim slot).

2. **On-Disk Metadata Corruption**:
   During the setup/preparation phase of a `send_chat_message` call (or for backends before process/turn registration completes), `send_chat_message` held a `SendClaim` in `ACTIVE_SENDS`, but the session was not yet in the process/flag registries.
   `recover_incomplete_runs` evaluated `actively_managed = false`, checked that PID was unregistered and JSONL had no result line, and falsely assumed the run had crashed—**writing `run.status = RunStatus::Crashed` directly to `metadata.json` on disk**.

3. **Web UI vs Desktop App Discrepancy**:
   - **Desktop App**: Held the in-memory React Query cache and continued streaming/rendering in UI without reading the corrupted disk metadata immediately.
   - **Web UI**: On page reload or fresh HTTP `get_session` fetch, loaded the corrupted `Crashed` status from disk. Because the assistant response had not finished streaming, `load_session_messages` populated the empty assistant message with `*Response lost - Jean was closed before receiving a response.*`.

## Solution

1. **Centralized Active Sends Tracking**:
   Moved `ACTIVE_SENDS` and `SendClaim` management to `jean-core/src/chat/registry.rs`.
2. **Updated Active Session Guards**:
   Extended `get_actively_managed_sessions()` and `is_session_actively_managed()` to include `ACTIVE_SENDS`.
   Now, as long as a `send_chat_message` call holds a `SendClaim` for a session, `recover_incomplete_runs` will recognize the session as actively managed and **will not mutate `metadata.json` on disk to `Crashed`**.
3. **Correct Web UI Resumable Recovery**:
   `check_resumable_sessions` now correctly reports in-flight active sends as `resumable: true` to Web UI clients, allowing the frontend to show streaming UI seamlessly instead of error placeholders.

## Changes Made

- **`jean-core/src/chat/registry.rs`**:
  - Moved `ACTIVE_SENDS`, `SEND_CLAIM_GENERATION`, `SendClaim`, `release_active_send`, and `has_active_send` into `registry.rs`.
  - Updated `get_actively_managed_sessions()`, `is_session_actively_managed()`, and `clear_registries()` to include `ACTIVE_SENDS`.
  - Added unit test `send_claim_marks_session_as_actively_managed`.
- **`jean-core/src/chat/commands.rs`**:
  - Refactored `SendClaim` usages to import from `super::registry`.

## Testing

- Added unit test `send_claim_marks_session_as_actively_managed` verifying that `SendClaim` correctly marks a session as actively managed while acquired and clears it upon drop.
- Executed full test suite: `cargo test --manifest-path jean-core/Cargo.toml`
  - **Result**: All 1040/1040 unit tests passed cleanly.


<img width="995" height="486" alt="CleanShot 2026-08-08 at 15 05 01" src="https://github.com/user-attachments/assets/5c9eaf25-1efe-4b96-ac64-e7618ce326cc" />
