### PR TITLE
feat(glab): add GitLab CLI and multi-forge support

### DIFF
--- a/e2e/fixtures/invoke-handlers.ts
+++ b/e2e/fixtures/invoke-handlers.ts
@@ -80,6 +80,15 @@ export const defaultResponses: Record<string, unknown> = {
   check_claude_cli_auth: { authenticated: true },
   check_gh_cli_installed: { installed: true },
   check_gh_cli_auth: { authenticated: true },
+  check_glab_cli_installed: { installed: false },
+  check_glab_cli_auth: { authenticated: false },
+  detect_glab_in_path: {
+    found: false,
+    path: null,
+    version: null,
+    package_manager: null,
+  },
+  detect_project_forge: 'unknown',
   get_available_cli_versions: [],
   get_available_gh_versions: [],
 

--- a/jean-core/src/chat/claude.rs
+++ b/jean-core/src/chat/claude.rs
@@ -602,15 +602,17 @@ fn build_claude_args(
     }
 
     // Allow embedded/resolved CLI binaries without approval via --allowedTools
-    // Claude wraps paths with spaces in quotes, so use glob patterns to match
-    let gh_binary = crate::gh_cli::config::resolve_gh_binary(app);
-    let gh_path_str = gh_binary.to_string_lossy();
-    args.push("--allowedTools".to_string());
-    args.push(format!("Bash(*{gh_path_str}*)"));
-    // Also allow the Jean-managed path pattern when user configured system PATH gh
-    if !gh_path_str.contains("gh-cli/gh") {
+    // Claude wraps paths with spaces in quotes, so use glob patterns to match.
+    // Only pre-approve `gh` when it is actually installed.
+    if let Some(gh_binary) = crate::gh_cli::config::resolve_available_gh_binary(app) {
+        let gh_path_str = gh_binary.to_string_lossy();
         args.push("--allowedTools".to_string());
-        args.push("Bash(*gh-cli/gh*)".to_string());
+        args.push(format!("Bash(*{gh_path_str}*)"));
+        // Also allow the Jean-managed path pattern when user configured system PATH gh
+        if !gh_path_str.contains("gh-cli/gh") {
+            args.push("--allowedTools".to_string());
+            args.push("Bash(*gh-cli/gh*)".to_string());
+        }
     }
     args.push("--allowedTools".to_string());
     args.push("Bash(*claude-cli/claude*)".to_string());
@@ -691,15 +693,8 @@ fn build_claude_args(
         }
     }
 
-    // Embedded gh CLI path - tell Claude to use the app's bundled binary
-    let gh_binary = crate::gh_cli::config::resolve_gh_binary(app);
-    if gh_binary != std::path::PathBuf::from("gh") {
-        system_prompt_parts.push(format!(
-            "When running GitHub CLI commands, use the full path to the embedded binary: {}\n\
-             Do NOT use bare `gh` — always use the full path above.",
-            gh_binary.display()
-        ));
-    }
+    // GitHub CLI: path hint when installed; strip discovery + forbid gh when not
+    crate::gh_cli::config::append_gh_cli_system_prompt(&mut system_prompt_parts, app);
 
     // Embedded Claude CLI path - tell Claude to use the app's bundled binary
     if let Ok(claude_binary) = crate::claude_cli::get_cli_binary_path(app) {

--- a/jean-core/src/chat/codex.rs
+++ b/jean-core/src/chat/codex.rs
@@ -3133,13 +3133,15 @@ fn handle_approval_request(
                 return;
             }
 
-            // Auto-approve embedded/resolved CLI binaries (matches Claude's --allowedTools)
-            let gh_binary = crate::gh_cli::config::resolve_gh_binary(app);
-            let gh_str = gh_binary.to_string_lossy();
-            if command.contains(&*gh_str)
-                || command.contains("gh-cli/gh")
-                || command.contains("claude-cli/claude")
-            {
+            // Auto-approve embedded/resolved CLI binaries (matches Claude's --allowedTools).
+            // Only treat `gh` as auto-approved when it is actually installed.
+            let gh_auto_approve = crate::gh_cli::config::resolve_available_gh_binary(app)
+                .map(|path| {
+                    let gh_str = path.to_string_lossy().into_owned();
+                    command.contains(&gh_str) || command.contains("gh-cli/gh")
+                })
+                .unwrap_or(false);
+            if gh_auto_approve || command.contains("claude-cli/claude") {
                 log::trace!("Auto-accepting CLI command (rpc_id={rpc_id}): {command}");
                 if let Err(e) = super::codex_server::send_response(
                     rpc_id,

--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -528,13 +528,7 @@ fn build_kimi_system_prompt(
             }
         }
     }
-    let gh_binary = crate::gh_cli::config::resolve_gh_binary(app);
-    if gh_binary != std::path::PathBuf::from("gh") {
-        parts.push(format!(
-            "When running GitHub CLI commands, use this binary: {}. Do not use bare `gh`.",
-            gh_binary.display()
-        ));
-    }
+    crate::gh_cli::config::append_gh_cli_system_prompt(&mut parts, app);
     if super::should_add_recap_instruction(app) {
         parts.push(super::RECAP_INSTRUCTION.to_string());
     }
@@ -3737,15 +3731,11 @@ pub async fn send_chat_message(
                         }
                     }
 
-                    // Embedded binary path hints
-                    let gh_binary = crate::gh_cli::config::resolve_gh_binary(&thread_app);
-                    if gh_binary != std::path::PathBuf::from("gh") {
-                        system_prompt_parts.push(format!(
-                            "When running GitHub CLI commands, use the full path to the embedded binary: {}\n\
-                             Do NOT use bare `gh` — always use the full path above.",
-                            gh_binary.display()
-                        ));
-                    }
+                    // Embedded binary path hints (gh only when installed)
+                    crate::gh_cli::config::append_gh_cli_system_prompt(
+                        &mut system_prompt_parts,
+                        &thread_app,
+                    );
                     if let Ok(claude_binary) = crate::claude_cli::get_cli_binary_path(&thread_app) {
                         if claude_binary.exists() {
                             system_prompt_parts.push(format!(
@@ -4150,15 +4140,11 @@ pub async fn send_chat_message(
                         }
                     }
 
-                    // Embedded binary path hints
-                    let gh_binary = crate::gh_cli::config::resolve_gh_binary(&thread_app);
-                    if gh_binary != std::path::PathBuf::from("gh") {
-                        system_prompt_parts.push(format!(
-                            "When running GitHub CLI commands, use the full path to the embedded binary: {}\n\
-                             Do NOT use bare `gh` — always use the full path above.",
-                            gh_binary.display()
-                        ));
-                    }
+                    // Embedded binary path hints (gh only when installed)
+                    crate::gh_cli::config::append_gh_cli_system_prompt(
+                        &mut system_prompt_parts,
+                        &thread_app,
+                    );
                     if let Ok(claude_binary) = crate::claude_cli::get_cli_binary_path(&thread_app) {
                         if claude_binary.exists() {
                             system_prompt_parts.push(format!(
@@ -4501,14 +4487,7 @@ pub async fn send_chat_message(
                         }
                     }
 
-                    let gh_binary = crate::gh_cli::config::resolve_gh_binary(&thread_app);
-                    if gh_binary != std::path::PathBuf::from("gh") {
-                        parts.push(format!(
-                            "When running GitHub CLI commands, use the full path to the embedded binary: {}\n\
-                             Do NOT use bare `gh` — always use the full path above.",
-                            gh_binary.display()
-                        ));
-                    }
+                    crate::gh_cli::config::append_gh_cli_system_prompt(&mut parts, &thread_app);
                     if let Ok(claude_binary) = crate::claude_cli::get_cli_binary_path(&thread_app) {
                         if claude_binary.exists() {
                             parts.push(format!(
@@ -4685,14 +4664,7 @@ pub async fn send_chat_message(
                         }
                     }
 
-                    let gh_binary = crate::gh_cli::config::resolve_gh_binary(&thread_app);
-                    if gh_binary != std::path::PathBuf::from("gh") {
-                        parts.push(format!(
-                            "When running GitHub CLI commands, use the full path to the embedded binary: {}\n\
-                             Do NOT use bare `gh` — always use the full path above.",
-                            gh_binary.display()
-                        ));
-                    }
+                    crate::gh_cli::config::append_gh_cli_system_prompt(&mut parts, &thread_app);
                     if let Ok(claude_binary) = crate::claude_cli::get_cli_binary_path(&thread_app) {
                         if claude_binary.exists() {
                             parts.push(format!(
@@ -4828,14 +4800,7 @@ pub async fn send_chat_message(
                         }
                     }
 
-                    let gh_binary = crate::gh_cli::config::resolve_gh_binary(&thread_app);
-                    if gh_binary != std::path::PathBuf::from("gh") {
-                        parts.push(format!(
-                            "When running GitHub CLI commands, use the full path to the embedded binary: {}\n\
-                             Do NOT use bare `gh` — always use the full path above.",
-                            gh_binary.display()
-                        ));
-                    }
+                    crate::gh_cli::config::append_gh_cli_system_prompt(&mut parts, &thread_app);
                     if let Ok(claude_binary) = crate::claude_cli::get_cli_binary_path(&thread_app) {
                         if claude_binary.exists() {
                             parts.push(format!(

--- a/jean-core/src/chat/context_instructions.rs
+++ b/jean-core/src/chat/context_instructions.rs
@@ -112,14 +112,7 @@ fn build_system_prompt_parts(
         }
     }
 
-    let gh_binary = crate::gh_cli::config::resolve_gh_binary(app);
-    if gh_binary != std::path::PathBuf::from("gh") {
-        parts.push(format!(
-            "When running GitHub CLI commands, use the full path to the embedded binary: {}\n\
-             Do NOT use bare `gh` — always use the full path above.",
-            gh_binary.display()
-        ));
-    }
+    crate::gh_cli::config::append_gh_cli_system_prompt(&mut parts, app);
     if let Ok(claude_binary) = crate::claude_cli::get_cli_binary_path(app) {
         if claude_binary.exists() {
             parts.push(format!(

--- a/jean-core/src/gh_cli/config.rs
+++ b/jean-core/src/gh_cli/config.rs
@@ -110,6 +110,101 @@ pub fn ensure_gh_cli_dir(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(cli_dir)
 }
 
+/// Resolve GitHub CLI binary only when it is actually installed/runnable.
+///
+/// Unlike [`resolve_gh_binary`], this returns `None` when the preferred binary
+/// path does not exist (or is not executable in WSL). Use this for system
+/// prompt injection so we never tell the model to use a missing `gh`.
+pub fn resolve_available_gh_binary(app: &AppHandle) -> Option<PathBuf> {
+    let path = resolve_gh_binary(app);
+    let wsl = get_wsl_config();
+    if wsl.enabled {
+        let tool = path.to_string_lossy();
+        let installed = if tool.starts_with('/') {
+            crate::platform::wsl_file_executable(&wsl.distro, &tool)
+        } else {
+            crate::platform::check_wsl_tool(&wsl.distro, &tool)
+        };
+        return installed.then_some(path);
+    }
+    path.exists().then_some(path)
+}
+
+/// System prompt block injected when GitHub CLI is not available.
+pub const GH_CLI_UNAVAILABLE_INSTRUCTION: &str = "\
+## GitHub CLI\n\
+- GitHub CLI (`gh`) is not installed in this environment.\n\
+- Do NOT run `gh` or other GitHub CLI commands; they will fail.\n\
+- Skip GitHub issue, PR, discussion, and Actions discovery unless the user provides that context another way.\n\
+- Prefer local git for remotes/branches. For GitLab or other hosts, use that host's tools if available.";
+
+/// Heading used by the default global system prompt for post-change GitHub discovery.
+pub const GITHUB_DISCOVERY_SECTION_MARKER: &str = "## GitHub Issue and Discussion Discovery";
+
+/// Remove the GitHub Issue/Discussion Discovery section from a prompt string.
+///
+/// Used when `gh` is unavailable so the model is not instructed to search
+/// GitHub issues that require the GitHub CLI.
+pub fn strip_github_discovery_section(prompt: &str) -> String {
+    let Some(start) = prompt.find(GITHUB_DISCOVERY_SECTION_MARKER) else {
+        return prompt.to_string();
+    };
+
+    let after_marker = &prompt[start + GITHUB_DISCOVERY_SECTION_MARKER.len()..];
+    // Next markdown H2 (or end of string) ends the discovery section.
+    let section_end_rel = after_marker
+        .find("\n## ")
+        .map(|i| i + 1) // include the leading newline of the next heading
+        .unwrap_or(after_marker.len());
+    let end = start + GITHUB_DISCOVERY_SECTION_MARKER.len() + section_end_rel;
+
+    let before = prompt[..start].trim_end();
+    let after = prompt[end..].trim_start();
+    if before.is_empty() {
+        return after.to_string();
+    }
+    if after.is_empty() {
+        return before.to_string();
+    }
+    format!("{before}\n\n{after}")
+}
+
+/// Append GitHub + GitLab CLI guidance to system prompt parts based on availability.
+///
+/// - When `gh` is installed: inject the full path so agents use Jean's binary.
+/// - When `gh` is missing: strip GitHub-discovery duties from earlier parts and
+///   tell the model not to invoke `gh`.
+/// - When `glab` is installed: inject path and instruct use for GitLab remotes.
+/// - When `glab` is missing: note that GitLab CLI commands will fail.
+pub fn append_gh_cli_system_prompt(parts: &mut Vec<String>, app: &AppHandle) {
+    match resolve_available_gh_binary(app) {
+        Some(path) => {
+            parts.push(format!(
+                "When running GitHub CLI commands for GitHub remotes, use the full path to the embedded binary: {}\n\
+                 Do NOT use bare `gh` — always use the full path above.\n\
+                 Do not use `gh` for GitLab remotes.",
+                path.display()
+            ));
+        }
+        None => {
+            for part in parts.iter_mut() {
+                *part = strip_github_discovery_section(part);
+            }
+            parts.push(GH_CLI_UNAVAILABLE_INSTRUCTION.to_string());
+        }
+    }
+
+    // GitLab CLI (optional, host-aware)
+    match crate::glab_cli::config::resolve_available_glab_binary(app) {
+        Some(path) => {
+            parts.push(crate::glab_cli::config::glab_path_instruction(&path));
+        }
+        None => {
+            parts.push(crate::glab_cli::config::GLAB_CLI_UNAVAILABLE_NOTE.to_string());
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -120,5 +215,48 @@ mod tests {
 
         assert!(resolved.ends_with(GH_CLI_BINARY_NAME));
         assert!(resolved.to_string_lossy().contains(GH_CLI_DIR_NAME));
+    }
+
+    #[test]
+    fn strip_github_discovery_section_removes_middle_block() {
+        let input = "\
+## Core Principles
+- Keep it simple
+
+## GitHub Issue and Discussion Discovery
+- Search issues after changes
+- Include links in the recap
+
+## Jean Worktree Policy
+- Do not create worktrees manually";
+
+        let stripped = strip_github_discovery_section(input);
+        assert!(!stripped.contains("GitHub Issue and Discussion Discovery"));
+        assert!(!stripped.contains("Search issues after changes"));
+        assert!(stripped.contains("## Core Principles"));
+        assert!(stripped.contains("## Jean Worktree Policy"));
+        assert!(stripped.contains("Do not create worktrees manually"));
+    }
+
+    #[test]
+    fn strip_github_discovery_section_is_noop_when_absent() {
+        let input = "## Core Principles\n- Keep it simple";
+        assert_eq!(strip_github_discovery_section(input), input);
+    }
+
+    #[test]
+    fn strip_github_discovery_section_handles_trailing_section() {
+        let input = "\
+## Core Principles
+- Keep it simple
+
+## GitHub Issue and Discussion Discovery
+- Search issues after changes
+";
+        let stripped = strip_github_discovery_section(input);
+        assert_eq!(
+            stripped,
+            "## Core Principles\n- Keep it simple"
+        );
     }
 }

--- a/jean-core/src/glab_cli/commands.rs
+++ b/jean-core/src/glab_cli/commands.rs
@@ -1,0 +1,595 @@
+//! Tauri commands for GitLab CLI (`glab`) management
+
+use serde::{Deserialize, Serialize};
+use std::io::{Cursor, Read};
+use tauri::AppHandle;
+
+use super::config::{
+    ensure_glab_cli_dir, get_glab_cli_binary_path, get_glab_cli_dir, resolve_glab_binary,
+    GLAB_CLI_BINARY_NAME, GLAB_CLI_BINARY_NAME_UNIX,
+};
+
+const FALLBACK_GLAB_VERSION: &str = "1.109.0";
+const GLAB_VERSIONS_CACHE_FILE: &str = "glab-versions-cache.json";
+/// Official GitLab CLI project on gitlab.com
+const GLAB_RELEASES_API: &str =
+    "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GlabCliStatus {
+    pub installed: bool,
+    pub version: Option<String>,
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GlabReleaseInfo {
+    pub version: String,
+    pub tag_name: String,
+    pub published_at: String,
+    pub prerelease: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GlabInstallProgress {
+    pub stage: String,
+    pub message: String,
+    pub percent: u8,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GlabAuthStatus {
+    pub authenticated: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GlabPathDetection {
+    pub found: bool,
+    pub path: Option<String>,
+    pub version: Option<String>,
+    pub package_manager: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitLabRelease {
+    tag_name: String,
+    #[serde(default)]
+    released_at: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    upcoming_release: bool,
+}
+
+fn emit_progress(app: &AppHandle, stage: &str, message: &str, percent: u8) {
+    use crate::http_server::EmitExt;
+    let _ = app.emit_all(
+        "glab-cli:install-progress",
+        &GlabInstallProgress {
+            stage: stage.to_string(),
+            message: message.to_string(),
+            percent,
+        },
+    );
+}
+
+pub async fn check_glab_cli_installed(app: AppHandle) -> Result<GlabCliStatus, String> {
+    let wsl = crate::platform::get_wsl_config();
+    let binary_path = resolve_glab_binary(&app);
+
+    if wsl.enabled {
+        let tool = binary_path.to_string_lossy().to_string();
+        let installed = if tool.starts_with('/') {
+            crate::platform::wsl_file_executable(&wsl.distro, &tool)
+        } else {
+            crate::platform::check_wsl_tool(&wsl.distro, &tool)
+        };
+        if !installed {
+            return Ok(GlabCliStatus {
+                installed: false,
+                version: None,
+                path: None,
+            });
+        }
+        let version = crate::platform::wsl_tool_version(&wsl.distro, &tool).and_then(|v| {
+            // glab version 1.x.x ...
+            v.split_whitespace()
+                .nth(2)
+                .or_else(|| v.lines().next())
+                .map(|s| s.trim().to_string())
+        });
+        return Ok(GlabCliStatus {
+            installed: true,
+            version,
+            path: Some(tool),
+        });
+    }
+
+    if !binary_path.exists() {
+        return Ok(GlabCliStatus {
+            installed: false,
+            version: None,
+            path: None,
+        });
+    }
+
+    let version = match crate::platform::cli_command(&binary_path.to_string_lossy(), None)
+        .arg("version")
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            // "glab 1.109.0" or "glab version 1.109.0"
+            let ver = text
+                .split_whitespace()
+                .find(|t| t.chars().next().is_some_and(|c| c.is_ascii_digit()))
+                .unwrap_or(&text)
+                .to_string();
+            Some(ver)
+        }
+        _ => None,
+    };
+
+    Ok(GlabCliStatus {
+        installed: true,
+        version,
+        path: Some(binary_path.to_string_lossy().to_string()),
+    })
+}
+
+pub async fn check_glab_cli_auth(app: AppHandle) -> Result<GlabAuthStatus, String> {
+    let wsl = crate::platform::get_wsl_config();
+    let binary_path = resolve_glab_binary(&app);
+
+    if !wsl.enabled && !binary_path.exists() {
+        return Ok(GlabAuthStatus {
+            authenticated: false,
+            error: Some("GitLab CLI not installed".to_string()),
+        });
+    }
+    if wsl.enabled {
+        let tool = binary_path.to_string_lossy().to_string();
+        let installed = if tool.starts_with('/') {
+            crate::platform::wsl_file_executable(&wsl.distro, &tool)
+        } else {
+            crate::platform::check_wsl_tool(&wsl.distro, &tool)
+        };
+        if !installed {
+            return Ok(GlabAuthStatus {
+                authenticated: false,
+                error: Some("GitLab CLI not installed inside WSL".to_string()),
+            });
+        }
+    }
+
+    let binary_str = binary_path.to_string_lossy().to_string();
+    let output = crate::platform::wsl_aware_command(&binary_str, None)
+        .args(["auth", "status"])
+        .output()
+        .map_err(|e| format!("Failed to execute GitLab CLI: {e}"))?;
+
+    if output.status.success() {
+        Ok(GlabAuthStatus {
+            authenticated: true,
+            error: None,
+        })
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        Ok(GlabAuthStatus {
+            authenticated: false,
+            error: Some(if stderr.is_empty() {
+                "Not authenticated".to_string()
+            } else {
+                stderr
+            }),
+        })
+    }
+}
+
+pub async fn detect_glab_in_path(app: AppHandle) -> Result<GlabPathDetection, String> {
+    let jean_managed_path = get_glab_cli_binary_path(&app)
+        .ok()
+        .and_then(|p| std::fs::canonicalize(&p).ok());
+    let wsl = crate::platform::get_wsl_config();
+    let jean_managed_wsl = if wsl.enabled {
+        super::config::get_wsl_glab_binary_path(&wsl.distro).ok()
+    } else {
+        None
+    };
+
+    if wsl.enabled {
+        if let Some(unix_path) =
+            crate::platform::wsl_which(&wsl.distro, "glab", jean_managed_wsl.as_deref())
+        {
+            if jean_managed_wsl
+                .as_ref()
+                .is_some_and(|p| p == &unix_path)
+            {
+                return Ok(GlabPathDetection {
+                    found: false,
+                    path: None,
+                    version: None,
+                    package_manager: None,
+                });
+            }
+            let version = crate::platform::wsl_tool_version(&wsl.distro, &unix_path);
+            return Ok(GlabPathDetection {
+                found: true,
+                path: Some(unix_path),
+                version,
+                package_manager: None,
+            });
+        }
+        return Ok(GlabPathDetection {
+            found: false,
+            path: None,
+            version: None,
+            package_manager: None,
+        });
+    }
+
+    if let Some(path) = crate::platform::find_cli_in_host_path("glab", None) {
+        if jean_managed_path
+            .as_ref()
+            .and_then(|j| std::fs::canonicalize(&path).ok().map(|c| c == *j))
+            .unwrap_or(false)
+        {
+            return Ok(GlabPathDetection {
+                found: false,
+                path: None,
+                version: None,
+                package_manager: None,
+            });
+        }
+        let version = crate::platform::cli_command(&path.to_string_lossy(), None)
+            .arg("version")
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+        return Ok(GlabPathDetection {
+            found: true,
+            path: Some(path.to_string_lossy().to_string()),
+            version,
+            package_manager: None,
+        });
+    }
+
+    Ok(GlabPathDetection {
+        found: false,
+        path: None,
+        version: None,
+        package_manager: None,
+    })
+}
+
+pub async fn get_available_glab_versions(app: AppHandle) -> Result<Vec<GlabReleaseInfo>, String> {
+    match fetch_glab_versions_from_api().await {
+        Ok(versions) if !versions.is_empty() => {
+            save_glab_versions_cache(&app, &versions);
+            Ok(versions)
+        }
+        Ok(_) | Err(_) => Ok(load_glab_versions_cache(&app).unwrap_or_else(fallback_glab_versions)),
+    }
+}
+
+async fn fetch_glab_versions_from_api() -> Result<Vec<GlabReleaseInfo>, String> {
+    let client = reqwest::Client::builder()
+        .user_agent("Jean-App/1.0")
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+
+    let response = client
+        .get(format!("{GLAB_RELEASES_API}?per_page=10"))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch glab releases: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!("GitLab API returned status: {}", response.status()));
+    }
+
+    let releases: Vec<GitLabRelease> = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse GitLab API response: {e}"))?;
+
+    let versions: Vec<GlabReleaseInfo> = releases
+        .into_iter()
+        .filter(|r| !r.upcoming_release)
+        .take(5)
+        .map(|r| {
+            let version = r
+                .tag_name
+                .strip_prefix('v')
+                .unwrap_or(&r.tag_name)
+                .to_string();
+            GlabReleaseInfo {
+                version,
+                tag_name: r.tag_name,
+                published_at: r
+                    .released_at
+                    .or(r.created_at)
+                    .unwrap_or_default(),
+                prerelease: false,
+            }
+        })
+        .collect();
+
+    Ok(versions)
+}
+
+pub async fn check_glab_cli_version_exists(
+    _app: AppHandle,
+    version: String,
+) -> Result<bool, String> {
+    let version = version.trim().trim_start_matches('v');
+    if version.is_empty() {
+        return Ok(false);
+    }
+    let client = reqwest::Client::builder()
+        .user_agent("Jean-App/1.0")
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+    let response = client
+        .get(format!("{GLAB_RELEASES_API}/v{version}"))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to check glab version: {e}"))?;
+    Ok(response.status().is_success())
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CachedGlabVersions {
+    versions: Vec<GlabReleaseInfo>,
+    fetched_at: String,
+}
+
+fn save_glab_versions_cache(app: &AppHandle, versions: &[GlabReleaseInfo]) {
+    let cache_path = match ensure_glab_cli_dir(app) {
+        Ok(dir) => dir.join(GLAB_VERSIONS_CACHE_FILE),
+        Err(_) => return,
+    };
+    let cached = CachedGlabVersions {
+        versions: versions.to_vec(),
+        fetched_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs().to_string())
+            .unwrap_or_default(),
+    };
+    if let Ok(json) = serde_json::to_string(&cached) {
+        let _ = std::fs::write(cache_path, json);
+    }
+}
+
+fn load_glab_versions_cache(app: &AppHandle) -> Option<Vec<GlabReleaseInfo>> {
+    let cache_path = get_glab_cli_dir(app).ok()?.join(GLAB_VERSIONS_CACHE_FILE);
+    let contents = std::fs::read_to_string(cache_path).ok()?;
+    let cached: CachedGlabVersions = serde_json::from_str(&contents).ok()?;
+    if cached.versions.is_empty() {
+        None
+    } else {
+        Some(cached.versions)
+    }
+}
+
+fn fallback_glab_versions() -> Vec<GlabReleaseInfo> {
+    vec![GlabReleaseInfo {
+        version: FALLBACK_GLAB_VERSION.to_string(),
+        tag_name: format!("v{FALLBACK_GLAB_VERSION}"),
+        published_at: String::new(),
+        prerelease: false,
+    }]
+}
+
+/// Returns (platform_token, archive_ext) matching glab release asset names.
+fn get_glab_platform() -> Result<(&'static str, &'static str), String> {
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        return Ok(("darwin_arm64", "tar.gz"));
+    }
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    {
+        return Ok(("darwin_amd64", "tar.gz"));
+    }
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        return Ok(("linux_amd64", "tar.gz"));
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        return Ok(("linux_arm64", "tar.gz"));
+    }
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        return Ok(("windows_amd64", "zip"));
+    }
+    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+    {
+        return Ok(("windows_arm64", "zip"));
+    }
+    #[allow(unreachable_code)]
+    Err("Unsupported platform for GitLab CLI".to_string())
+}
+
+fn wsl_glab_platform(distro: &str) -> Result<(&'static str, &'static str), String> {
+    match crate::platform::wsl_detect_arch(distro) {
+        Some("linux-x64") => Ok(("linux_amd64", "tar.gz")),
+        Some("linux-arm64") => Ok(("linux_arm64", "tar.gz")),
+        _ => Err("Unsupported WSL architecture for glab".to_string()),
+    }
+}
+
+pub async fn install_glab_cli(app: AppHandle, version: Option<String>) -> Result<(), String> {
+    let running_sessions = crate::chat::registry::get_running_sessions();
+    if !running_sessions.is_empty() {
+        return Err(format!(
+            "Cannot install GitLab CLI while {} session(s) running. Stop active sessions first.",
+            running_sessions.len()
+        ));
+    }
+
+    let wsl = crate::platform::get_wsl_config();
+    emit_progress(&app, "starting", "Preparing installation...", 0);
+
+    let version = match version {
+        Some(v) => v.trim().trim_start_matches('v').to_string(),
+        None => {
+            let versions = get_available_glab_versions(app.clone()).await?;
+            versions
+                .into_iter()
+                .next()
+                .map(|v| v.version)
+                .unwrap_or_else(|| FALLBACK_GLAB_VERSION.to_string())
+        }
+    };
+
+    let (platform, archive_ext) = if wsl.enabled {
+        wsl_glab_platform(&wsl.distro)?
+    } else {
+        get_glab_platform()?
+    };
+
+    let archive_name = format!("glab_{version}_{platform}.{archive_ext}");
+    let download_url = format!(
+        "https://gitlab.com/gitlab-org/cli/-/releases/v{version}/downloads/{archive_name}"
+    );
+
+    emit_progress(&app, "downloading", "Downloading GitLab CLI...", 20);
+
+    let client = reqwest::Client::builder()
+        .user_agent("Jean-App/1.0")
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+
+    let response = client
+        .get(&download_url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to download GitLab CLI: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "Failed to download GitLab CLI: HTTP {} ({download_url})",
+            response.status()
+        ));
+    }
+
+    let archive_content = response
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read archive: {e}"))?;
+
+    emit_progress(&app, "extracting", "Extracting archive...", 40);
+
+    let binary_bytes = if archive_ext == "zip" {
+        extract_glab_from_zip(&archive_content)?
+    } else {
+        extract_glab_from_tar_gz(&archive_content)?
+    };
+
+    emit_progress(&app, "installing", "Installing GitLab CLI...", 60);
+
+    if wsl.enabled {
+        let unix_path = super::config::get_wsl_glab_binary_path(&wsl.distro)?;
+        crate::platform::wsl_write_bytes(&wsl.distro, &unix_path, &binary_bytes)
+            .map_err(|e| format!("Failed to write binary into WSL: {e}"))?;
+        crate::platform::wsl_chmod_exec(&wsl.distro, &unix_path)?;
+        emit_progress(&app, "complete", "Installation complete!", 100);
+        return Ok(());
+    }
+
+    let _ = ensure_glab_cli_dir(&app)?;
+    let binary_path = get_glab_cli_binary_path(&app)?;
+    crate::platform::write_binary_file(&binary_path, &binary_bytes)
+        .map_err(|e| format!("Failed to write binary: {e}"))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&binary_path)
+            .map_err(|e| format!("Failed to get binary metadata: {e}"))?
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&binary_path, perms)
+            .map_err(|e| format!("Failed to set binary permissions: {e}"))?;
+    }
+
+    emit_progress(&app, "verifying", "Verifying installation...", 80);
+
+    let version_output = crate::platform::cli_command(&binary_path.to_string_lossy(), None)
+        .arg("version")
+        .output()
+        .map_err(|e| format!("Failed to verify GitLab CLI: {e}"))?;
+
+    if !version_output.status.success() {
+        return Err("GitLab CLI binary verification failed".to_string());
+    }
+
+    emit_progress(&app, "complete", "Installation complete!", 100);
+    Ok(())
+}
+
+pub async fn uninstall_glab_cli(app: AppHandle) -> Result<(), String> {
+    let cli_dir = get_glab_cli_dir(&app)?;
+    if cli_dir.exists() {
+        std::fs::remove_dir_all(&cli_dir)
+            .map_err(|e| format!("Failed to remove GitLab CLI directory: {e}"))?;
+    }
+    Ok(())
+}
+
+fn extract_glab_from_tar_gz(archive_content: &[u8]) -> Result<Vec<u8>, String> {
+    use flate2::read::GzDecoder;
+    use tar::Archive;
+
+    let cursor = Cursor::new(archive_content);
+    let decoder = GzDecoder::new(cursor);
+    let mut archive = Archive::new(decoder);
+
+    for entry in archive
+        .entries()
+        .map_err(|e| format!("Failed to read tar entries: {e}"))?
+    {
+        let mut entry = entry.map_err(|e| format!("Failed to read tar entry: {e}"))?;
+        let path = entry
+            .path()
+            .map_err(|e| format!("Failed to read tar entry path: {e}"))?;
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        if name == GLAB_CLI_BINARY_NAME_UNIX || name == "glab" {
+            let mut data = Vec::new();
+            entry
+                .read_to_end(&mut data)
+                .map_err(|e| format!("Failed to read binary from tar.gz: {e}"))?;
+            return Ok(data);
+        }
+    }
+    Err("Binary 'glab' not found inside archive".to_string())
+}
+
+fn extract_glab_from_zip(archive_content: &[u8]) -> Result<Vec<u8>, String> {
+    use zip::ZipArchive;
+
+    let cursor = Cursor::new(archive_content);
+    let mut archive =
+        ZipArchive::new(cursor).map_err(|e| format!("Failed to open zip archive: {e}"))?;
+
+    for i in 0..archive.len() {
+        let mut file = archive
+            .by_index(i)
+            .map_err(|e| format!("Failed to read zip entry: {e}"))?;
+        let name = file.name().to_string();
+        let base = name.rsplit('/').next().unwrap_or(&name);
+        if base == GLAB_CLI_BINARY_NAME || base == "glab.exe" || base == "glab" {
+            let mut data = Vec::new();
+            file.read_to_end(&mut data)
+                .map_err(|e| format!("Failed to read binary from zip: {e}"))?;
+            return Ok(data);
+        }
+    }
+    Err("Binary 'glab' not found inside zip archive".to_string())
+}

--- a/jean-core/src/glab_cli/config.rs
+++ b/jean-core/src/glab_cli/config.rs
@@ -1,0 +1,119 @@
+//! Configuration and path management for the embedded GitLab CLI (`glab`)
+
+use crate::platform::{get_wsl_config, get_wsl_home_dir};
+use std::path::PathBuf;
+use tauri::AppHandle;
+
+pub const GLAB_CLI_DIR_NAME: &str = "glab-cli";
+
+#[cfg(not(target_os = "windows"))]
+pub const GLAB_CLI_BINARY_NAME: &str = "glab";
+
+#[cfg(target_os = "windows")]
+pub const GLAB_CLI_BINARY_NAME: &str = "glab.exe";
+
+pub const GLAB_CLI_BINARY_NAME_UNIX: &str = "glab";
+
+pub fn get_wsl_glab_binary_path(distro: &str) -> Result<String, String> {
+    let home = get_wsl_home_dir(distro)?;
+    Ok(format!(
+        "{home}/.local/share/jean/{GLAB_CLI_DIR_NAME}/{GLAB_CLI_BINARY_NAME_UNIX}"
+    ))
+}
+
+pub fn get_glab_cli_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data directory: {e}"))?;
+    Ok(app_data_dir.join(GLAB_CLI_DIR_NAME))
+}
+
+pub fn get_glab_cli_binary_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(get_glab_cli_dir(app)?.join(GLAB_CLI_BINARY_NAME))
+}
+
+/// Resolve GitLab CLI binary path based on `glab_cli_source` preference.
+pub fn resolve_glab_binary(app: &AppHandle) -> PathBuf {
+    let use_path = match crate::get_preferences_path(app) {
+        Ok(prefs_path) => {
+            if let Ok(contents) = std::fs::read_to_string(&prefs_path) {
+                if let Ok(prefs) = serde_json::from_str::<crate::AppPreferences>(&contents) {
+                    prefs.glab_cli_source == "path"
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        }
+        Err(_) => false,
+    };
+
+    if use_path {
+        let wsl = get_wsl_config();
+        if wsl.enabled {
+            if let Some(unix_path) = crate::platform::wsl_which(
+                &wsl.distro,
+                "glab",
+                get_wsl_glab_binary_path(&wsl.distro).ok().as_deref(),
+            ) {
+                return PathBuf::from(unix_path);
+            }
+        } else if let Some(path) = crate::platform::find_cli_in_host_path("glab", None) {
+            return path;
+        }
+        log::warn!(
+            "glab_cli_source is 'path' but could not find glab in PATH, falling back to Jean-managed binary"
+        );
+    }
+
+    let wsl = get_wsl_config();
+    if wsl.enabled {
+        return get_wsl_glab_binary_path(&wsl.distro)
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(GLAB_CLI_BINARY_NAME_UNIX));
+    }
+
+    get_glab_cli_binary_path(app)
+        .unwrap_or_else(|_| PathBuf::from(GLAB_CLI_DIR_NAME).join(GLAB_CLI_BINARY_NAME))
+}
+
+pub fn ensure_glab_cli_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let cli_dir = get_glab_cli_dir(app)?;
+    std::fs::create_dir_all(&cli_dir)
+        .map_err(|e| format!("Failed to create GitLab CLI directory: {e}"))?;
+    Ok(cli_dir)
+}
+
+/// Resolve GitLab CLI only when installed/runnable.
+pub fn resolve_available_glab_binary(app: &AppHandle) -> Option<PathBuf> {
+    let path = resolve_glab_binary(app);
+    let wsl = get_wsl_config();
+    if wsl.enabled {
+        let tool = path.to_string_lossy();
+        let installed = if tool.starts_with('/') {
+            crate::platform::wsl_file_executable(&wsl.distro, &tool)
+        } else {
+            crate::platform::check_wsl_tool(&wsl.distro, &tool)
+        };
+        return installed.then_some(path);
+    }
+    path.exists().then_some(path)
+}
+
+/// System prompt when glab is available.
+pub fn glab_path_instruction(path: &std::path::Path) -> String {
+    format!(
+        "When running GitLab CLI commands for GitLab remotes, use the full path to the binary: {}\n\
+         Do NOT use bare `glab` — always use the full path above.\n\
+         Use `glab` for issues, merge requests (`mr`), and CI — not `gh`.",
+        path.display()
+    )
+}
+
+pub const GLAB_CLI_UNAVAILABLE_NOTE: &str = "\
+## GitLab CLI\n\
+- GitLab CLI (`glab`) is not installed.\n\
+- Do NOT run `glab` commands; they will fail.\n\
+- For GitLab repositories, use local git only unless the user provides another way to access GitLab.";

--- a/jean-core/src/glab_cli/mod.rs
+++ b/jean-core/src/glab_cli/mod.rs
@@ -1,0 +1,9 @@
+//! GitLab CLI (`glab`) management module
+//!
+//! Handles resolving, installing, and authenticating the GitLab CLI binary
+//! for GitLab-hosted repositories (mirror of `gh_cli` for GitHub).
+
+mod commands;
+pub(crate) mod config;
+
+pub use commands::*;

--- a/jean-core/src/http_server/dispatch.rs
+++ b/jean-core/src/http_server/dispatch.rs
@@ -2721,6 +2721,42 @@ pub async fn dispatch_command(
             Ok(Value::Null)
         }
 
+        "check_glab_cli_installed" => {
+            let result = crate::glab_cli::check_glab_cli_installed(app.clone()).await?;
+            to_value(result)
+        }
+        "detect_glab_in_path" => {
+            let result = crate::glab_cli::detect_glab_in_path(app.clone()).await?;
+            to_value(result)
+        }
+        "check_glab_cli_auth" => {
+            let result = crate::glab_cli::check_glab_cli_auth(app.clone()).await?;
+            to_value(result)
+        }
+        "get_available_glab_versions" => {
+            let result = crate::glab_cli::get_available_glab_versions(app.clone()).await?;
+            to_value(result)
+        }
+        "check_glab_cli_version_exists" => {
+            let version: String = from_field(&args, "version")?;
+            let result = crate::glab_cli::check_glab_cli_version_exists(app.clone(), version).await?;
+            to_value(result)
+        }
+        "install_glab_cli" => {
+            let version: Option<String> = from_field_opt(&args, "version")?;
+            crate::glab_cli::install_glab_cli(app.clone(), version).await?;
+            Ok(Value::Null)
+        }
+        "uninstall_glab_cli" => {
+            crate::glab_cli::uninstall_glab_cli(app.clone()).await?;
+            Ok(Value::Null)
+        }
+        "detect_project_forge" => {
+            let project_path: String = field(&args, "projectPath", "project_path")?;
+            let result = crate::projects::detect_project_forge(project_path).await?;
+            to_value(result)
+        }
+
         "check_coderabbit_cli_installed" => {
             let result = crate::coderabbit_cli::check_coderabbit_cli_installed(app.clone()).await?;
             to_value(result)

--- a/jean-core/src/http_server/websocket.rs
+++ b/jean-core/src/http_server/websocket.rs
@@ -28,6 +28,7 @@ fn command_should_run_on_blocking_pool(command: &str) -> bool {
             | "install_grok_cli"
             | "update_grok_cli"
             | "install_gh_cli"
+            | "install_glab_cli"
             | "install_coderabbit_cli"
             | "update_coderabbit_cli"
             | "install_agent_browser"

--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -47,6 +47,7 @@ mod codex_cli;
 mod commandcode_cli;
 mod cursor_cli;
 mod gh_cli;
+mod glab_cli;
 mod grok_cli;
 pub mod http_server;
 pub mod jean_mcp_config;
@@ -399,6 +400,8 @@ pub struct AppPreferences {
     pub antigravity_cli_source: String, // Antigravity CLI source: "jean" (managed) or "path" (system PATH)
     #[serde(default = "default_cli_source")]
     pub gh_cli_source: String, // GitHub CLI source: "jean" (managed) or "path" (system PATH)
+    #[serde(default = "default_cli_source")]
+    pub glab_cli_source: String, // GitLab CLI source: "jean" (managed) or "path" (system PATH)
     #[serde(default)]
     pub wsl_mode_chosen: bool, // Whether WSL mode selection has been made (prevents re-asking)
     #[serde(default)]
@@ -2653,6 +2656,7 @@ impl Default for AppPreferences {
             kimi_cli_source: default_cli_source(),
             antigravity_cli_source: default_cli_source(),
             gh_cli_source: default_cli_source(),
+            glab_cli_source: default_cli_source(),
             wsl_mode_chosen: false,
             wsl_enabled: false,
             wsl_distro: String::new(),

--- a/jean-core/src/projects/commands.rs
+++ b/jean-core/src/projects/commands.rs
@@ -5527,6 +5527,7 @@ pub async fn open_pull_request(
     // (not only the project default) so stacked branches target the right base.
     let gh = resolve_gh_binary(&app);
     let result = git::open_pull_request(
+        &app,
         &worktree.path,
         title.as_deref(),
         body.as_deref(),

--- a/jean-core/src/projects/forge.rs
+++ b/jean-core/src/projects/forge.rs
@@ -1,0 +1,196 @@
+//! Git forge detection (GitHub vs GitLab) from repository remotes.
+
+use crate::platform::wsl_aware_command;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Hosting forge for a repository remote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ForgeKind {
+    GitHub,
+    GitLab,
+    Unknown,
+}
+
+impl ForgeKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::GitHub => "github",
+            Self::GitLab => "gitlab",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Detect forge kind from a single remote URL.
+///
+/// Recognizes:
+/// - GitHub.com and common GHE patterns (`github.`)
+/// - GitLab.com and hosts containing `gitlab`
+pub fn detect_forge_from_url(remote_url: &str) -> ForgeKind {
+    let url = remote_url.trim().to_lowercase();
+    if url.is_empty() {
+        return ForgeKind::Unknown;
+    }
+
+    // SSH: git@host:owner/repo.git  or  ssh://git@host/owner/repo.git
+    // HTTPS: https://host/owner/repo.git
+    if let Some(host) = extract_host(&url) {
+        if host == "github.com" || host.starts_with("github.") || host.ends_with(".ghe.com") {
+            return ForgeKind::GitHub;
+        }
+        if host == "gitlab.com"
+            || host.starts_with("gitlab.")
+            || host.contains("gitlab")
+            || host.ends_with(".gitlab.io")
+        {
+            return ForgeKind::GitLab;
+        }
+    } else {
+        // Path-style heuristics when host parsing fails
+        if url.contains("github.com") || url.contains("github.") {
+            return ForgeKind::GitHub;
+        }
+        if url.contains("gitlab.com") || url.contains("gitlab.") || url.contains("gitlab") {
+            return ForgeKind::GitLab;
+        }
+    }
+
+    ForgeKind::Unknown
+}
+
+fn extract_host(url: &str) -> Option<&str> {
+    if let Some(rest) = url.strip_prefix("git@") {
+        // git@host:path
+        return rest.split([':', '/']).next().filter(|h| !h.is_empty());
+    }
+    if let Some(rest) = url
+        .strip_prefix("ssh://git@")
+        .or_else(|| url.strip_prefix("ssh://"))
+        .or_else(|| url.strip_prefix("https://"))
+        .or_else(|| url.strip_prefix("http://"))
+    {
+        return rest.split(['/', ':', '?']).next().filter(|h| !h.is_empty());
+    }
+    None
+}
+
+/// Detect forge for a repository by inspecting git remotes (prefers origin).
+pub fn detect_forge(repo_path: &str) -> ForgeKind {
+    let remotes = list_remote_urls(repo_path);
+    if remotes.is_empty() {
+        return ForgeKind::Unknown;
+    }
+
+    // Prefer origin when present
+    if let Some((_, url)) = remotes.iter().find(|(name, _)| name == "origin") {
+        let kind = detect_forge_from_url(url);
+        if kind != ForgeKind::Unknown {
+            return kind;
+        }
+    }
+
+    for (_, url) in &remotes {
+        let kind = detect_forge_from_url(url);
+        if kind != ForgeKind::Unknown {
+            return kind;
+        }
+    }
+
+    ForgeKind::Unknown
+}
+
+fn list_remote_urls(repo_path: &str) -> Vec<(String, String)> {
+    let output = match wsl_aware_command("git", Some(Path::new(repo_path)))
+        .args(["remote", "-v"])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+
+    let mut result = Vec::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        // origin  https://github.com/o/r.git (fetch)
+        let mut parts = line.split_whitespace();
+        let name = match parts.next() {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        let url = match parts.next() {
+            Some(u) => u.to_string(),
+            None => continue,
+        };
+        let kind = parts.next().unwrap_or("");
+        if kind.contains("fetch") || kind.is_empty() {
+            // Dedup name: keep first (fetch)
+            if !result.iter().any(|(n, _)| n == &name) {
+                result.push((name, url));
+            }
+        }
+    }
+    result
+}
+
+/// Tauri/command entry: detect forge for a project path.
+pub async fn detect_project_forge(project_path: String) -> Result<ForgeKind, String> {
+    Ok(detect_forge(&project_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_github_https_and_ssh() {
+        assert_eq!(
+            detect_forge_from_url("https://github.com/acme/app.git"),
+            ForgeKind::GitHub
+        );
+        assert_eq!(
+            detect_forge_from_url("git@github.com:acme/app.git"),
+            ForgeKind::GitHub
+        );
+        assert_eq!(
+            detect_forge_from_url("https://github.mycorp.com/acme/app"),
+            ForgeKind::GitHub
+        );
+    }
+
+    #[test]
+    fn detects_gitlab_https_and_ssh() {
+        assert_eq!(
+            detect_forge_from_url("https://gitlab.com/acme/app.git"),
+            ForgeKind::GitLab
+        );
+        assert_eq!(
+            detect_forge_from_url("git@gitlab.com:acme/app.git"),
+            ForgeKind::GitLab
+        );
+        assert_eq!(
+            detect_forge_from_url("https://gitlab.example.com/group/proj.git"),
+            ForgeKind::GitLab
+        );
+        assert_eq!(
+            detect_forge_from_url("git@git.company.com:group/proj.git"),
+            ForgeKind::Unknown // no gitlab in host
+        );
+    }
+
+    #[test]
+    fn self_hosted_gitlab_with_gitlab_in_hostname() {
+        assert_eq!(
+            detect_forge_from_url("https://gitlab.internal.corp/team/repo.git"),
+            ForgeKind::GitLab
+        );
+    }
+
+    #[test]
+    fn does_not_detect_gitlab_from_repository_path_when_host_was_parsed() {
+        assert_eq!(
+            detect_forge_from_url("https://git.example.com/acme/gitlab-tools.git"),
+            ForgeKind::Unknown
+        );
+    }
+}

--- a/jean-core/src/projects/git.rs
+++ b/jean-core/src/projects/git.rs
@@ -1936,16 +1936,18 @@ pub fn commit_changes(repo_path: &str, message: &str, stage_all: bool) -> Result
     Ok(hash)
 }
 
-/// Open a pull request using the GitHub CLI (gh)
+/// Open a pull request (GitHub) or merge request (GitLab) using the forge CLI.
 ///
 /// * `repo_path` - Path to the repository
-/// * `title` - Optional PR title (if None, gh will prompt or use default)
-/// * `body` - Optional PR body
-/// * `draft` - Whether to create as draft PR
+/// * `title` - Optional PR/MR title (if None, the forge CLI may prompt or fill)
+/// * `body` - Optional body
+/// * `draft` - Whether to create as draft (GitHub; ignored on GitLab if unsupported)
 /// * `base_branch` - Optional base branch (when set, passed as `gh pr create --base`)
+/// * `gh_binary` - GitHub CLI path (used when remote is GitHub)
 ///
-/// Returns the PR URL on success
+/// Returns the PR/MR URL on success
 pub fn open_pull_request(
+    app: &tauri::AppHandle,
     repo_path: &str,
     title: Option<&str>,
     body: Option<&str>,
@@ -1953,7 +1955,7 @@ pub fn open_pull_request(
     base_branch: Option<&str>,
     gh_binary: &std::path::Path,
 ) -> Result<String, String> {
-    log::trace!("Opening pull request from {repo_path}");
+    log::trace!("Opening pull/merge request from {repo_path}");
 
     // Push current branch to remote first
     log::trace!("Pushing current branch to remote...");
@@ -1970,6 +1972,39 @@ pub fn open_pull_request(
         }
     }
     log::trace!("Push completed");
+
+    if super::forge::detect_forge(repo_path) == super::forge::ForgeKind::GitLab {
+        let glab_path = crate::glab_cli::config::resolve_available_glab_binary(app)
+            .ok_or_else(|| "GitLab CLI not installed".to_string())?;
+
+        let mut args = vec!["mr", "create", "--yes", "--fill"];
+        if let Some(t) = title {
+            args.push("--title");
+            args.push(t);
+        }
+        if let Some(b) = body {
+            args.push("--description");
+            args.push(b);
+        }
+        if draft {
+            args.push("--draft");
+        }
+
+        let output = crate::platform::resolved_cli_command(&glab_path, Some(Path::new(repo_path)))
+            .args(&args)
+            .output()
+            .map_err(|e| format!("Failed to run glab mr create: {e}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("already exists") {
+                return Err("A merge request for this branch already exists".to_string());
+            }
+            return Err(format!("Failed to create merge request: {stderr}"));
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        return Ok(stdout);
+    }
 
     // Build the gh pr create command
     let mut args = vec!["pr", "create", "--fill"];
@@ -2761,6 +2796,18 @@ fn handle_merge_failure(repo_path: &str, stdout: &[u8], stderr: &[u8]) -> MergeR
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn open_pull_request_accepts_app_handle_for_forge_cli_resolution() {
+        let _: fn(
+            &tauri::AppHandle,
+            &str,
+            Option<&str>,
+            Option<&str>,
+            bool,
+            &Path,
+        ) -> Result<String, String> = open_pull_request;
+    }
 
     // ========================================================================
     // remove_dir_all_with_retry tests

--- a/jean-core/src/projects/github_issues.rs
+++ b/jean-core/src/projects/github_issues.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::AppHandle;
 
+use super::forge::{detect_forge, ForgeKind};
 use super::git::get_repo_identifier;
 use crate::gh_cli::config::resolve_gh_binary;
 
@@ -85,6 +86,11 @@ pub async fn list_github_labels(
 ) -> Result<Vec<GitHubLabel>, String> {
     log::trace!("Listing GitHub labels for {project_path}");
 
+    if detect_forge(&project_path) == ForgeKind::GitLab {
+        // glab label list -F json when available; empty is fine for MVP
+        return Ok(Vec::new());
+    }
+
     let gh = resolve_gh_binary(&app);
     let output = gh_command(&gh, &project_path)
         .args(["label", "list", "--json", "name,color", "-L", "1000"])
@@ -159,6 +165,10 @@ pub async fn list_github_issues(
     state: Option<String>,
 ) -> Result<GitHubIssueListResult, String> {
     log::trace!("Listing GitHub issues for {project_path} with state: {state:?}");
+
+    if detect_forge(&project_path) == ForgeKind::GitLab {
+        return super::gitlab_ops::list_gitlab_issues(&app, &project_path, state).await;
+    }
 
     let gh = resolve_gh_binary(&app);
     let state_arg = state.unwrap_or_else(|| "open".to_string());
@@ -299,6 +309,20 @@ pub async fn get_github_issue_by_number(
 ) -> Result<GitHubIssue, String> {
     log::trace!("Getting GitHub issue #{issue_number} by number for {project_path}");
 
+    if detect_forge(&project_path) == ForgeKind::GitLab {
+        let detail =
+            super::gitlab_ops::get_gitlab_issue(&app, &project_path, issue_number).await?;
+        return Ok(GitHubIssue {
+            number: detail.number,
+            title: detail.title,
+            body: detail.body,
+            state: detail.state,
+            labels: detail.labels,
+            created_at: detail.created_at,
+            author: detail.author,
+        });
+    }
+
     let gh = resolve_gh_binary(&app);
     let output = gh_command(&gh, &project_path)
         .args([
@@ -339,6 +363,10 @@ pub async fn get_github_issue(
     issue_number: u32,
 ) -> Result<GitHubIssueDetail, String> {
     log::trace!("Getting GitHub issue #{issue_number} for {project_path}");
+
+    if detect_forge(&project_path) == ForgeKind::GitLab {
+        return super::gitlab_ops::get_gitlab_issue(&app, &project_path, issue_number).await;
+    }
 
     let gh = resolve_gh_binary(&app);
     // Run gh issue view
@@ -1545,6 +1573,10 @@ pub async fn list_github_prs(
 ) -> Result<Vec<GitHubPullRequest>, String> {
     log::trace!("Listing GitHub PRs for {project_path} with state: {state:?}");
 
+    if detect_forge(&project_path) == ForgeKind::GitLab {
+        return super::gitlab_ops::list_gitlab_mrs(&app, &project_path, state).await;
+    }
+
     let gh = resolve_gh_binary(&app);
     let state_arg = state.unwrap_or_else(|| "open".to_string());
 
@@ -1645,6 +1677,10 @@ pub async fn get_github_pr_by_number(
     pr_number: u32,
 ) -> Result<GitHubPullRequest, String> {
     log::trace!("Getting GitHub PR #{pr_number} by number for {project_path}");
+
+    if detect_forge(&project_path) == ForgeKind::GitLab {
+        return super::gitlab_ops::get_gitlab_mr(&app, &project_path, pr_number).await;
+    }
 
     let gh = resolve_gh_binary(&app);
     let output = gh_command(&gh, &project_path)

--- a/jean-core/src/projects/gitlab_ops.rs
+++ b/jean-core/src/projects/gitlab_ops.rs
@@ -1,0 +1,455 @@
+//! GitLab forge operations via `glab`, mapped into Jean's existing GitHub-shaped types
+//! so the UI can show issues/MRs without a full type redesign.
+
+use serde::Deserialize;
+use std::path::Path;
+use tauri::AppHandle;
+
+use super::github_issues::{
+    GitHubAuthor, GitHubIssue, GitHubIssueDetail, GitHubIssueListResult, GitHubLabel,
+    GitHubPullRequest,
+};
+use crate::glab_cli::config::resolve_glab_binary;
+
+fn glab_command(glab: &Path, project_path: &str) -> std::process::Command {
+    crate::platform::resolved_cli_command(glab, Some(Path::new(project_path)))
+}
+
+fn is_glab_auth_error(stderr: &str) -> bool {
+    let lower = stderr.to_lowercase();
+    lower.contains("not authenticated")
+        || lower.contains("auth login")
+        || lower.contains("no token")
+        || lower.contains("401")
+        || lower.contains("unauthorized")
+}
+
+/// Flexible author from glab JSON (username or login).
+#[derive(Debug, Deserialize)]
+struct GlabAuthor {
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    login: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+impl GlabAuthor {
+    fn login(&self) -> String {
+        self.username
+            .clone()
+            .or_else(|| self.login.clone())
+            .or_else(|| self.name.clone())
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GlabLabel {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    color: Option<String>,
+}
+
+impl GlabLabel {
+    fn to_github(&self) -> Option<GitHubLabel> {
+        let name = self
+            .name
+            .clone()
+            .or_else(|| self.title.clone())
+            .filter(|s| !s.is_empty())?;
+        Some(GitHubLabel {
+            name,
+            color: self
+                .color
+                .clone()
+                .unwrap_or_else(|| "808080".to_string())
+                .trim_start_matches('#')
+                .to_string(),
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GlabIssue {
+    #[serde(default)]
+    iid: Option<u32>,
+    #[serde(default)]
+    number: Option<u32>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    labels: Option<serde_json::Value>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default, alias = "createdAt")]
+    created_at_camel: Option<String>,
+    #[serde(default)]
+    author: Option<GlabAuthor>,
+    #[serde(default)]
+    web_url: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+}
+
+fn parse_labels(value: Option<serde_json::Value>) -> Vec<GitHubLabel> {
+    let Some(value) = value else {
+        return Vec::new();
+    };
+    if let Ok(labels) = serde_json::from_value::<Vec<GlabLabel>>(value.clone()) {
+        return labels.into_iter().filter_map(|l| l.to_github()).collect();
+    }
+    if let Some(arr) = value.as_array() {
+        return arr
+            .iter()
+            .filter_map(|v| {
+                if let Some(s) = v.as_str() {
+                    return Some(GitHubLabel {
+                        name: s.to_string(),
+                        color: "808080".to_string(),
+                    });
+                }
+                serde_json::from_value::<GlabLabel>(v.clone())
+                    .ok()
+                    .and_then(|l| l.to_github())
+            })
+            .collect();
+    }
+    // nodes wrapper
+    if let Some(nodes) = value.get("nodes").and_then(|n| n.as_array()) {
+        return nodes
+            .iter()
+            .filter_map(|v| {
+                serde_json::from_value::<GlabLabel>(v.clone())
+                    .ok()
+                    .and_then(|l| l.to_github())
+            })
+            .collect();
+    }
+    Vec::new()
+}
+
+fn normalize_state(state: &str) -> String {
+    match state.to_lowercase().as_str() {
+        "opened" | "open" => "OPEN".to_string(),
+        "closed" => "CLOSED".to_string(),
+        "merged" => "MERGED".to_string(),
+        other => other.to_uppercase(),
+    }
+}
+
+impl GlabIssue {
+    fn to_github_issue(&self) -> Option<GitHubIssue> {
+        let number = self.iid.or(self.number)?;
+        Some(GitHubIssue {
+            number,
+            title: self.title.clone().unwrap_or_default(),
+            body: self.description.clone().or_else(|| self.body.clone()),
+            state: normalize_state(self.state.as_deref().unwrap_or("opened")),
+            labels: parse_labels(self.labels.clone()),
+            created_at: self
+                .created_at
+                .clone()
+                .or_else(|| self.created_at_camel.clone())
+                .unwrap_or_default(),
+            author: GitHubAuthor {
+                login: self
+                    .author
+                    .as_ref()
+                    .map(|a| a.login())
+                    .unwrap_or_else(|| "unknown".to_string()),
+            },
+        })
+    }
+
+    fn to_github_issue_detail(&self) -> Option<GitHubIssueDetail> {
+        let base = self.to_github_issue()?;
+        Some(GitHubIssueDetail {
+            number: base.number,
+            title: base.title,
+            body: base.body,
+            state: base.state,
+            labels: base.labels,
+            created_at: base.created_at,
+            author: base.author,
+            url: self
+                .web_url
+                .clone()
+                .or_else(|| self.url.clone())
+                .unwrap_or_default(),
+            comments: Vec::new(),
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GlabMr {
+    #[serde(default)]
+    iid: Option<u32>,
+    #[serde(default)]
+    number: Option<u32>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    labels: Option<serde_json::Value>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default, alias = "createdAt")]
+    created_at_camel: Option<String>,
+    #[serde(default)]
+    author: Option<GlabAuthor>,
+    #[serde(default)]
+    web_url: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    source_branch: Option<String>,
+    #[serde(default, alias = "headRefName")]
+    head_ref_name: Option<String>,
+    #[serde(default)]
+    target_branch: Option<String>,
+    #[serde(default, alias = "baseRefName")]
+    base_ref_name: Option<String>,
+}
+
+impl GlabMr {
+    fn to_pr(&self) -> Option<GitHubPullRequest> {
+        let number = self.iid.or(self.number)?;
+        let state = normalize_state(self.state.as_deref().unwrap_or("opened"));
+        Some(GitHubPullRequest {
+            number,
+            title: self.title.clone().unwrap_or_default(),
+            body: self.description.clone().or_else(|| self.body.clone()),
+            state,
+            labels: parse_labels(self.labels.clone()),
+            created_at: self
+                .created_at
+                .clone()
+                .or_else(|| self.created_at_camel.clone())
+                .unwrap_or_default(),
+            author: GitHubAuthor {
+                login: self
+                    .author
+                    .as_ref()
+                    .map(|a| a.login())
+                    .unwrap_or_else(|| "unknown".to_string()),
+            },
+            head_ref_name: self
+                .source_branch
+                .clone()
+                .or_else(|| self.head_ref_name.clone())
+                .unwrap_or_default(),
+            base_ref_name: self
+                .target_branch
+                .clone()
+                .or_else(|| self.base_ref_name.clone())
+                .unwrap_or_default(),
+            is_draft: false,
+        })
+    }
+}
+
+pub async fn list_gitlab_issues(
+    app: &AppHandle,
+    project_path: &str,
+    state: Option<String>,
+) -> Result<GitHubIssueListResult, String> {
+    let glab = resolve_glab_binary(app);
+    if !crate::glab_cli::config::resolve_available_glab_binary(app).is_some() {
+        return Err(
+            "GitLab CLI not installed. Install glab from Settings or onboarding to use GitLab issues."
+                .to_string(),
+        );
+    }
+
+    let state_arg = match state.as_deref().unwrap_or("open") {
+        "closed" => "closed",
+        "all" => "all",
+        _ => "opened",
+    };
+
+    let output = glab_command(&glab, project_path)
+        .args(["issue", "list", "-F", "json", "-P", "100", "--state", state_arg])
+        .output()
+        .map_err(|e| format!("Failed to run glab issue list: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_glab_auth_error(&stderr) {
+            return Err(
+                "GitLab CLI not authenticated. Run 'glab auth login' first.".to_string(),
+            );
+        }
+        return Err(format!("glab issue list failed: {stderr}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let raw: Vec<GlabIssue> = serde_json::from_str(&stdout)
+        .map_err(|e| format!("Failed to parse glab issue list: {e}"))?;
+    let issues: Vec<GitHubIssue> = raw.iter().filter_map(|i| i.to_github_issue()).collect();
+    let total_count = issues.len() as u32;
+    Ok(GitHubIssueListResult {
+        issues,
+        total_count,
+    })
+}
+
+pub async fn get_gitlab_issue(
+    app: &AppHandle,
+    project_path: &str,
+    issue_number: u32,
+) -> Result<GitHubIssueDetail, String> {
+    let glab = resolve_glab_binary(app);
+    if crate::glab_cli::config::resolve_available_glab_binary(app).is_none() {
+        return Err("GitLab CLI not installed".to_string());
+    }
+
+    let output = glab_command(&glab, project_path)
+        .args(["issue", "view", &issue_number.to_string(), "-F", "json"])
+        .output()
+        .map_err(|e| format!("Failed to run glab issue view: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_glab_auth_error(&stderr) {
+            return Err(
+                "GitLab CLI not authenticated. Run 'glab auth login' first.".to_string(),
+            );
+        }
+        return Err(format!("glab issue view failed: {stderr}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let raw: GlabIssue = serde_json::from_str(&stdout)
+        .map_err(|e| format!("Failed to parse glab issue view: {e}"))?;
+    raw.to_github_issue_detail()
+        .ok_or_else(|| "Invalid glab issue response".to_string())
+}
+
+pub async fn list_gitlab_mrs(
+    app: &AppHandle,
+    project_path: &str,
+    state: Option<String>,
+) -> Result<Vec<GitHubPullRequest>, String> {
+    let glab = resolve_glab_binary(app);
+    if crate::glab_cli::config::resolve_available_glab_binary(app).is_none() {
+        return Err(
+            "GitLab CLI not installed. Install glab to list merge requests.".to_string(),
+        );
+    }
+
+    let state_arg = match state.as_deref().unwrap_or("open") {
+        "closed" => "closed",
+        "merged" => "merged",
+        "all" => "all",
+        _ => "opened",
+    };
+
+    let output = glab_command(&glab, project_path)
+        .args(["mr", "list", "-F", "json", "-P", "100", "--state", state_arg])
+        .output()
+        .map_err(|e| format!("Failed to run glab mr list: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_glab_auth_error(&stderr) {
+            return Err(
+                "GitLab CLI not authenticated. Run 'glab auth login' first.".to_string(),
+            );
+        }
+        return Err(format!("glab mr list failed: {stderr}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let raw: Vec<GlabMr> =
+        serde_json::from_str(&stdout).map_err(|e| format!("Failed to parse glab mr list: {e}"))?;
+    Ok(raw.iter().filter_map(|m| m.to_pr()).collect())
+}
+
+pub async fn get_gitlab_mr(
+    app: &AppHandle,
+    project_path: &str,
+    mr_number: u32,
+) -> Result<GitHubPullRequest, String> {
+    let glab = resolve_glab_binary(app);
+    if crate::glab_cli::config::resolve_available_glab_binary(app).is_none() {
+        return Err("GitLab CLI not installed".to_string());
+    }
+
+    let output = glab_command(&glab, project_path)
+        .args(["mr", "view", &mr_number.to_string(), "-F", "json"])
+        .output()
+        .map_err(|e| format!("Failed to run glab mr view: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_glab_auth_error(&stderr) {
+            return Err(
+                "GitLab CLI not authenticated. Run 'glab auth login' first.".to_string(),
+            );
+        }
+        return Err(format!("glab mr view failed: {stderr}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let raw: GlabMr =
+        serde_json::from_str(&stdout).map_err(|e| format!("Failed to parse glab mr view: {e}"))?;
+    raw.to_pr()
+        .ok_or_else(|| "Invalid glab mr response".to_string())
+}
+
+pub fn create_gitlab_mr(
+    app: &AppHandle,
+    project_path: &str,
+    title: &str,
+    body: Option<&str>,
+) -> Result<String, String> {
+    let glab = resolve_glab_binary(app);
+    if crate::glab_cli::config::resolve_available_glab_binary(app).is_none() {
+        return Err("GitLab CLI not installed".to_string());
+    }
+
+    let mut cmd = glab_command(&glab, project_path);
+    cmd.args(["mr", "create", "--title", title, "--yes", "--fill"]);
+    if let Some(body) = body {
+        if !body.is_empty() {
+            cmd.args(["--description", body]);
+        }
+    }
+
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to run glab mr create: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("glab mr create failed: {stderr}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Prefer a URL line in the output
+    for line in stdout.lines() {
+        let t = line.trim();
+        if t.starts_with("http://") || t.starts_with("https://") {
+            return Ok(t.to_string());
+        }
+    }
+    Ok(stdout.trim().to_string())
+}
+

--- a/jean-core/src/projects/mod.rs
+++ b/jean-core/src/projects/mod.rs
@@ -1,10 +1,12 @@
 pub mod checkpoints;
 mod commands;
+pub mod forge;
 pub mod git;
 pub mod git_log;
 pub mod git_status;
 pub mod github_actions;
 pub mod github_issues;
+pub mod gitlab_ops;
 pub mod linear_issues;
 mod names;
 pub mod pr_status;
@@ -22,6 +24,7 @@ pub use checkpoints::{
     restore_ai_checkpoint_file, restore_ai_checkpoint_turn,
 };
 pub use commands::*;
+pub use forge::*;
 pub use github_actions::*;
 pub use github_issues::*;
 pub use linear_issues::*;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1005,7 +1005,7 @@ function App() {
     enabled: nativeCli && !!ghStatus?.installed,
   })
 
-  // Show onboarding if GitHub CLI is not ready, or no AI backend is ready.
+// Show onboarding if no AI backend is ready. GitHub CLI is optional.
   // Only in native app - pure web access uses the host's already-setup CLIs.
   useEffect(() => {
     if (!isNativeApp()) return
@@ -1186,14 +1186,14 @@ function App() {
       (ghStatus?.installed && isGhAuthLoading)
     if (isLoading) return
 
-    const ghReady = !!ghStatus?.installed && !!ghAuth?.authenticated
-    const hasAiBackendReady = aiStatuses.some(
+const hasAiBackendReady = aiStatuses.some(
       (status, index) =>
         !!status?.installed && !!aiAuth[index]?.authenticated
     )
 
     // If setup is incomplete, onboarding owns the startup surface.
-    if (!ghReady || !hasAiBackendReady) return
+    // GitHub CLI is optional and must not block post-setup intros.
+    if (!hasAiBackendReady) return
 
     // Existing first-run tour has priority; show MCP intro on a later tick/reload
     // after that preference has been marked seen.

--- a/src/components/layout/SetupIncompleteBanner.test.tsx
+++ b/src/components/layout/SetupIncompleteBanner.test.tsx
@@ -58,11 +58,6 @@ vi.mock('@/services/kimi-cli', () => ({
   useKimiCliAuth: () => authResult(),
 }))
 
-vi.mock('@/services/gh-cli', () => ({
-  useGhCliStatus: () => statusResult(true),
-  useGhCliAuth: () => authResult(true),
-}))
-
 describe('SetupIncompleteBanner', () => {
   beforeEach(() => {
     mocks.cursorInstalled = true
@@ -82,5 +77,8 @@ describe('SetupIncompleteBanner', () => {
     render(<SetupIncompleteBanner />)
 
     expect(screen.getByText(/setup incomplete/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/at least one AI backend/i)
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/layout/SetupIncompleteBanner.tsx
+++ b/src/components/layout/SetupIncompleteBanner.tsx
@@ -12,7 +12,6 @@ import {
 } from '@/services/commandcode-cli'
 import { useGrokCliStatus, useGrokCliAuth } from '@/services/grok-cli'
 import { useKimiCliStatus, useKimiCliAuth } from '@/services/kimi-cli'
-import { useGhCliStatus, useGhCliAuth } from '@/services/gh-cli'
 import { useUIStore } from '@/store/ui-store'
 import { isNativeApp } from '@/lib/environment'
 import { Loader2 } from 'lucide-react'
@@ -37,7 +36,6 @@ export function SetupIncompleteBanner() {
   const commandcodeStatus = useCommandCodeCliStatus()
   const grokStatus = useGrokCliStatus()
   const kimiStatus = useKimiCliStatus()
-  const ghStatus = useGhCliStatus()
 
   const claudeAuth = useClaudeCliAuth({
     enabled: !!claudeStatus.data?.installed,
@@ -57,7 +55,6 @@ export function SetupIncompleteBanner() {
     enabled: !!grokStatus.data?.installed,
   })
   const kimiAuth = useKimiCliAuth({ enabled: !!kimiStatus.data?.installed })
-  const ghAuth = useGhCliAuth({ enabled: !!ghStatus.data?.installed })
 
   if (!isNativeApp()) return null
   // Only show after user has dismissed onboarding, and while it's not currently open
@@ -73,8 +70,7 @@ export function SetupIncompleteBanner() {
     (cursorStatus.data?.installed &&
       (cursorAuth.isLoading || cursorAuth.isFetching)) ||
     grokStatus.isLoading ||
-    kimiStatus.isLoading ||
-    ghStatus.isLoading
+    kimiStatus.isLoading
 
   if (isLoading) {
     return (
@@ -85,7 +81,6 @@ export function SetupIncompleteBanner() {
     )
   }
 
-  const ghReady = !!ghStatus.data?.installed && !!ghAuth.data?.authenticated
   const hasAiBackendReady =
     (!!claudeStatus.data?.installed && !!claudeAuth.data?.authenticated) ||
     (!!codexStatus.data?.installed && !!codexAuth.data?.authenticated) ||
@@ -97,13 +92,13 @@ export function SetupIncompleteBanner() {
     (!!grokStatus.data?.installed && !!grokAuth.data?.authenticated) ||
     (!!kimiStatus.data?.installed && !!kimiAuth.data?.authenticated)
 
-  // Everything is set up — no banner needed
-  if (ghReady && hasAiBackendReady) return null
+  // At least one AI backend is enough — GitHub CLI is optional
+  if (hasAiBackendReady) return null
 
   return (
     <div className="flex w-full shrink-0 items-center justify-center gap-2 bg-amber-500/15 px-4 py-1.5 text-xs text-amber-400">
       <span>
-        Setup incomplete — Jean requires GitHub CLI and at least one AI backend.
+        Setup incomplete — Jean requires at least one AI backend.
       </span>
       <button
         type="button"

--- a/src/components/onboarding/CliSetupComponents.tsx
+++ b/src/components/onboarding/CliSetupComponents.tsx
@@ -62,6 +62,8 @@ export interface SetupStateProps {
   onVersionChange: (version: string) => void
   onCheckManualVersion?: (version: string) => Promise<boolean>
   onInstall: () => void
+  /** Optional skip action (e.g. optional GitHub CLI during onboarding). */
+  onSkip?: () => void
 }
 
 type ManualVersionStatus = 'idle' | 'checking' | 'valid' | 'invalid' | 'error'
@@ -77,6 +79,7 @@ export function SetupState({
   onVersionChange,
   onCheckManualVersion,
   onInstall,
+  onSkip,
 }: SetupStateProps) {
   const [manualVersion, setManualVersion] = useState('')
   const [manualVersionStatus, setManualVersionStatus] =
@@ -295,15 +298,27 @@ export function SetupState({
         </p>
       </div>
 
-      <Button
-        onClick={onInstall}
-        disabled={!selectedVersion || isLoading || manualVersionNeedsCheck}
-        className="w-full"
-        size="lg"
-      >
-        <Download className="size-4" />
-        {currentVersion ? 'Install Selected Version' : `Install ${cliName}`}
-      </Button>
+      <div className="flex flex-col gap-2">
+        <Button
+          onClick={onInstall}
+          disabled={!selectedVersion || isLoading || manualVersionNeedsCheck}
+          className="w-full"
+          size="lg"
+        >
+          <Download className="size-4" />
+          {currentVersion ? 'Install Selected Version' : `Install ${cliName}`}
+        </Button>
+        {onSkip && (
+          <Button
+            onClick={onSkip}
+            variant="outline"
+            className="w-full"
+            size="lg"
+          >
+            Skip for Now
+          </Button>
+        )}
+      </div>
     </div>
   )
 }
@@ -585,6 +600,8 @@ export interface CliPathSelectorProps {
   jeanInstalled?: boolean
   onSelectPath: () => void
   onSelectJean: () => void
+  /** Optional skip action (e.g. optional GitHub CLI during onboarding). */
+  onSkip?: () => void
 }
 
 export function CliPathSelector({
@@ -597,6 +614,7 @@ export function CliPathSelector({
   jeanInstalled,
   onSelectPath,
   onSelectJean,
+  onSkip,
 }: CliPathSelectorProps) {
   useEffect(() => {
     dbg(
@@ -681,6 +699,18 @@ export function CliPathSelector({
           </div>
         </button>
       </div>
+
+      {onSkip && (
+        <Button
+          onClick={onSkip}
+          variant="outline"
+          className="w-full"
+          size="lg"
+          disabled={isLoading}
+        >
+          Skip for Now
+        </Button>
+      )}
     </div>
   )
 }

--- a/src/components/onboarding/OnboardingDialog.test.tsx
+++ b/src/components/onboarding/OnboardingDialog.test.tsx
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   cursorAuthenticated: false,
   cursorAuthRefetchCount: 0,
   cursorInstallSucceeds: true,
+  glabInstalled: false,
+  glabPath: null as string | null,
   patchPreferences: vi.fn(
     (_patch: unknown, options?: { onSuccess?: () => void }) =>
       options?.onSuccess?.()
@@ -142,6 +144,12 @@ vi.mock('@/services/gh-cli', () => ({
   useGhPathDetection: () => pathResult(true, '/usr/bin/gh'),
 }))
 
+vi.mock('@/services/glab-cli', () => ({
+  useGlabCliSetup: () => setupResult(mocks.glabInstalled, mocks.glabPath),
+  useGlabCliAuth: () => authResult(false),
+  useGlabPathDetection: () => pathResult(false),
+}))
+
 vi.mock('@/services/preferences', () => ({
   usePreferences: () => ({
     data: {
@@ -155,6 +163,7 @@ vi.mock('@/services/preferences', () => ({
       kimi_cli_source: 'path',
       antigravity_cli_source: 'path',
       gh_cli_source: 'path',
+      glab_cli_source: 'path',
     },
   }),
   usePatchPreferences: () => ({
@@ -174,21 +183,49 @@ vi.mock('./CliSetupComponents', async importOriginal => {
     ...original,
     AuthLoginState: ({
       action = 'login',
+      command,
+      commandArgs,
       onComplete,
+      onSkip,
     }: {
       action?: 'login' | 'install'
+      command?: string
+      commandArgs?: string[]
       onComplete: () => void
-    }) => <button onClick={onComplete}>Complete Cursor {action}</button>,
+      onSkip?: () => void
+    }) => (
+      <div>
+        {command && (
+          <div data-testid="auth-login-command">
+            {[command, ...(commandArgs ?? [])].join(' ')}
+          </div>
+        )}
+        <button onClick={onComplete}>Complete Cursor {action}</button>
+        {onSkip && <button onClick={onSkip}>Skip for Now</button>}
+      </div>
+    ),
     AuthCheckingState: ({ cliName }: { cliName: string }) => (
       <div>Checking {cliName}</div>
     ),
     CliPathSelector: ({
       cliName,
       onSelectPath,
+      onSelectJean,
+      onSkip,
     }: {
       cliName: string
       onSelectPath: () => void
-    }) => <button onClick={onSelectPath}>Use {cliName} from PATH</button>,
+      onSelectJean?: () => void
+      onSkip?: () => void
+    }) => (
+      <div>
+        <button onClick={onSelectPath}>Use {cliName} from PATH</button>
+        {onSelectJean && (
+          <button onClick={onSelectJean}>Use Jean-managed {cliName}</button>
+        )}
+        {onSkip && <button onClick={onSkip}>Skip for Now</button>}
+      </div>
+    ),
   }
 })
 
@@ -198,6 +235,8 @@ describe('OnboardingDialog backends', () => {
     mocks.cursorAuthenticated = false
     mocks.cursorAuthRefetchCount = 0
     mocks.cursorInstallSucceeds = true
+    mocks.glabInstalled = false
+    mocks.glabPath = null
     mocks.patchPreferences.mockClear()
     mocks.patchPreferencesAsync.mockClear()
     useUIStore.setState({
@@ -289,9 +328,87 @@ describe('OnboardingDialog backends', () => {
     await user.click(
       await screen.findByRole('button', { name: 'Use GitHub CLI from PATH' })
     )
+    // Optional GitLab CLI step after GitHub
+    await user.click(
+      await screen.findByRole('button', { name: 'Skip for Now' })
+    )
 
-    expect(await screen.findByText('All Tools Ready')).toBeInTheDocument()
+    expect(await screen.findByText("You're Ready")).toBeInTheDocument()
     expect(screen.getByText('Cursor CLI: Installed')).toBeInTheDocument()
+  })
+
+  it('allows skipping optional GitHub CLI setup after an AI backend is ready', async () => {
+    const user = userEvent.setup()
+    const { OnboardingDialog } = await import('./OnboardingDialog')
+    render(<OnboardingDialog />)
+
+    await chooseLocalAndContinue(user)
+    await user.click(
+      await screen.findByRole('checkbox', { name: /cursor cli/i })
+    )
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+    await user.click(
+      await screen.findByRole('button', { name: /^Install Cursor Agent/ })
+    )
+    await user.click(
+      await screen.findByRole('button', { name: 'Complete Cursor install' })
+    )
+    await user.click(
+      await screen.findByRole('button', { name: 'Complete Cursor login' })
+    )
+
+    expect(
+      await screen.findByRole('button', { name: 'Skip for Now' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Use GitHub CLI from PATH' })
+    ).toBeInTheDocument()
+
+    // Skip GitHub CLI → optional GitLab CLI
+    await user.click(screen.getByRole('button', { name: 'Skip for Now' }))
+    expect(
+      await screen.findByRole('button', { name: 'Skip for Now' })
+    ).toBeInTheDocument()
+    // Skip GitLab CLI → complete
+    await user.click(screen.getByRole('button', { name: 'Skip for Now' }))
+
+    expect(await screen.findByText("You're Ready")).toBeInTheDocument()
+    expect(screen.getByText('Cursor CLI: Installed')).toBeInTheDocument()
+  })
+
+  it('uses the resolved Jean-managed glab binary for authentication', async () => {
+    mocks.glabInstalled = true
+    mocks.glabPath = '/app-data/cli/glab'
+    const user = userEvent.setup()
+    const { OnboardingDialog } = await import('./OnboardingDialog')
+    render(<OnboardingDialog />)
+
+    await chooseLocalAndContinue(user)
+    await user.click(
+      await screen.findByRole('checkbox', { name: /cursor cli/i })
+    )
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+    await user.click(
+      await screen.findByRole('button', { name: /^Install Cursor Agent/ })
+    )
+    await user.click(
+      await screen.findByRole('button', { name: 'Complete Cursor install' })
+    )
+    await user.click(
+      await screen.findByRole('button', { name: 'Complete Cursor login' })
+    )
+    await user.click(
+      await screen.findByRole('button', { name: 'Use GitHub CLI from PATH' })
+    )
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'Use Jean-managed GitLab CLI',
+      })
+    )
+
+    expect(await screen.findByTestId('auth-login-command')).toHaveTextContent(
+      '/app-data/cli/glab auth login'
+    )
   })
 
   it('returns to backend selection after a failed Cursor install check and Back', async () => {

--- a/src/components/onboarding/OnboardingDialog.tsx
+++ b/src/components/onboarding/OnboardingDialog.tsx
@@ -2,7 +2,8 @@
  * Onboarding Dialog for CLI Setup
  *
  * Multi-step wizard that handles installation and authentication of at least
- * one supported AI backend CLI plus mandatory GitHub CLI.
+ * one supported AI backend CLI. GitHub CLI is optional (recommended for GitHub
+ * features; skippable for GitLab/Bitbucket users).
  */
 
 /* eslint-disable no-console */
@@ -71,6 +72,11 @@ import {
   useGhCliAuth,
   useGhPathDetection,
 } from '@/services/gh-cli'
+import {
+  useGlabCliSetup,
+  useGlabCliAuth,
+  useGlabPathDetection,
+} from '@/services/glab-cli'
 import {
   SetupState,
   InstallingState,
@@ -188,6 +194,10 @@ type OnboardingStep =
   | 'gh-installing'
   | 'gh-auth-checking'
   | 'gh-auth-login'
+  | 'glab-setup'
+  | 'glab-installing'
+  | 'glab-auth-checking'
+  | 'glab-auth-login'
   | 'complete'
 
 /**
@@ -221,6 +231,8 @@ const BACK_NAVIGABLE_STEPS: readonly OnboardingStep[] = [
   'antigravity-auth-login',
   'gh-setup',
   'gh-auth-login',
+  'glab-setup',
+  'glab-auth-login',
 ] as const
 
 interface VersionOption {
@@ -389,6 +401,8 @@ function OnboardingDialogContent() {
   const antigravitySetup = useAntigravityCliSetup()
   const ghPathDetection = useGhPathDetection()
   const ghSetup = useGhCliSetup()
+  const glabPathDetection = useGlabPathDetection()
+  const glabSetup = useGlabCliSetup()
 
   const claudeAuth = useClaudeCliAuth({
     enabled: !!claudeSetup.status?.installed,
@@ -410,6 +424,7 @@ function OnboardingDialogContent() {
     enabled: !!antigravitySetup.status?.installed,
   })
   const ghAuth = useGhCliAuth({ enabled: !!ghSetup.status?.installed })
+  const glabAuth = useGlabCliAuth({ enabled: !!glabSetup.status?.installed })
 
   const [step, _setStepRaw] = useState<OnboardingStep>('backend-select')
   const stepRef = useRef<OnboardingStep>('backend-select')
@@ -464,6 +479,8 @@ function OnboardingDialogContent() {
   const [antigravityInstallFailed, setAntigravityInstallFailed] =
     useState(false)
   const [ghInstallFailed, setGhInstallFailed] = useState(false)
+  const [glabPathSelected, setGlabPathSelected] = useState(false)
+  const [glabUsePath, setGlabUsePath] = useState(false)
   const [claudePathSelected, setClaudePathSelected] = useState(false)
   const [codexPathSelected, setCodexPathSelected] = useState(false)
   const [opencodePathSelected, setOpencodePathSelected] = useState(false)
@@ -484,6 +501,7 @@ function OnboardingDialogContent() {
   const [kimiLoginAttempt, setKimiLoginAttempt] = useState(0)
   const [antigravityLoginAttempt, setAntigravityLoginAttempt] = useState(0)
   const [ghLoginAttempt, setGhLoginAttempt] = useState(0)
+  const [glabLoginAttempt, setGlabLoginAttempt] = useState(0)
 
   const goBack = useCallback(() => {
     const current = stepRef.current
@@ -629,6 +647,7 @@ function OnboardingDialogContent() {
   const kimiLoginTerminalId = `onboarding-kimi-login-${loginSessionSeed}-${kimiLoginAttempt}`
   const antigravityLoginTerminalId = `onboarding-antigravity-login-${loginSessionSeed}-${antigravityLoginAttempt}`
   const ghLoginTerminalId = `onboarding-gh-login-${loginSessionSeed}-${ghLoginAttempt}`
+  const glabLoginTerminalId = `onboarding-glab-login-${loginSessionSeed}-${glabLoginAttempt}`
 
   const stableClaudeVersions = claudeSetup.versions.filter(v => !v.prerelease)
   const stableCodexVersions = codexSetup.versions.filter(v => !v.prerelease)
@@ -1010,15 +1029,16 @@ function OnboardingDialogContent() {
       return
     }
 
-    // Already on a remote: skip usage mode and continue CLI setup there.
+// Already on a remote: skip usage mode and continue CLI setup there.
     // WSL mode only applies to local Windows development.
+    // At least one AI backend is enough; GitHub CLI is optional.
     if (remoteActive) {
-      if (ghReady && readyBackends.length > 0) {
-        // Auto-opened with tools already ready (e.g. reconnecting to a remote
+      if (readyBackends.length > 0) {
+        // Auto-opened with AI already ready (e.g. reconnecting to a remote
         // that was set up earlier). Don't force the "Setup Complete" screen —
         // that was reappearing on every remote session open.
         if (!onboardingManuallyTriggered) {
-          dbg('init effect: remote all ready → auto-dismiss')
+          dbg('init effect: remote AI ready → auto-dismiss')
           useUIStore.setState({
             onboardingOpen: false,
             onboardingStartStep: null,
@@ -1026,12 +1046,13 @@ function OnboardingDialogContent() {
           })
           return
         }
-        dbg('init effect: remote all ready → complete')
-        queueMicrotask(() => setStep('complete', { replace: true }))
-        return
-      }
-      if (readyBackends.length > 0) {
-        dbg('init effect: remote + some backends ready → after backends')
+        if (ghReady) {
+          dbg('init effect: remote AI + optional gh ready → complete')
+          queueMicrotask(() => setStep('complete', { replace: true }))
+          return
+        }
+        // Manual re-open with AI ready: offer optional forge CLI setup.
+        dbg('init effect: remote + AI ready → after backends')
         queueMicrotask(() => {
           setSelectedBackends(readyBackends)
           setStep(getNextStepAfterBackends(), { replace: true })
@@ -1046,10 +1067,10 @@ function OnboardingDialogContent() {
     const needsWslChoice =
       isServerWindows() && !!preferences && !preferences.wsl_mode_chosen
 
-    // Local tools already ready and environment chosen → finish.
-    if (ghReady && readyBackends.length > 0 && !needsWslChoice) {
+    // Local: AI ready and environment chosen → finish (gh is optional).
+    if (readyBackends.length > 0 && !needsWslChoice) {
       if (!onboardingManuallyTriggered) {
-        dbg('init effect: all ready → auto-dismiss')
+        dbg('init effect: AI ready → auto-dismiss')
         useUIStore.setState({
           onboardingOpen: false,
           onboardingStartStep: null,
@@ -1057,14 +1078,13 @@ function OnboardingDialogContent() {
         })
         return
       }
-      dbg('init effect: all ready → complete')
-      queueMicrotask(() => setStep('complete', { replace: true }))
-      return
-    }
-
-    // Partial local progress (and WSL already chosen): resume CLI setup.
-    if (readyBackends.length > 0 && !needsWslChoice) {
-      dbg('init effect: some backends ready → skip to after backends')
+      if (ghReady) {
+        dbg('init effect: AI + optional gh ready → complete')
+        queueMicrotask(() => setStep('complete', { replace: true }))
+        return
+      }
+      // Offer optional GitHub CLI setup once an AI backend is ready.
+      dbg('init effect: AI ready → optional gh-setup')
       queueMicrotask(() => {
         setSelectedBackends(readyBackends)
         setStep(getNextStepAfterBackends(), { replace: true })
@@ -1311,8 +1331,8 @@ function OnboardingDialogContent() {
     if (ghAuth.isLoading || ghAuth.isFetching) return
 
     if (ghAuth.data?.authenticated) {
-      dbg('gh auth OK → complete')
-      queueMicrotask(() => setStep('complete'))
+      dbg('gh auth OK → optional glab-setup')
+      queueMicrotask(() => setStep('glab-setup'))
     } else {
       dbg('gh auth NOT OK → gh-auth-login')
       queueMicrotask(() => setStep('gh-auth-login'))
@@ -1326,6 +1346,22 @@ function OnboardingDialogContent() {
     ghAuth.fetchStatus,
     ghAuth.error,
     ghSetup.status?.installed,
+    setStep,
+  ])
+
+  useEffect(() => {
+    if (step !== 'glab-auth-checking') return
+    if (glabAuth.isLoading || glabAuth.isFetching) return
+    if (glabAuth.data?.authenticated) {
+      queueMicrotask(() => setStep('complete'))
+    } else {
+      queueMicrotask(() => setStep('glab-auth-login'))
+    }
+  }, [
+    step,
+    glabAuth.isLoading,
+    glabAuth.isFetching,
+    glabAuth.data?.authenticated,
     setStep,
   ])
 
@@ -2045,6 +2081,11 @@ function OnboardingDialogContent() {
     dbg('handleGhLoginComplete: refetch result =', result.data)
   }, [ghAuth, setStep])
 
+  const handleGlabLoginComplete = useCallback(async () => {
+    setStep('glab-auth-checking')
+    await glabAuth.refetch()
+  }, [glabAuth, setStep])
+
   const handleClaudeLoginRetry = useCallback(() => {
     setClaudeLoginAttempt(prev => prev + 1)
   }, [])
@@ -2085,6 +2126,22 @@ function OnboardingDialogContent() {
     setGhLoginAttempt(prev => prev + 1)
   }, [])
 
+  const handleGlabLoginRetry = useCallback(() => {
+    setGlabLoginAttempt(prev => prev + 1)
+  }, [])
+
+  /** Skip optional GitHub CLI setup; offer GitLab CLI next. */
+  const handleGhSkip = useCallback(() => {
+    dbg('handleGhSkip: skipping optional GitHub CLI → glab-setup')
+    setStep('glab-setup')
+  }, [setStep])
+
+  /** Skip optional GitLab CLI setup and finish onboarding. */
+  const handleGlabSkip = useCallback(() => {
+    dbg('handleGlabSkip: skipping optional GitLab CLI → complete')
+    setStep('complete')
+  }, [setStep])
+
   const handleComplete = useCallback(async () => {
     claudeSetup.refetchStatus()
     codexSetup.refetchStatus()
@@ -2096,6 +2153,7 @@ function OnboardingDialogContent() {
     kimiSetup.refetchStatus()
     antigravitySetup.refetchStatus()
     ghSetup.refetchStatus()
+    glabSetup.refetchStatus()
     // Set the first selected backend as the default so the preference
     // isn't left pointing at an uninstalled backend (e.g. 'claude').
     const authenticatedBackends: Partial<Record<AIBackend, boolean>> = {
@@ -2144,6 +2202,7 @@ function OnboardingDialogContent() {
     kimiSetup,
     antigravitySetup,
     ghSetup,
+    glabSetup,
     claudeAuth.data?.authenticated,
     codexAuth.data?.authenticated,
     opencodeAuth.data?.authenticated,
@@ -2320,7 +2379,8 @@ function OnboardingDialogContent() {
       return {
         type: 'gh',
         title: 'GitHub CLI',
-        description: 'GitHub CLI is required for GitHub integration.',
+        description:
+          'Optional — enables GitHub issues, PRs, and dashboard features. Skip if you use GitLab or another host.',
         versions: stableGhVersions,
         isVersionsLoading: ghSetup.isVersionsLoading,
         isVersionsError: ghSetup.isVersionsError,
@@ -2404,7 +2464,12 @@ function OnboardingDialogContent() {
     ghPathSelected && ghPathDetection.data?.path
       ? ghPathDetection.data.path
       : (ghSetup.status?.path ?? '')
-  const ghLoginArgs = AUTH_LOGIN_ARGS
+const ghLoginArgs = AUTH_LOGIN_ARGS
+  const glabLoginCommand =
+    glabUsePath && glabPathDetection.data?.path
+      ? glabPathDetection.data.path
+      : (glabSetup.status?.path ?? '')
+  const glabLoginArgs = AUTH_LOGIN_ARGS
 
   dbg('login commands:', {
     claude: {
@@ -2531,7 +2596,7 @@ function OnboardingDialogContent() {
           : 'Welcome to Jean',
         description: onboardingManuallyTriggered
           ? 'Select additional AI backends to install.'
-          : 'Select at least one AI backend to install. GitHub CLI setup is required next.',
+          : 'Select at least one AI backend to install. GitHub CLI is optional next.',
       }
     }
 
@@ -2539,26 +2604,42 @@ function OnboardingDialogContent() {
       return {
         title: 'Setup Complete',
         description:
-          'All required tools have been installed and authenticated.',
+          'Required tools have been installed and authenticated. You can add GitHub CLI later from Settings.',
       }
     }
 
     if (dialogStep === 'gh-setup' || dialogStep === 'gh-installing') {
       const hasPathCli = ghPathDetection.data?.found
       return {
-        title: isGhReinstall ? 'Change GitHub CLI Version' : 'Setup GitHub CLI',
+        title: isGhReinstall
+          ? 'Change GitHub CLI Version'
+          : 'Setup GitHub CLI (optional)',
         description: isGhReinstall
           ? 'Select a version to install. This will replace the current installation.'
           : hasPathCli
-            ? 'Choose to use your system GitHub CLI or install with Jean.'
-            : 'GitHub CLI is required for GitHub integration.',
+            ? 'Choose to use your system GitHub CLI or install with Jean. You can skip if you do not use GitHub.'
+            : 'Optional — enables GitHub issues, PRs, and dashboard features. Skip if you use GitLab or another host.',
       }
     }
 
     if (dialogStep === 'gh-auth-checking' || dialogStep === 'gh-auth-login') {
       return {
         title: 'Authenticate GitHub CLI',
-        description: 'GitHub CLI authentication is required to continue.',
+        description:
+          'Sign in to GitHub for issue/PR features, or skip if you do not use GitHub.',
+      }
+    }
+
+    if (
+      dialogStep === 'glab-setup' ||
+      dialogStep === 'glab-installing' ||
+      dialogStep === 'glab-auth-checking' ||
+      dialogStep === 'glab-auth-login'
+    ) {
+      return {
+        title: 'Setup GitLab CLI (optional)',
+        description:
+          'Optional — enables GitLab issues and merge requests via glab. Skip if you only use GitHub or plain git.',
       }
     }
 
@@ -2742,7 +2823,7 @@ function OnboardingDialogContent() {
       step.startsWith('grok-') ||
       step.startsWith('kimi-') ||
       step.startsWith('antigravity-')
-    const isGhStep = step.startsWith('gh-')
+    const isGhStep = step.startsWith('gh-') || step.startsWith('glab-')
 
     const backendComplete = !isBackendSelection && !isBackendStep
     const ghComplete = step === 'complete'
@@ -2772,7 +2853,7 @@ function OnboardingDialogContent() {
           }`}
         >
           <span className="font-medium">2</span>
-          <span>GitHub CLI</span>
+          <span>GitHub / GitLab CLI (optional)</span>
         </div>
         <div className="w-4 h-px bg-border" />
         <div
@@ -3237,7 +3318,83 @@ function OnboardingDialogContent() {
                 jeanInstalled={!!ghSetup.status?.installed}
                 onSelectPath={handleGhPathSelect}
                 onSelectJean={handleGhJeanSelect}
+                onSkip={handleGhSkip}
               />
+            ) : step === 'glab-setup' && !glabPathSelected ? (
+              <CliPathSelector
+                cliName="GitLab CLI"
+                pathFound={!!glabPathDetection.data?.found}
+                pathVersion={glabPathDetection.data?.version ?? null}
+                pathPath={glabPathDetection.data?.path ?? null}
+                isLoading={glabPathSelected}
+                currentSource={preferences?.glab_cli_source ?? null}
+                jeanInstalled={!!glabSetup.status?.installed}
+                onSelectPath={() => {
+                  setGlabPathSelected(true)
+                  setGlabUsePath(true)
+                  patchPreferences.mutate(
+                    { glab_cli_source: 'path' },
+                    {
+                      onSuccess: () => {
+                        setStep('glab-auth-checking')
+                        glabAuth.refetch()
+                      },
+                    }
+                  )
+                }}
+                onSelectJean={() => {
+                  setGlabPathSelected(true)
+                  setGlabUsePath(false)
+                  patchPreferences.mutate(
+                    { glab_cli_source: 'jean' },
+                    {
+                      onSuccess: () => {
+                        if (glabSetup.status?.installed) {
+                          setStep('glab-auth-checking')
+                          glabAuth.refetch()
+                          return
+                        }
+                        const version =
+                          glabSetup.versions?.[0]?.version ?? undefined
+                        setStep('glab-installing')
+                        glabSetup.install(version, {
+                          onSuccess: () => {
+                            setStep('glab-auth-checking')
+                            glabAuth.refetch()
+                          },
+                          onError: () => {
+                            setGlabPathSelected(false)
+                            setStep('glab-setup')
+                          },
+                        })
+                      },
+                    }
+                  )
+                }}
+                onSkip={handleGlabSkip}
+              />
+            ) : step === 'glab-installing' ? (
+              <InstallingState
+                cliName="GitLab CLI"
+                progress={glabSetup.progress}
+              />
+            ) : step === 'glab-auth-checking' ? (
+              <AuthCheckingState cliName="GitLab CLI" />
+            ) : step === 'glab-auth-login' ? (
+              glabLoginCommand ? (
+                <AuthLoginState
+                  key={glabLoginTerminalId}
+                  cliName="GitLab CLI"
+                  terminalId={glabLoginTerminalId}
+                  command={glabLoginCommand}
+                  commandArgs={glabLoginArgs}
+                  onComplete={handleGlabLoginComplete}
+                  onRetry={handleGlabLoginRetry}
+                  onSkip={handleGlabSkip}
+                />
+              ) : (
+                <AuthCheckingState cliName="GitLab CLI" />
+              )
             ) : step === 'gh-auth-login' ? (
               ghLoginCommand ? (
                 <AuthLoginState
@@ -3248,6 +3405,7 @@ function OnboardingDialogContent() {
                   commandArgs={ghLoginArgs}
                   onComplete={handleGhLoginComplete}
                   onRetry={handleGhLoginRetry}
+                  onSkip={handleGhSkip}
                 />
               ) : (
                 <AuthCheckingState cliName="GitHub CLI" />
@@ -3276,6 +3434,7 @@ function OnboardingDialogContent() {
                                     ? handleAntigravityInstall
                                     : handleGhInstall
                   }
+                  onSkip={cliData.type === 'gh' ? handleGhSkip : undefined}
                 />
               ) : (
                 <SetupState
@@ -3356,6 +3515,7 @@ function OnboardingDialogContent() {
                                     ? handleAntigravityInstall
                                     : handleGhInstall
                   }
+                  onSkip={cliData.type === 'gh' ? handleGhSkip : undefined}
                 />
               )
             ) : (
@@ -3616,7 +3776,7 @@ function SuccessState({
   return (
     <div className="space-y-6">
       <div className="text-center">
-        <p className="font-medium">All Tools Ready</p>
+        <p className="font-medium">You&apos;re Ready</p>
         <div className="text-sm text-muted-foreground mt-2 space-y-1">
           {claudeVersion && <p>Claude CLI: v{claudeVersion}</p>}
           {codexVersion && <p>Codex CLI: v{codexVersion}</p>}

--- a/src/lib/startup-onboarding.test.ts
+++ b/src/lib/startup-onboarding.test.ts
@@ -22,7 +22,7 @@ describe('getStartupOnboardingAction', () => {
     ).toBe('wait')
   })
 
-  it('closes startup onboarding when required tools are already ready', () => {
+  it('closes startup onboarding when an AI backend is ready', () => {
     expect(
       getStartupOnboardingAction({
         aiStatuses: [missingStatus, readyStatus, missingStatus],
@@ -52,7 +52,7 @@ describe('getStartupOnboardingAction', () => {
     ).toBe('ready')
   })
 
-  it('treats Grok (or any later backend) as a valid ready AI backend', () => {
+it('treats Grok (or any later backend) as a valid ready AI backend', () => {
     // Regression: startup used to only count Claude/Codex/OpenCode, so remotes
     // with only Grok ready reopened the "Setup Complete" dialog every launch.
     expect(
@@ -87,6 +87,34 @@ describe('getStartupOnboardingAction', () => {
     ).toBe('ready')
   })
 
+  it('treats GitHub CLI as optional when an AI backend is ready', () => {
+    expect(
+      getStartupOnboardingAction({
+        aiStatuses: [readyStatus, missingStatus, missingStatus],
+        aiAuth: [authenticated, undefined, undefined],
+        ghStatus: missingStatus,
+        ghAuth: undefined,
+        onboardingOpen: false,
+        onboardingDismissed: false,
+        onboardingManuallyTriggered: false,
+        requiresWslChoice: false,
+      })
+    ).toBe('ready')
+
+    expect(
+      getStartupOnboardingAction({
+        aiStatuses: [readyStatus, missingStatus, missingStatus],
+        aiAuth: [authenticated, undefined, undefined],
+        ghStatus: missingStatus,
+        ghAuth: undefined,
+        onboardingOpen: true,
+        onboardingDismissed: false,
+        onboardingManuallyTriggered: false,
+        requiresWslChoice: false,
+      })
+    ).toBe('close')
+  })
+
   it('does not open for WSL when tools are already ready', () => {
     expect(
       getStartupOnboardingAction({
@@ -117,7 +145,7 @@ describe('getStartupOnboardingAction', () => {
     ).toBe('none')
   })
 
-  it('opens onboarding when setup is definitively incomplete', () => {
+  it('opens onboarding when no AI backend is ready', () => {
     expect(
       getStartupOnboardingAction({
         aiStatuses: [missingStatus, missingStatus, missingStatus],

--- a/src/lib/startup-onboarding.ts
+++ b/src/lib/startup-onboarding.ts
@@ -63,15 +63,15 @@ export function getStartupOnboardingAction({
   if (aiAuthPending || ghAuthPending) return 'wait'
 
   // Any authenticated AI backend counts (Claude, Codex, Grok, Pi, …).
+  // GitHub CLI is optional (GitLab/Bitbucket users should not be blocked).
   const hasAiBackendReady = aiStatuses.some((status, index) =>
     isReady(status, aiAuth[index])
   )
-  const ghReady = isReady(ghStatus, ghAuth)
 
   // Tools already good: never force the setup wizard (including the "Setup
   // Complete" success screen). WSL choice can wait until the user actually
   // needs local CLI installs.
-  if (ghReady && hasAiBackendReady) {
+  if (hasAiBackendReady) {
     return onboardingOpen ? 'close' : 'ready'
   }
 

--- a/src/services/glab-cli.ts
+++ b/src/services/glab-cli.ts
@@ -1,0 +1,198 @@
+/**
+ * GitLab CLI (`glab`) management service
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { invoke, useWsConnectionStatus } from '@/lib/transport'
+import { listen } from '@/lib/transport'
+import { toast } from 'sonner'
+import { useCallback, useEffect, useState } from 'react'
+import { logger } from '@/lib/logger'
+import type {
+  GlabCliStatus,
+  GlabAuthStatus,
+  GlabReleaseInfo,
+  GlabInstallProgress,
+  ForgeKind,
+} from '@/types/glab-cli'
+import { hasBackendTransport } from '@/lib/environment'
+
+const isTauri = hasBackendTransport
+
+export const glabCliQueryKeys = {
+  all: ['glab-cli'] as const,
+  status: () => [...glabCliQueryKeys.all, 'status'] as const,
+  auth: () => [...glabCliQueryKeys.all, 'auth'] as const,
+  versions: () => [...glabCliQueryKeys.all, 'versions'] as const,
+  forge: (path: string) => [...glabCliQueryKeys.all, 'forge', path] as const,
+}
+
+export function useGlabPathDetection(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: [...glabCliQueryKeys.all, 'path-detection'],
+    queryFn: async () => {
+      if (!isTauri()) {
+        return { found: false, path: null, version: null, package_manager: null }
+      }
+      try {
+        return await invoke<{
+          found: boolean
+          path: string | null
+          version: string | null
+          package_manager: string | null
+        }>('detect_glab_in_path')
+      } catch {
+        return { found: false, path: null, version: null, package_manager: null }
+      }
+    },
+    enabled: options?.enabled ?? true,
+    staleTime: 1000 * 60 * 30,
+  })
+}
+
+export function useGlabCliStatus(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: glabCliQueryKeys.status(),
+    queryFn: async (): Promise<GlabCliStatus> => {
+      if (!isTauri()) {
+        return { installed: false, version: null, path: null }
+      }
+      try {
+        return await invoke<GlabCliStatus>('check_glab_cli_installed')
+      } catch (error) {
+        logger.error('Failed to check GitLab CLI status', { error })
+        return { installed: false, version: null, path: null }
+      }
+    },
+    enabled: options?.enabled ?? true,
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useGlabCliAuth(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: glabCliQueryKeys.auth(),
+    queryFn: async (): Promise<GlabAuthStatus> => {
+      if (!isTauri()) {
+        return { authenticated: false, error: 'Not in Tauri context' }
+      }
+      try {
+        return await invoke<GlabAuthStatus>('check_glab_cli_auth')
+      } catch (error) {
+        return {
+          authenticated: false,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      }
+    },
+    enabled: options?.enabled ?? true,
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useAvailableGlabVersions(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: glabCliQueryKeys.versions(),
+    queryFn: async (): Promise<GlabReleaseInfo[]> => {
+      if (!isTauri()) return []
+      return invoke<GlabReleaseInfo[]>('get_available_glab_versions')
+    },
+    enabled: options?.enabled ?? true,
+    staleTime: 1000 * 60 * 30,
+  })
+}
+
+export function useProjectForge(
+  projectPath: string | null | undefined,
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: glabCliQueryKeys.forge(projectPath ?? ''),
+    queryFn: async (): Promise<ForgeKind> => {
+      if (!isTauri() || !projectPath) return 'unknown'
+      try {
+        return await invoke<ForgeKind>('detect_project_forge', {
+          projectPath,
+        })
+      } catch {
+        return 'unknown'
+      }
+    },
+    enabled: (options?.enabled ?? true) && !!projectPath,
+    staleTime: 1000 * 60 * 10,
+  })
+}
+
+export function useGlabCliSetup() {
+  const queryClient = useQueryClient()
+  const [progress, setProgress] = useState<GlabInstallProgress | null>(null)
+  const { data: status, isLoading: isStatusLoading, refetch: refetchStatus } =
+    useGlabCliStatus()
+  const {
+    data: versions = [],
+    isLoading: isVersionsLoading,
+    isError: isVersionsError,
+    refetch: refetchVersions,
+  } = useAvailableGlabVersions()
+
+  useEffect(() => {
+    if (!isTauri()) return
+    let unlisten: (() => void) | undefined
+    listen<GlabInstallProgress>('glab-cli:install-progress', event => {
+      setProgress(event.payload)
+    }).then(fn => {
+      unlisten = fn
+    })
+    return () => {
+      unlisten?.()
+    }
+  }, [])
+
+  const installMutation = useMutation({
+    mutationFn: async (version?: string) => {
+      setProgress({ stage: 'starting', message: 'Starting…', percent: 0 })
+      await invoke('install_glab_cli', { version: version ?? null })
+    },
+    onSuccess: async () => {
+      toast.success('GitLab CLI installed')
+      await queryClient.invalidateQueries({ queryKey: glabCliQueryKeys.all })
+      setProgress(null)
+    },
+    onError: (error: unknown) => {
+      toast.error(
+        `GitLab CLI install failed: ${error instanceof Error ? error.message : String(error)}`
+      )
+      setProgress(null)
+    },
+  })
+
+  const install = useCallback(
+    (
+      version?: string,
+      options?: { onSuccess?: () => void; onError?: (e: unknown) => void }
+    ) => {
+      installMutation.mutate(version, {
+        onSuccess: () => options?.onSuccess?.(),
+        onError: e => options?.onError?.(e),
+      })
+    },
+    [installMutation]
+  )
+
+  return {
+    status,
+    isStatusLoading,
+    versions,
+    isVersionsLoading,
+    isVersionsError,
+    refetchVersions,
+    isInstalling: installMutation.isPending,
+    installError: installMutation.error,
+    progress,
+    install,
+    refetchStatus,
+  }
+}
+
+// Keep connection type imported for parity with other CLI services
+void useWsConnectionStatus

--- a/src/types/glab-cli.ts
+++ b/src/types/glab-cli.ts
@@ -1,0 +1,38 @@
+/**
+ * Types for GitLab CLI (`glab`) integration
+ */
+
+export interface GlabCliStatus {
+  installed: boolean
+  version: string | null
+  path: string | null
+}
+
+export interface GlabAuthStatus {
+  authenticated: boolean
+  error: string | null
+}
+
+export interface GlabReleaseInfo {
+  version: string
+  tagName: string
+  publishedAt: string
+  prerelease: boolean
+  /** snake_case aliases from Rust */
+  tag_name?: string
+  published_at?: string
+}
+
+export interface GlabInstallProgress {
+  stage:
+    | 'starting'
+    | 'downloading'
+    | 'extracting'
+    | 'installing'
+    | 'verifying'
+    | 'complete'
+  message: string
+  percent: number
+}
+
+export type ForgeKind = 'github' | 'gitlab' | 'unknown'

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1309,6 +1309,7 @@ export interface AppPreferences {
   kimi_cli_source?: 'jean' | 'path' // Kimi Code CLI source: 'jean' (managed) or 'path' (system PATH)
   antigravity_cli_source?: 'jean' | 'path' // Antigravity CLI source: 'jean' (managed) or 'path' (system PATH)
   gh_cli_source: 'jean' | 'path' // GitHub CLI source: 'jean' (managed) or 'path' (system PATH)
+  glab_cli_source?: 'jean' | 'path' // GitLab CLI source: 'jean' (managed) or 'path' (system PATH)
   pi_cli_source: 'jean' | 'path' // PI CLI source: 'jean' (managed) or 'path' (system PATH)
   commandcode_cli_source?: 'jean' | 'path' // Command Code CLI source: 'jean' (managed) or 'path' (system PATH)
   wsl_mode_chosen: boolean // Whether WSL mode selection has been made (prevents re-asking on Windows)
@@ -2432,6 +2433,7 @@ export const defaultPreferences: AppPreferences = {
   kimi_cli_source: 'jean', // Default: Jean-managed
   antigravity_cli_source: 'jean', // Default: Jean-managed
   gh_cli_source: 'jean', // Default: Jean-managed
+  glab_cli_source: 'jean', // Default: Jean-managed
   pi_cli_source: 'jean', // Default: Jean-managed
   commandcode_cli_source: 'jean', // Default: Jean-managed
   wsl_mode_chosen: false, // Default: not yet chosen


### PR DESCRIPTION
## Summary

- Add GitLab CLI (`glab`) install, auth, and managed/PATH source support alongside GitHub CLI
- Detect project forge (GitHub/GitLab/unknown) so forge-aware workflows can use the right CLI
- Make GitHub CLI optional: only pre-approve and path-hint `gh` when it is installed; otherwise instruct agents not to discover or use it
- Wire glab preferences, Tauri/web-access commands, and e2e fixtures for the new multi-forge CLI path

## Breaking Changes

None.