### PR TITLE
feat(preferences): add AI server warming control

### DIFF
--- a/jean-core/src/chat/codex_server.rs
+++ b/jean-core/src/chat/codex_server.rs
@@ -1000,6 +1000,15 @@ pub fn unregister_session(thread_id: &str) {
 
     let prev = USAGE_COUNT.fetch_sub(1, Ordering::SeqCst);
     if prev == 1 {
+        let keep_warm = APP_HANDLE
+            .get()
+            .and_then(|app| crate::load_preferences_sync(app).ok())
+            .map(|preferences| preferences.keep_ai_servers_warm)
+            .unwrap_or(true);
+        if !keep_warm {
+            shutdown_idle_server();
+            return;
+        }
         // Last session finished — schedule delayed shutdown (10min grace period
         // to keep server warm for typical work sessions).
         // Capture generation so we don't kill a newly-spawned server.
@@ -1013,6 +1022,16 @@ pub fn unregister_session(thread_id: &str) {
                 shutdown_server();
             }
         });
+    }
+}
+
+/// Shut down an idle server even if the just-finished run has not yet been
+/// removed from the incomplete-run manifest.
+fn shutdown_idle_server() {
+    let mut guard = CODEX_SERVER.lock().unwrap();
+    if let Some(server) = guard.take() {
+        log::info!("AI server warming disabled — shutting down codex app-server");
+        kill_server(server);
     }
 }
 

--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -216,6 +216,8 @@ pub struct AppPreferences {
     pub compact_chat_view_enabled: bool, // Collapse intermediate tool calls into single ticker line
     #[serde(default = "default_auto_recaps_enabled")]
     pub auto_recaps_enabled: bool, // Ask agents to end multi-step turns with a recap block
+    #[serde(default = "default_keep_ai_servers_warm")]
+    pub keep_ai_servers_warm: bool, // Keep Codex/OpenCode servers alive briefly after a request
     #[serde(default)]
     pub magic_prompts: MagicPrompts, // Customizable prompts for AI-powered features
     #[serde(default)]
@@ -667,6 +669,10 @@ fn default_compact_chat_view_enabled() -> bool {
 
 fn default_auto_recaps_enabled() -> bool {
     true // Enabled by default
+}
+
+fn default_keep_ai_servers_warm() -> bool {
+    true // Enabled by default to make follow-up requests start faster
 }
 
 fn default_chrome_enabled() -> bool {
@@ -2561,6 +2567,7 @@ impl Default for AppPreferences {
             parallel_execution_prompt_enabled: default_parallel_execution_prompt_enabled(),
             compact_chat_view_enabled: default_compact_chat_view_enabled(),
             auto_recaps_enabled: default_auto_recaps_enabled(),
+            keep_ai_servers_warm: default_keep_ai_servers_warm(),
             magic_prompts: MagicPrompts::default(),
             magic_prompt_models: MagicPromptModels::default(),
             magic_code_review_configs: Vec::new(),

--- a/jean-core/src/opencode_server/mod.rs
+++ b/jean-core/src/opencode_server/mod.rs
@@ -411,6 +411,17 @@ pub fn acquire(app: &AppHandle) -> Result<String, String> {
 pub fn release() {
     let prev = USAGE_COUNT.fetch_sub(1, Ordering::SeqCst);
     if prev == 1 {
+        let keep_warm = APP_HANDLE
+            .get()
+            .and_then(|app| crate::load_preferences_sync(app).ok())
+            .map(|preferences| preferences.keep_ai_servers_warm)
+            .unwrap_or(true);
+        if !keep_warm {
+            if let Err(e) = stop_managed_server_inner() {
+                log::warn!("Failed to stop managed OpenCode server on last release: {e}");
+            }
+            return;
+        }
         // Schedule delayed shutdown — if no one re-acquires within 10min, stop the server.
         std::thread::spawn(|| {
             std::thread::sleep(Duration::from_secs(600));

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -3914,6 +3914,18 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
             </InlineField>
 
             <InlineField
+              label="Keep AI servers warm"
+              description="Keep Codex and OpenCode running for 10 minutes after a request so follow-up prompts start faster"
+            >
+              <Switch
+                checked={preferences?.keep_ai_servers_warm ?? true}
+                onCheckedChange={checked => {
+                  patchPreferences.mutate({ keep_ai_servers_warm: checked })
+                }}
+              />
+            </InlineField>
+
+            <InlineField
               label="Parallel execution prompting"
               description="Add system prompt encouraging sub-agent parallelization for faster task execution"
             >

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1209,6 +1209,7 @@ export interface AppPreferences {
   parallel_execution_prompt_enabled: boolean // Add system prompt to encourage parallel sub-agent execution
   compact_chat_view_enabled: boolean // Collapse intermediate tool calls/replies into a single ticker line, only showing the latest activity
   auto_recaps_enabled?: boolean // Ask agents to end multi-step/tool turns with a recap
+  keep_ai_servers_warm?: boolean // Keep Codex/OpenCode servers alive briefly between requests
   magic_prompts: MagicPrompts // Customizable prompts for AI-powered features
   magic_prompt_models: MagicPromptModels // Per-prompt model overrides
   magic_code_review_configs?: MagicCodeReviewConfig[] // Up to five backend/model/reasoning review runners
@@ -1880,7 +1881,9 @@ export function isKimiModel(model: string): model is KimiModel {
   return model.startsWith('kimi/')
 }
 /** Check if a model string identifies a Antigravity CLI model */
-export function isAntigravityCliModel(model: string): model is AntigravityModel {
+export function isAntigravityCliModel(
+  model: string
+): model is AntigravityModel {
   return model.startsWith('antigravity/')
 }
 
@@ -2342,6 +2345,7 @@ export const defaultPreferences: AppPreferences = {
   parallel_execution_prompt_enabled: true, // Default: enabled
   compact_chat_view_enabled: true, // Default: enabled
   auto_recaps_enabled: true, // Default: enabled
+  keep_ai_servers_warm: true, // Default: enabled for faster follow-up requests
   magic_prompts: DEFAULT_MAGIC_PROMPTS,
   magic_prompt_models: DEFAULT_MAGIC_PROMPT_MODELS,
   magic_code_review_configs: [],


### PR DESCRIPTION
## Summary

- add a preference to keep Codex and OpenCode servers warm for faster follow-up requests
- allow users to disable warming so idle AI servers stop immediately and release resources
- preserve the existing 10-minute warm period by default for backward-compatible behavior

---

Fixes #662