### PR TITLE
fix(codex): discover symlinked skills and reload MCP

### DIFF
--- a/jean-core/src/chat/codex.rs
+++ b/jean-core/src/chat/codex.rs
@@ -1009,6 +1009,12 @@ pub fn build_turn_steer_params_with_input(
 // Execution via app-server
 // =============================================================================
 
+fn reload_mcp_servers_before_thread_start(
+    send_request: impl FnOnce(&str, serde_json::Value) -> Result<serde_json::Value, String>,
+) -> Result<(), String> {
+    send_request("config/mcpServer/reload", serde_json::Value::Null).map(|_| ())
+}
+
 /// Execute a Codex chat message via the persistent app-server.
 ///
 /// Handles thread creation/resume, turn execution, event mapping, and approvals.
@@ -1052,6 +1058,13 @@ pub fn execute_codex_via_server(
 
     // Ensure the app-server is running
     codex_server::ensure_running(app)?;
+    // The app-server outlives individual Jean sessions, so its MCP registry may
+    // predate changes to ~/.codex/config.toml. Refresh it before starting or
+    // resuming a thread so configured servers match a fresh Codex CLI process.
+    if let Err(error) = reload_mcp_servers_before_thread_start(codex_server::send_request) {
+        codex_server::decrement_usage_count();
+        return Err(format!("Failed to reload Codex MCP servers: {error}"));
+    }
 
     // Start or resume thread
     // Wrapped in a closure so we can decrement USAGE_COUNT on failure
@@ -5283,6 +5296,25 @@ fn build_one_shot_codex_args(
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reloads_mcp_servers_with_app_server_protocol_before_thread_start() {
+        let result = reload_mcp_servers_before_thread_start(|method, params| {
+            assert_eq!(method, "config/mcpServer/reload");
+            assert_eq!(params, serde_json::Value::Null);
+            Ok(serde_json::json!({}))
+        });
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn fails_thread_start_when_mcp_reload_fails() {
+        let error = reload_mcp_servers_before_thread_start(|_, _| Err("reload failed".into()))
+            .expect_err("reload failure must block thread start");
+
+        assert_eq!(error, "reload failed");
+    }
 
     #[cfg(unix)]
     #[test]

--- a/jean-core/src/codex_cli/mcp.rs
+++ b/jean-core/src/codex_cli/mcp.rs
@@ -138,3 +138,28 @@ fn entry_to_json_map(entry: &CodexMcpServerEntry) -> serde_json::Map<String, ser
 
     map
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovers_enabled_oauth_http_server_without_explicit_enabled_flag() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let config = temp.path().join("config.toml");
+        std::fs::write(
+            &config,
+            "[mcp_servers.clickup]\nurl = \"https://mcp.clickup.com/mcp\"\n",
+        )
+        .expect("write config");
+
+        let mut servers = Vec::new();
+        let mut seen = HashSet::new();
+        collect_from_toml(&config, "user", &mut servers, &mut seen);
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "clickup");
+        assert!(!servers[0].disabled);
+        assert_eq!(servers[0].config["url"], "https://mcp.clickup.com/mcp");
+    }
+}

--- a/jean-core/src/projects/commands.rs
+++ b/jean-core/src/projects/commands.rs
@@ -13089,15 +13089,15 @@ fn collect_skills_from_dir_inner(
             }
         };
         let path = entry.path();
-        if !file_type.is_dir() || file_type.is_symlink() {
+        let is_linked_directory = file_type.is_symlink()
+            && std::fs::metadata(&path).is_ok_and(|metadata| metadata.is_dir());
+        if !file_type.is_dir() && !is_linked_directory {
             continue;
         }
 
         let skill_file = path.join("SKILL.md");
         let is_skill_file = match std::fs::symlink_metadata(&skill_file) {
-            Ok(metadata) => {
-                metadata.file_type().is_file() && !metadata.file_type().is_symlink()
-            }
+            Ok(metadata) => metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
             Err(error) => {
                 log::warn!("Failed to inspect skill file {skill_file:?}: {error}");
@@ -13105,7 +13105,9 @@ fn collect_skills_from_dir_inner(
             }
         };
         if !is_skill_file {
-            if entry_depth < MAX_SKILL_DIRECTORY_DEPTH {
+            // Follow symlinks only when they directly point at a skill root.
+            // This matches Codex skill installs while avoiding directory cycles.
+            if !is_linked_directory && entry_depth < MAX_SKILL_DIRECTORY_DEPTH {
                 collect_skills_from_dir_inner(&path, skills, entry_depth);
             }
             continue;
@@ -13769,7 +13771,9 @@ mod tests {
 
         assert_eq!(skills.len(), 2);
         assert_eq!(
-            skills.get("flat").and_then(|skill| skill.description.as_deref()),
+            skills
+                .get("flat")
+                .and_then(|skill| skill.description.as_deref()),
             Some("Flat skill")
         );
         assert_eq!(
@@ -13850,7 +13854,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn skill_discovery_does_not_follow_symlinks() {
+    fn skill_discovery_finds_symlinked_skill_directories_without_following_symlinked_files() {
         use std::os::unix::fs::symlink;
 
         let temp = tempfile::tempdir().expect("temp dir");
@@ -13862,15 +13866,39 @@ mod tests {
         std::fs::create_dir_all(&linked_file_skill).expect("linked file skill dir");
         std::fs::write(outside.join("SKILL.md"), "# Outside\n").expect("outside skill");
         symlink(&outside, root.join("linked-directory")).expect("directory symlink");
-        symlink(
-            outside.join("SKILL.md"),
-            linked_file_skill.join("SKILL.md"),
-        )
-        .expect("skill file symlink");
+        symlink(outside.join("SKILL.md"), linked_file_skill.join("SKILL.md"))
+            .expect("skill file symlink");
 
         let skills = collect_test_skills(&root);
 
-        assert!(skills.is_empty());
+        assert_eq!(skills.len(), 1);
+        assert_eq!(
+            skills
+                .get("linked-directory")
+                .and_then(|skill| skill.description.as_deref()),
+            Some("Outside")
+        );
+        assert_eq!(
+            skills
+                .get("linked-directory")
+                .map(|skill| std::path::PathBuf::from(&skill.path)),
+            Some(root.join("linked-directory/SKILL.md"))
+        );
+        assert!(!skills.contains_key("linked-file-skill"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skill_discovery_does_not_follow_symlinked_category_cycles() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let root = temp.path().join("skills");
+        let category = root.join("category");
+        std::fs::create_dir_all(&category).expect("category dir");
+        symlink(&root, category.join("cycle")).expect("category cycle");
+
+        assert!(collect_test_skills(&root).is_empty());
     }
 
     fn run_test_git(repo: &Path, args: &[&str]) {


### PR DESCRIPTION
## What changed

- discover Codex skills installed as symlinked directories while preserving physical and nested skill discovery
- avoid recursively following symlinked categories, preventing directory cycles
- reload the persistent Codex app-server MCP registry before every thread start or resume
- fail the turn explicitly if the MCP registry cannot be refreshed instead of continuing with stale tools
- add regression coverage for symlinked skills, symlink cycles, OAuth HTTP MCP discovery, and the app-server reload protocol

## Why

This fixes a regression introduced by #666 (`feat(skills): discover skills in nested category directories`). That change added recursive category discovery, but also explicitly rejected every symlinked directory and added a test asserting that symlinks must not be followed.

Codex CLI supports skill installations such as `~/.agents/skills/feature-flow -> ~/.claude/skills/feature-flow`. After #666, Jean could still receive metadata for such a skill through explicit prompt injection, but excluded it from the invocable skill registry. Physical skill directories continued to work, which made the regression specific to symlink-based installations.

This PR restores Codex-compatible directory-symlink discovery without reverting the useful nested-category support from #666: only symlinks that directly resolve to a skill root are accepted, while symlinked categories are not traversed recursively.

Separately, Jean keeps `codex app-server` alive across sessions. Its MCP registry could therefore predate changes to `~/.codex/config.toml`, causing configured servers such as ClickUp to be absent even though a fresh `codex mcp list` reported them as enabled.

## Validation

- `cargo test --manifest-path jean-core/Cargo.toml` — 1080 passed, 1 ignored on upstream main
- targeted `rustfmt --check` for all changed Rust files
- manual Codex app-server protocol check: `config/mcpServer/reload` succeeded and `mcpServerStatus/list` included ClickUp
- manual Jean dev smoke test for symlinked skill discovery

`bun run check:all` currently stops on the existing unrelated lint error in `src/components/chat/ChatInput.test.tsx:37` (`@typescript-eslint/consistent-type-imports`).
