### PR TITLE
fix(pi): run PATH installation correctly through WSL

### DIFF
--- a/jean-core/src/chat/antigravity.rs
+++ b/jean-core/src/chat/antigravity.rs
@@ -531,7 +531,6 @@ pub fn execute_antigravity(
             usage: None,
             terminal_error: None,
             diagnostics: vec![],
-            diagnostics: vec![],
         };
         for line in BufReader::new(stdout).lines() {
             let line =

--- a/jean-core/src/chat/pi.rs
+++ b/jean-core/src/chat/pi.rs
@@ -1281,7 +1281,7 @@ pub fn execute_pi(
     pid_callback: Option<Box<dyn FnOnce(u32) + Send>>,
 ) -> Result<PiResponse, String> {
     let cli_path = crate::pi_cli::resolve_cli_binary(app);
-    if !cli_path.exists() {
+    if !crate::platform::resolved_cli_exists(&cli_path) {
         return Err("PI CLI not installed".to_string());
     }
 
@@ -1388,15 +1388,17 @@ pub fn execute_pi(
         pi_tools_for_mode(execution_mode.unwrap_or("plan"))
     );
 
-        let mut child =
-            crate::platform::cli_command(&cli_path.to_string_lossy(), Some(working_dir))
-                .args(args)
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .env("JEAN_SESSION_ID", session_id)
-                .env("JEAN_WORKTREE_ID", worktree_id)
-                .spawn()
-                .map_err(|e| format!("Failed to spawn PI CLI: {e}"))?;
+        let mut child = crate::platform::wsl_resolved_cli_command(
+            &cli_path.to_string_lossy(),
+            Some(working_dir),
+        )
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("JEAN_SESSION_ID", session_id)
+        .env("JEAN_WORKTREE_ID", worktree_id)
+        .spawn()
+        .map_err(|e| format!("Failed to spawn PI CLI: {e}"))?;
         let pid = child.id();
         if let Some(callback) = pid_callback {
             callback(pid);
@@ -1491,11 +1493,11 @@ pub fn execute_one_shot_pi(
     effort_level: Option<&str>,
 ) -> Result<String, String> {
     let cli_path = crate::pi_cli::resolve_cli_binary(app);
-    if !cli_path.exists() {
+    if !crate::platform::resolved_cli_exists(&cli_path) {
         return Err("PI CLI not installed".to_string());
     }
     let dir = working_dir.unwrap_or_else(|| Path::new("."));
-    let mut cmd = crate::platform::cli_command(&cli_path.to_string_lossy(), Some(dir));
+    let mut cmd = crate::platform::wsl_resolved_cli_command(&cli_path.to_string_lossy(), Some(dir));
     cmd.args(["--mode", "json", "--no-session"]);
     cmd.args(["--model", raw_pi_model(Some(model)).unwrap_or(model)]);
     if let Some(effort) = effort_level {

--- a/jean-core/src/pi_cli/commands.rs
+++ b/jean-core/src/pi_cli/commands.rs
@@ -167,42 +167,65 @@ mod tests {
     }
 }
 
-fn pi_auth_file_exists() -> bool {
-    dirs::home_dir()
+const PI_AUTH_ENV_KEYS: [&str; 5] = [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+];
+
+fn host_pi_auth_exists() -> bool {
+    let auth_file_exists = dirs::home_dir()
         .map(|home| home.join(".pi").join("agent").join("auth.json"))
         .filter(|path| path.exists())
         .and_then(|path| std::fs::read_to_string(path).ok())
         .map(|contents| !contents.trim().is_empty() && contents.trim() != "{}")
-        .unwrap_or(false)
+        .unwrap_or(false);
+
+    auth_file_exists
+        || PI_AUTH_ENV_KEYS.iter().any(|key| {
+            std::env::var(key)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .is_some()
+        })
 }
 
-fn pi_env_auth_exists() -> bool {
-    [
-        "ANTHROPIC_API_KEY",
-        "OPENAI_API_KEY",
-        "GOOGLE_API_KEY",
-        "GEMINI_API_KEY",
-        "OPENROUTER_API_KEY",
-    ]
-    .iter()
-    .any(|key| {
-        std::env::var(key)
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-            .is_some()
-    })
+#[cfg(windows)]
+fn pi_auth_exists() -> bool {
+    let wsl = crate::platform::get_wsl_config();
+    if wsl.enabled {
+        let script = "auth=\"$HOME/.pi/agent/auth.json\"; \
+                      if [ -s \"$auth\" ] && [ \"$(tr -d '[:space:]' < \"$auth\")\" != '{}' ]; then exit 0; fi; \
+                      for key in ANTHROPIC_API_KEY OPENAI_API_KEY GOOGLE_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY; do \
+                        eval \"value=\\${$key-}\"; [ -n \"$value\" ] && exit 0; \
+                      done; exit 1";
+        return silent_command("wsl.exe")
+            .args(["-d", &wsl.distro, "--exec", "bash", "-lc", script])
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false);
+    }
+
+    host_pi_auth_exists()
+}
+
+#[cfg(not(windows))]
+fn pi_auth_exists() -> bool {
+    host_pi_auth_exists()
 }
 
 pub async fn check_pi_cli_installed(app: AppHandle) -> Result<PiCliStatus, String> {
     let path = resolve_cli_binary(&app);
-    if !path.exists() {
+    if !crate::platform::resolved_cli_exists(&path) {
         return Ok(PiCliStatus {
             installed: false,
             version: None,
             path: None,
         });
     }
-    let version = crate::platform::cli_command(&path.to_string_lossy(), None)
+    let version = crate::platform::wsl_resolved_cli_command(&path.to_string_lossy(), None)
         .arg("--version")
         .output()
         .ok()
@@ -224,13 +247,18 @@ pub async fn detect_pi_in_path(_app: AppHandle) -> Result<PiPathDetection, Strin
             package_manager: None,
         });
     };
-    let version = crate::platform::cli_command(&path.to_string_lossy(), None)
+    let version = crate::platform::wsl_resolved_cli_command(&path.to_string_lossy(), None)
         .arg("--version")
         .output()
         .ok()
         .filter(|o| o.status.success())
         .and_then(|o| parse_version(&o.stdout, &o.stderr));
-    let package_manager = crate::platform::detect_package_manager(&path);
+    let wsl = crate::platform::get_wsl_config();
+    let package_manager = if cfg!(windows) && wsl.enabled {
+        crate::platform::wsl_detect_package_manager(&path.to_string_lossy())
+    } else {
+        crate::platform::detect_package_manager(&path)
+    };
     Ok(PiPathDetection {
         found: true,
         path: Some(path.to_string_lossy().to_string()),
@@ -240,7 +268,7 @@ pub async fn detect_pi_in_path(_app: AppHandle) -> Result<PiPathDetection, Strin
 }
 
 pub async fn check_pi_cli_auth(_app: AppHandle) -> Result<PiAuthStatus, String> {
-    let authenticated = pi_auth_file_exists() || pi_env_auth_exists();
+    let authenticated = pi_auth_exists();
     Ok(PiAuthStatus {
         authenticated,
         error: if authenticated {
@@ -256,10 +284,10 @@ pub async fn check_pi_cli_auth(_app: AppHandle) -> Result<PiAuthStatus, String> 
 
 pub async fn list_pi_models(app: AppHandle) -> Result<Vec<PiModelInfo>, String> {
     let path = resolve_cli_binary(&app);
-    if !path.exists() {
+    if !crate::platform::resolved_cli_exists(&path) {
         return Ok(default_pi_models());
     }
-    let output = crate::platform::cli_command(&path.to_string_lossy(), None)
+    let output = crate::platform::wsl_resolved_cli_command(&path.to_string_lossy(), None)
         .arg("--list-models")
         .output();
     let Ok(output) = output else {

--- a/jean-core/src/pi_cli/config.rs
+++ b/jean-core/src/pi_cli/config.rs
@@ -42,7 +42,10 @@ pub fn resolve_cli_binary(app: &AppHandle) -> PathBuf {
     }
 
     if wsl.enabled {
-        return PathBuf::from("pi");
+        // WSL has no Jean-managed PI installation yet. Resolve the selected
+        // distro's executable so npm shebangs can use the matching sibling Node
+        // runtime even when the non-login WSL environment has a different PATH.
+        return find_pi_in_path().unwrap_or_else(|| PathBuf::from("pi"));
     }
 
     get_cli_binary_path(app).unwrap_or_else(|_| PathBuf::from(CLI_BINARY_NAME))

--- a/jean-core/src/platform/wsl.rs
+++ b/jean-core/src/platform/wsl.rs
@@ -267,12 +267,63 @@ fn cli_launch_plan(
 pub fn cli_command(program: &str, cwd: Option<&std::path::Path>) -> Command {
     let config = get_wsl_config();
     let plan = cli_launch_plan(program, cwd, cfg!(windows), config.enabled, &config.distro);
+    command_from_cli_launch_plan(plan)
+}
+
+fn wsl_resolved_cli_launch_plan(
+    program: &str,
+    cwd: Option<&std::path::Path>,
+    is_windows: bool,
+    wsl_enabled: bool,
+    wsl_distro: &str,
+) -> CliLaunchPlan {
+    if is_windows && wsl_enabled {
+        let mut args = vec!["-d".to_string(), wsl_distro.to_string()];
+        if let Some(dir) = cwd {
+            args.extend(["--cd".to_string(), win_to_wsl_path(&dir.to_string_lossy())]);
+        }
+        // npm-installed CLIs commonly use `#!/usr/bin/env node`. A login shell
+        // loads Homebrew/nvm/bun PATH and provider API keys from the user's
+        // profile. Additional Command arguments become positional parameters;
+        // `exec "$@"` preserves them exactly without shell interpolation.
+        args.extend([
+            "--exec".to_string(),
+            "bash".to_string(),
+            "-lc".to_string(),
+            "exec \"$@\"".to_string(),
+            "jean-cli".to_string(),
+            program.to_string(),
+        ]);
+        return CliLaunchPlan {
+            program: "wsl.exe".to_string(),
+            args,
+            cwd: None,
+        };
+    }
+
+    cli_launch_plan(program, cwd, is_windows, false, wsl_distro)
+}
+
+fn command_from_cli_launch_plan(plan: CliLaunchPlan) -> Command {
     let mut cmd = silent_command(plan.program);
     cmd.args(plan.args);
     if let Some(dir) = plan.cwd {
         cmd.current_dir(dir);
     }
     cmd
+}
+
+/// Create a command for a WSL-resolved CLI in the user's login environment.
+///
+/// Use this when a WSL-resolved executable can depend on user-configured PATH
+/// entries or provider environment variables (for example, an npm shim whose
+/// shebang uses `/usr/bin/env node`). On non-WSL hosts this behaves like
+/// [`cli_command`].
+pub fn wsl_resolved_cli_command(program: &str, cwd: Option<&std::path::Path>) -> Command {
+    let config = get_wsl_config();
+    let plan =
+        wsl_resolved_cli_launch_plan(program, cwd, cfg!(windows), config.enabled, &config.distro);
+    command_from_cli_launch_plan(plan)
 }
 
 /// True when `path` is a Unix-style absolute path that only exists inside WSL.
@@ -879,6 +930,45 @@ mod tests {
                 "/home/u/.local/bin/codex"
             ]
         );
+        assert_eq!(plan.cwd, None);
+    }
+
+    #[test]
+    fn wsl_resolved_cli_launch_plan_loads_login_environment_and_preserves_appended_args() {
+        let plan = wsl_resolved_cli_launch_plan(
+            "/home/linuxbrew/.linuxbrew/bin/pi",
+            Some(std::path::Path::new(r"D:\repos\jean")),
+            true,
+            true,
+            "Ubuntu-22.04",
+        );
+
+        assert_eq!(plan.program, "wsl.exe");
+        assert_eq!(
+            plan.args,
+            vec![
+                "-d",
+                "Ubuntu-22.04",
+                "--cd",
+                "/mnt/d/repos/jean",
+                "--exec",
+                "bash",
+                "-lc",
+                "exec \"$@\"",
+                "jean-cli",
+                "/home/linuxbrew/.linuxbrew/bin/pi",
+            ]
+        );
+        assert_eq!(plan.cwd, None);
+    }
+
+    #[test]
+    fn wsl_resolved_cli_launch_plan_keeps_native_windows_cli_behavior() {
+        let plan =
+            wsl_resolved_cli_launch_plan(r"D:\nodejs\npm.cmd", None, true, false, "Ubuntu-22.04");
+
+        assert_eq!(plan.program, "cmd.exe");
+        assert_eq!(plan.args, vec!["/C", r"D:\nodejs\npm.cmd"]);
         assert_eq!(plan.cwd, None);
     }
 


### PR DESCRIPTION
## Problem

On Windows with **Use WSL** enabled, Jean could not use an existing PI installation from the selected distro. A typical working installation looked like:

```text
/home/linuxbrew/.linuxbrew/bin/pi   -> PI 0.84.1
/home/linuxbrew/.linuxbrew/bin/node -> Node 25.3.0
```

Jean still reported **PI not found in System PATH**. Choosing **Install now** could instead report:

```text
Failed to run npm install for PI: program not found
```

The machine did not lack PI, Node, or npm. The failures came from crossing the Windows/WSL boundary inconsistently.

## Root cause

1. PI discovery queried the selected WSL distro, but status/model/chat code later used native Windows `Path::exists()` on Linux paths such as `/home/linuxbrew/.linuxbrew/bin/pi`.
2. WSL execution did not load the user's login environment. An npm shim with `#!/usr/bin/env node` could therefore resolve WSL's old `/usr/bin/node` instead of the matching Linuxbrew/nvm/bun runtime.
3. Authentication checked the Windows home and process environment rather than the selected distro's `~/.pi/agent/auth.json` and provider variables.
4. Package-manager detection attempted Windows filesystem canonicalization for Linux paths.
5. PI's WSL fallback could become bare `pi` instead of retaining the absolute path found by `wsl_which()`.

## Solution

- resolve PI through `wsl_which()` and retain the absolute Linux executable path
- use `resolved_cli_exists()` so Linux executables are checked inside the selected distro
- launch resolved WSL PI commands as:

  ```text
  wsl.exe -d <distro> --cd <translated-cwd> --exec \
    bash -lc 'exec "$@"' jean-cli <absolute-pi-path> <pi-args...>
  ```

- pass the executable and PI arguments as positional parameters, preventing shell interpolation of prompts, paths, model IDs, quotes, metacharacters, or multiline values
- use the login environment consistently for status, model listing, one-shot execution, normal chat execution, and provider keys
- check PI authentication inside the selected distro
- use WSL-aware Linuxbrew/npm/bun package-manager detection

Native Windows behavior remains unchanged when WSL is disabled.

## Additional production-build repair

A pre-existing duplicate `diagnostics` field in `jean-core/src/chat/antigravity.rs` prevented Rust/Tauri production compilation with `E0062`. The duplicate initializer was removed in this PR so the Windows production build can complete.

## Validation

### Rust tests

- `cargo test --manifest-path jean-core/Cargo.toml platform::wsl::tests --lib` — **31 passed**
- `cargo test --manifest-path jean-core/Cargo.toml pi_cli::commands::tests --lib` — **3 passed**
- `cargo test --manifest-path jean-core/Cargo.toml chat::pi::tests --lib` — **19 passed**

### Real Windows → WSL smoke tests

Using `Ubuntu-22.04` and Linuxbrew:

- resolved `/home/linuxbrew/.linuxbrew/bin/pi`
- `pi --version` returned **0.84.1**
- `pi --list-models` completed successfully
- WSL authentication detection found distro credentials
- argument round-trip preserved spaces, both quote styles, `$HOME`, `$(uname)`, globs, and multiline values without expansion

### Frontend

The reported Pierre TypeScript errors came from stale local dependencies: `node_modules` contained `@pierre/diffs@1.0.11`, while `package.json` and `bun.lock` require `1.3.2`.

After:

```bash
bun install --frozen-lockfile
```

validation passed:

- `bun run typecheck` — **passed**
- `bun run build` — **passed**

No dependency or frontend source change was required; the manifest and lockfile were already correct.

### Windows Tauri production build

With the MSVC linker selected explicitly because Git's unrelated `link.exe` shadows it in this shell:

- frontend production build — **passed**
- Rust release compilation — **passed**
- application generated at `src-tauri/target/release/jean.exe`
- MSI generated: `Jean_0.1.73_x64_en-US.msi`
- NSIS generated: `Jean_0.1.73_x64-setup.exe`

The command then stopped only at updater signing because this local environment does not have `TAURI_SIGNING_PRIVATE_KEY`. Compilation and both Windows installer bundles completed successfully.

## Scope note

WSL custom-provider `models.json` storage remains host-home based. That is a separate pre-existing integration gap and is not required for using an already installed/authenticated WSL PI through System PATH.
