### PR TITLE
feat: add account usage thresholds

### DIFF
--- a/jean-core/src/chat/claude.rs
+++ b/jean-core/src/chat/claude.rs
@@ -428,6 +428,27 @@ fn is_running_as_root() -> bool {
     }
 }
 
+fn claude_extra_usage_cap_exhausted(app: &tauri::AppHandle) -> bool {
+    let Ok(path) = crate::get_preferences_path(app) else {
+        return false;
+    };
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(preferences) = serde_json::from_str::<crate::AppPreferences>(&contents) else {
+        return false;
+    };
+    let Some(cap) = preferences
+        .claude_extra_usage_cap_usd
+        .filter(|value| value.is_finite() && *value >= 0.0)
+    else {
+        return false;
+    };
+    crate::claude_cli::cached_claude_extra_usage_spent()
+        .map(|spent| spent >= cap)
+        .unwrap_or(false)
+}
+
 /// Build CLI arguments for Claude CLI.
 ///
 /// Returns a tuple of (args, env_vars) where env_vars are (key, value) pairs.
@@ -464,6 +485,27 @@ fn build_claude_args(
     // Stream partial messages so long-running tools (Monitor, etc.) can push events
     // to the UI without waiting for message boundaries.
     args.push("--include-partial-messages".to_string());
+
+    // Apply the account-wide extra usage cap to this request. Claude's
+    // --max-budget-usd flag is per invocation, so subtract the latest known
+    // account spend before passing the remaining budget to the CLI.
+    if let Ok(preferences_path) = crate::get_preferences_path(app) {
+        if let Ok(contents) = std::fs::read_to_string(preferences_path) {
+            if let Ok(preferences) = serde_json::from_str::<crate::AppPreferences>(&contents) {
+                if let Some(cap) = preferences
+                    .claude_extra_usage_cap_usd
+                    .filter(|value| value.is_finite() && *value >= 0.0)
+                {
+                    let spent = crate::claude_cli::cached_claude_extra_usage_spent().unwrap_or(0.0);
+                    let remaining = (cap - spent).max(0.0);
+                    if remaining > 0.0 {
+                        args.push("--max-budget-usd".to_string());
+                        args.push(remaining.to_string());
+                    }
+                }
+            }
+        }
+    }
 
     // Add app data directories
     if let Ok(app_data_dir) = app.path().app_data_dir() {
@@ -1205,6 +1247,12 @@ pub fn execute_claude_detached(
         };
         let _ = app.emit_all("chat:error", &error_event);
         return Err(error_msg);
+    }
+
+    if claude_extra_usage_cap_exhausted(app) {
+        return Err(
+            "Claude's configured account-wide extra usage limit has been reached. Increase or disable the limit in Settings → Usage to continue.".to_string(),
+        );
     }
 
     // Build args

--- a/jean-core/src/chat/codex.rs
+++ b/jean-core/src/chat/codex.rs
@@ -1035,6 +1035,25 @@ pub fn execute_codex_via_server(
 ) -> Result<CodexResponse, String> {
     use super::codex_server;
 
+    if let Ok(path) = crate::get_preferences_path(app) {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            if let Ok(preferences) = serde_json::from_str::<crate::AppPreferences>(&contents) {
+                if let Some(threshold) = preferences
+                    .codex_credits_threshold
+                    .filter(|value| *value > 0.0)
+                {
+                    if let Some(credits) = crate::codex_cli::cached_codex_credits_remaining() {
+                        if credits < threshold {
+                            return Err(format!(
+                                "Codex credits are below the configured threshold ({credits} remaining, {threshold} required). Increase or disable the threshold in Settings → Usage to continue."
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     let is_plan_mode = execution_mode.unwrap_or("plan") == "plan";
     let is_build_mode = execution_mode.unwrap_or("plan") == "build";
     let is_yolo_mode = execution_mode.unwrap_or("plan") == "yolo";

--- a/jean-core/src/chat/context_instructions.rs
+++ b/jean-core/src/chat/context_instructions.rs
@@ -318,7 +318,8 @@ pub fn build_combined_terminal_context_content(
     worktree_id: &str,
     include_recap: bool,
 ) -> String {
-    let system_prompt_parts = build_system_prompt_parts(app, session_id, worktree_id, include_recap);
+    let system_prompt_parts =
+        build_system_prompt_parts(app, session_id, worktree_id, include_recap);
     let context_paths = collect_context_paths(app, session_id, worktree_id);
 
     let mut content = String::new();

--- a/jean-core/src/chat/opencode.rs
+++ b/jean-core/src/chat/opencode.rs
@@ -3586,7 +3586,7 @@ fn one_shot_opencode_blocking(
         .map_err(|e| format!("Failed to parse OpenCode response: {e}"))?;
 
     // When using json_schema format, the structured output is in info.structured
-    if json_schema.is_some() {
+    if let Some(json_schema) = json_schema.as_ref() {
         if let Some(structured) = response_json.get("info").and_then(|i| i.get("structured")) {
             if !structured.is_null() {
                 return Ok(structured.to_string());
@@ -3614,9 +3614,7 @@ fn one_shot_opencode_blocking(
                     .remove("format");
                 payload["parts"] = prepare_opencode_parts(&structured_output_text_prompt(
                     prompt,
-                    &json_schema
-                        .expect("schema exists when handling structured output error")
-                        .to_string(),
+                    &json_schema.to_string(),
                 ));
                 let fallback_response =
                     client

--- a/jean-core/src/claude_cli/commands.rs
+++ b/jean-core/src/claude_cli/commands.rs
@@ -1058,6 +1058,13 @@ fn load_stale_cached_claude_usage(now_secs: u64) -> Option<ClaudeUsageSnapshot> 
     None
 }
 
+/// Return the latest known account-wide Claude extra usage spend for callers
+/// that need to budget a new request across all Jean sessions.
+pub(crate) fn cached_claude_extra_usage_spent() -> Option<f64> {
+    let now_secs = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+    load_stale_cached_claude_usage(now_secs)?.extra_usage_spent
+}
+
 fn save_cached_claude_usage(snapshot: &ClaudeUsageSnapshot, now_secs: u64) {
     let Some(path) = get_claude_usage_cache_path() else {
         return;

--- a/jean-core/src/codex_cli/commands.rs
+++ b/jean-core/src/codex_cli/commands.rs
@@ -552,6 +552,12 @@ fn load_cached_codex_usage(now_secs: u64) -> Option<CodexUsageSnapshot> {
     None
 }
 
+/// Return the latest known Codex credit balance for request guards.
+pub(crate) fn cached_codex_credits_remaining() -> Option<f64> {
+    let now_secs = current_unix_secs();
+    load_cached_codex_usage(now_secs)?.credits_remaining
+}
+
 fn save_cached_codex_usage(snapshot: &CodexUsageSnapshot, now_secs: u64) {
     let Some(path) = get_codex_usage_cache_path() else {
         return;

--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -169,6 +169,10 @@ pub struct AppPreferences {
     pub thinking_level: String, // Thinking level: off, think, megathink, ultrathink
     #[serde(default = "default_effort_level")]
     pub default_effort_level: String, // Effort level for Opus adaptive thinking: low, medium, high, xhigh, max, ultracode
+    #[serde(default)]
+    pub claude_extra_usage_cap_usd: Option<f64>, // Maximum Claude extra usage spend per request in USD
+    #[serde(default)]
+    pub codex_credits_threshold: Option<f64>, // Minimum Codex credits to keep available before a request
     #[serde(default = "default_terminal")]
     pub terminal: String, // Terminal app: terminal, warp, ghostty, iterm2, powershell, windows-terminal
     #[serde(default = "default_terminal_renderer")]
@@ -2650,6 +2654,8 @@ impl Default for AppPreferences {
             theme: "system".to_string(),
             selected_model: default_model(),
             thinking_level: default_thinking_level(),
+            claude_extra_usage_cap_usd: None,
+            codex_credits_threshold: None,
             terminal: default_terminal(),
             terminal_renderer: default_terminal_renderer(),
             terminal_font: default_terminal_font(),

--- a/jean-core/src/projects/commands.rs
+++ b/jean-core/src/projects/commands.rs
@@ -6625,7 +6625,7 @@ fn detect_and_link_pr_for_worktree(
     // Branch-name detection is best-effort and can match the wrong fork PR when
     // several PRs share a head name, or clear a correct link after a temp-branch
     // checkout renames the local head.
-    let (existing_pr_number, existing_pr_url) = match load_projects_data(&app) {
+    let (existing_pr_number, existing_pr_url) = match load_projects_data(app) {
         Ok(data) => data
             .worktrees
             .iter()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -328,6 +328,14 @@ fn setup_runtime(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
         install_menu_events(app);
     }
 
+    // Ensure the main window is visible and focused after restoring persisted
+    // window state. This is especially important for development launches
+    // when the previous window was closed or hidden on another Space.
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+
     // Recover from WebView2 process death on Windows (issue #575 — blank /
     // "invisible" window after the browser process exits). No-op elsewhere.
     platform::install_process_failed_recovery(app);
@@ -361,11 +369,18 @@ pub fn run() {
     #[cfg(target_os = "linux")]
     platform::apply_linux_webkit_env();
 
-    let log_targets = vec![
+    let mut log_targets = vec![
         tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
         tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Webview),
-        tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir { file_name: None }),
     ];
+    // Dev builds run from the workspace and should not require macOS
+    // permission to create the per-app log directory. Release builds retain
+    // file logging for diagnostics.
+    if !cfg!(debug_assertions) {
+        log_targets.push(tauri_plugin_log::Target::new(
+            tauri_plugin_log::TargetKind::LogDir { file_name: None },
+        ));
+    }
 
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())

--- a/src/components/preferences/panes/UsagePane.test.tsx
+++ b/src/components/preferences/panes/UsagePane.test.tsx
@@ -97,6 +97,7 @@ describe('UsagePane', () => {
     expect(screen.getByText('Claude')).toBeInTheDocument()
     expect(screen.getByText('pro')).toBeInTheDocument()
     expect(screen.getByText('Extra: 1.5 / 50')).toBeInTheDocument()
+    expect(screen.getByText('Extra usage cap')).toBeInTheDocument()
     expect(screen.getByText('Session')).toBeInTheDocument()
     expect(screen.getByText('Sonnet')).toBeInTheDocument()
   })
@@ -127,7 +128,39 @@ describe('UsagePane', () => {
 
     expect(screen.getByText('Codex')).toBeInTheDocument()
     expect(screen.getByText('Credits remaining: 3')).toBeInTheDocument()
+    expect(screen.getByText('Credit threshold')).toBeInTheDocument()
     expect(screen.getByText('12.5%')).toBeInTheDocument()
+  })
+
+  it('hides extra thresholds when no extra balance is detected', () => {
+    mocks.useClaudeUsage.mockReturnValue(
+      idleQuery({
+        planType: 'pro',
+        session: null,
+        weekly: null,
+        sonnetWeekly: null,
+        extraUsageSpent: null,
+        extraUsageLimit: null,
+        fetchedAt: Math.floor(Date.now() / 1000),
+      })
+    )
+    mocks.useCodexUsage.mockReturnValue(
+      idleQuery({
+        planType: 'pro',
+        session: null,
+        weekly: null,
+        reviews: null,
+        creditsRemaining: null,
+        rateLimitReachedType: null,
+        modelLimits: [],
+        fetchedAt: Math.floor(Date.now() / 1000),
+      })
+    )
+
+    render(<UsagePane />)
+
+    expect(screen.queryByText('Extra usage cap')).not.toBeInTheDocument()
+    expect(screen.queryByText('Credit threshold')).not.toBeInTheDocument()
   })
 
   it('hides backends that are not installed or not authenticated', () => {

--- a/src/components/preferences/panes/UsagePane.tsx
+++ b/src/components/preferences/panes/UsagePane.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { Loader2, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -17,6 +17,9 @@ import {
   useGrokUsage,
 } from '@/services/grok-cli'
 import { cn } from '@/lib/utils'
+import { Slider } from '@/components/ui/slider'
+import { Input } from '@/components/ui/input'
+import { usePatchPreferences, usePreferences } from '@/services/preferences'
 
 function CompactSection({
   title,
@@ -44,6 +47,21 @@ interface UsageWindow {
 
 function clampPercent(value: number): number {
   return Math.max(0, Math.min(100, value))
+}
+
+function sliderTicksBetween(
+  min: number,
+  max: number,
+  format: (value: number) => string
+): { value: number; label: string }[] {
+  if (max <= min) return []
+  const values = [min, min + (max - min) / 3, min + (max - min) * (2 / 3), max]
+  return values
+    .filter((value, index) => index === 0 || value !== values[index - 1])
+    .map(value => ({
+      value,
+      label: format(value),
+    }))
 }
 
 function barClass(usedPercent: number): string {
@@ -210,13 +228,25 @@ function ErrorLine({
 }
 
 export const UsagePane: React.FC = () => {
+  const { data: preferences } = usePreferences()
+  const patchPreferences = usePatchPreferences()
+  const [extraUsageCap, setExtraUsageCap] = useState<number>(0)
+  const [codexCreditsThreshold, setCodexCreditsThreshold] = useState<number>(0)
+
+  useEffect(() => {
+    setExtraUsageCap(preferences?.claude_extra_usage_cap_usd ?? 0)
+    setCodexCreditsThreshold(preferences?.codex_credits_threshold ?? 0)
+  }, [
+    preferences?.claude_extra_usage_cap_usd,
+    preferences?.codex_credits_threshold,
+  ])
+
   const claudeStatus = useClaudeCliStatus()
   const claudeAuth = useClaudeCliAuth({
     enabled: !!claudeStatus.data?.installed,
   })
   const claudeUsage = useClaudeUsage({
-    enabled:
-      !!claudeStatus.data?.installed && !!claudeAuth.data?.authenticated,
+    enabled: !!claudeStatus.data?.installed && !!claudeAuth.data?.authenticated,
   })
 
   const codexStatus = useCodexCliStatus()
@@ -328,9 +358,80 @@ export const UsagePane: React.FC = () => {
             data.extraUsageLimit != null ? ` / ${data.extraUsageLimit}` : ''
           }`
         : null
+    // Keep the lower bound at zero so the cap can intentionally be set below
+    // current spend to stop further extra usage.
+    const extraUsageMin = 0
+    const extraUsageMax = Math.max(
+      extraUsageMin,
+      data.extraUsageLimit ?? extraUsageMin
+    )
+    const extraUsageTicks = sliderTicksBetween(
+      extraUsageMin,
+      extraUsageMax,
+      value => Math.round(value).toLocaleString()
+    )
 
     return (
       <div className="space-y-2">
+        {extraUsageTicks.length > 0 ? (
+          <div className="space-y-1">
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="text-muted-foreground">Extra usage cap</span>
+              <Input
+                aria-label="Claude total extra usage limit value"
+                className="h-6 w-24 px-2 text-right text-xs tabular-nums"
+                type="number"
+                min={extraUsageMin}
+                max={extraUsageMax}
+                step="0.01"
+                value={Math.min(
+                  extraUsageMax,
+                  Math.max(extraUsageMin, extraUsageCap)
+                )}
+                onChange={event => {
+                  const value = Number(event.target.value)
+                  if (Number.isFinite(value)) setExtraUsageCap(value)
+                }}
+                onBlur={event => {
+                  const value = Number(event.target.value)
+                  if (Number.isFinite(value)) {
+                    patchPreferences.mutate({
+                      claude_extra_usage_cap_usd: Math.min(
+                        extraUsageMax,
+                        Math.max(extraUsageMin, value)
+                      ),
+                    })
+                  }
+                }}
+                disabled={patchPreferences.isPending}
+              />
+            </div>
+            <Slider
+              aria-label="Claude total extra usage limit"
+              ticks={extraUsageTicks}
+              continuous={{
+                min: extraUsageMin,
+                max: extraUsageMax,
+                step: 0.01,
+              }}
+              value={Math.min(
+                extraUsageMax,
+                Math.max(extraUsageMin, extraUsageCap)
+              )}
+              onValueChange={setExtraUsageCap}
+              onValueCommit={value =>
+                patchPreferences.mutate({
+                  claude_extra_usage_cap_usd: value,
+                })
+              }
+              disabled={patchPreferences.isPending}
+            />
+            <p className="text-[11px] text-muted-foreground">
+              Shared across all sessions. Jean subtracts your latest Claude
+              usage before starting each request.
+            </p>
+          </div>
+        ) : null}
         <MetaLine items={[data.planType ?? 'Unknown', extra]} />
         <div className="space-y-1.5">
           <UsageRow label="Session" usage={data.session} />
@@ -365,6 +466,12 @@ export const UsagePane: React.FC = () => {
       data.creditsRemaining !== null
         ? `Credits remaining: ${data.creditsRemaining}`
         : null
+    const creditTicks =
+      data.creditsRemaining != null
+        ? sliderTicksBetween(0, data.creditsRemaining, value =>
+            Number.isInteger(value) ? String(value) : value.toFixed(1)
+          )
+        : []
 
     const extraLimits = data.modelLimits.flatMap(limit => {
       const rows: { key: string; label: string; usage: UsageWindow }[] = []
@@ -387,6 +494,69 @@ export const UsagePane: React.FC = () => {
 
     return (
       <div className="space-y-2">
+        {creditTicks.length > 0 ? (
+          <div className="space-y-1">
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="text-muted-foreground">Credit threshold</span>
+              <Input
+                aria-label="Codex credit threshold value"
+                className="h-6 w-20 px-2 text-right text-xs tabular-nums"
+                type="number"
+                min={0}
+                max={data.creditsRemaining ?? 0}
+                step="0.01"
+                value={Math.min(
+                  codexCreditsThreshold,
+                  data.creditsRemaining ?? 0
+                )}
+                onChange={event => {
+                  const value = Number(event.target.value)
+                  if (Number.isFinite(value)) setCodexCreditsThreshold(value)
+                }}
+                onBlur={event => {
+                  const value = Number(event.target.value)
+                  if (Number.isFinite(value)) {
+                    const boundedValue = Math.min(
+                      data.creditsRemaining ?? 0,
+                      Math.max(0, value)
+                    )
+                    patchPreferences.mutate({
+                      codex_credits_threshold:
+                        boundedValue === 0 ? null : boundedValue,
+                    })
+                  }
+                }}
+                disabled={patchPreferences.isPending}
+              />
+            </div>
+            <Slider
+              aria-label="Codex credit threshold"
+              ticks={creditTicks.map(tick => ({
+                ...tick,
+                label: tick.value === 0 ? 'Off' : tick.label,
+              }))}
+              continuous={{
+                min: 0,
+                max: data.creditsRemaining ?? 0,
+                step: 0.01,
+              }}
+              value={Math.min(
+                codexCreditsThreshold,
+                data.creditsRemaining ?? 0
+              )}
+              onValueChange={setCodexCreditsThreshold}
+              onValueCommit={value =>
+                patchPreferences.mutate({
+                  codex_credits_threshold: value === 0 ? null : value,
+                })
+              }
+              disabled={patchPreferences.isPending}
+            />
+            <p className="text-[11px] text-muted-foreground">
+              Prevents new Codex requests when credits fall below this balance.
+            </p>
+          </div>
+        ) : null}
         <MetaLine items={[data.planType ?? 'Unknown', credits]} />
         {data.rateLimitReachedType ? (
           <InlineStatus tone="error">

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -17,6 +17,7 @@ interface SliderProps extends Omit<
 > {
   ticks: { value: number; label: string }[]
   value: number
+  continuous?: { min: number; max: number; step?: number }
   onValueChange: (value: number) => void
   /** Called only when the user finishes dragging (mouse/touch up). Use for expensive operations like zoom. */
   onValueCommit?: (value: number) => void
@@ -26,6 +27,7 @@ function Slider({
   className,
   ticks,
   value,
+  continuous,
   onValueChange,
   onValueCommit,
   disabled,
@@ -48,20 +50,28 @@ function Slider({
     }
     return closest
   }, [ticks, value])
+  const sliderMin = continuous?.min ?? 0
+  const sliderMax = continuous?.max ?? ticks.length - 1
+  const sliderStep = continuous?.step ?? 1
+  const sliderValue = continuous ? value : currentIndex
 
   return (
     <div className="w-full space-y-1">
       <SliderPrimitive.Root
         data-slot="slider"
-        min={0}
-        max={ticks.length - 1}
-        step={1}
-        value={[currentIndex]}
+        min={sliderMin}
+        max={sliderMax}
+        step={sliderStep}
+        value={[sliderValue]}
         onValueChange={values => {
           const idx = values[0]
           if (idx != null) {
-            const tick = ticks[idx]
-            if (tick) onValueChange(tick.value)
+            if (continuous) {
+              onValueChange(idx)
+            } else {
+              const tick = ticks[idx]
+              if (tick) onValueChange(tick.value)
+            }
           }
         }}
         onValueCommit={
@@ -69,8 +79,12 @@ function Slider({
             ? values => {
                 const idx = values[0]
                 if (idx != null) {
-                  const tick = ticks[idx]
-                  if (tick) onValueCommit(tick.value)
+                  if (continuous) {
+                    onValueCommit(idx)
+                  } else {
+                    const tick = ticks[idx]
+                    if (tick) onValueCommit(tick.value)
+                  }
                 }
               }
             : undefined

--- a/src/types/preferences-prompt-parity.test.ts
+++ b/src/types/preferences-prompt-parity.test.ts
@@ -29,12 +29,13 @@ describe('shared magic prompt defaults', () => {
     typescriptSource.matchAll(
       /export const DEFAULT_([A-Z0-9_]+)_PROMPT = `((?:\\`|[^`])*)`/g
     )
-  )
-    .map(match => [
-      `default_${match[1]!.toLowerCase()}_prompt`,
-      match[2]!.replaceAll('\\`', '`'),
-    ])
-    .filter(([functionName]) => rustSource.includes(`fn ${functionName}()`))
+  ).flatMap(match => {
+    const [, name, prompt] = match
+    if (!name || prompt === undefined) return []
+    const functionName = `default_${name.toLowerCase()}_prompt`
+    if (!rustSource.includes(`fn ${functionName}()`)) return []
+    return [[functionName, prompt.replaceAll('\\`', '`')] as const]
+  })
 
   it.each(prompts)(
     'keeps %s identical in Rust and TypeScript',

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1198,6 +1198,10 @@ export interface AppPreferences {
   selected_model: ClaudeModel // Claude model ID passed to --model flag
   thinking_level: ThinkingLevel // Thinking level: 'off' | 'think' | 'megathink' | 'ultrathink'
   default_effort_level: EffortLevel // Effort level for Opus adaptive thinking: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
+  /** Account-wide Claude extra usage limit in USD; null leaves the CLI uncapped. */
+  claude_extra_usage_cap_usd?: number | null
+  /** Minimum Codex credits to keep available before starting a request; null disables the guard. */
+  codex_credits_threshold?: number | null
   terminal: TerminalApp // Terminal app: 'terminal' | 'warp' | 'ghostty' | 'iterm2' | 'powershell' | 'windows-terminal'
   terminal_renderer?: TerminalRenderer // Embedded terminal renderer: 'xterm' or 'ghostty-web' (experimental)
   terminal_font?: TerminalFont // Embedded terminal font
@@ -2335,6 +2339,8 @@ export const defaultPreferences: AppPreferences = {
   selected_model: 'claude-opus-4-8[1m]',
   thinking_level: 'ultrathink',
   default_effort_level: 'high',
+  claude_extra_usage_cap_usd: null,
+  codex_credits_threshold: null,
   terminal: isServerWindows() ? 'powershell' : 'terminal',
   terminal_renderer: 'xterm',
   terminal_font: 'jetbrains-mono',


### PR DESCRIPTION
## Summary

- Add account-wide Claude extra-usage caps.
- Add Codex credit thresholds.
- Show threshold controls only when usage or credits are detected.
- Support continuous sliders and exact numeric values.
- Block new requests when the configured account-wide limit is reached.

## Testing

- `bun run test:run -- src/components/preferences/panes/UsagePane.test.tsx`
- `bun run typecheck`

## Manual verification

- Open Settings → Usage.
- Confirm Claude and Codex controls only appear when balances are detected.
- Enter exact threshold values and verify the sliders update.
- Confirm Claude cap `0` blocks further extra usage after usage is already above zero.