### PR TITLE
fix(chat): ignore IME composition Escape in session modal

### DIFF
--- a/src/components/chat/SessionChatModal.removal-behavior.test.ts
+++ b/src/components/chat/SessionChatModal.removal-behavior.test.ts
@@ -185,4 +185,15 @@ describe('SessionChatModal removal behavior', () => {
       /reconnectNativeCliSession\(nativeSession, worktreeId, \{[\s\S]*?openModal: false/
     )
   })
+
+  it('ignores Escape that cancels an IME composition instead of closing the modal', () => {
+    const source = readSource('src/components/chat/SessionChatModal.tsx')
+    const start = source.indexOf('const onEscapeClose = useEffectEvent(')
+    const end = source.indexOf('handleClose()', start)
+    const onEscapeClose =
+      start === -1 || end === -1 ? '' : source.slice(start, end)
+
+    expect(onEscapeClose).toBeTruthy()
+    expect(onEscapeClose).toContain('if (isImeComposingEvent(e)) return')
+  })
 })

--- a/src/components/chat/SessionChatModal.tsx
+++ b/src/components/chat/SessionChatModal.tsx
@@ -77,6 +77,7 @@ import {
 import { isBaseSession } from '@/types/projects'
 import type { Session } from '@/types/chat'
 import { isNativeApp } from '@/lib/environment'
+import { isImeComposingEvent } from '@/lib/ime-composition'
 import { notify } from '@/lib/notifications'
 import { copyToClipboard } from '@/lib/clipboard'
 import { toast } from 'sonner'
@@ -1048,6 +1049,9 @@ export function SessionChatModal({
   // Close on Escape key
   const onEscapeClose = useEffectEvent((e: KeyboardEvent) => {
     if (e.key !== 'Escape') return
+    // CJK IME: Escape cancels the active composition — must not close the
+    // modal. keyCode 229 covers Safari/WKWebView (see issue #584 for Enter).
+    if (isImeComposingEvent(e)) return
     const target = e.target as HTMLElement
     const portalAncestor = target?.closest?.(
       '[data-slot="dialog-portal"], [data-slot="alert-dialog-portal"], [data-slot="sheet-portal"]'


### PR DESCRIPTION
## Summary

- Pressing Escape to cancel a CJK IME candidate selection (Chinese/Japanese/Korean) in the chat input also closed the session panel and returned to the project root
- Skip the window-level Escape handler in `SessionChatModal` while a composition is active, reusing the `isImeComposingEvent` guard already applied to Enter in `ChatInput` (#584); covers both `isComposing` and Safari/WKWebView `keyCode 229`
- Add a regression test alongside the existing `SessionChatModal` behavior tests

## Test plan

- [x] `bun run test:run src/components/chat/SessionChatModal.removal-behavior.test.ts`
- [x] `bun run typecheck && bun run lint`
- [x] Manual (macOS, `bun run tauri:dev`): open a session panel, type with a Chinese IME, press Escape while candidates are shown → candidates dismiss, panel stays open; press Escape outside composition → panel closes as before
