### PR TITLE
feat: copy file path when viewing files

### DIFF
--- a/src/components/chat/FileContentModal.tsx
+++ b/src/components/chat/FileContentModal.tsx
@@ -15,8 +15,11 @@ import {
   Eye,
   Save,
   ExternalLink,
+  Copy,
+  Check,
 } from 'lucide-react'
 import { invoke } from '@/lib/transport'
+import { copyToClipboard } from '@/lib/clipboard'
 import {
   Dialog,
   DialogContent,
@@ -123,6 +126,16 @@ export function FileContentModal({ filePath, onClose }: FileContentModalProps) {
 
   const { theme } = useTheme()
   const { data: preferences } = usePreferences()
+  const [copiedPath, setCopiedPath] = useState(false)
+
+  const handleCopyPath = useCallback(() => {
+    if (filePath) {
+      void copyToClipboard(filePath)
+      toast.success('Copied file path to clipboard')
+      setCopiedPath(true)
+      setTimeout(() => setCopiedPath(false), 2000)
+    }
+  }, [filePath])
 
   // Resolve 'system' theme to actual dark/light
   const resolvedTheme = useMemo((): 'dark' | 'light' => {
@@ -355,9 +368,24 @@ export function FileContentModal({ filePath, onClose }: FileContentModalProps) {
             )}
           </div>
           {filePath && (
-            <span className="text-muted-foreground font-normal text-xs break-all [overflow-wrap:anywhere]">
-              {filePath}
-            </span>
+            <div className="flex items-center gap-1.5 mt-0.5 select-text group/path min-w-0">
+              <span className="text-muted-foreground font-normal text-xs break-all [overflow-wrap:anywhere] select-text">
+                {filePath}
+              </span>
+              <button
+                type="button"
+                onClick={handleCopyPath}
+                className="inline-flex items-center justify-center h-5 w-5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0 cursor-pointer"
+                title="Copy file path"
+              >
+                {copiedPath ? (
+                  <Check className="h-3 w-3 text-green-500" />
+                ) : (
+                  <Copy className="h-3 w-3" />
+                )}
+                <span className="sr-only">Copy file path</span>
+              </button>
+            </div>
           )}
         </DialogTitle>
         <DialogDescription className="sr-only">

--- a/src/components/chat/FileEditsDiffModal.tsx
+++ b/src/components/chat/FileEditsDiffModal.tsx
@@ -1,4 +1,5 @@
-import { FileText } from 'lucide-react'
+import { useState, useCallback } from 'react'
+import { FileText, Copy, Check } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -7,6 +8,8 @@ import {
 } from '@/components/ui/dialog'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { getFilename } from '@/lib/path-utils'
+import { copyToClipboard } from '@/lib/clipboard'
+import { toast } from 'sonner'
 import { InlineFileDiff } from './InlineFileDiff'
 
 export interface FileEdit {
@@ -32,6 +35,16 @@ export function FileEditsDiffModal({
   onClose,
 }: FileEditsDiffModalProps) {
   const filename = filePath ? getFilename(filePath) : null
+  const [copiedPath, setCopiedPath] = useState(false)
+
+  const handleCopyPath = useCallback(() => {
+    if (filePath) {
+      void copyToClipboard(filePath)
+      toast.success('Copied file path to clipboard')
+      setCopiedPath(true)
+      setTimeout(() => setCopiedPath(false), 2000)
+    }
+  }, [filePath])
 
   return (
     <Dialog open={!!filePath} onOpenChange={open => !open && onClose()}>
@@ -47,9 +60,24 @@ export function FileEditsDiffModal({
             )}
           </div>
           {filePath && (
-            <span className="text-muted-foreground font-normal text-xs truncate">
-              {filePath}
-            </span>
+            <div className="flex items-center gap-1.5 mt-0.5 select-text group/path min-w-0">
+              <span className="text-muted-foreground font-normal text-xs truncate select-text">
+                {filePath}
+              </span>
+              <button
+                type="button"
+                onClick={handleCopyPath}
+                className="inline-flex items-center justify-center h-5 w-5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0 cursor-pointer"
+                title="Copy file path"
+              >
+                {copiedPath ? (
+                  <Check className="h-3 w-3 text-green-500" />
+                ) : (
+                  <Copy className="h-3 w-3" />
+                )}
+                <span className="sr-only">Copy file path</span>
+              </button>
+            </div>
           )}
         </DialogTitle>
         <DialogDescription className="sr-only">


### PR DESCRIPTION
## Description
This pull request addresses issue #684 by adding the ability to copy file paths directly from the file viewer and file edits diff modals. Previously, the file path was unclickable and unselectable, making it difficult to reference or copy.

## Changes Made
- **Selectable Path Text**: Added `select-text` CSS class to the file path element in the viewer modals to make the text selectable by default.
- **Copy Button**: Added a copy icon button next to the file path display.
- **Micro-interactions**: Integrated the clipboard helper (`copyToClipboard`) to copy the path to the user's clipboard and implemented a transient success checkmark transition state (reverts after 2 seconds) for a native, satisfying feel.
- **Toast Notifications**: Added standard success toast notifications upon successfully copying the path.

## Affected Components
- `src/components/chat/FileContentModal.tsx`: The main modal for viewing file/image contents and editing.
- `src/components/chat/FileEditsDiffModal.tsx`: The modal for reviewing applied edits from assistant messages.

## Testing Done
- Verified TypeScript compilation.
- Verified ESLint rules (lint checks passed with no warnings/errors on modified files).
- Ran the full test suite (`npm run test:run`) with all 2,109 tests passing.
