### PR TITLE
fix(terminal): insert a newline on Shift+Enter

### DIFF
--- a/docs/developer/keyboard-shortcuts.md
+++ b/docs/developer/keyboard-shortcuts.md
@@ -378,3 +378,28 @@ fn default_keybindings() -> std::collections::HashMap<String, String> {
 5. **Support migration**: Add to `MIGRATED_KEYBINDINGS` when changing defaults
 6. **Use `mod` prefix**: Allows cross-platform compatibility
 7. **Provide feedback**: Use notifications or UI changes to confirm execution
+
+## Shift+Enter in the embedded terminal
+
+Terminals send a bare carriage return for both Enter and Shift+Enter, so a CLI
+that submits on Enter (Claude Code, Codex, …) cannot tell them apart and sends
+the message instead of inserting a newline. Terminals that can distinguish them
+encode the modifier with CSI u; xterm.js does not implement that protocol, so
+`src/lib/terminal-instances.ts` injects `\x1b[13;2u` itself.
+
+Two details make it work:
+
+- **Every event of the press is claimed, not just `keydown`.** The renderer
+  calls its key handler for `keydown`, `keypress` and `keyup`; letting
+  `keypress` through makes it emit its own carriage return in addition to the
+  sequence, which the CLI still reads as submit.
+- **The sequence is only sent when the foreground program can read it**
+  (`acceptsModifierEncodedKeys`), tracked from the program's own output: a
+  kitty keyboard protocol push, or focus reporting (`CSI ? 1004 h`). Claude Code
+  negotiates no keyboard protocol yet parses CSI u anyway, so focus reporting is
+  the signal it is recognised by. The alternate screen buffer is deliberately
+  **not** trusted — `vim`, `less`, `htop` and `fzf` use it without reading CSI u,
+  and in vim's insert mode the sequence would leave insert and undo changes.
+
+A plain shell prompt enables neither, so Shift+Enter there behaves like Enter
+instead of echoing a raw `;2u`.

--- a/src/lib/terminal-instances.shift-enter.test.ts
+++ b/src/lib/terminal-instances.shift-enter.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  SHIFT_ENTER_SEQUENCE,
+  acceptsModifierEncodedKeys,
+  handleShiftEnterKey,
+  isShiftEnterEvent,
+  shouldSendShiftEnterSequence,
+  trackTerminalKeyboardMode,
+} from './terminal-instances'
+
+const invokeMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/transport', () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+  isTransportConnected: () => true,
+  listen: vi.fn().mockResolvedValue(() => undefined),
+  requestTerminalReplay: vi.fn(),
+}))
+
+const keyEvent = (init: Partial<KeyboardEvent> & { type?: string }) =>
+  ({
+    type: 'keydown',
+    key: 'Enter',
+    shiftKey: false,
+    ctrlKey: false,
+    altKey: false,
+    metaKey: false,
+    isComposing: false,
+    keyCode: 13,
+    ...init,
+  }) as KeyboardEvent
+
+const terminalWrites = () =>
+  invokeMock.mock.calls.filter(([command]) => command === 'terminal_write')
+
+/** Input is coalesced on a short timer before it reaches the pty. */
+const flushInput = () => new Promise(resolve => setTimeout(resolve, 25))
+
+/**
+ * Terminals send a bare carriage return for both Enter and Shift+Enter, so a
+ * CLI that submits on Enter never sees the difference. CSI u encodes the
+ * modifier, which is what Claude Code reads; ESC+CR is not enough.
+ */
+describe('terminal Shift+Enter', () => {
+  beforeEach(() => {
+    invokeMock.mockReset()
+    invokeMock.mockResolvedValue(undefined)
+  })
+
+  it('sends the CSI u encoding of Shift+Enter', () => {
+    expect(SHIFT_ENTER_SEQUENCE).toBe('\x1b[13;2u')
+  })
+
+  it('sends the sequence once and keeps the renderer out of the press', async () => {
+    const id = 'handler-1'
+    trackTerminalKeyboardMode(id, '\x1b[?1004h')
+
+    // Every event of the press must be claimed: letting keypress through makes
+    // the renderer add its own carriage return, which the CLI reads as submit.
+    for (const type of ['keydown', 'keypress', 'keyup']) {
+      expect(handleShiftEnterKey(id, keyEvent({ type, shiftKey: true }))).toBe(
+        true
+      )
+    }
+    await flushInput()
+
+    expect(terminalWrites()).toEqual([
+      ['terminal_write', { terminalId: id, data: SHIFT_ENTER_SEQUENCE }],
+    ])
+  })
+
+  it('stays out of the way at a shell prompt', async () => {
+    const id = 'handler-shell'
+    trackTerminalKeyboardMode(id, '\x1b[?2004h')
+
+    expect(handleShiftEnterKey(id, keyEvent({ shiftKey: true }))).toBe(false)
+    await flushInput()
+
+    expect(terminalWrites()).toEqual([])
+  })
+
+  it('leaves plain Enter to the renderer even inside a TUI', async () => {
+    const id = 'handler-enter'
+    trackTerminalKeyboardMode(id, '\x1b[?1004h')
+
+    expect(handleShiftEnterKey(id, keyEvent({}))).toBe(false)
+    await flushInput()
+
+    expect(terminalWrites()).toEqual([])
+  })
+
+  it('ignores an Enter that confirms IME composition', () => {
+    const id = 'handler-ime'
+    trackTerminalKeyboardMode(id, '\x1b[?1004h')
+
+    expect(
+      handleShiftEnterKey(id, keyEvent({ shiftKey: true, isComposing: true }))
+    ).toBe(false)
+    // WKWebView reports keyCode 229 instead of isComposing (issue #584).
+    expect(
+      handleShiftEnterKey(id, keyEvent({ shiftKey: true, keyCode: 229 }))
+    ).toBe(false)
+  })
+
+  it('emits the sequence once per press', () => {
+    expect(shouldSendShiftEnterSequence(keyEvent({ shiftKey: true }))).toBe(true)
+    expect(
+      shouldSendShiftEnterSequence(
+        keyEvent({ type: 'keypress', shiftKey: true })
+      )
+    ).toBe(false)
+    expect(
+      shouldSendShiftEnterSequence(keyEvent({ type: 'keyup', shiftKey: true }))
+    ).toBe(false)
+  })
+
+  it('leaves other modifier combinations alone', () => {
+    expect(isShiftEnterEvent(keyEvent({ shiftKey: true, ctrlKey: true }))).toBe(
+      false
+    )
+    expect(isShiftEnterEvent(keyEvent({ shiftKey: true, altKey: true }))).toBe(
+      false
+    )
+    expect(isShiftEnterEvent(keyEvent({ shiftKey: true, metaKey: true }))).toBe(
+      false
+    )
+    expect(isShiftEnterEvent(keyEvent({ key: 'a', shiftKey: true }))).toBe(false)
+  })
+
+  it('follows the program in and out of the kitty keyboard protocol', () => {
+    const id = 'kitty-1'
+    expect(acceptsModifierEncodedKeys(id)).toBe(false)
+
+    trackTerminalKeyboardMode(id, '\x1b[>1u')
+    expect(acceptsModifierEncodedKeys(id)).toBe(true)
+
+    trackTerminalKeyboardMode(id, '\x1b[<1u')
+    expect(acceptsModifierEncodedKeys(id)).toBe(false)
+
+    trackTerminalKeyboardMode(id, '\x1b[=5;1u')
+    expect(acceptsModifierEncodedKeys(id)).toBe(true)
+    trackTerminalKeyboardMode(id, '\x1b[=0;1u')
+    expect(acceptsModifierEncodedKeys(id)).toBe(false)
+  })
+
+  it('trusts focus reporting, including inside a parameter list', () => {
+    // Claude Code negotiates no keyboard protocol; focus reporting is the
+    // narrowest mode it does enable.
+    const id = 'tui-focus'
+    trackTerminalKeyboardMode(id, '\x1b[?1004h')
+    expect(acceptsModifierEncodedKeys(id)).toBe(true)
+    trackTerminalKeyboardMode(id, '\x1b[?1004l')
+    expect(acceptsModifierEncodedKeys(id)).toBe(false)
+
+    const multi = 'tui-multi'
+    trackTerminalKeyboardMode(multi, '\x1b[?1004;1049h')
+    expect(acceptsModifierEncodedKeys(multi)).toBe(true)
+  })
+
+  it('does not trust the alternate screen on its own', () => {
+    // vim, less, htop and fzf use it without reading CSI u — and in vim's
+    // insert mode the sequence would leave insert and then undo two changes.
+    const id = 'alt-screen'
+    trackTerminalKeyboardMode(id, '\x1b[?1049h')
+    expect(acceptsModifierEncodedKeys(id)).toBe(false)
+  })
+
+  it('leaves a plain shell prompt alone', () => {
+    // zsh turns on bracketed paste only, and would echo the raw sequence.
+    const id = 'shell-1'
+    trackTerminalKeyboardMode(id, '\x1b[?2004h')
+    expect(acceptsModifierEncodedKeys(id)).toBe(false)
+  })
+
+  it('reads a sequence split across two output chunks', () => {
+    const id = 'split-1'
+    trackTerminalKeyboardMode(id, 'output\x1b[>')
+    expect(acceptsModifierEncodedKeys(id)).toBe(false)
+    trackTerminalKeyboardMode(id, '1u more output')
+    expect(acceptsModifierEncodedKeys(id)).toBe(true)
+  })
+
+  it('reads a sequence split immediately after the CSI introducer', () => {
+    // A pty read can end anywhere, including between `[` and its parameters.
+    const id = 'split-2'
+    trackTerminalKeyboardMode(id, 'output\x1b[')
+    trackTerminalKeyboardMode(id, '?1004h')
+    expect(acceptsModifierEncodedKeys(id)).toBe(true)
+  })
+
+  it('counts a push only once when a chunk boundary is carried over', () => {
+    const id = 'split-3'
+    trackTerminalKeyboardMode(id, '\x1b[>1u')
+    trackTerminalKeyboardMode(id, 'plain output')
+    trackTerminalKeyboardMode(id, '\x1b[<1u')
+    expect(acceptsModifierEncodedKeys(id)).toBe(false)
+  })
+
+  it('does not grow the carried-over tail without bound', () => {
+    const id = 'split-4'
+    for (let i = 0; i < 50; i += 1) {
+      trackTerminalKeyboardMode(id, '\x1b[?' + '1;'.repeat(20))
+    }
+    // A stuck partial sequence must not turn every chunk into a longer rescan.
+    trackTerminalKeyboardMode(id, '1004h')
+    expect(acceptsModifierEncodedKeys(id)).toBe(false)
+  })
+})

--- a/src/lib/terminal-instances.ts
+++ b/src/lib/terminal-instances.ts
@@ -577,6 +577,149 @@ function shouldLetAppHandleShortcut(event: KeyboardEvent): boolean {
   return event.altKey && (code === 'Backspace' || code === 'Delete')
 }
 
+/**
+ * Terminals send the same carriage return for Enter and Shift+Enter, so a CLI
+ * that submits on Enter (Claude Code, Codex, …) sends the message instead of
+ * inserting a newline. Terminals that can tell them apart encode the modifier
+ * with CSI u (kitty keyboard protocol): `CSI 13 ; 2 u` is Enter with Shift.
+ * xterm.js does not implement that protocol, so the sequence is injected here.
+ * https://code.claude.com/docs/en/terminal-config
+ */
+export const SHIFT_ENTER_SEQUENCE = '\x1b[13;2u'
+
+/**
+ * True for every event of a Shift+Enter press. The renderer calls its key
+ * handler for keydown, keypress and keyup, so all three must be suppressed —
+ * letting keypress through makes the terminal send its own carriage return in
+ * addition to the sequence, which the CLI reads as submit.
+ */
+export function isShiftEnterEvent(event: KeyboardEvent): boolean {
+  return (
+    event.key === 'Enter' &&
+    event.shiftKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.metaKey &&
+    // An Enter that confirms IME composition belongs to the composition, not
+    // to the terminal (issue #584; WKWebView reports keyCode 229 instead).
+    !event.isComposing &&
+    event.keyCode !== 229
+  )
+}
+
+/**
+ * Handle one key event of a possible Shift+Enter press for a terminal.
+ *
+ * Returns true when the renderer must not process the event itself: emitting
+ * the sequence AND letting the renderer run would send a carriage return too,
+ * which the CLI reads as submit. Callers map that to their own convention.
+ */
+export function handleShiftEnterKey(
+  terminalId: string,
+  event: KeyboardEvent
+): boolean {
+  if (!isShiftEnterEvent(event)) return false
+  if (!acceptsModifierEncodedKeys(terminalId)) return false
+  if (shouldSendShiftEnterSequence(event)) {
+    queueTerminalInput(terminalId, SHIFT_ENTER_SEQUENCE)
+  }
+  return true
+}
+
+/** Only the keydown of that press may emit the sequence, or it repeats. */
+export function shouldSendShiftEnterSequence(event: KeyboardEvent): boolean {
+  return event.type === 'keydown' && isShiftEnterEvent(event)
+}
+
+/**
+ * Whether the foreground program can read modifier-encoded keys, tracked from
+ * its own output. Two signals:
+ *
+ * - The kitty keyboard protocol: a program pushes flags with `CSI > flags u`,
+ *   restores them with `CSI < number u`, or sets them with `CSI = flags ; n u`.
+ *   This is the only signal a real terminal acts on.
+ * - Focus reporting (`CSI ? 1004 h`). Claude Code negotiates no keyboard
+ *   protocol at all, yet parses CSI u input; focus reporting is the narrowest
+ *   mode it does enable. Trusting it is deliberately more aggressive than any
+ *   terminal emulator, so keep it as tight as possible: the alternate screen
+ *   buffer is NOT trusted, because `less`, `htop`, `fzf` and classic `vim` use
+ *   it without reading CSI u — and in vim's insert mode a stray `\x1b[13;2u`
+ *   leaves insert, repeats a search and then undoes two changes.
+ *
+ * A plain shell prompt enables neither, which is what keeps Shift+Enter from
+ * spraying `;2u` into a command line that cannot read it.
+ *
+ * ponytail: a program killed before it restores the mode leaves the verdict
+ * stuck on until the terminal is closed. Track the foreground process if that
+ * ever matters.
+ */
+interface TerminalKeyboardState {
+  /** Depth of the kitty keyboard flag stack. */
+  kittyDepth: number
+  focusReporting: boolean
+  /** Trailing partial escape sequence carried over between output chunks. */
+  tail: string
+}
+
+const keyboardStates = new Map<string, TerminalKeyboardState>()
+// eslint-disable-next-line no-control-regex -- ESC starts every CSI sequence
+const KITTY_KEYBOARD_SEQUENCE = /\x1b\[([<>=])([0-9;]*)u/g
+// eslint-disable-next-line no-control-regex -- ESC starts every CSI sequence
+const PRIVATE_MODE_SEQUENCE = /\x1b\[\?([0-9;]+)([hl])/g
+// eslint-disable-next-line no-control-regex -- ESC starts every CSI sequence
+const PARTIAL_TAIL = /\x1b\[?[<>=?]?[0-9;]*$/
+/** A CSI introducer is a handful of bytes; never carry more than this. */
+const MAX_TAIL_LENGTH = 32
+
+function getKeyboardState(terminalId: string): TerminalKeyboardState {
+  const existing = keyboardStates.get(terminalId)
+  if (existing) return existing
+  const created = { kittyDepth: 0, focusReporting: false, tail: '' }
+  keyboardStates.set(terminalId, created)
+  return created
+}
+
+export function trackTerminalKeyboardMode(
+  terminalId: string,
+  data: string
+): void {
+  const existing = keyboardStates.get(terminalId)
+  if (!existing?.tail && !data.includes('\x1b')) return
+
+  const state = getKeyboardState(terminalId)
+  const text = state.tail + data
+
+  for (const [, kind, params] of text.matchAll(KITTY_KEYBOARD_SEQUENCE)) {
+    if (kind === '>') {
+      state.kittyDepth += 1
+    } else if (kind === '<') {
+      state.kittyDepth = Math.max(0, state.kittyDepth - (Number(params) || 1))
+    } else {
+      const flags = Number(params?.split(';')[0])
+      state.kittyDepth = flags > 0 ? Math.max(state.kittyDepth, 1) : 0
+    }
+  }
+
+  for (const [, params, action] of text.matchAll(PRIVATE_MODE_SEQUENCE)) {
+    const enabled = action === 'h'
+    for (const mode of (params ?? '').split(';')) {
+      if (mode === '1004') state.focusReporting = enabled
+    }
+  }
+
+  state.tail = (text.match(PARTIAL_TAIL)?.[0] ?? '').slice(-MAX_TAIL_LENGTH)
+}
+
+export function acceptsModifierEncodedKeys(terminalId: string): boolean {
+  const state = keyboardStates.get(terminalId)
+  if (!state) return false
+  return state.kittyDepth > 0 || state.focusReporting
+}
+
+function forgetTerminalKeyboardMode(terminalId: string): void {
+  keyboardStates.delete(terminalId)
+}
+
 const INPUT_FLUSH_DELAY_MS = 5
 
 /** Control chars that must never be silently dropped on a brief WS disconnect
@@ -744,7 +887,8 @@ function queueTerminalOutput(instance: PersistentTerminal, data: string): void {
 
 async function createTerminalForRenderer(
   renderer: TerminalRenderer,
-  worktreePath: string
+  worktreePath: string,
+  terminalId: string
 ): Promise<{
   terminal: EmbeddedTerminal
   fitAddon: EmbeddedFitAddon
@@ -766,6 +910,7 @@ async function createTerminalForRenderer(
     terminal.attachCustomKeyEventHandler(event => {
       // ghostty-web uses the inverse convention from xterm.js:
       // true means "custom handler consumed/prevented default".
+      if (handleShiftEnterKey(terminalId, event)) return true
       return shouldLetAppHandleShortcut(event)
     })
     const fitAddon = new GhosttyWebFitAddon()
@@ -778,6 +923,12 @@ async function createTerminalForRenderer(
     allowProposedApi: true,
   })
   terminal.attachCustomKeyEventHandler(event => {
+    // Returning false keeps xterm from also sending its own carriage return.
+    // xterm skips its own cancel() on that path, so prevent the default here.
+    if (handleShiftEnterKey(terminalId, event)) {
+      event.preventDefault()
+      return false
+    }
     if (shouldLetAppHandleShortcut(event)) return false
     // All other CMD shortcuts: xterm consumes them (prevents app actions)
     return true
@@ -813,7 +964,8 @@ async function ensureTerminalCreated(
   try {
     const { terminal, fitAddon, appearance } = await createTerminalForRenderer(
       instance.renderer,
-      instance.worktreePath
+      instance.worktreePath,
+      terminalId
     )
 
     if (!isCurrentInstance(terminalId, instance)) {
@@ -856,6 +1008,10 @@ function ensureTerminalBackendListeners(): Promise<void> {
         const terminalId = event.payload.terminal_id
         const inst = instances.get(terminalId)
         if (!inst) return
+        // Track here, not in queueTerminalOutput: buffered output re-enters
+        // that function, which would count a kitty push twice and leave the
+        // stack permanently non-empty.
+        trackTerminalKeyboardMode(terminalId, event.payload.data)
         queueTerminalOutput(inst, event.payload.data)
       }),
       listen<TerminalStartedEvent>('terminal:started', event => {
@@ -1350,6 +1506,7 @@ export async function disposeTerminal(terminalId: string): Promise<void> {
   instances.delete(terminalId)
   discardTerminalInput(terminalId)
   outputBuffers.delete(terminalId)
+  forgetTerminalKeyboardMode(terminalId)
   instance.pendingOutput = []
   instance.readyForOutput = false
   instance.outputReadyPromise = null


### PR DESCRIPTION
## Summary

- Make Shift+Enter insert a newline in the embedded terminal instead of submitting: terminals send a bare carriage return for both Enter and Shift+Enter, so Claude Code and friends cannot tell them apart. xterm.js cannot produce the CSI u encoding that would, so inject `\x1b[13;2u` and claim every event of the press, or the renderer adds its own carriage return and the CLI still submits.
- Send it only while the foreground program has shown it reads that encoding — a kitty keyboard protocol push, or focus reporting (`CSI ? 1004 h`, which Claude Code enables). The alternate screen is deliberately not trusted: `vim`, `less` and `fzf` use it without reading CSI u. A plain shell prompt qualifies for neither, so Shift+Enter there still behaves like Enter and never echoes a raw `;2u`.
- Add 15 tests covering the encoding, per-press emission, IME-composition Enter, protocol tracking, and the output chunk-split edge cases.

## Test plan

`bun run check:all` passes. Verified manually on macOS with xterm.js: Shift+Enter inserts a newline in Claude Code, Enter still submits, the zsh prompt is clean, and Ctrl+C/Ctrl+D are unaffected. The `ghostty-web` renderer shares the handler but was not exercised by hand.
