### PR TITLE
feat(terminal): report Claude Code status; fix stuck Codex sessions

### DIFF
--- a/docs/developer/architecture-guide.md
+++ b/docs/developer/architecture-guide.md
@@ -159,14 +159,30 @@ Additional systems (no dedicated docs yet):
   terminal session from the session-tab context menu; the original chat session
   remains unchanged.
 
-  **Codex terminal attention.** Full-screen Codex terminals receive a
-  session-scoped `notify` override for the official `agent-turn-complete`
-  event. Jean tails that notification file, persists the Codex thread id and
-  terminal activity timestamp, marks the session waiting, invalidates session
-  caches, and emits `terminal:attention`. Submitting terminal input clears the
+  **Terminal attention.** Full-screen Codex and Claude terminals report their
+  turn lifecycle into a terminal-scoped signal file
+  (`<app_data>/terminal-notifications/{terminal}.jsonl`, one NDJSON line per
+  event — keyed by terminal, not session, because the tailer thread that deletes
+  the file lives and dies with its terminal). Codex gets a `notify` override for
+  the official `agent-turn-complete`
+  event; Claude gets `UserPromptSubmit` / `Stop` / `Notification`
+  (`permission_prompt`) / `SessionEnd` hooks injected as inline `--settings`
+  JSON, so the user's own `~/.claude/settings.json` is never touched. Jean tails
+  the file, persists the Codex thread id and terminal activity timestamp, flips
+  the session between working, waiting, and idle, invalidates session caches,
+  and emits `terminal:working` / `terminal:attention` / `terminal:idle`.
+  Attention also plays the configured waiting sound and fires an OS banner,
+  matching `chat:done`; `terminal:idle` (the CLI is gone) silently clears both
+  flags. The tailer emits one final `terminal:idle` when its terminal
+  disappears, whatever ended the CLI — Codex has no session-end event to report
+  with, and submitting `/exit` itself counts as terminal input, so without it a
+  quit Codex session stays pinned to "in progress". Submitting terminal input clears the
   waiting state. The backing Jean `sessionId` must therefore be carried through
   terminal creation, native-session reconnect, frontend terminal persistence,
-  `start_terminal`, and both native/WebSocket transports.
+  `start_terminal`, and both native/WebSocket transports. Terminals opened in an
+  *external* OS terminal cannot be instrumented and stay idle. Only the CLI
+  Jean itself launches is instrumented; one the user starts *by hand* in that
+  terminal carries no hook and does not report.
 
   **Web-mode persistence.** In web access (Axum HTTP server + WebSocket),
   panel/side/drawer and modal terminals survive a full browser refresh. Three

--- a/jean-core/src/terminal/attention.rs
+++ b/jean-core/src/terminal/attention.rs
@@ -1,4 +1,10 @@
-//! Lifecycle signals for Codex sessions running in Jean's native terminal.
+//! Lifecycle signals for backend CLI sessions running in Jean's native terminal.
+//!
+//! Codex reports turn completion through its `notify` config hook; Claude Code
+//! reports through `UserPromptSubmit` / `Stop` / `Notification` hooks injected
+//! with an inline `--settings` JSON. Both write one NDJSON line per event into
+//! a per-terminal signal file that a tailer thread turns into `terminal:working`
+//! / `terminal:attention` / `terminal:idle` events.
 
 use once_cell::sync::Lazy;
 use serde::Deserialize;
@@ -15,6 +21,9 @@ use crate::http_server::EmitExt;
 static TERMINAL_SESSIONS: Lazy<Mutex<HashMap<String, (AppHandle, String)>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
+/// Grace period before an unregistered terminal's signal file is reclaimed.
+const FRESH_SIGNAL_FILE: Duration = Duration::from_secs(60);
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct CodexNotification {
@@ -25,13 +34,32 @@ struct CodexNotification {
     input_messages: Vec<String>,
 }
 
-#[derive(Debug, PartialEq)]
-struct ParsedNotification {
-    thread_id: Option<String>,
-    first_prompt: Option<String>,
+/// Claude Code hook payload (delivered on the hook's stdin).
+#[derive(Debug, Deserialize)]
+struct ClaudeHookEvent {
+    hook_event_name: String,
+    prompt: Option<String>,
+    notification_type: Option<String>,
 }
 
-fn signal_file(app: &AppHandle, session_id: &str) -> Result<PathBuf, String> {
+/// A lifecycle transition parsed out of a signal file line.
+#[derive(Debug, PartialEq)]
+enum Signal {
+    /// The user submitted a prompt: the session is working again.
+    TurnStart { first_prompt: Option<String> },
+    /// The agent finished or needs input: the session wants attention.
+    Attention {
+        thread_id: Option<String>,
+        first_prompt: Option<String>,
+    },
+    /// The CLI exited while the terminal stayed open: nothing to wait for.
+    Idle,
+}
+
+/// Keyed by terminal id, not session id: the tailer thread that deletes this
+/// file exits with its terminal. A session-keyed path would let the outgoing
+/// tailer of a reopened session terminal unlink the incoming terminal's file.
+fn signal_file(app: &AppHandle, terminal_id: &str) -> Result<PathBuf, String> {
     let dir = app
         .path()
         .app_data_dir()
@@ -39,15 +67,53 @@ fn signal_file(app: &AppHandle, session_id: &str) -> Result<PathBuf, String> {
         .join("terminal-notifications");
     std::fs::create_dir_all(&dir)
         .map_err(|error| format!("Failed to create terminal notification dir: {error}"))?;
-    let safe_session_id = crate::chat::storage::sanitize_filename(session_id);
-    Ok(dir.join(format!("{safe_session_id}.jsonl")))
+    sweep_orphaned_signal_files(&dir);
+    let safe_terminal_id = crate::chat::storage::sanitize_filename(terminal_id);
+    Ok(dir.join(format!("{safe_terminal_id}.jsonl")))
+}
+
+/// The tailer deletes its own signal file, but it dies with the process on a
+/// crash or force quit. Reclaim files whose terminal is gone whenever a new
+/// instrumented terminal starts.
+fn sweep_orphaned_signal_files(dir: &Path) {
+    let live: Vec<String> = super::registry::get_all_terminal_ids()
+        .iter()
+        .map(|id| crate::chat::storage::sanitize_filename(id))
+        .collect();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let is_live = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .is_some_and(|stem| live.iter().any(|id| id == stem));
+        // A terminal starting right now has already written its file but is not
+        // registered until it spawns, so leave fresh files alone.
+        let is_fresh = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .is_ok_and(|modified| modified.elapsed().is_ok_and(|age| age < FRESH_SIGNAL_FILE));
+        if !is_live && !is_fresh {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+fn command_basename_is(command: &str, name: &str) -> bool {
+    Path::new(command)
+        .file_name()
+        .and_then(|file_name| file_name.to_str())
+        .is_some_and(|file_name| file_name == name || file_name == format!("{name}.exe"))
 }
 
 pub fn is_codex_command(command: &str) -> bool {
-    Path::new(command)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name == "codex" || name == "codex.exe")
+    command_basename_is(command, "codex")
+}
+
+pub fn is_claude_command(command: &str) -> bool {
+    command_basename_is(command, "claude")
 }
 
 #[cfg(unix)]
@@ -72,23 +138,91 @@ fn notify_command(signal_path: &Path) -> Vec<String> {
     ]
 }
 
-fn codex_notify_args(signal_path: &Path, args: Vec<String>) -> Vec<String> {
+/// Shell command a Claude hook runs: append its stdin JSON as one NDJSON line.
+///
+/// Built as a single `printf` so hooks do not interleave a half line into the
+/// signal file. `O_APPEND` only makes that atomic below `PIPE_BUF`, but the
+/// hooks Jean registers never fire concurrently in practice.
+#[cfg(unix)]
+fn claude_hook_command(signal_path: &Path) -> String {
+    let path = crate::platform::shell_escape(&signal_path.to_string_lossy());
+    format!("printf '%s\\n' \"$(tr -d '\\n')\" >> {path}")
+}
+
+#[cfg(windows)]
+fn claude_hook_command(signal_path: &Path) -> String {
+    let path = signal_path.to_string_lossy().replace('\'', "''");
+    format!(
+        "powershell.exe -NoProfile -Command \"Add-Content -LiteralPath '{path}' -Value ([Console]::In.ReadToEnd() -replace '[\\r\\n]','')\""
+    )
+}
+
+/// Claude Code lifecycle hooks, as an inline `--settings` JSON payload.
+///
+/// `UserPromptSubmit` marks the session working, `Stop` and permission prompts
+/// mark it as needing attention, and `SessionEnd` clears both so a session whose
+/// CLI exited does not sit on a stale waiting badge.
+pub(super) fn claude_hook_args(signal_path: &Path, args: Vec<String>) -> Vec<String> {
+    // Two `--settings` flags means one silently loses. A custom launch config
+    // that already carries one keeps it; that terminal just does not report.
+    if args.iter().any(|arg| arg == "--settings") {
+        log::warn!("terminal notifications: launch args already set --settings, not instrumenting");
+        return args;
+    }
+    let command = claude_hook_command(signal_path);
+    let hooks = serde_json::json!([{ "type": "command", "command": command }]);
+    let entry = serde_json::json!([{ "hooks": hooks.clone() }]);
+    let settings = serde_json::json!({
+        "hooks": {
+            "UserPromptSubmit": entry.clone(),
+            "Stop": entry.clone(),
+            // No matcher: every end reason (clear, resume, logout,
+            // prompt_input_exit, ...) should release the waiting state.
+            "SessionEnd": entry,
+            "Notification": [{
+                "matcher": "permission_prompt",
+                "hooks": hooks,
+            }],
+        }
+    });
+    let mut augmented = vec!["--settings".to_string(), settings.to_string()];
+    augmented.extend(args);
+    augmented
+}
+
+pub(super) fn codex_notify_args(signal_path: &Path, args: Vec<String>) -> Vec<String> {
+    // Same silent-loss problem as the Claude `--settings` guard: one of the two
+    // `notify` overrides wins and the other vanishes. Keep the user's.
+    if args
+        .windows(2)
+        .any(|pair| pair[0] == "-c" && pair[1].starts_with("notify="))
+    {
+        log::warn!("terminal notifications: launch args already set notify=, not instrumenting");
+        return args;
+    }
     let notify = serde_json::to_string(&notify_command(signal_path)).unwrap_or_default();
     let mut augmented = vec!["-c".to_string(), format!("notify={notify}")];
     augmented.extend(args);
     augmented
 }
 
-pub fn inject_codex_notify(
+/// Prepend the backend's lifecycle-hook arguments so it reports turn state into
+/// a per-terminal signal file. Returns the args unchanged for backends we cannot
+/// instrument.
+pub fn inject_lifecycle_hook(
     app: &AppHandle,
-    session_id: &str,
+    terminal_id: &str,
     command: &str,
     args: Vec<String>,
 ) -> (Vec<String>, Option<PathBuf>) {
-    if !is_codex_command(command) {
+    let build_args: fn(&Path, Vec<String>) -> Vec<String> = if is_codex_command(command) {
+        codex_notify_args
+    } else if is_claude_command(command) {
+        claude_hook_args
+    } else {
         return (args, None);
-    }
-    let path = match signal_file(app, session_id) {
+    };
+    let path = match signal_file(app, terminal_id) {
         Ok(path) => path,
         Err(error) => {
             log::warn!("terminal notifications: {error}");
@@ -99,10 +233,14 @@ pub fn inject_codex_notify(
         log::warn!("terminal notifications: cannot reset signal file: {error}");
         return (args, None);
     }
-    (codex_notify_args(&path, args), Some(path))
+    (build_args(&path, args), Some(path))
 }
 
-fn parse_codex_notification(line: &str) -> Option<ParsedNotification> {
+fn non_empty(value: Option<String>) -> Option<String> {
+    value.filter(|text| !text.trim().is_empty())
+}
+
+fn parse_codex_notification(line: &str) -> Option<Signal> {
     let notification: CodexNotification = serde_json::from_str(line).ok()?;
     if notification.event_type != "agent-turn-complete" {
         return None;
@@ -111,10 +249,43 @@ fn parse_codex_notification(line: &str) -> Option<ParsedNotification> {
         .input_messages
         .into_iter()
         .find(|message| !message.trim().is_empty());
-    Some(ParsedNotification {
+    Some(Signal::Attention {
         thread_id: notification.thread_id,
         first_prompt,
     })
+}
+
+fn parse_claude_hook(line: &str) -> Option<Signal> {
+    let event: ClaudeHookEvent = serde_json::from_str(line).ok()?;
+    match event.hook_event_name.as_str() {
+        "UserPromptSubmit" => Some(Signal::TurnStart {
+            first_prompt: non_empty(event.prompt),
+        }),
+        "Stop" => Some(Signal::Attention {
+            thread_id: None,
+            first_prompt: None,
+        }),
+        // The CLI matches `matcher` as an unanchored regex, so subagent prompts
+        // (`worker_permission_prompt`) reach us too. They block the turn just
+        // like a top-level prompt, so treat both as attention.
+        "Notification"
+            if event
+                .notification_type
+                .as_deref()
+                .is_some_and(|kind| kind.ends_with("permission_prompt")) =>
+        {
+            Some(Signal::Attention {
+                thread_id: None,
+                first_prompt: None,
+            })
+        }
+        "SessionEnd" => Some(Signal::Idle),
+        _ => None,
+    }
+}
+
+fn parse_signal_line(line: &str) -> Option<Signal> {
+    parse_codex_notification(line).or_else(|| parse_claude_hook(line))
 }
 
 fn set_waiting(app: &AppHandle, session_id: &str, waiting: bool, codex_thread_id: Option<&str>) {
@@ -151,54 +322,91 @@ pub fn spawn_signal_tailer(
         .unwrap()
         .insert(terminal_id.clone(), (app.clone(), session_id.clone()));
     std::thread::spawn(move || {
-        let mut tailer = match NdjsonTailer::new_from_start(&signal_path) {
-            Ok(tailer) => tailer,
-            Err(error) => {
-                log::warn!("terminal notifications: cannot tail signal file: {error}");
-                TERMINAL_SESSIONS.lock().unwrap().remove(&terminal_id);
+        let mut naming_attempted = false;
+        let mut maybe_name_session = |first_prompt: Option<String>| {
+            if naming_attempted {
                 return;
             }
-        };
-        let mut naming_attempted = false;
-        let mut handle_line = |line: &str| {
-            let Some(notification) = parse_codex_notification(line.trim()) else {
+            let Some(prompt) = first_prompt else {
                 return;
             };
-            set_waiting(&app, &session_id, true, notification.thread_id.as_deref());
-            if !naming_attempted {
-                if let Some(prompt) = notification.first_prompt {
-                    naming_attempted = true;
-                    let app = app.clone();
-                    let session_id = session_id.clone();
-                    tauri::async_runtime::spawn(async move {
-                        crate::chat::trigger_terminal_session_naming(app, session_id, prompt).await;
-                    });
-                }
-            }
-            let _ = app.emit_all(
-                "terminal:attention",
-                &serde_json::json!({ "sessionId": session_id }),
-            );
+            naming_attempted = true;
+            let app = app.clone();
+            let session_id = session_id.clone();
+            tauri::async_runtime::spawn(async move {
+                crate::chat::trigger_terminal_session_naming(app, session_id, prompt).await;
+            });
         };
-        loop {
-            if let Ok(lines) = tailer.poll() {
-                for line in lines {
-                    handle_line(&line);
+        let handle_line = |line: &str| {
+            let Some(signal) = parse_signal_line(line.trim()) else {
+                return;
+            };
+            let (waiting, event, thread_id, first_prompt) = match signal {
+                Signal::TurnStart { first_prompt } => {
+                    (false, "terminal:working", None, first_prompt)
                 }
-            }
-            if !super::registry::has_terminal(&terminal_id) {
-                if let Ok(lines) = tailer.poll() {
-                    for line in lines {
-                        handle_line(&line);
-                    }
-                }
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(200));
-        }
+                Signal::Attention {
+                    thread_id,
+                    first_prompt,
+                } => (true, "terminal:attention", thread_id, first_prompt),
+                Signal::Idle => (false, "terminal:idle", None, None),
+            };
+            set_waiting(&app, &session_id, waiting, thread_id.as_deref());
+            maybe_name_session(first_prompt);
+            let _ = app.emit_all(event, &serde_json::json!({ "sessionId": session_id }));
+        };
+        tail_until_closed(
+            &signal_path,
+            || super::registry::has_terminal(&terminal_id),
+            handle_line,
+        );
         TERMINAL_SESSIONS.lock().unwrap().remove(&terminal_id);
-        let _ = std::fs::remove_file(signal_path);
+        // The CLI is gone, whatever ended it (`/exit`, Ctrl-C, crash, kill).
+        // Without this the session keeps whichever state its last signal left —
+        // and submitting `/exit` itself counts as input, so the last state is
+        // "working". Codex has no session-end event of its own to report with;
+        // for Claude this just repeats an already-handled `SessionEnd`.
+        set_waiting(&app, &session_id, false, None);
+        let _ = app.emit_all(
+            "terminal:idle",
+            &serde_json::json!({ "sessionId": session_id }),
+        );
     });
+}
+
+/// Tail `signal_path` until `is_open` goes false, then delete it.
+///
+/// Drains once more after the terminal is gone so a final `Stop` written during
+/// teardown is not dropped. Always removes the file, including on open failure.
+fn tail_until_closed(
+    signal_path: &Path,
+    mut is_open: impl FnMut() -> bool,
+    mut handle_line: impl FnMut(&str),
+) {
+    let mut tailer = match NdjsonTailer::new_from_start(signal_path) {
+        Ok(tailer) => tailer,
+        Err(error) => {
+            log::warn!("terminal notifications: cannot tail signal file: {error}");
+            let _ = std::fs::remove_file(signal_path);
+            return;
+        }
+    };
+    let mut drain = |tailer: &mut NdjsonTailer| {
+        if let Ok(lines) = tailer.poll() {
+            for line in lines {
+                handle_line(&line);
+            }
+        }
+    };
+    loop {
+        drain(&mut tailer);
+        if !is_open() {
+            drain(&mut tailer);
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    let _ = std::fs::remove_file(signal_path);
 }
 
 fn input_submits_prompt(data: &str) -> bool {
@@ -234,6 +442,18 @@ mod tests {
     }
 
     #[test]
+    fn detects_claude_command_by_name_and_path() {
+        assert!(is_claude_command("claude"));
+        assert!(is_claude_command(
+            "/Users/x/Library/Application Support/jean/claude-cli/claude"
+        ));
+        assert!(is_claude_command("claude.exe"));
+        assert!(!is_claude_command("codex"));
+        assert!(!is_claude_command("claude-extra"));
+        assert!(!is_claude_command(""));
+    }
+
+    #[test]
     fn terminal_signal_filename_cannot_escape_notification_directory() {
         let safe_session_id = crate::chat::storage::sanitize_filename("../../session/1");
 
@@ -256,21 +476,164 @@ mod tests {
 
     #[test]
     fn parses_agent_turn_complete_payload() {
-        let payload = parse_codex_notification(
+        let payload = parse_signal_line(
             r#"{"type":"agent-turn-complete","thread-id":"thread-1","input-messages":["Fix the terminal state"],"last-assistant-message":"Done"}"#,
         )
         .unwrap();
-        assert_eq!(payload.thread_id.as_deref(), Some("thread-1"));
         assert_eq!(
-            payload.first_prompt.as_deref(),
-            Some("Fix the terminal state")
+            payload,
+            Signal::Attention {
+                thread_id: Some("thread-1".to_string()),
+                first_prompt: Some("Fix the terminal state".to_string()),
+            }
         );
     }
 
     #[test]
     fn ignores_other_notification_events() {
-        assert!(parse_codex_notification(r#"{"type":"other"}"#).is_none());
-        assert!(parse_codex_notification("not-json").is_none());
+        assert!(parse_signal_line(r#"{"type":"other"}"#).is_none());
+        assert!(parse_signal_line("not-json").is_none());
+    }
+
+    #[test]
+    fn claude_settings_hook_is_inserted_before_resume_args() {
+        let result = claude_hook_args(
+            Path::new("/tmp/session.jsonl"),
+            vec!["--resume".to_string(), "abc".to_string()],
+        );
+        assert_eq!(result[0], "--settings");
+        assert_eq!(&result[2..], ["--resume", "abc"]);
+
+        let settings: serde_json::Value = serde_json::from_str(&result[1]).unwrap();
+        let hooks = &settings["hooks"];
+        for event in ["UserPromptSubmit", "Stop", "SessionEnd", "Notification"] {
+            let command = hooks[event][0]["hooks"][0]["command"].as_str().unwrap();
+            assert!(command.contains("session.jsonl"), "{event}: {command}");
+            assert_eq!(hooks[event][0]["hooks"][0]["type"], "command");
+        }
+        assert_eq!(hooks["Notification"][0]["matcher"], "permission_prompt");
+    }
+
+    #[test]
+    fn parses_claude_stop_and_permission_prompt_as_attention() {
+        let attention = Signal::Attention {
+            thread_id: None,
+            first_prompt: None,
+        };
+        assert_eq!(
+            parse_signal_line(r#"{"hook_event_name":"Stop","session_id":"s1"}"#).unwrap(),
+            attention
+        );
+        assert_eq!(
+            parse_signal_line(
+                r#"{"hook_event_name":"Notification","notification_type":"permission_prompt"}"#
+            )
+            .unwrap(),
+            attention
+        );
+    }
+
+    #[test]
+    fn parses_claude_user_prompt_submit_as_turn_start_with_prompt() {
+        assert_eq!(
+            parse_signal_line(
+                r#"{"hook_event_name":"UserPromptSubmit","prompt":"Fix the terminal state"}"#
+            )
+            .unwrap(),
+            Signal::TurnStart {
+                first_prompt: Some("Fix the terminal state".to_string()),
+            }
+        );
+        assert_eq!(
+            parse_signal_line(r#"{"hook_event_name":"UserPromptSubmit","prompt":"   "}"#).unwrap(),
+            Signal::TurnStart { first_prompt: None }
+        );
+    }
+
+    #[test]
+    fn parses_claude_session_end_as_idle() {
+        assert_eq!(
+            parse_signal_line(r#"{"hook_event_name":"SessionEnd","session_id":"s1"}"#).unwrap(),
+            Signal::Idle
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_claude_hook_events() {
+        assert!(parse_signal_line(r#"{"hook_event_name":"PreToolUse"}"#).is_none());
+        assert!(parse_signal_line(
+            r#"{"hook_event_name":"Notification","notification_type":"idle_prompt"}"#
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn subagent_permission_prompts_also_ask_for_attention() {
+        assert_eq!(
+            parse_signal_line(
+                r#"{"hook_event_name":"Notification","notification_type":"worker_permission_prompt"}"#
+            ),
+            Some(Signal::Attention {
+                thread_id: None,
+                first_prompt: None,
+            })
+        );
+    }
+
+    #[test]
+    fn tailer_drains_teardown_writes_then_deletes_the_signal_file() {
+        use std::io::Write;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("signal.jsonl");
+        let mut file = std::fs::File::create(&path).unwrap();
+        writeln!(
+            file,
+            r#"{{"hook_event_name":"UserPromptSubmit","prompt":"hi"}}"#
+        )
+        .unwrap();
+
+        // Closes after the first poll, and writes a final line during teardown:
+        // the extra drain has to pick it up.
+        let open = AtomicBool::new(true);
+        let mut seen = Vec::new();
+        tail_until_closed(
+            &path,
+            || {
+                if open.swap(false, Ordering::SeqCst) {
+                    writeln!(file, r#"{{"hook_event_name":"Stop"}}"#).unwrap();
+                    true
+                } else {
+                    false
+                }
+            },
+            |line| seen.push(parse_signal_line(line.trim())),
+        );
+
+        assert_eq!(
+            seen,
+            vec![
+                Some(Signal::TurnStart {
+                    first_prompt: Some("hi".to_string())
+                }),
+                Some(Signal::Attention {
+                    thread_id: None,
+                    first_prompt: None,
+                }),
+            ]
+        );
+        assert!(!path.exists(), "signal file must not outlive its terminal");
+    }
+
+    /// `is_open` never goes false here: an unopenable signal file has to bail
+    /// out instead of spinning forever.
+    #[test]
+    fn tailer_gives_up_when_the_signal_file_cannot_be_opened() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing.jsonl");
+        tail_until_closed(&path, || true, |_| panic!("no lines expected"));
+        assert!(!path.exists());
     }
 
     #[test]

--- a/jean-core/src/terminal/commands.rs
+++ b/jean-core/src/terminal/commands.rs
@@ -58,9 +58,9 @@ pub async fn start_terminal(
     let (command_args, signal) = match (command.as_deref(), session_id.as_deref()) {
         (Some(command), Some(session_id)) => {
             let had_args = command_args.is_some();
-            let (args, signal) = super::attention::inject_codex_notify(
+            let (args, signal) = super::attention::inject_lifecycle_hook(
                 &app,
-                session_id,
+                &terminal_id,
                 command,
                 command_args.unwrap_or_default(),
             );
@@ -74,7 +74,9 @@ pub async fn start_terminal(
         _ => (command_args, None),
     };
 
-    spawn_terminal(
+    // The tailer owns cleanup of the signal file, so a spawn failure (no
+    // tailer) has to clean up after itself.
+    let spawned = spawn_terminal(
         &app,
         terminal_id.clone(),
         worktree_path,
@@ -83,7 +85,13 @@ pub async fn start_terminal(
         command,
         command_args,
         session_id,
-    )?;
+    );
+    if spawned.is_err() {
+        if let Some((_, signal_path)) = &signal {
+            let _ = std::fs::remove_file(signal_path);
+        }
+    }
+    spawned?;
     if let Some((session_id, signal_path)) = signal {
         super::attention::spawn_signal_tailer(app, session_id, terminal_id, signal_path);
     }

--- a/src/hooks/terminal-lifecycle-events.test.ts
+++ b/src/hooks/terminal-lifecycle-events.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient } from '@tanstack/react-query'
+import { useChatStore } from '@/store/chat-store'
+import { chatQueryKeys } from '@/services/chat'
+import { preferencesQueryKeys } from '@/services/preferences'
+import type { AppPreferences } from '@/types/preferences'
+import type { Session } from '@/types/chat'
+
+const { mockPlayWaitingSound, mockNotify } = vi.hoisted(() => ({
+  mockPlayWaitingSound: vi.fn(),
+  mockNotify: vi.fn(),
+}))
+
+vi.mock('@/lib/sounds', () => ({
+  playWaitingSound: mockPlayWaitingSound,
+  playNotificationSound: vi.fn(),
+  preloadAllSounds: vi.fn(),
+}))
+
+vi.mock('@/lib/session-notifications', () => ({
+  notifySessionNeedsAttention: mockNotify,
+  notifyIfBackground: vi.fn(),
+  isSessionCurrentlyViewed: () => false,
+}))
+
+vi.mock('@/lib/transport', () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+  listen: vi.fn().mockResolvedValue(() => undefined),
+  listenLocal: vi.fn().mockResolvedValue(() => undefined),
+}))
+
+const { applyTerminalLifecycleEvent } = await import(
+  './useMainWindowEventListeners'
+)
+
+const SESSION_ID = 'session-1'
+
+function setPreferences(
+  queryClient: QueryClient,
+  prefs: Partial<AppPreferences>
+): void {
+  queryClient.setQueryData(preferencesQueryKeys.preferences(), prefs)
+}
+
+describe('applyTerminalLifecycleEvent', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    mockPlayWaitingSound.mockClear()
+    mockNotify.mockClear()
+    queryClient = new QueryClient()
+    useChatStore.setState({
+      sendingSessionIds: {},
+      waitingForInputSessionIds: {},
+    })
+  })
+
+  it('marks the session running on working', () => {
+    useChatStore.getState().setWaitingForInput(SESSION_ID, true)
+
+    applyTerminalLifecycleEvent(
+      'working',
+      { sessionId: SESSION_ID },
+      queryClient
+    )
+
+    const state = useChatStore.getState()
+    expect(state.sendingSessionIds[SESSION_ID]).toBe(true)
+    expect(state.waitingForInputSessionIds[SESSION_ID]).toBeFalsy()
+    expect(mockPlayWaitingSound).not.toHaveBeenCalled()
+  })
+
+  it('marks the session waiting, plays the sound and notifies on attention', () => {
+    setPreferences(queryClient, { waiting_sound: 'jobsdone' })
+    queryClient.setQueryData<Session>(chatQueryKeys.session(SESSION_ID), {
+      name: 'My session',
+    } as Session)
+    useChatStore.getState().addSendingSession(SESSION_ID)
+
+    applyTerminalLifecycleEvent(
+      'attention',
+      { sessionId: SESSION_ID },
+      queryClient
+    )
+
+    const state = useChatStore.getState()
+    expect(state.sendingSessionIds[SESSION_ID]).toBeFalsy()
+    expect(state.waitingForInputSessionIds[SESSION_ID]).toBe(true)
+    expect(mockPlayWaitingSound).toHaveBeenCalledWith({
+      waiting_sound: 'jobsdone',
+    })
+    expect(mockNotify).toHaveBeenCalledWith(
+      SESSION_ID,
+      'Needs your input',
+      'My session'
+    )
+  })
+
+  it('still plays the sound when desktop notifications are disabled', () => {
+    setPreferences(queryClient, { desktop_notifications_enabled: false })
+
+    applyTerminalLifecycleEvent(
+      'attention',
+      { sessionId: SESSION_ID },
+      queryClient
+    )
+
+    expect(mockPlayWaitingSound).toHaveBeenCalled()
+    expect(mockNotify).not.toHaveBeenCalled()
+  })
+
+  it('clears both running and waiting on idle', () => {
+    useChatStore.getState().addSendingSession(SESSION_ID)
+    useChatStore.getState().setWaitingForInput(SESSION_ID, true)
+
+    applyTerminalLifecycleEvent('idle', { sessionId: SESSION_ID }, queryClient)
+
+    const state = useChatStore.getState()
+    expect(state.sendingSessionIds[SESSION_ID]).toBeFalsy()
+    expect(state.waitingForInputSessionIds[SESSION_ID]).toBeFalsy()
+    expect(mockPlayWaitingSound).not.toHaveBeenCalled()
+    expect(mockNotify).not.toHaveBeenCalled()
+  })
+
+  it('ignores events without a session id', () => {
+    applyTerminalLifecycleEvent('attention', {}, queryClient)
+    applyTerminalLifecycleEvent('attention', undefined, queryClient)
+
+    expect(mockPlayWaitingSound).not.toHaveBeenCalled()
+    expect(mockNotify).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useMainWindowEventListeners.ts
+++ b/src/hooks/useMainWindowEventListeners.ts
@@ -19,7 +19,10 @@ import type {
 import { disposeTerminal, startHeadless } from '@/lib/terminal-instances'
 import { toast } from 'sonner'
 import { useCommandContext } from './use-command-context'
-import { usePreferences } from '@/services/preferences'
+import { usePreferences, preferencesQueryKeys } from '@/services/preferences'
+import type { AppPreferences } from '@/types/preferences'
+import { notifySessionNeedsAttention } from '@/lib/session-notifications'
+import { playWaitingSound } from '@/lib/sounds'
 import { logger } from '@/lib/logger'
 import {
   eventToShortcutString,
@@ -204,6 +207,46 @@ export function applySessionRenamedToCaches(
     })
     return changed ? { ...old, entries } : old
   })
+}
+
+/**
+ * Apply a native-terminal lifecycle event to the chat store.
+ *
+ * Terminal sessions have no run transcript, so these events are the only thing
+ * driving their status: `working` on prompt submit, `attention` when the CLI
+ * finishes or asks for permission, `idle` when the CLI exits but the terminal
+ * stays open. Attention mirrors `chat:done` — sound always, OS banner unless the
+ * user is already looking at this session.
+ */
+export function applyTerminalLifecycleEvent(
+  kind: 'working' | 'idle' | 'attention',
+  payload: { sessionId?: string } | undefined,
+  queryClient: QueryClient
+): void {
+  const sessionId = payload?.sessionId
+  if (!sessionId) return
+
+  const store = useChatStore.getState()
+  if (kind === 'working') {
+    store.addSendingSession(sessionId)
+    store.setWaitingForInput(sessionId, false)
+    return
+  }
+
+  store.removeSendingSession(sessionId)
+  store.setWaitingForInput(sessionId, kind === 'attention')
+  if (kind !== 'attention') return
+
+  const prefs = queryClient.getQueryData<AppPreferences>(
+    preferencesQueryKeys.preferences()
+  )
+  playWaitingSound(prefs)
+  if (prefs?.desktop_notifications_enabled === false) return
+  notifySessionNeedsAttention(
+    sessionId,
+    'Needs your input',
+    queryClient.getQueryData<Session>(chatQueryKeys.session(sessionId))?.name
+  )
 }
 
 export function shouldAllowKeybindingThroughOpenOverlay(
@@ -997,24 +1040,17 @@ export function useMainWindowEventListeners() {
     const setupMenuListeners = async () => {
       logger.debug('Setting up menu event listeners')
       const unlisteners = await Promise.all([
-        listen<{ sessionId: string }>('terminal:working', event => {
-          const sessionId = event.payload?.sessionId
-          if (!sessionId) return
-          const store = useChatStore.getState()
-          store.addSendingSession(sessionId)
-          // Mirror chat turn start: clear waiting so the session shows as running.
-          store.setWaitingForInput(sessionId, false)
-        }),
+        listen<{ sessionId: string }>('terminal:working', event =>
+          applyTerminalLifecycleEvent('working', event.payload, queryClient)
+        ),
 
-        listen<{ sessionId: string }>('terminal:attention', event => {
-          const sessionId = event.payload?.sessionId
-          if (!sessionId) return
-          const store = useChatStore.getState()
-          store.removeSendingSession(sessionId)
-          // Mirror chat:done waiting so canvas/list badges update before sessions
-          // cache invalidation lands (terminal sessions have no run transcript).
-          store.setWaitingForInput(sessionId, true)
-        }),
+        listen<{ sessionId: string }>('terminal:idle', event =>
+          applyTerminalLifecycleEvent('idle', event.payload, queryClient)
+        ),
+
+        listen<{ sessionId: string }>('terminal:attention', event =>
+          applyTerminalLifecycleEvent('attention', event.payload, queryClient)
+        ),
 
         listenLocal('menu-about', async () => {
           logger.debug('About menu event received')

--- a/src/lib/sounds.test.ts
+++ b/src/lib/sounds.test.ts
@@ -181,4 +181,25 @@ describe('notification sounds', () => {
     expect(fetchMock).toHaveBeenCalledWith('/sounds/work-work.wav')
     expect(fetchMock).toHaveBeenCalledWith('/sounds/jobs-done.wav')
   })
+
+  it('plays the waiting sound from preferences', async () => {
+    nativeApp = true
+    const { playWaitingSound } = await import('./sounds')
+
+    playWaitingSound({ waiting_sound: 'jobsdone' } as never)
+
+    await vi.waitFor(() => expect(startedBuffers).toHaveLength(1))
+    expect(fetchMock).toHaveBeenCalledWith('/sounds/jobs-done.wav')
+  })
+
+  it('stays silent when the waiting sound preference is unset', async () => {
+    nativeApp = true
+    const { playWaitingSound } = await import('./sounds')
+
+    playWaitingSound(undefined)
+    await Promise.resolve()
+
+    expect(startedBuffers).toHaveLength(0)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/lib/sounds.ts
+++ b/src/lib/sounds.ts
@@ -12,6 +12,7 @@
  */
 
 import {
+  type AppPreferences,
   type NotificationSound,
   notificationSoundOptions,
 } from '../types/preferences'
@@ -189,6 +190,19 @@ export function playNotificationSound(
       if (requestId !== playRequestId) return
       playFallbackBeep(ctx, sound)
     })
+}
+
+/**
+ * Play the configured "session needs input" sound.
+ *
+ * `useStreamingEvents.ts` inlines the same mapping: its test file mocks this
+ * module and asserts on `playNotificationSound` directly, so routing it through
+ * here would hide the sound name those assertions check.
+ */
+export function playWaitingSound(prefs: AppPreferences | undefined): void {
+  playNotificationSound((prefs?.waiting_sound ?? 'none') as NotificationSound, {
+    webAccessSoundsEnabled: prefs?.web_access_sounds_enabled ?? true,
+  })
 }
 
 /**


### PR DESCRIPTION
## Summary

- report Claude Code turn lifecycle in native terminals through `UserPromptSubmit` / `Stop` / `Notification` / `SessionEnd` hooks injected as inline `--settings` JSON, leaving the user's own `~/.claude/settings.json` untouched
- generalize the Codex-only `inject_codex_notify` into `inject_lifecycle_hook` and add a `terminal:idle` event
- emit a final `terminal:idle` when a tailer loses its terminal, so quitting either CLI no longer pins the session to "in progress" until the app restarts
- key the signal file by terminal id, so a reopened session terminal cannot have its file unlinked by the outgoing tailer
- treat `worker_permission_prompt` as attention, so subagent prompts surface like top-level ones
- reclaim orphaned signal files, and skip instrumentation when launch args already carry `--settings` or `-c notify=`
- drop the per-terminal PATH shim; it did not instrument hand-launched CLIs in practice

Builds on #634, which added this mechanism for Codex.

## Why

Codex's `notify` only fires `agent-turn-complete`, so nothing reports the CLI exiting — and `clear_attention_on_input` reads the Enter that submits `/exit` as a prompt submit, flipping the session to working right before the CLI dies. Terminal sessions have no run transcript, so that stale flag is the only thing driving their badge; it stayed on "in progress" until the app restarted.

The signal file was keyed by session but deleted by a thread that lives and dies with its terminal, so reopening a session terminal inside the outgoing tailer's 200 ms poll window let the old thread unlink the new terminal's file.

## Test plan

- [x] `bun run check:all` — typecheck, lint, rustfmt, clippy `-D warnings`, 2116 frontend tests, 1116 Rust tests
- [x] new Rust tests: Claude hook payload and arg ordering, tailer teardown drain and cleanup, `worker_permission_prompt`
- [x] new frontend tests: `terminal:working` / `attention` / `idle` handlers, sound and notification suppression
- [x] `git diff --check`

## Manual test

1. Submit a prompt in a native Claude Code session; confirm it shows as running, then as waiting on completion (sound, plus a banner when unfocused).
2. Approve a permission prompt, including one raised by a subagent; both surface as attention.
3. Quit with `/exit`, then with Ctrl-C twice; the session returns to idle instead of staying "in progress". Repeat with Codex.
4. Close a session terminal and immediately reopen it; status still tracks correctly.

Tested on macOS. Windows + WSL is untested and likely still silent: the `#[cfg(windows)]` hook commands are handed to a Linux hook runner when the terminal routes through `wsl.exe`. That predates this change and needs its own issue.
