### PR TITLE
fix: prevent projects.json corruption (#679)

### DIFF
--- a/docs/developer/data-persistence.md
+++ b/docs/developer/data-persistence.md
@@ -130,6 +130,25 @@ async fn save_preferences(app: AppHandle, preferences: AppPreferences) -> Result
 
 **Note:** Using UUID in temp filenames (instead of just `.tmp`) prevents conflicts when multiple writes happen concurrently.
 
+### Durable Writes and Recovery for Critical Data
+
+For user data where losing the file can make the application appear empty, an atomic
+rename alone is not sufficient: the temporary file must be flushed before it becomes
+the live file. The project registry (`projects.json`) uses the stronger pattern in
+`jean-core/src/projects/storage.rs`:
+
+- Write to a unique sibling temporary file with `create_new`.
+- Call `sync_all` before atomically replacing the destination; also sync the parent
+  directory on Unix and use write-through replacement on Windows.
+- Keep three rotating backups (`projects.json.bak`, `.bak.1`, and `.bak.2`).
+- If the primary JSON is invalid, validate backups and leftover temporary files,
+  preserve the corrupt primary, and restore the first valid candidate.
+- If recovery is impossible, return an error. Never convert a failed read into an
+  empty collection in the UI or an API response.
+
+Use this pattern for other critical persisted data instead of silently falling back
+to defaults after a parse failure.
+
 ### Loading with Defaults
 
 ```rust
@@ -562,7 +581,7 @@ function migrateKeybindings(
 
 ## Best Practices
 
-1. **Use atomic writes**: Always write to temp file then rename
+1. **Use durable atomic writes**: Flush the temp file before replacing the destination, and sync the parent directory where supported
 2. **Validate inputs**: Check filenames and data before writing
 3. **Handle defaults**: Provide sensible defaults when files don't exist
 4. **Log operations**: Log all file operations for debugging

--- a/jean-core/Cargo.toml
+++ b/jean-core/Cargo.toml
@@ -38,7 +38,7 @@ libc = "0.2"
 tokio-tungstenite = "0.28"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_Foundation"] }
+windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 tempfile = "3.23.0"

--- a/jean-core/src/http_server/server.rs
+++ b/jean-core/src/http_server/server.rs
@@ -547,6 +547,7 @@ async fn init_handler(
     response["serverPlatform"] = Value::String(crate::server_platform_name().to_string());
     response["nativeOpenAllowed"] = Value::Bool(crate::platform::native_open_allowed());
 
+    let projects_load_failed = projects_result.is_err();
     let projects = match projects_result {
         Ok(projects) => projects,
         Err(e) => {
@@ -795,9 +796,13 @@ async fn init_handler(
         }
     }
 
-    // Serialize projects (always included)
-    if let Ok(val) = serde_json::to_value(&projects) {
-        response["projects"] = val;
+    // Do not serialize a failed project load as an empty list. Omitting the key
+    // lets the frontend run its normal list_projects query and surface the
+    // storage error instead of presenting data corruption as an empty account.
+    if !projects_load_failed {
+        if let Ok(val) = serde_json::to_value(&projects) {
+            response["projects"] = val;
+        }
     }
 
     // Only emit worktrees/sessions keys when we actually have data.

--- a/jean-core/src/projects/storage.rs
+++ b/jean-core/src/projects/storage.rs
@@ -1,8 +1,12 @@
-use std::path::PathBuf;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use once_cell::sync::Lazy;
 use tauri::AppHandle;
+use uuid::Uuid;
 
 use super::types::ProjectsData;
 
@@ -10,6 +14,8 @@ use super::types::ProjectsData;
 /// Multiple threads (e.g., fetch_worktrees_status) can call save_projects_data simultaneously,
 /// causing race conditions with the atomic write pattern (temp file + rename).
 static PROJECTS_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+const PROJECTS_BACKUP_COUNT: usize = 3;
 
 /// Get the path to the projects.json data file
 pub fn get_projects_path(app: &AppHandle) -> Result<PathBuf, String> {
@@ -97,25 +103,303 @@ pub fn sanitize_directory_name(name: &str) -> String {
         .collect()
 }
 
+fn projects_backup_path(path: &Path, generation: usize) -> PathBuf {
+    let filename = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| std::borrow::Cow::Borrowed("projects.json"));
+    let suffix = if generation == 0 {
+        ".bak".to_string()
+    } else {
+        format!(".bak.{generation}")
+    };
+    path.with_file_name(format!("{filename}{suffix}"))
+}
+
+fn projects_temp_path(path: &Path) -> PathBuf {
+    let filename = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| std::borrow::Cow::Borrowed("projects.json"));
+    path.with_file_name(format!("{filename}.tmp-{}", Uuid::new_v4()))
+}
+
+/// Flush a directory entry update where the platform supports opening and syncing directories.
+/// Windows uses write-through replacement plus a synced temp file instead; opening a directory as
+/// a File is not supported by the Windows standard library.
+fn sync_parent_directory(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::fs::File;
+
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        File::open(parent)?.sync_all()
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn replace_file_atomically(temp_path: &Path, path: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, ReplaceFileW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        REPLACEFILE_WRITE_THROUGH,
+    };
+
+    let target_exists = path.exists();
+    let temp_path: Vec<u16> = temp_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let path: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let result = unsafe {
+        if target_exists {
+            ReplaceFileW(
+                path.as_ptr(),
+                temp_path.as_ptr(),
+                std::ptr::null(),
+                REPLACEFILE_WRITE_THROUGH,
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        } else {
+            MoveFileExW(
+                temp_path.as_ptr(),
+                path.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        }
+    };
+
+    if result == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+fn replace_file_atomically(temp_path: &Path, path: &Path) -> io::Result<()> {
+    fs::rename(temp_path, path)
+}
+
+/// Write a file to a unique sibling temp file, flush its contents, then atomically replace the
+/// destination. The old destination is never opened for writing, so a power loss cannot turn it
+/// into a partially-written or NUL-filled file.
+fn write_file_atomically(path: &Path, contents: &[u8]) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let temp_path = projects_temp_path(path);
+    let mut temp_created = false;
+    let result = (|| {
+        let mut temp_file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)?;
+        temp_created = true;
+        temp_file.write_all(contents)?;
+        temp_file.sync_all()?;
+        drop(temp_file);
+
+        replace_file_atomically(&temp_path, path)?;
+        sync_parent_directory(path)
+    })();
+
+    if temp_created && result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+
+    result
+}
+
+fn rotate_projects_backups(path: &Path, current_contents: &[u8]) -> Result<(), String> {
+    for generation in (1..PROJECTS_BACKUP_COUNT).rev() {
+        let source = projects_backup_path(path, generation - 1);
+        if !source.exists() {
+            continue;
+        }
+
+        let contents = fs::read(&source)
+            .map_err(|e| format!("Failed to read projects backup {}: {e}", source.display()))?;
+        let target = projects_backup_path(path, generation);
+        write_file_atomically(&target, &contents)
+            .map_err(|e| format!("Failed to rotate projects backup {}: {e}", target.display()))?;
+    }
+
+    let latest = projects_backup_path(path, 0);
+    write_file_atomically(&latest, current_contents)
+        .map_err(|e| format!("Failed to write projects backup {}: {e}", latest.display()))
+}
+
+fn save_projects_data_file(path: &Path, data: &ProjectsData) -> Result<(), String> {
+    let json_content = serde_json::to_string_pretty(data).map_err(|e| {
+        log::error!("Failed to serialize projects data: {e}");
+        format!("Failed to serialize projects data: {e}")
+    })?;
+
+    if path.exists() {
+        let current_contents = fs::read(path).map_err(|e| {
+            log::error!("Failed to read projects file before saving: {e}");
+            format!("Failed to read projects file before saving: {e}")
+        })?;
+        rotate_projects_backups(path, &current_contents)?;
+    }
+
+    write_file_atomically(path, json_content.as_bytes()).map_err(|e| {
+        log::error!("Failed to finalize projects file: {e}");
+        format!("Failed to finalize projects file: {e}")
+    })
+}
+
+fn parse_projects_bytes(path: &Path, contents: &[u8]) -> Result<ProjectsData, String> {
+    serde_json::from_slice(contents).map_err(|e| {
+        log::error!("Failed to parse projects JSON at {}: {e}", path.display());
+        format!("Failed to parse projects data: {e}")
+    })
+}
+
+fn recovery_candidates(path: &Path) -> Vec<PathBuf> {
+    let mut candidates = (0..PROJECTS_BACKUP_COUNT)
+        .map(|generation| projects_backup_path(path, generation))
+        .collect::<Vec<_>>();
+
+    let filename = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "projects.json".to_string());
+    let legacy_temp = path.with_file_name(format!("{filename}.tmp"));
+    if legacy_temp.is_file() {
+        candidates.push(legacy_temp);
+    }
+
+    if let Some(parent) = path.parent() {
+        if let Ok(entries) = fs::read_dir(parent) {
+            let mut temp_files = entries
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .filter(|candidate| {
+                    candidate.is_file()
+                        && candidate
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .is_some_and(|name| name.starts_with(&format!("{filename}.tmp-")))
+                })
+                .collect::<Vec<_>>();
+            temp_files.sort_by_key(|candidate| {
+                fs::metadata(candidate)
+                    .and_then(|metadata| metadata.modified())
+                    .ok()
+            });
+            temp_files.reverse();
+            candidates.extend(temp_files);
+        }
+    }
+
+    candidates
+}
+
+fn preserve_corrupt_projects_file(path: &Path, contents: &[u8]) -> Option<PathBuf> {
+    let filename = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| std::borrow::Cow::Borrowed("projects.json"));
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    let corrupt_path =
+        path.with_file_name(format!("{filename}.corrupt-{timestamp}-{}", Uuid::new_v4()));
+
+    match write_file_atomically(&corrupt_path, contents) {
+        Ok(()) => Some(corrupt_path),
+        Err(error) => {
+            log::warn!(
+                "Failed to preserve corrupt projects file {}: {error}",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+fn load_projects_file_with_recovery(path: &Path) -> Result<ProjectsData, String> {
+    let (primary_contents, primary_error, primary_missing) = match fs::read(path) {
+        Ok(contents) => match parse_projects_bytes(path, &contents) {
+            Ok(data) => return Ok(data),
+            Err(error) => (Some(contents), error, false),
+        },
+        Err(error) => (
+            None,
+            format!("Failed to read projects file: {error}"),
+            error.kind() == io::ErrorKind::NotFound,
+        ),
+    };
+
+    for candidate in recovery_candidates(path) {
+        let Ok(contents) = fs::read(&candidate) else {
+            continue;
+        };
+        let Ok(data) = parse_projects_bytes(&candidate, &contents) else {
+            log::warn!(
+                "Ignoring invalid projects recovery candidate {}",
+                candidate.display()
+            );
+            continue;
+        };
+
+        let corrupt_path = primary_contents
+            .as_deref()
+            .and_then(|contents| preserve_corrupt_projects_file(path, contents));
+        write_file_atomically(path, &contents).map_err(|error| {
+            format!(
+                "Recovered projects data from {} but failed to restore {}: {error}",
+                candidate.display(),
+                path.display()
+            )
+        })?;
+
+        log::warn!(
+            "Recovered projects data from {} into {}{}",
+            candidate.display(),
+            path.display(),
+            corrupt_path
+                .as_ref()
+                .map(|path| format!("; preserved corrupt file at {}", path.display()))
+                .unwrap_or_default()
+        );
+        return Ok(data);
+    }
+
+    if primary_missing {
+        log::trace!("Projects file not found, returning empty data");
+        return Ok(ProjectsData::default());
+    }
+
+    Err(format!(
+        "Projects data is corrupt at {}: {primary_error}. No valid backup could be recovered; the original file was left untouched.",
+        path.display()
+    ))
+}
+
 /// Load projects data from disk (internal, no locking)
 fn load_projects_data_internal(app: &AppHandle) -> Result<ProjectsData, String> {
     log::trace!("Loading projects data from disk");
     let path = get_projects_path(app)?;
 
-    if !path.exists() {
-        log::trace!("Projects file not found, returning empty data");
-        return Ok(ProjectsData::default());
-    }
-
-    let contents = std::fs::read_to_string(&path).map_err(|e| {
-        log::error!("Failed to read projects file: {e}");
-        format!("Failed to read projects file: {e}")
-    })?;
-
-    let mut data: ProjectsData = serde_json::from_str(&contents).map_err(|e| {
-        log::error!("Failed to parse projects JSON: {e}");
-        format!("Failed to parse projects data: {e}")
-    })?;
+    let mut data = load_projects_file_with_recovery(&path)?;
 
     for worktree in &mut data.worktrees {
         worktree.normalize_labels();
@@ -183,28 +467,12 @@ pub fn load_projects_data(app: &AppHandle) -> Result<ProjectsData, String> {
     load_projects_data_internal(app)
 }
 
-/// Save projects data to disk (internal, no locking - atomic write: temp file + rename)
+/// Save projects data to disk (internal, no locking - durable atomic write with backups)
 fn save_projects_data_internal(app: &AppHandle, data: &ProjectsData) -> Result<(), String> {
     log::trace!("Saving projects data to disk");
     let path = get_projects_path(app)?;
 
-    let json_content = serde_json::to_string_pretty(data).map_err(|e| {
-        log::error!("Failed to serialize projects data: {e}");
-        format!("Failed to serialize projects data: {e}")
-    })?;
-
-    // Write to a temporary file first, then rename (atomic operation)
-    let temp_path = path.with_extension("tmp");
-
-    std::fs::write(&temp_path, json_content).map_err(|e| {
-        log::error!("Failed to write projects file: {e}");
-        format!("Failed to write projects file: {e}")
-    })?;
-
-    std::fs::rename(&temp_path, &path).map_err(|e| {
-        log::error!("Failed to finalize projects file: {e}");
-        format!("Failed to finalize projects file: {e}")
-    })?;
+    save_projects_data_file(&path, data)?;
 
     log::trace!(
         "Saved {} projects and {} worktrees to {path:?}",
@@ -232,5 +500,98 @@ mod tests {
         assert_eq!(sanitize_directory_name("my/project"), "my-project");
         assert_eq!(sanitize_directory_name("my_project"), "my_project");
         assert_eq!(sanitize_directory_name("MyProject123"), "MyProject123");
+    }
+
+    fn test_data(project_id: &str) -> ProjectsData {
+        serde_json::from_value(serde_json::json!({
+            "projects": [{
+                "id": project_id,
+                "name": project_id,
+                "path": "",
+                "default_branch": "main",
+                "added_at": 1
+            }],
+            "worktrees": []
+        }))
+        .expect("valid project test data")
+    }
+
+    #[test]
+    fn durable_atomic_write_replaces_file_without_leaving_a_shared_temp_file() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let path = directory.path().join("projects.json");
+
+        write_file_atomically(&path, br#"{"version":1}"#).expect("first write");
+        write_file_atomically(&path, br#"{"version":2}"#).expect("second write");
+
+        assert_eq!(fs::read(&path).expect("read result"), br#"{"version":2}"#);
+        assert!(!directory.path().join("projects.json.tmp").exists());
+    }
+
+    #[test]
+    fn save_rotates_previous_projects_data_into_recoverable_backups() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let path = directory.path().join("projects.json");
+        let first = test_data("first");
+        let second = test_data("second");
+        let third = test_data("third");
+
+        save_projects_data_file(&path, &first).expect("first save");
+        save_projects_data_file(&path, &second).expect("second save");
+        save_projects_data_file(&path, &third).expect("third save");
+
+        let latest_backup: ProjectsData = serde_json::from_slice(
+            &fs::read(projects_backup_path(&path, 0)).expect("latest backup"),
+        )
+        .expect("latest backup JSON");
+        let older_backup: ProjectsData = serde_json::from_slice(
+            &fs::read(projects_backup_path(&path, 1)).expect("older backup"),
+        )
+        .expect("older backup JSON");
+
+        assert!(latest_backup.find_project("second").is_some());
+        assert!(older_backup.find_project("first").is_some());
+    }
+
+    #[test]
+    fn corrupt_primary_is_quarantined_and_restored_from_backup() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let path = directory.path().join("projects.json");
+        let first = test_data("first");
+        let second = test_data("second");
+
+        save_projects_data_file(&path, &first).expect("first save");
+        save_projects_data_file(&path, &second).expect("second save");
+        fs::write(&path, vec![0; 128]).expect("corrupt primary");
+
+        let recovered = load_projects_file_with_recovery(&path).expect("recover projects");
+
+        assert!(recovered.find_project("first").is_some());
+        assert!(recovered.find_project("second").is_none());
+        assert!(serde_json::from_slice::<ProjectsData>(
+            &fs::read(&path).expect("restored primary")
+        )
+        .is_ok());
+        assert!(fs::read_dir(directory.path())
+            .expect("read directory")
+            .filter_map(Result::ok)
+            .any(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("projects.json.corrupt-")
+            }));
+    }
+
+    #[test]
+    fn corrupt_primary_without_a_valid_recovery_source_returns_an_error() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let path = directory.path().join("projects.json");
+        fs::write(&path, vec![0; 128]).expect("corrupt primary");
+
+        let error = load_projects_file_with_recovery(&path).expect_err("corrupt data error");
+
+        assert!(error.contains("Projects data is corrupt"));
+        assert_eq!(fs::read(&path).expect("original primary"), vec![0; 128]);
     }
 }

--- a/src/components/layout/MainWindowContent.tsx
+++ b/src/components/layout/MainWindowContent.tsx
@@ -103,7 +103,7 @@ export function MainWindowContent({
   const setAddProjectDialogOpen = useProjectsStore(
     state => state.setAddProjectDialogOpen
   )
-  const { data: projects = [] } = useProjects()
+  const { data: projects = [], isError: projectsLoadError } = useProjects()
   const [backendCheckReady, setBackendCheckReady] = useState(false)
   useEffect(() => scheduleIdleWork(() => setBackendCheckReady(true), 1500), [])
 
@@ -118,7 +118,11 @@ export function MainWindowContent({
   const awaitingBackendCheck = showWelcome && !backendCheckReady
   const setupIncomplete =
     shouldCheckBackends && !backendsLoading && installedBackends.length === 0
-  const showAddButton = showWelcome && projects.length === 0 && !setupIncomplete
+  const showAddButton =
+    showWelcome &&
+    projects.length === 0 &&
+    !projectsLoadError &&
+    !setupIncomplete
 
   const handleProjectClick = useCallback((projectId: string) => {
     const { selectProject, expandProject } = useProjectsStore.getState()
@@ -164,6 +168,18 @@ export function MainWindowContent({
     </Suspense>
   ) : children ? (
     children
+  ) : projectsLoadError && projects.length === 0 ? (
+    <div
+      className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center font-sans"
+      role="alert"
+    >
+      <h1 className="text-2xl font-bold text-foreground">
+        Unable to load Jean projects
+      </h1>
+      <p className="text-sm text-muted-foreground">
+        Check the projects sidebar for recovery details.
+      </p>
+    </div>
   ) : realProjects.length > 0 ? (
     <WelcomeProjectGrid
       projects={realProjects}

--- a/src/components/projects/ProjectsSidebar.tsx
+++ b/src/components/projects/ProjectsSidebar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Plus, Folder, Archive, Briefcase } from 'lucide-react'
+import { Plus, Folder, Archive, Briefcase, AlertTriangle } from 'lucide-react'
 import { useSidebarWidth } from '@/components/layout/SidebarWidthContext'
 import {
   DropdownMenu,
@@ -23,7 +23,13 @@ function closeMobileSidebarIfNeeded(isMobile: boolean) {
 }
 
 export function ProjectsSidebar() {
-  const { data: projects = [], isLoading } = useProjects()
+  const {
+    data: projects = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useProjects()
   const { setAddProjectDialogOpen } = useProjectsStore()
   const createFolder = useCreateFolder()
   const sidebarWidth = useSidebarWidth()
@@ -55,6 +61,32 @@ export function ProjectsSidebar() {
         {isLoading ? (
           <div className="flex items-center justify-center p-4">
             <span className="text-sm text-muted-foreground">Loading...</span>
+          </div>
+        ) : isError && projects.length === 0 ? (
+          <div
+            className="flex h-full flex-col items-center justify-center gap-2 px-3 text-center"
+            role="alert"
+          >
+            <AlertTriangle className="size-4 text-destructive" />
+            <span className="text-sm text-muted-foreground">
+              Unable to load projects
+            </span>
+            <span className="text-xs text-muted-foreground/70">
+              Your project data may be corrupted. Jean kept the file unchanged
+              so it can be recovered.
+            </span>
+            <button
+              type="button"
+              className="text-xs text-primary underline-offset-4 hover:underline"
+              onClick={() => void refetch()}
+            >
+              Retry
+            </button>
+            {error && (
+              <span className="sr-only">
+                {error instanceof Error ? error.message : String(error)}
+              </span>
+            )}
           </div>
         ) : projects.length === 0 ? (
           <div className="flex h-full items-center justify-center px-2">


### PR DESCRIPTION
## Summary

- Make `projects.json` writes durable with flushed unique temp files and atomic replacement.
- Add rotating backups and automatic recovery/quarantine for corrupt project data.
- Surface project-load failures instead of presenting an empty project list.
- Document the crash-safe persistence pattern.

Fixes #679

## Validation

- Full `jean-core` Rust test suite: 1018 passed.
- Rust clippy passed for `jean-core`, `src-server`, and `src-tauri`.
- TypeScript, changed-file ESLint, and Prettier checks passed.
- Targeted frontend tests passed; repository-wide checks still encounter pre-existing unrelated lint/test failures.