### PR TITLE
fix(persistence): make Claude/Codex sessions persist on Windows

### DIFF
--- a/docs/developer/data-persistence.md
+++ b/docs/developer/data-persistence.md
@@ -111,24 +111,13 @@ async fn save_preferences(app: AppHandle, preferences: AppPreferences) -> Result
     let json_content = serde_json::to_string_pretty(&preferences)
         .map_err(|e| format!("Failed to serialize preferences: {e}"))?;
 
-    // Write to temporary file with UUID for safety, then rename (atomic operation)
-    let temp_path = prefs_path.with_file_name(format!(
-        "{}.{}.tmp",
-        prefs_path.file_name().unwrap().to_string_lossy(),
-        uuid::Uuid::new_v4()
-    ));
-
-    std::fs::write(&temp_path, json_content)
-        .map_err(|e| format!("Failed to write preferences file: {e}"))?;
-
-    std::fs::rename(&temp_path, &prefs_path)
-        .map_err(|e| format!("Failed to finalize preferences file: {e}"))?;
+    crate::platform::write_file_atomically(&prefs_path, json_content.as_bytes())?;
 
     Ok(())
 }
 ```
 
-**Note:** Using UUID in temp filenames (instead of just `.tmp`) prevents conflicts when multiple writes happen concurrently.
+`write_file_atomically` creates a unique sibling temp file, flushes it, and replaces the destination. It uses the native Windows replacement APIs because `std::fs::rename` cannot overwrite an existing file on Windows; using `std::fs::rename` directly causes every save after the first one to fail.
 
 ### Loading with Defaults
 
@@ -215,14 +204,7 @@ async fn save_emergency_data(
     let json_content = serde_json::to_string_pretty(&data)
         .map_err(|e| format!("Failed to serialize emergency data: {e}"))?;
 
-    // Atomic write pattern
-    let temp_path = file_path.with_extension("tmp");
-
-    std::fs::write(&temp_path, json_content)
-        .map_err(|e| format!("Failed to write emergency data file: {e}"))?;
-
-    std::fs::rename(&temp_path, &file_path)
-        .map_err(|e| format!("Failed to finalize emergency data file: {e}"))?;
+    crate::platform::write_file_atomically(&file_path, json_content.as_bytes())?;
 
     Ok(())
 }

--- a/jean-core/Cargo.toml
+++ b/jean-core/Cargo.toml
@@ -38,7 +38,7 @@ libc = "0.2"
 tokio-tungstenite = "0.28"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_Foundation"] }
+windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 tempfile = "3.23.0"

--- a/jean-core/src/agent_browser/mod.rs
+++ b/jean-core/src/agent_browser/mod.rs
@@ -687,20 +687,7 @@ fn write_atomic_with_backup(path: &Path, content: &str) -> Result<Option<PathBuf
         None
     };
 
-    let tmp = path.with_extension(format!(
-        "{}.tmp",
-        path.extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("config")
-    ));
-    std::fs::write(&tmp, content).map_err(|e| format!("Failed to write {}: {e}", tmp.display()))?;
-    std::fs::rename(&tmp, path).map_err(|e| {
-        format!(
-            "Failed to replace {} with {}: {e}",
-            path.display(),
-            tmp.display()
-        )
-    })?;
+    crate::platform::write_file_atomically(path, content.as_bytes())?;
     Ok(backup)
 }
 

--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -6126,11 +6126,7 @@ fn save_image_to_disk(
     let filename = format!("image-{timestamp}-{short_uuid}.{ext}");
     let file_path = images_dir.join(&filename);
 
-    let temp_path = file_path.with_extension("tmp");
-    std::fs::write(&temp_path, data).map_err(|e| format!("Failed to write image file: {e}"))?;
-
-    std::fs::rename(&temp_path, &file_path)
-        .map_err(|e| format!("Failed to finalize image file: {e}"))?;
+    crate::platform::write_file_atomically(&file_path, data)?;
 
     let path_str = file_path
         .to_str()
@@ -6314,12 +6310,7 @@ pub async fn save_pasted_text(
     let filename = pasted_text_filename(filename.as_deref());
     let file_path = pastes_dir.join(&filename);
 
-    // Write file atomically (temp file + rename)
-    let temp_path = file_path.with_extension("tmp");
-    std::fs::write(&temp_path, &content).map_err(|e| format!("Failed to write text file: {e}"))?;
-
-    std::fs::rename(&temp_path, &file_path)
-        .map_err(|e| format!("Failed to finalize text file: {e}"))?;
+    crate::platform::write_file_atomically(&file_path, content.as_bytes())?;
 
     let path_str = file_path
         .to_str()
@@ -6428,12 +6419,7 @@ pub async fn update_pasted_text(
         return Err("Invalid path: must be within allowed directories".to_string());
     }
 
-    // Write file atomically (temp file + rename)
-    let temp_path = file_path.with_extension("tmp");
-    std::fs::write(&temp_path, &content).map_err(|e| format!("Failed to write text file: {e}"))?;
-
-    std::fs::rename(&temp_path, &file_path)
-        .map_err(|e| format!("Failed to finalize text file: {e}"))?;
+    crate::platform::write_file_atomically(&file_path, content.as_bytes())?;
 
     log::trace!("Text file updated: {path}");
     Ok(size)
@@ -7095,13 +7081,7 @@ pub async fn save_context_file(
 
     let file_path = contexts_dir.join(&filename);
 
-    // Write content atomically (temp file + rename)
-    let temp_path = file_path.with_extension("tmp");
-    std::fs::write(&temp_path, &content)
-        .map_err(|e| format!("Failed to write context file: {e}"))?;
-
-    std::fs::rename(&temp_path, &file_path)
-        .map_err(|e| format!("Failed to finalize context file: {e}"))?;
+    crate::platform::write_file_atomically(&file_path, content.as_bytes())?;
 
     let path_str = file_path
         .to_str()
@@ -7760,13 +7740,7 @@ pub async fn generate_context_from_session(
             (new_filename, new_path, false)
         };
 
-    // Write content atomically
-    let temp_path = file_path.with_extension("tmp");
-    std::fs::write(&temp_path, &summary)
-        .map_err(|e| format!("Failed to write context file: {e}"))?;
-
-    std::fs::rename(&temp_path, &file_path)
-        .map_err(|e| format!("Failed to finalize context file: {e}"))?;
+    crate::platform::write_file_atomically(&file_path, summary.as_bytes())?;
 
     // Update session mapping in metadata
     metadata

--- a/jean-core/src/chat/storage.rs
+++ b/jean-core/src/chat/storage.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
-use std::io::{BufReader, BufWriter};
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -175,21 +175,14 @@ fn load_index_internal(app: &AppHandle, worktree_id: &str) -> Result<WorktreeInd
 fn save_index_internal(app: &AppHandle, index: &WorktreeIndex) -> Result<(), String> {
     log::trace!("Saving index for worktree: {}", index.worktree_id);
     let path = get_index_path(app, &index.worktree_id)?;
-    let temp_path = path.with_extension("tmp");
-
     let json_content = serde_json::to_string_pretty(index).map_err(|e| {
         log::error!("Failed to serialize index: {e}");
         format!("Failed to serialize index: {e}")
     })?;
 
-    fs::write(&temp_path, &json_content).map_err(|e| {
-        log::error!("Failed to write index file: {e}");
-        format!("Failed to write index: {e}")
-    })?;
-
-    fs::rename(&temp_path, &path).map_err(|e| {
-        log::error!("Failed to finalize index file: {e}");
-        format!("Failed to finalize index: {e}")
+    crate::platform::write_file_atomically(&path, json_content.as_bytes()).map_err(|error| {
+        log::error!("Failed to save index file: {error}");
+        error
     })?;
 
     log::trace!(
@@ -274,16 +267,11 @@ fn save_metadata_internal(app: &AppHandle, metadata: &SessionMetadata) -> Result
 
 fn save_metadata_file(app: &AppHandle, metadata: &SessionMetadata) -> Result<(), String> {
     let path = get_metadata_path(app, &metadata.id)?;
-    let temp_path = path.with_extension("tmp");
-
-    let file = File::create(&temp_path)
-        .map_err(|e| format!("Failed to create temp metadata file: {e}"))?;
-
-    let writer = BufWriter::new(file);
-    serde_json::to_writer_pretty(writer, metadata)
+    let json_content = serde_json::to_vec_pretty(metadata)
         .map_err(|e| format!("Failed to write metadata: {e}"))?;
 
-    fs::rename(&temp_path, &path).map_err(|e| format!("Failed to rename metadata file: {e}"))?;
+    crate::platform::write_file_atomically(&path, &json_content)
+        .map_err(|error| format!("Failed to save metadata file: {error}"))?;
 
     log::trace!("Saved metadata for session: {}", metadata.id);
     Ok(())
@@ -1126,14 +1114,11 @@ pub fn save_saved_contexts_metadata(
     let _lock = SAVED_CONTEXTS_LOCK.lock().unwrap();
 
     let path = get_saved_contexts_metadata_path(app)?;
-    let temp_path = path.with_extension("tmp");
-
     let json = serde_json::to_string_pretty(metadata)
         .map_err(|e| format!("Failed to serialize metadata: {e}"))?;
 
-    fs::write(&temp_path, &json).map_err(|e| format!("Failed to write metadata file: {e}"))?;
-
-    fs::rename(&temp_path, &path).map_err(|e| format!("Failed to finalize metadata file: {e}"))?;
+    crate::platform::write_file_atomically(&path, json.as_bytes())
+        .map_err(|error| format!("Failed to save metadata file: {error}"))?;
 
     Ok(())
 }

--- a/jean-core/src/jean_mcp_config.rs
+++ b/jean-core/src/jean_mcp_config.rs
@@ -509,20 +509,7 @@ fn write_atomic_with_backup(path: &Path, content: &str) -> Result<Option<PathBuf
         None
     };
 
-    let tmp = path.with_extension(format!(
-        "{}.tmp",
-        path.extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("config")
-    ));
-    std::fs::write(&tmp, content).map_err(|e| format!("Failed to write {}: {e}", tmp.display()))?;
-    std::fs::rename(&tmp, path).map_err(|e| {
-        format!(
-            "Failed to replace {} with {}: {e}",
-            path.display(),
-            tmp.display()
-        )
-    })?;
+    crate::platform::write_file_atomically(path, content.as_bytes())?;
     Ok(backup)
 }
 

--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -3134,21 +3134,12 @@ async fn save_preferences(app: AppHandle, preferences: AppPreferences) -> Result
         format!("Failed to serialize preferences: {e}")
     })?;
 
-    // Write to a temporary file first, then rename (atomic operation)
-    // Use unique temp file to avoid race conditions with concurrent saves
-    let temp_path = prefs_path.with_extension(format!("{}.tmp", uuid::Uuid::new_v4()));
-
-    std::fs::write(&temp_path, json_content).map_err(|e| {
-        log::error!("Failed to write preferences file: {e}");
-        format!("Failed to write preferences file: {e}")
-    })?;
-
-    std::fs::rename(&temp_path, &prefs_path).map_err(|e| {
-        // Clean up temp file on rename failure
-        let _ = std::fs::remove_file(&temp_path);
-        log::error!("Failed to finalize preferences file: {e}");
-        format!("Failed to finalize preferences file: {e}")
-    })?;
+    crate::platform::write_file_atomically(&prefs_path, json_content.as_bytes()).map_err(
+        |error| {
+            log::error!("Failed to save preferences file: {error}");
+            error
+        },
+    )?;
 
     log::trace!("Successfully saved preferences to {prefs_path:?}");
 
@@ -3195,13 +3186,7 @@ async fn save_cli_profile(name: String, settings_json: String) -> Result<String,
         std::fs::create_dir_all(parent).map_err(|e| format!("Failed to create directory: {e}"))?;
     }
 
-    // Atomic write via temp file
-    let temp = path.with_extension("tmp");
-    std::fs::write(&temp, &settings_json).map_err(|e| format!("Failed to write: {e}"))?;
-    std::fs::rename(&temp, &path).map_err(|e| {
-        let _ = std::fs::remove_file(&temp);
-        format!("Failed to finalize: {e}")
-    })?;
+    crate::platform::write_file_atomically(&path, settings_json.as_bytes())?;
 
     let path_str = path.to_string_lossy().to_string();
     log::trace!("Saved CLI profile '{name}' to {path_str}");
@@ -3262,21 +3247,12 @@ async fn save_ui_state(app: AppHandle, ui_state: UIState) -> Result<(), String> 
         format!("Failed to serialize UI state: {e}")
     })?;
 
-    // Write to a temporary file first, then rename (atomic operation)
-    // Use unique temp file to avoid race conditions with concurrent saves
-    let temp_path = state_path.with_extension(format!("{}.tmp", uuid::Uuid::new_v4()));
-
-    std::fs::write(&temp_path, json_content).map_err(|e| {
-        log::error!("Failed to write UI state file: {e}");
-        format!("Failed to write UI state file: {e}")
-    })?;
-
-    std::fs::rename(&temp_path, &state_path).map_err(|e| {
-        // Clean up temp file on rename failure
-        let _ = std::fs::remove_file(&temp_path);
-        log::error!("Failed to finalize UI state file: {e}");
-        format!("Failed to finalize UI state file: {e}")
-    })?;
+    crate::platform::write_file_atomically(&state_path, json_content.as_bytes()).map_err(
+        |error| {
+            log::error!("Failed to save UI state file: {error}");
+            error
+        },
+    )?;
 
     log::trace!("Saved UI state to {state_path:?}");
     Ok(())
@@ -3327,18 +3303,12 @@ async fn save_emergency_data(app: AppHandle, filename: String, data: Value) -> R
         format!("Failed to serialize data: {e}")
     })?;
 
-    // Write to a temporary file first, then rename (atomic operation)
-    let temp_path = file_path.with_extension("tmp");
-
-    std::fs::write(&temp_path, json_content).map_err(|e| {
-        log::error!("Failed to write emergency data file: {e}");
-        format!("Failed to write data file: {e}")
-    })?;
-
-    std::fs::rename(&temp_path, &file_path).map_err(|e| {
-        log::error!("Failed to finalize emergency data file: {e}");
-        format!("Failed to finalize data file: {e}")
-    })?;
+    crate::platform::write_file_atomically(&file_path, json_content.as_bytes()).map_err(
+        |error| {
+            log::error!("Failed to save emergency data file: {error}");
+            error
+        },
+    )?;
 
     log::trace!("Successfully saved emergency data to {file_path:?}");
     Ok(())

--- a/jean-core/src/pi_cli/commands.rs
+++ b/jean-core/src/pi_cli/commands.rs
@@ -312,12 +312,7 @@ fn write_pi_models_json(value: &serde_json::Value) -> Result<(), String> {
     }
     let pretty = serde_json::to_string_pretty(value)
         .map_err(|e| format!("Failed to serialize models.json: {e}"))?;
-    let temp = path.with_extension("tmp");
-    std::fs::write(&temp, pretty).map_err(|e| format!("Failed to write models.json: {e}"))?;
-    std::fs::rename(&temp, &path).map_err(|e| {
-        let _ = std::fs::remove_file(&temp);
-        format!("Failed to finalize models.json: {e}")
-    })?;
+    crate::platform::write_file_atomically(&path, pretty.as_bytes())?;
     Ok(())
 }
 

--- a/jean-core/src/platform/file.rs
+++ b/jean-core/src/platform/file.rs
@@ -1,0 +1,159 @@
+//! Cross-platform file persistence helpers.
+
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let filename = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| std::borrow::Cow::Borrowed("file"));
+
+    path.with_file_name(format!("{filename}.tmp-{}", Uuid::new_v4()))
+}
+
+/// Flush a directory entry update where the platform supports opening and syncing directories.
+/// Windows does not support opening a directory as a `File` through the standard library.
+fn sync_parent_directory(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        fs::File::open(parent)?.sync_all()
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn replace_file_atomically(temp_path: &Path, path: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, ReplaceFileW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        REPLACEFILE_WRITE_THROUGH,
+    };
+
+    let target_exists = path.exists();
+    let temp_path: Vec<u16> = temp_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let path: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    // ReplaceFileW preserves the destination's metadata when it exists. If the
+    // destination was removed between the existence check and this call, use
+    // MoveFileExW as a race-safe fallback.
+    if target_exists {
+        let replaced = unsafe {
+            ReplaceFileW(
+                path.as_ptr(),
+                temp_path.as_ptr(),
+                std::ptr::null(),
+                REPLACEFILE_WRITE_THROUGH,
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        };
+
+        if replaced != 0 {
+            return Ok(());
+        }
+    }
+
+    let moved = unsafe {
+        MoveFileExW(
+            temp_path.as_ptr(),
+            path.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+
+    if moved == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+fn replace_file_atomically(temp_path: &Path, path: &Path) -> io::Result<()> {
+    fs::rename(temp_path, path)
+}
+
+/// Write bytes through a unique sibling temp file and atomically replace `path`.
+///
+/// POSIX `rename` replaces an existing destination. Windows requires the native
+/// replacement APIs instead; using `std::fs::rename` there silently turns every
+/// update after the first successful write into an error.
+pub fn write_file_atomically(path: &Path, contents: &[u8]) -> Result<(), String> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("Failed to create parent directory: {error}"))?;
+    }
+
+    let temp_path = temporary_path(path);
+    let mut temp_created = false;
+    let result = (|| {
+        let mut temp_file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)?;
+        temp_created = true;
+        temp_file.write_all(contents)?;
+        temp_file.sync_all()?;
+        drop(temp_file);
+
+        replace_file_atomically(&temp_path, path)?;
+        sync_parent_directory(path)
+    })();
+
+    if temp_created && result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+
+    result.map_err(|error| format!("Failed to atomically replace {}: {error}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replaces_an_existing_file() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let path = directory.path().join("state.json");
+
+        write_file_atomically(&path, br#"{"version":1}"#).expect("first write");
+        write_file_atomically(&path, br#"{"version":2}"#).expect("second write");
+
+        assert_eq!(fs::read(&path).expect("read result"), br#"{"version":2}"#);
+        let has_temp_file = fs::read_dir(directory.path())
+            .expect("read directory")
+            .filter_map(Result::ok)
+            .any(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("state.json.tmp-")
+            });
+        assert!(!has_temp_file);
+    }
+}

--- a/jean-core/src/platform/mod.rs
+++ b/jean-core/src/platform/mod.rs
@@ -1,11 +1,13 @@
 // Cross-platform abstractions for shell execution and process management
 
 pub mod cli_detect;
+pub mod file;
 pub mod process;
 pub mod shell;
 pub mod wsl;
 
 pub use cli_detect::*;
+pub use file::*;
 pub use process::*;
 pub use shell::*;
 pub use wsl::*;

--- a/jean-core/src/projects/checkpoints.rs
+++ b/jean-core/src/projects/checkpoints.rs
@@ -159,9 +159,7 @@ fn save_store(app: &AppHandle, worktree_id: &str, store: &CheckpointStore) -> Re
     let path = store_path(app, worktree_id)?;
     let json = serde_json::to_string_pretty(store)
         .map_err(|e| format!("Failed to serialize checkpoints: {e}"))?;
-    let tmp = path.with_extension(format!("{}.tmp", Uuid::new_v4()));
-    fs::write(&tmp, json).map_err(|e| format!("Failed to write checkpoints: {e}"))?;
-    fs::rename(&tmp, &path).map_err(|e| format!("Failed to finalize checkpoints: {e}"))?;
+    crate::platform::write_file_atomically(&path, json.as_bytes())?;
     Ok(())
 }
 

--- a/jean-core/src/projects/storage.rs
+++ b/jean-core/src/projects/storage.rs
@@ -193,17 +193,9 @@ fn save_projects_data_internal(app: &AppHandle, data: &ProjectsData) -> Result<(
         format!("Failed to serialize projects data: {e}")
     })?;
 
-    // Write to a temporary file first, then rename (atomic operation)
-    let temp_path = path.with_extension("tmp");
-
-    std::fs::write(&temp_path, json_content).map_err(|e| {
-        log::error!("Failed to write projects file: {e}");
-        format!("Failed to write projects file: {e}")
-    })?;
-
-    std::fs::rename(&temp_path, &path).map_err(|e| {
-        log::error!("Failed to finalize projects file: {e}");
-        format!("Failed to finalize projects file: {e}")
+    crate::platform::write_file_atomically(&path, json_content.as_bytes()).map_err(|error| {
+        log::error!("Failed to save projects file: {error}");
+        error
     })?;
 
     log::trace!(

--- a/src/hooks/useUIStatePersistence.ts
+++ b/src/hooks/useUIStatePersistence.ts
@@ -68,22 +68,37 @@ function serializePendingTextFiles(
 function debounce<T extends (...args: Parameters<T>) => void>(
   fn: T,
   delay: number
-): T & { cancel: () => void } {
+): T & { cancel: () => void; flush: () => void } {
   let timeoutId: ReturnType<typeof setTimeout> | null = null
+  let pendingArgs: Parameters<T> | null = null
 
   const debounced = ((...args: Parameters<T>) => {
-    if (timeoutId) clearTimeout(timeoutId)
+    if (timeoutId !== null) clearTimeout(timeoutId)
+    pendingArgs = args
     timeoutId = setTimeout(() => {
-      fn(...args)
       timeoutId = null
+      const argsToApply = pendingArgs
+      pendingArgs = null
+      if (argsToApply) fn(...(argsToApply as Parameters<T>))
     }, delay)
-  }) as T & { cancel: () => void }
+  }) as T & { cancel: () => void; flush: () => void }
 
   debounced.cancel = () => {
-    if (timeoutId) {
+    if (timeoutId !== null) {
       clearTimeout(timeoutId)
       timeoutId = null
     }
+    pendingArgs = null
+  }
+
+  debounced.flush = () => {
+    if (timeoutId === null || pendingArgs === null) return
+
+    clearTimeout(timeoutId)
+    timeoutId = null
+    const argsToApply = pendingArgs
+    pendingArgs = null
+    fn(...(argsToApply as Parameters<T>))
   }
 
   return debounced
@@ -114,9 +129,27 @@ export function useUIStatePersistence() {
     }, 500)
 
     return () => {
+      debouncedSaveRef.current?.flush()
       debouncedSaveRef.current?.cancel()
     }
   }, [saveUIState])
+
+  // The last active session is part of the debounced UI-state snapshot. Flush
+  // it when the native window is closing so a recent session switch is not
+  // lost before the next 500ms timer fires.
+  useEffect(() => {
+    const flushPendingSave = () => {
+      debouncedSaveRef.current?.flush()
+    }
+
+    window.addEventListener('beforeunload', flushPendingSave)
+    window.addEventListener('pagehide', flushPendingSave)
+
+    return () => {
+      window.removeEventListener('beforeunload', flushPendingSave)
+      window.removeEventListener('pagehide', flushPendingSave)
+    }
+  }, [])
 
   // Helper to get current UI state from stores
   // NOTE: Durable session-specific state is stored in Session files. Unsent
@@ -1316,6 +1349,7 @@ export function useUIStatePersistence() {
       unsubChat()
       unsubTerminal()
       unsubBrowser()
+      debouncedSaveRef.current?.flush()
       debouncedSaveRef.current?.cancel()
       logger.debug('UI state persistence subscriptions cleaned up')
     }


### PR DESCRIPTION
## Summary
- Add Windows-safe atomic file replacement for persisted JSON and configuration files.
- Fix session indexes, session metadata, UI state, and related persistence writers.
- Flush the debounced active-session UI snapshot during window shutdown.

## Validation
- `cargo test --manifest-path jean-core/Cargo.toml platform::file --lib --offline` (Windows, passing)
- TypeScript, ESLint, Prettier, and diff checks passing.