### PR TITLE
feat(web): sign-in screen and browser sign-out for web access

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import {
   invoke,
   useWsConnectionStatus,
   useWsAuthError,
+  useWsAuthReason,
   preloadInitialData,
   setAppDataDir,
   hasPreloadedData,
@@ -121,9 +122,10 @@ function handleWsAuthTokenSubmit(token: string) {
   window.location.reload()
 }
 
-/** Full-screen auth error overlay for web access mode. */
+/** Sign-in surface for web access mode, shown until the session is authorized. */
 function WsAuthErrorOverlay() {
   const authError = useWsAuthError()
+  const authReason = useWsAuthReason()
   const remote = getActiveRemoteConnection()
 
   if (!authError) return null
@@ -133,9 +135,10 @@ function WsAuthErrorOverlay() {
   }
 
   return (
-    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-background/90">
+    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-background">
       <WebAccessAuthScreen
         authError={authError}
+        reason={authReason ?? 'signed-out'}
         onTokenSubmit={handleWsAuthTokenSubmit}
       />
     </div>
@@ -1635,6 +1638,14 @@ function App() {
   // on WS when preload failed and we have nothing to show.
   const blockOnWs =
     webBackend && !wsConnected && !wsAuthError && !hasPreloadedData()
+
+  // A browser session that has not authenticated yet has nothing to show
+  // behind the sign-in prompt. Render it alone instead of booting the whole
+  // app underneath and covering it with an overlay. Native remote clients keep
+  // the overlay: their local UI stays usable while a remote is unreachable.
+  if (webBackend && wsAuthError && !getActiveRemoteConnection()) {
+    return <WsAuthErrorOverlay />
+  }
 
   if (isPreloading || blockOnWs) {
     return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,7 +138,10 @@ function WsAuthErrorOverlay() {
     <div className="fixed inset-0 z-[80] flex items-center justify-center bg-background">
       <WebAccessAuthScreen
         authError={authError}
-        reason={authReason ?? 'signed-out'}
+        // 'unreachable' only arises on remote paths; if one slips through
+        // (remote removed right after a drop), the sign-in form still works —
+        // submitting reloads the page, which is how connections recover.
+        reason={authReason === 'rejected' ? 'rejected' : 'signed-out'}
         onTokenSubmit={handleWsAuthTokenSubmit}
       />
     </div>

--- a/src/components/preferences/panes/GeneralPane.structure.test.ts
+++ b/src/components/preferences/panes/GeneralPane.structure.test.ts
@@ -246,9 +246,10 @@ describe('GeneralPane settings structure', () => {
     expect(sectionIndex).toBeGreaterThan(-1)
 
     // The control must be gated on web access: the desktop app manages its
-    // connection from the title bar, not from a token in localStorage.
-    const guard = source.slice(sectionIndex - 400, sectionIndex)
-    expect(guard).toContain('isWebAccessView')
+    // connection from the title bar, not from a token in localStorage. Match
+    // the exact guard expression so an inverted or loosened condition fails.
+    const guard = source.slice(Math.max(0, sectionIndex - 400), sectionIndex)
+    expect(guard).toContain('isGeneralScope && isWebAccessView && (')
     expect(source).toContain('signOutOfWebAccess')
   })
 })

--- a/src/components/preferences/panes/GeneralPane.structure.test.ts
+++ b/src/components/preferences/panes/GeneralPane.structure.test.ts
@@ -235,4 +235,20 @@ describe('GeneralPane settings structure', () => {
       '<SettingsSection'
     )
   })
+
+  it('offers a browser sign-out only when running as web access', () => {
+    const source = readFileSync(
+      'src/components/preferences/panes/GeneralPane.tsx',
+      'utf8'
+    )
+
+    const sectionIndex = source.indexOf('pref-general-section-session')
+    expect(sectionIndex).toBeGreaterThan(-1)
+
+    // The control must be gated on web access: the desktop app manages its
+    // connection from the title bar, not from a token in localStorage.
+    const guard = source.slice(sectionIndex - 400, sectionIndex)
+    expect(guard).toContain('isWebAccessView')
+    expect(source).toContain('signOutOfWebAccess')
+  })
 })

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -203,7 +203,11 @@ import {
   formatJeanVersionLabel,
 } from '@/lib/remote-version'
 import type { ThinkingLevel, EffortLevel } from '@/types/chat'
-import { hasBackend, isNativeApp } from '@/lib/environment'
+import {
+  hasBackend,
+  isNativeApp,
+  webAccessServerLabel,
+} from '@/lib/environment'
 import { isWindows, openExternal } from '@/lib/platform'
 import { isNewerVersion } from '@/lib/version-utils'
 import { cn } from '@/lib/utils'
@@ -4131,7 +4135,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
                             ? commandCodeModelOptions
                             : effectiveBuildBackend === 'grok'
                               ? grokModelOptions
-                            : remoteClaudeModelOptions
+                              : remoteClaudeModelOptions
                         ).map(option => (
                           <SelectItem key={option.value} value={option.value}>
                             {option.label}
@@ -4378,7 +4382,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
                             ? commandCodeModelOptions
                             : effectiveYoloBackend === 'grok'
                               ? grokModelOptions
-                            : remoteClaudeModelOptions
+                              : remoteClaudeModelOptions
                         ).map(option => (
                           <SelectItem key={option.value} value={option.value}>
                             {option.label}
@@ -5034,7 +5038,7 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
           variant="card"
         >
           <InlineField
-            label={window.location.host}
+            label={webAccessServerLabel()}
             description="Signing out forgets the token on this device only. The server keeps running and your other devices stay signed in."
           >
             <Button

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -6,11 +6,11 @@ import React, {
   useRef,
   type FC,
 } from 'react'
-import { invoke } from '@/lib/transport'
+import { invoke, signOutOfWebAccess } from '@/lib/transport'
 import { loginArgsForBackend } from '@/lib/cli-auth'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { Loader2, Check, ChevronsUpDown, Play } from 'lucide-react'
+import { Loader2, Check, ChevronsUpDown, LogOut, Play } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -5024,6 +5024,30 @@ export const GeneralPane: React.FC<{ scope?: PreferencesPaneScope }> = ({
             </div>
           </SettingsSection>
         </>
+      )}
+
+      {isGeneralScope && isWebAccessView && (
+        <SettingsSection
+          title="This browser"
+          description="You are signed in to this Jean server with an access token kept in this browser."
+          anchorId="pref-general-section-session"
+          variant="card"
+        >
+          <InlineField
+            label={window.location.host}
+            description="Signing out forgets the token on this device only. The server keeps running and your other devices stay signed in."
+          >
+            <Button
+              variant="outline"
+              size="sm"
+              className="sm:ml-auto"
+              onClick={signOutOfWebAccess}
+            >
+              <LogOut className="size-3.5" />
+              Sign out
+            </Button>
+          </InlineField>
+        </SettingsSection>
       )}
 
       <AlertDialog

--- a/src/components/web/WebAccessAuthScreen.test.tsx
+++ b/src/components/web/WebAccessAuthScreen.test.tsx
@@ -8,7 +8,7 @@ describe('WebAccessAuthScreen', () => {
 
     render(
       <WebAccessAuthScreen
-        authError="No access token provided."
+        authError="Enter the access token."
         onTokenSubmit={onTokenSubmit}
       />
     )
@@ -16,7 +16,7 @@ describe('WebAccessAuthScreen', () => {
     fireEvent.change(screen.getByLabelText(/access token/i), {
       target: { value: 'secret-token' },
     })
-    fireEvent.click(screen.getByRole('button', { name: /connect/i }))
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
 
     expect(onTokenSubmit).toHaveBeenCalledWith('secret-token')
   })
@@ -26,7 +26,7 @@ describe('WebAccessAuthScreen', () => {
 
     render(
       <WebAccessAuthScreen
-        authError="No access token provided."
+        authError="Enter the access token."
         onTokenSubmit={onTokenSubmit}
       />
     )
@@ -34,9 +34,55 @@ describe('WebAccessAuthScreen', () => {
     fireEvent.change(screen.getByLabelText(/access token/i), {
       target: { value: '   ' },
     })
-    fireEvent.click(screen.getByRole('button', { name: /connect/i }))
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
 
     expect(onTokenSubmit).not.toHaveBeenCalled()
     expect(screen.getByText(/enter the access token/i)).toBeInTheDocument()
+  })
+
+  it('greets a first visit instead of reporting a failure', () => {
+    render(
+      <WebAccessAuthScreen
+        authError="Enter the access token from Jean's Web Access settings."
+        reason="signed-out"
+        onTokenSubmit={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole('heading', { name: /sign in to jean/i })
+    ).toBeInTheDocument()
+    // A first visit has failed at nothing — no alert should be raised.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('flags the field when the server refused the token', () => {
+    render(
+      <WebAccessAuthScreen
+        authError="That access token was refused."
+        reason="rejected"
+        onTokenSubmit={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/refused/i)
+    expect(screen.getByLabelText(/access token/i)).toHaveAttribute(
+      'aria-invalid',
+      'true'
+    )
+  })
+
+  it('hides the form when the server cannot be reached', () => {
+    render(
+      <WebAccessAuthScreen
+        authError="Jean could not reach the server."
+        reason="unreachable"
+        onTokenSubmit={vi.fn()}
+      />
+    )
+
+    // Pasting a token cannot fix an unreachable server, so don't ask for one.
+    expect(screen.queryByLabelText(/access token/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent(/could not reach/i)
   })
 })

--- a/src/components/web/WebAccessAuthScreen.test.tsx
+++ b/src/components/web/WebAccessAuthScreen.test.tsx
@@ -19,6 +19,10 @@ describe('WebAccessAuthScreen', () => {
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
 
     expect(onTokenSubmit).toHaveBeenCalledWith('secret-token')
+
+    // Submitting reloads the page; the button stays locked until then so the
+    // user gets feedback and cannot double-submit.
+    expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled()
   })
 
   it('does not submit blank tokens', async () => {

--- a/src/components/web/WebAccessAuthScreen.test.tsx
+++ b/src/components/web/WebAccessAuthScreen.test.tsx
@@ -76,6 +76,28 @@ describe('WebAccessAuthScreen', () => {
     )
   })
 
+  it('clears the refused-token alert once the user edits the field', () => {
+    render(
+      <WebAccessAuthScreen
+        authError="That access token was refused."
+        reason="rejected"
+        onTokenSubmit={vi.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText(/access token/i), {
+      target: { value: 'fresh-token' },
+    })
+
+    // The alert described the previous submission — a fresh entry has not
+    // failed at anything yet.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByLabelText(/access token/i)).toHaveAttribute(
+      'aria-invalid',
+      'false'
+    )
+  })
+
   it('always offers the token form — submitting reloads, which is how a lost connection recovers', () => {
     render(
       <WebAccessAuthScreen

--- a/src/components/web/WebAccessAuthScreen.test.tsx
+++ b/src/components/web/WebAccessAuthScreen.test.tsx
@@ -72,17 +72,15 @@ describe('WebAccessAuthScreen', () => {
     )
   })
 
-  it('hides the form when the server cannot be reached', () => {
+  it('always offers the token form — submitting reloads, which is how a lost connection recovers', () => {
     render(
       <WebAccessAuthScreen
-        authError="Jean could not reach the server."
-        reason="unreachable"
+        authError="Connection to the server was lost."
         onTokenSubmit={vi.fn()}
       />
     )
 
-    // Pasting a token cannot fix an unreachable server, so don't ask for one.
-    expect(screen.queryByLabelText(/access token/i)).not.toBeInTheDocument()
-    expect(screen.getByRole('alert')).toHaveTextContent(/could not reach/i)
+    expect(screen.getByLabelText(/access token/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeEnabled()
   })
 })

--- a/src/components/web/WebAccessAuthScreen.tsx
+++ b/src/components/web/WebAccessAuthScreen.tsx
@@ -28,8 +28,16 @@ export function WebAccessAuthScreen({
   const [token, setToken] = useState('')
   const [emptyError, setEmptyError] = useState(false)
   const [submitting, setSubmitting] = useState(false)
+  // The refused-token message describes the previous submission; drop it as
+  // soon as the user starts editing a replacement.
+  const [edited, setEdited] = useState(false)
 
   const host = serverLabel()
+  const fieldError = emptyError
+    ? "Enter the access token from Jean's Web Access settings."
+    : reason === 'rejected' && !edited
+      ? authError
+      : null
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
@@ -77,25 +85,19 @@ export function WebAccessAuthScreen({
             onChange={event => {
               setToken(event.target.value)
               if (emptyError) setEmptyError(false)
+              if (!edited) setEdited(true)
             }}
             placeholder="Paste your Jean access token"
-            aria-describedby={
-              reason === 'rejected' ? 'web-access-token-error' : undefined
-            }
-            aria-invalid={reason === 'rejected' || emptyError}
+            aria-describedby={fieldError ? 'web-access-token-error' : undefined}
+            aria-invalid={!!fieldError}
           />
-          {emptyError && (
-            <p className="text-xs text-destructive">
-              Enter the access token from Jean&apos;s Web Access settings.
-            </p>
-          )}
-          {reason === 'rejected' && !emptyError && (
+          {fieldError && (
             <p
               id="web-access-token-error"
               role="alert"
               className="text-xs text-destructive"
             >
-              {authError}
+              {fieldError}
             </p>
           )}
         </div>

--- a/src/components/web/WebAccessAuthScreen.tsx
+++ b/src/components/web/WebAccessAuthScreen.tsx
@@ -6,8 +6,10 @@ import type { WsAuthReason } from '@/lib/transport'
 
 interface WebAccessAuthScreenProps {
   authError: string
-  /** Why we are asking. Defaults to a first visit rather than a failure. */
-  reason?: WsAuthReason
+  /** Why we are asking. Defaults to a first visit rather than a failure.
+   * Whatever the reason, the form stays available: submitting a token
+   * reloads the page, which is also how a lost connection recovers. */
+  reason?: Exclude<WsAuthReason, 'unreachable'>
   onTokenSubmit: (token: string) => void | Promise<void>
 }
 
@@ -28,9 +30,6 @@ export function WebAccessAuthScreen({
   const [submitting, setSubmitting] = useState(false)
 
   const host = serverLabel()
-  // An unreachable server is not something a token can fix — don't invite the
-  // user to paste one into the void.
-  const canSubmit = reason !== 'unreachable'
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault()
@@ -59,7 +58,7 @@ export function WebAccessAuthScreen({
           className="size-12 rounded-xl"
         />
         <h1 className="mt-5 text-xl font-semibold tracking-tight">
-          {canSubmit ? 'Sign in to Jean' : 'Server unavailable'}
+          Sign in to Jean
         </h1>
         {host && (
           <p className="mt-1.5 font-mono text-xs text-muted-foreground">
@@ -68,56 +67,49 @@ export function WebAccessAuthScreen({
         )}
       </div>
 
-      {canSubmit ? (
-        <form className="mt-8 space-y-4" onSubmit={handleSubmit}>
-          <div className="space-y-2">
-            <Label htmlFor="web-access-token">Access token</Label>
-            <Input
-              id="web-access-token"
-              type="password"
-              autoComplete="current-password"
-              autoFocus
-              value={token}
-              onChange={event => {
-                setToken(event.target.value)
-                if (emptyError) setEmptyError(false)
-              }}
-              placeholder="Paste your Jean access token"
-              aria-describedby={
-                reason === 'rejected' ? 'web-access-token-error' : undefined
-              }
-              aria-invalid={reason === 'rejected' || emptyError}
-            />
-            {emptyError && (
-              <p className="text-xs text-destructive">
-                Enter the access token from Jean&apos;s Web Access settings.
-              </p>
-            )}
-            {reason === 'rejected' && !emptyError && (
-              <p
-                id="web-access-token-error"
-                role="alert"
-                className="text-xs text-destructive"
-              >
-                {authError}
-              </p>
-            )}
-          </div>
+      <form className="mt-8 space-y-4" onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <Label htmlFor="web-access-token">Access token</Label>
+          <Input
+            id="web-access-token"
+            type="password"
+            autoComplete="current-password"
+            autoFocus
+            value={token}
+            onChange={event => {
+              setToken(event.target.value)
+              if (emptyError) setEmptyError(false)
+            }}
+            placeholder="Paste your Jean access token"
+            aria-describedby={
+              reason === 'rejected' ? 'web-access-token-error' : undefined
+            }
+            aria-invalid={reason === 'rejected' || emptyError}
+          />
+          {emptyError && (
+            <p className="text-xs text-destructive">
+              Enter the access token from Jean&apos;s Web Access settings.
+            </p>
+          )}
+          {reason === 'rejected' && !emptyError && (
+            <p
+              id="web-access-token-error"
+              role="alert"
+              className="text-xs text-destructive"
+            >
+              {authError}
+            </p>
+          )}
+        </div>
 
-          <Button type="submit" className="w-full" disabled={submitting}>
-            {submitting ? 'Signing in…' : 'Sign in'}
-          </Button>
-        </form>
-      ) : (
-        <p role="alert" className="mt-8 text-sm text-muted-foreground">
-          {authError}
-        </p>
-      )}
+        <Button type="submit" className="w-full" disabled={submitting}>
+          {submitting ? 'Signing in…' : 'Sign in'}
+        </Button>
+      </form>
 
       <p className="mt-8 text-center text-xs text-muted-foreground">
-        {canSubmit
-          ? 'Find the token in Web Access settings, or in /etc/jean-server.env on the server.'
-          : 'Jean will reconnect on its own once the server answers again.'}
+        Find the token in Web Access settings, or in /etc/jean-server.env on the
+        server.
       </p>
     </div>
   )

--- a/src/components/web/WebAccessAuthScreen.tsx
+++ b/src/components/web/WebAccessAuthScreen.tsx
@@ -108,8 +108,7 @@ export function WebAccessAuthScreen({
       </form>
 
       <p className="mt-8 text-center text-xs text-muted-foreground">
-        Find the token in Web Access settings, or in /etc/jean-server.env on the
-        server.
+        Find the token in Jean&apos;s Web Access settings.
       </p>
     </div>
   )

--- a/src/components/web/WebAccessAuthScreen.tsx
+++ b/src/components/web/WebAccessAuthScreen.tsx
@@ -2,20 +2,37 @@ import { useState, type FormEvent } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import type { WsAuthReason } from '@/lib/transport'
 
 interface WebAccessAuthScreenProps {
   authError: string
-  onTokenSubmit: (token: string) => void
+  /** Why we are asking. Defaults to a first visit rather than a failure. */
+  reason?: WsAuthReason
+  onTokenSubmit: (token: string) => void | Promise<void>
+}
+
+/** Host the token unlocks, so people running several Jean servers can tell
+ * which one is asking. Falls back to nothing rather than guessing. */
+function serverLabel(): string {
+  if (typeof window === 'undefined') return ''
+  return window.location.host
 }
 
 export function WebAccessAuthScreen({
   authError,
+  reason = 'signed-out',
   onTokenSubmit,
 }: WebAccessAuthScreenProps) {
   const [token, setToken] = useState('')
   const [emptyError, setEmptyError] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
 
-  const handleSubmit = (event: FormEvent) => {
+  const host = serverLabel()
+  // An unreachable server is not something a token can fix — don't invite the
+  // user to paste one into the void.
+  const canSubmit = reason !== 'unreachable'
+
+  const handleSubmit = async (event: FormEvent) => {
     event.preventDefault()
     const trimmed = token.trim()
     if (!trimmed) {
@@ -23,47 +40,85 @@ export function WebAccessAuthScreen({
       return
     }
     setEmptyError(false)
-    onTokenSubmit(trimmed)
+    setSubmitting(true)
+    try {
+      await onTokenSubmit(trimmed)
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
-    <div className="mx-4 max-w-md rounded-lg border border-destructive/50 bg-background p-6 shadow-lg">
-      <div className="flex items-center gap-2 text-destructive">
-        <svg className="size-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
-          <path
-            fillRule="evenodd"
-            d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
-            clipRule="evenodd"
-          />
-        </svg>
-        <h2 className="text-sm font-semibold">Connection Failed</h2>
+    <div className="w-full max-w-sm px-6">
+      <div className="flex flex-col items-center text-center">
+        <img
+          src="/logo.png"
+          alt=""
+          width={48}
+          height={48}
+          className="size-12 rounded-xl"
+        />
+        <h1 className="mt-5 text-xl font-semibold tracking-tight">
+          {canSubmit ? 'Sign in to Jean' : 'Server unavailable'}
+        </h1>
+        {host && (
+          <p className="mt-1.5 font-mono text-xs text-muted-foreground">
+            {host}
+          </p>
+        )}
       </div>
-      <p className="mt-2 text-sm text-muted-foreground">{authError}</p>
 
-      <form className="mt-4 space-y-3" onSubmit={handleSubmit}>
-        <div className="space-y-1.5">
-          <Label htmlFor="web-access-token">Access token</Label>
-          <Input
-            id="web-access-token"
-            type="password"
-            autoComplete="current-password"
-            value={token}
-            onChange={event => {
-              setToken(event.target.value)
-              if (emptyError) setEmptyError(false)
-            }}
-            placeholder="Paste your Jean web access token"
-          />
-          {emptyError && (
-            <p className="text-xs text-destructive">
-              Enter the access token from Jean&apos;s Web Access settings.
-            </p>
-          )}
-        </div>
-        <Button type="submit" className="w-full">
-          Connect
-        </Button>
-      </form>
+      {canSubmit ? (
+        <form className="mt-8 space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="web-access-token">Access token</Label>
+            <Input
+              id="web-access-token"
+              type="password"
+              autoComplete="current-password"
+              autoFocus
+              value={token}
+              onChange={event => {
+                setToken(event.target.value)
+                if (emptyError) setEmptyError(false)
+              }}
+              placeholder="Paste your Jean access token"
+              aria-describedby={
+                reason === 'rejected' ? 'web-access-token-error' : undefined
+              }
+              aria-invalid={reason === 'rejected' || emptyError}
+            />
+            {emptyError && (
+              <p className="text-xs text-destructive">
+                Enter the access token from Jean&apos;s Web Access settings.
+              </p>
+            )}
+            {reason === 'rejected' && !emptyError && (
+              <p
+                id="web-access-token-error"
+                role="alert"
+                className="text-xs text-destructive"
+              >
+                {authError}
+              </p>
+            )}
+          </div>
+
+          <Button type="submit" className="w-full" disabled={submitting}>
+            {submitting ? 'Signing in…' : 'Sign in'}
+          </Button>
+        </form>
+      ) : (
+        <p role="alert" className="mt-8 text-sm text-muted-foreground">
+          {authError}
+        </p>
+      )}
+
+      <p className="mt-8 text-center text-xs text-muted-foreground">
+        {canSubmit
+          ? 'Find the token in Web Access settings, or in /etc/jean-server.env on the server.'
+          : 'Jean will reconnect on its own once the server answers again.'}
+      </p>
     </div>
   )
 }

--- a/src/components/web/WebAccessAuthScreen.tsx
+++ b/src/components/web/WebAccessAuthScreen.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import type { WsAuthReason } from '@/lib/transport'
+import { webAccessServerLabel } from '@/lib/environment'
 
 interface WebAccessAuthScreenProps {
   authError: string
@@ -11,13 +12,6 @@ interface WebAccessAuthScreenProps {
    * reloads the page, which is also how a lost connection recovers. */
   reason?: Exclude<WsAuthReason, 'unreachable'>
   onTokenSubmit: (token: string) => void
-}
-
-/** Host the token unlocks, so people running several Jean servers can tell
- * which one is asking. Falls back to nothing rather than guessing. */
-function serverLabel(): string {
-  if (typeof window === 'undefined') return ''
-  return window.location.host
 }
 
 export function WebAccessAuthScreen({
@@ -32,7 +26,7 @@ export function WebAccessAuthScreen({
   // soon as the user starts editing a replacement.
   const [edited, setEdited] = useState(false)
 
-  const host = serverLabel()
+  const host = webAccessServerLabel()
   const fieldError = emptyError
     ? "Enter the access token from Jean's Web Access settings."
     : reason === 'rejected' && !edited

--- a/src/components/web/WebAccessAuthScreen.tsx
+++ b/src/components/web/WebAccessAuthScreen.tsx
@@ -10,7 +10,7 @@ interface WebAccessAuthScreenProps {
    * Whatever the reason, the form stays available: submitting a token
    * reloads the page, which is also how a lost connection recovers. */
   reason?: Exclude<WsAuthReason, 'unreachable'>
-  onTokenSubmit: (token: string) => void | Promise<void>
+  onTokenSubmit: (token: string) => void
 }
 
 /** Host the token unlocks, so people running several Jean servers can tell
@@ -31,7 +31,7 @@ export function WebAccessAuthScreen({
 
   const host = serverLabel()
 
-  const handleSubmit = async (event: FormEvent) => {
+  const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
     const trimmed = token.trim()
     if (!trimmed) {
@@ -39,12 +39,10 @@ export function WebAccessAuthScreen({
       return
     }
     setEmptyError(false)
+    // Submitting reloads the page (validation happens on the fresh load), so
+    // never re-enable the button — the reload resets it.
     setSubmitting(true)
-    try {
-      await onTokenSubmit(trimmed)
-    } finally {
-      setSubmitting(false)
-    }
+    onTokenSubmit(trimmed)
   }
 
   return (

--- a/src/lib/environment.ts
+++ b/src/lib/environment.ts
@@ -27,6 +27,10 @@ export const isNativeApp = (): boolean =>
 export const isLocalBackend = (): boolean =>
   isNativeApp() && getActiveRemoteConnection() === null
 
+/** Label for the Jean server a web access session talks to, so people running
+ * several servers can tell which one is asking for or holding a token. */
+export const webAccessServerLabel = (): string => window.location.host
+
 /**
  * Whether the connected Jean backend can open host apps (editor/finder/terminal).
  * Set from `/api/init` (`nativeOpenAllowed`) for web/remote clients. Local

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -519,9 +519,14 @@ class WsTransport {
     this.notifySubscribers()
   }
 
+  // Overloads force every caller that sets a message to also classify it —
+  // otherwise the UI cannot tell a first visit from a refused token or a
+  // dead server, and silently picks the wrong screen.
+  private setAuthError(error: null): void
+  private setAuthError(error: string, reason: WsAuthReason): void
   private setAuthError(error: string | null, reason?: WsAuthReason): void {
     this._authError = error
-    this._authReason = error === null ? null : (reason ?? 'unreachable')
+    this._authReason = error === null ? null : (reason as WsAuthReason)
     this.notifySubscribers()
   }
 

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -19,6 +19,16 @@ import { getActiveRemoteConnection } from './remote-connections'
 import { prepareRemoteEditorOpenArgs } from './remote-editor'
 import { warnRemoteVersionMismatch } from './remote-version'
 
+/**
+ * Why the browser session is not authenticated yet.
+ *
+ * - `signed-out`  — no token has been presented; this is the normal first
+ *   visit and a sign-in prompt, not a failure.
+ * - `rejected`    — a token was presented and the server refused it.
+ * - `unreachable` — the server could not be reached or dropped the session.
+ */
+export type WsAuthReason = 'signed-out' | 'rejected' | 'unreachable'
+
 export function usesWebSocketBackend(): boolean {
   return !isNativeApp() || getActiveRemoteConnection() !== null
 }
@@ -475,6 +485,7 @@ class WsTransport {
   private _hasConnectedOnce = false
   private _connecting = false
   private _authError: string | null = null
+  private _authReason: WsAuthReason | null = null
   private _subscribers = new Set<() => void>()
   private _establishedDisconnectListeners = new Set<() => void>()
   private _connectEnabled = false
@@ -508,8 +519,9 @@ class WsTransport {
     this.notifySubscribers()
   }
 
-  private setAuthError(error: string | null): void {
+  private setAuthError(error: string | null, reason?: WsAuthReason): void {
     this._authError = error
+    this._authReason = error === null ? null : (reason ?? 'unreachable')
     this.notifySubscribers()
   }
 
@@ -536,6 +548,11 @@ class WsTransport {
   /** Get current auth error snapshot for useSyncExternalStore. */
   getAuthErrorSnapshot(): string | null {
     return this._authError
+  }
+
+  /** Get why authentication is pending, for useSyncExternalStore. */
+  getAuthReasonSnapshot(): WsAuthReason | null {
+    return this._authReason
   }
 
   /** Connect to the WebSocket server (validates token first). */
@@ -596,8 +613,9 @@ class WsTransport {
         }
         this.setAuthError(
           token
-            ? "Invalid access token. Check the URL in Jean's Web Access settings."
-            : "No access token provided. Use the URL from Jean's Web Access settings."
+            ? "That access token was refused. Check the token in Jean's Web Access settings."
+            : "Enter the access token from Jean's Web Access settings.",
+          token ? 'rejected' : 'signed-out'
         )
         return
       }
@@ -615,7 +633,8 @@ class WsTransport {
     } catch {
       if (remote) {
         this.setAuthError(
-          "Jean could not reach the server's authentication endpoint. Check that the server is running and the URL and port are correct. If the address opens in a browser, update and restart the remote Jean server so it allows desktop connections (CORS)."
+          "Jean could not reach the server's authentication endpoint. Check that the server is running and the URL and port are correct. If the address opens in a browser, update and restart the remote Jean server so it allows desktop connections (CORS).",
+          'unreachable'
         )
         return
       }
@@ -706,7 +725,10 @@ class WsTransport {
 
       this.setConnected(false)
       if (wasConnected && getActiveRemoteConnection()) {
-        this.setAuthError('Connection to the selected Jean server was lost.')
+        this.setAuthError(
+          'Connection to the selected Jean server was lost.',
+          'unreachable'
+        )
       }
 
       // Clear event buffer — stale events from a dead connection
@@ -1083,6 +1105,7 @@ const wsTransport = new WsTransport()
 const subscribe = (cb: () => void) => wsTransport.subscribe(cb)
 const getSnapshot = () => wsTransport.getSnapshot()
 const getAuthErrorSnapshot = () => wsTransport.getAuthErrorSnapshot()
+const getAuthReasonSnapshot = () => wsTransport.getAuthReasonSnapshot()
 
 // E2E mock: always report connected, no auth errors
 const isE2eMocked =
@@ -1138,5 +1161,17 @@ export function useWsAuthError(): string | null {
   return useSyncExternalStore(
     isE2eMocked ? noopSubscribe : subscribe,
     isE2eMocked ? () => null : getAuthErrorSnapshot
+  )
+}
+
+/**
+ * React hook that returns why authentication is pending, or null when the
+ * session is authenticated. Lets the UI tell a first visit apart from a
+ * refused token instead of reporting both as a connection failure.
+ */
+export function useWsAuthReason(): WsAuthReason | null {
+  return useSyncExternalStore(
+    isE2eMocked ? noopSubscribe : subscribe,
+    isE2eMocked ? () => null : getAuthReasonSnapshot
   )
 }

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -1175,3 +1175,16 @@ export function useWsAuthReason(): WsAuthReason | null {
     isE2eMocked ? () => null : getAuthReasonSnapshot
   )
 }
+
+/**
+ * Forget the access token stored in this browser and return to the sign-in
+ * screen. Only affects this device — the server keeps running and other
+ * browsers stay signed in.
+ */
+export function signOutOfWebAccess(): void {
+  localStorage.removeItem('jean-http-token')
+  // Reload on a bare origin. A bookmarked `?token=...` takes priority over
+  // localStorage on boot, so keeping the current URL would sign us straight
+  // back in and make the button look broken.
+  window.location.replace(`${window.location.origin}/`)
+}


### PR DESCRIPTION
Web access currently greets every unauthenticated browser with a bare token prompt that reports first visits, refused tokens and connection failures with the same generic error — and once signed in, there is no way to sign a browser out short of clearing localStorage by hand.

## What this PR does

- **Replaces the token prompt with a proper sign-in screen**: app logo, server host (so people running several Jean servers can tell which one is asking), a password-type field with `autocomplete="current-password"`, and distinct copy for a first visit vs a refused token.
- **Adds a "This browser" card in Settings → General** (web access only) with a **Sign out** button that forgets the token on this device only — the server keeps running and other devices stay signed in.
- **Threads an auth _reason_** (`signed-out` / `rejected`) from the transport. Overloads on `setAuthError` force every caller that sets a message to classify it, so the UI can never misreport an auth state.
- **Accessible error wiring**: one `fieldError` drives the message, `aria-describedby` and `aria-invalid` together; a stale "token refused" alert is retired as soon as the user edits the field. The submit button locks until the reload lands.
- **Web-only**: gated on `!isNativeApp()`, zero impact on the native desktop app. Frontend only, no Rust changes. Covered by component and structure tests.

## Screenshots

**First visit**
<img width="2560" height="1600" alt="screen-1-signed-out" src="https://github.com/user-attachments/assets/3bbb5149-bad8-46f7-b107-d03fb3f9ffd9" />

**Refused token**
<img width="2560" height="1600" alt="screen-2-rejected" src="https://github.com/user-attachments/assets/cf0e3f28-c1f9-43af-af49-71ebf4857679" />

**Sign out from Settings → General**
<img width="2560" height="1600" alt="screen-6-section-framed" src="https://github.com/user-attachments/assets/a4bb3c73-6d8c-4f76-8b2b-92bcd58a98df" />

🤖 Generated with Claude Code