### PR TITLE
fix(macos): raise desktop open file limit

### DIFF
--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -73,7 +73,7 @@ pub use version::{app_version, set_app_version};
 // launch logic stays shared and complete: binary mapping, -g goto args,
 // macOS app fallbacks, Windows .cmd wrappers).
 pub use chat::open_file_in_default_app;
-pub use platform::open_url_in_browser;
+pub use platform::{open_url_in_browser, raise_fd_limit};
 pub use projects::open_worktree_in_editor;
 
 // Validation functions

--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -73,8 +73,11 @@ pub use version::{app_version, set_app_version};
 // launch logic stays shared and complete: binary mapping, -g goto args,
 // macOS app fallbacks, Windows .cmd wrappers).
 pub use chat::open_file_in_default_app;
-pub use platform::{open_url_in_browser, raise_fd_limit};
+pub use platform::open_url_in_browser;
 pub use projects::open_worktree_in_editor;
+
+// Process startup helper shared by the desktop and headless entry points.
+pub use platform::raise_fd_limit;
 
 // Validation functions
 fn validate_filename(filename: &str) -> Result<(), String> {

--- a/jean-core/src/lib.rs
+++ b/jean-core/src/lib.rs
@@ -4578,6 +4578,10 @@ async fn wait_for_shutdown_signal() -> Result<(), String> {
 
 /// Run the standalone Axum adapter until it receives a shutdown signal.
 pub async fn run_server() -> Result<(), String> {
+    // Host modes (MCP stdio, PI RPC, Grok/Kimi ACP) return before the rest of
+    // startup. Raise the limit first so those processes get it when launched
+    // via jean-server rather than the desktop binary (which also raises in run()).
+    platform::raise_fd_limit();
     if std::env::args().any(|argument| argument == jean_mcp_core::JEAN_MCP_STDIO_ARG) {
         jean_mcp_stdio::run_stdio_server()?;
         return Ok(());
@@ -4595,7 +4599,6 @@ pub async fn run_server() -> Result<(), String> {
         return Ok(());
     }
     async_runtime::set(tokio::runtime::Handle::current());
-    platform::raise_fd_limit();
     #[cfg(target_os = "linux")]
     platform::fix_headless_path();
     let cli = parse_cli_args();

--- a/jean-core/src/platform/process.rs
+++ b/jean-core/src/platform/process.rs
@@ -116,6 +116,21 @@ pub fn open_url_in_browser(url: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Darwin historically advertised `OPEN_MAX` as 10240. The kernel rejects
+/// `RLIM_INFINITY` (and values above `kern.maxfilesperproc`) for `RLIMIT_NOFILE`.
+#[cfg(target_os = "macos")]
+const DARWIN_OPEN_MAX: libc::rlim_t = 10_240;
+
+#[cfg(unix)]
+fn fd_limit_warn(message: String) {
+    log::warn!("{message}");
+    // Desktop `run()` calls this before the Tauri log plugin is installed, so
+    // failures would otherwise vanish. Surface them on stderr in that case.
+    if !log::log_enabled!(log::Level::Warn) {
+        eprintln!("{message}");
+    }
+}
+
 /// Raise the open-file-descriptor soft limit (`RLIMIT_NOFILE`) to the hard limit.
 ///
 /// macOS GUI apps launch with a low default soft limit (often 256). Jean spawns
@@ -133,10 +148,10 @@ pub fn raise_fd_limit() {
             rlim_max: 0,
         };
         if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) != 0 {
-            log::warn!(
+            fd_limit_warn(format!(
                 "raise_fd_limit: getrlimit failed: {}",
                 std::io::Error::last_os_error()
-            );
+            ));
             return;
         }
 
@@ -148,13 +163,7 @@ pub fn raise_fd_limit() {
         let target = rlim.rlim_max;
 
         #[cfg(target_os = "macos")]
-        let target = {
-            let mut target = rlim.rlim_max;
-            if let Some(max_per_proc) = macos_maxfilesperproc() {
-                target = target.min(max_per_proc);
-            }
-            target
-        };
+        let target = macos_nofile_target(rlim.rlim_max);
 
         if old_cur >= target {
             log::info!("raise_fd_limit: soft fd limit already sufficient ({old_cur})");
@@ -163,14 +172,41 @@ pub fn raise_fd_limit() {
 
         rlim.rlim_cur = target;
         if libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) != 0 {
-            log::warn!(
+            #[cfg(target_os = "macos")]
+            if target > DARWIN_OPEN_MAX && old_cur < DARWIN_OPEN_MAX {
+                rlim.rlim_cur = DARWIN_OPEN_MAX;
+                if libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) == 0 {
+                    log::info!(
+                        "raise_fd_limit: raised soft fd limit {old_cur} -> {DARWIN_OPEN_MAX} (OPEN_MAX fallback)"
+                    );
+                    return;
+                }
+            }
+            fd_limit_warn(format!(
                 "raise_fd_limit: setrlimit to {target} failed: {}",
                 std::io::Error::last_os_error()
-            );
+            ));
             return;
         }
 
         log::info!("raise_fd_limit: raised soft fd limit {old_cur} -> {target}");
+    }
+}
+
+/// Choose a `RLIMIT_NOFILE` soft-limit target that macOS will accept.
+///
+/// GUI apps often report `rlim_max = RLIM_INFINITY`. The kernel rejects that
+/// with EINVAL, so clamp to `kern.maxfilesperproc`, or Darwin `OPEN_MAX` if
+/// the sysctl is unavailable.
+#[cfg(target_os = "macos")]
+fn macos_nofile_target(rlim_max: libc::rlim_t) -> libc::rlim_t {
+    if let Some(max_per_proc) = macos_maxfilesperproc() {
+        return rlim_max.min(max_per_proc);
+    }
+    if rlim_max == 0 || rlim_max == libc::RLIM_INFINITY {
+        DARWIN_OPEN_MAX
+    } else {
+        rlim_max.min(DARWIN_OPEN_MAX)
     }
 }
 
@@ -200,6 +236,102 @@ fn macos_maxfilesperproc() -> Option<libc::rlim_t> {
 /// No-op on Windows — there is no per-process open-file-descriptor limit to raise.
 #[cfg(windows)]
 pub fn raise_fd_limit() {}
+
+#[cfg(test)]
+mod fd_limit_tests {
+    use super::raise_fd_limit;
+
+    #[cfg(unix)]
+    fn nofile_limit() -> libc::rlimit {
+        unsafe {
+            let mut rlim = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            assert_eq!(
+                libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim),
+                0,
+                "getrlimit(RLIMIT_NOFILE) failed: {}",
+                std::io::Error::last_os_error()
+            );
+            rlim
+        }
+    }
+
+    #[test]
+    fn raise_fd_limit_does_not_panic() {
+        raise_fd_limit();
+        raise_fd_limit();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn raise_fd_limit_does_not_lower_soft_limit() {
+        let before = nofile_limit();
+        raise_fd_limit();
+        let after = nofile_limit();
+        assert!(
+            after.rlim_cur >= before.rlim_cur,
+            "soft limit decreased: {} -> {}",
+            before.rlim_cur,
+            after.rlim_cur
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn raise_fd_limit_is_idempotent() {
+        raise_fd_limit();
+        let once = nofile_limit();
+        raise_fd_limit();
+        let twice = nofile_limit();
+        assert_eq!(once.rlim_cur, twice.rlim_cur);
+        assert_eq!(once.rlim_max, twice.rlim_max);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_nofile_target_clamps_infinity_without_sysctl() {
+        // Even if sysctl works, infinity must never be returned as the target.
+        let target = super::macos_nofile_target(libc::RLIM_INFINITY);
+        assert_ne!(target, libc::RLIM_INFINITY);
+        assert!(target > 0);
+        assert!(target >= super::DARWIN_OPEN_MAX || super::macos_maxfilesperproc().is_some());
+    }
+
+    #[test]
+    fn desktop_run_raises_fd_limit_before_tauri() {
+        let source = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../src-tauri/src/lib.rs"
+        ));
+        let raise = source
+            .find("jean_core::raise_fd_limit();")
+            .expect("desktop run() must call jean_core::raise_fd_limit()");
+        let builder = source
+            .find("tauri::Builder::default()")
+            .expect("desktop Tauri builder");
+        assert!(
+            raise < builder,
+            "desktop run() must raise the fd limit before Tauri initializes"
+        );
+    }
+
+    #[test]
+    fn run_server_raises_fd_limit_before_host_early_returns() {
+        let source = include_str!("../lib.rs");
+        let raise = source
+            .find("platform::raise_fd_limit();")
+            .expect("run_server must call platform::raise_fd_limit()");
+        let pi_host = source
+            .find("chat::pi::run_pi_rpc_host_from_args")
+            .expect("PI RPC host early return");
+        assert!(
+            raise < pi_host,
+            "raise_fd_limit must run before PI RPC host early return so jean-server hosts inherit the limit"
+        );
+    }
+}
 
 /// Check if a process is still alive
 /// - Unix: Uses kill(pid, 0) to check

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -340,6 +340,11 @@ pub fn run() {
     // Product version must be the desktop package, not jean-core's library version.
     jean_core::set_app_version(env!("CARGO_PKG_VERSION"));
 
+    // macOS GUI apps inherit a low open-file limit (usually 256). Raise it
+    // before starting Tauri so detached AI servers and every other child
+    // process inherit the safer limit too.
+    jean_core::raise_fd_limit();
+
     if should_run_server() {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -340,9 +340,9 @@ pub fn run() {
     // Product version must be the desktop package, not jean-core's library version.
     jean_core::set_app_version(env!("CARGO_PKG_VERSION"));
 
-    // macOS GUI apps inherit a low open-file limit (usually 256). Raise it
-    // before starting Tauri so detached AI servers and every other child
-    // process inherit the safer limit too.
+    // macOS GUI apps inherit a low open-file limit (usually 256). On Unix,
+    // raise it when needed before starting Tauri so child processes inherit
+    // the safer limit too; this helper is a no-op on Windows.
     jean_core::raise_fd_limit();
 
     if should_run_server() {


### PR DESCRIPTION
## Summary

- raise `RLIMIT_NOFILE` at the start of the desktop entry point, before Tauri initializes
- ensure detached Codex app-server and other child processes inherit the raised limit
- reuse the existing cross-platform `raise_fd_limit` helper already used by headless mode

## Problem

macOS GUI applications commonly inherit a soft open-file limit of 256. Jean already raises this limit in headless/server mode, but not in the desktop entry point. With many concurrent Codex agents, the shared detached app-server can exhaust that limit and fail all file access and command spawning with `Too many open files (os error 24)`.

## Verification

- `PATH="$HOME/.nvm/versions/node/v22.12.0/bin:$PATH" bun run check:all`
- 303 frontend test files / 2,127 tests passed
- 1,102 jean-core tests passed (1 ignored)
- 11 Tauri library tests passed
- Rust formatting and clippy passed with warnings denied