### PR TITLE
fix(chat): restore prompt after normal cancellation

### DIFF
--- a/src/components/chat/hooks/useStreamingEvents.test.tsx
+++ b/src/components/chat/hooks/useStreamingEvents.test.tsx
@@ -898,7 +898,7 @@ describe('useStreamingEvents cancellation sanitization', () => {
     expect(useChatStore.getState().isSessionReviewing('session-1')).toBe(true)
   })
 
-  it('does not restore input when cancelling an already-running prompt with no streamed content yet', async () => {
+  it('restores input when cancelling an already-running prompt with no streamed content yet', async () => {
     const queryClient = createQueryClient()
     const wrapper = createWrapper(queryClient)
 
@@ -952,12 +952,14 @@ describe('useStreamingEvents cancellation sanitization', () => {
       messages: { id: string; role: string; content: string }[]
     }>(['chat', 'session', 'session-1'])
 
-    // Prompt already started — keep the user message, do not put it back in input.
+    // A live cancellation keeps the user message in history, but restores the
+    // draft so the prompt can be sent again.
     expect(session?.messages.map(message => message.id)).toEqual([
       'current-user',
-      'cancelled-session-1-2000',
     ])
-    expect(useChatStore.getState().inputDrafts['session-1']).toBe('')
+    expect(useChatStore.getState().inputDrafts['session-1']).toBe(
+      'already running'
+    )
     expect(useChatStore.getState().lastSentMessages['session-1']).toBe(
       undefined
     )

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -1929,12 +1929,11 @@ export default function useStreamingEvents({
         // Clear compacting state (safety net)
         useChatStore.getState().setCompacting(session_id, false)
 
-        // Restore message to input ONLY when the prompt never started
-        // (backend undo_send=true: process not registered / pending cancel).
-        // If the prompt is already running, do not restore even when no
-        // assistant content has streamed yet — cancel of a live run leaves
-        // the input empty. Also skip restore when queued messages exist
-        // ("Skip to Next").
+        // Restore a prompt with no assistant output, regardless of whether the
+        // backend classified cancellation as undo_send. Normal cancellation
+        // events use undo_send=false once a run has started, but the prompt is
+        // still retryable when nothing was streamed. Queued messages are
+        // handled by "Skip to Next" and must not be restored here.
         const hasToolCalls = toolCalls && toolCalls.length > 0
         const hasText = sanitizedContent.trim().length > 0
         const hasThinking = !!streamingThinkingContent[session_id]
@@ -1945,7 +1944,7 @@ export default function useStreamingEvents({
         const hasQueuedMessages =
           (useChatStore.getState().messageQueues[session_id] ?? []).length > 0
         const shouldHydrateCancelledFromBackend = !undo_send && !hasContent
-        const shouldRestoreMessage = !hasQueuedMessages && undo_send
+        const shouldRestoreMessage = !hasQueuedMessages && !hasContent
 
         const removeLatestUserMessageFromCache = () => {
           queryClient.setQueryData<Session>(
@@ -2013,10 +2012,13 @@ export default function useStreamingEvents({
             }
             clearLastSentMessage(session_id)
 
-            removeLatestUserMessageFromCache()
+            // undo_send means the prompt never entered the run history. A
+            // normal live cancellation keeps the user turn visible while the
+            // draft is restored for retry.
+            if (undo_send) removeLatestUserMessageFromCache()
           } else {
             useChatStore.getState().clearLastSentAttachments(session_id)
-            removeLatestUserMessageFromCache()
+            if (undo_send) removeLatestUserMessageFromCache()
           }
         } else {
           // Partial response exists — keep the prompt + streamed partial output

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -539,12 +539,14 @@ export interface ErrorEvent {
 }
 
 /**
- * Event payload for cancellation from Rust (user pressed Escape)
+ * Event payload for cancellation from Rust (user pressed Escape).
+ * undo_send only indicates whether the user turn should be removed from
+ * history; a prompt with no streamed output may still be restored when false.
  */
 export interface CancelledEvent {
   session_id: string
   worktree_id: string // Kept for backward compatibility
-  undo_send: boolean // True only when the prompt never started (restore to input)
+  undo_send: boolean
   emitted_at_ms: number
   run_id?: string
 }


### PR DESCRIPTION
## Summary

- Restore a cancelled prompt when no assistant output was streamed, including normal cancellations with `undo_send: false`.
- Keep `undo_send` responsible only for removing the user turn from visible history.
- Add a regression test for an already-running prompt cancelled before any output.

Fixes #671

## Validation

- `bun --bun node_modules/vitest/vitest.mjs run src/components/chat/hooks/useStreamingEvents.test.tsx`
- `bun run typecheck`
- Targeted ESLint
- `git diff --check`