### PR TITLE
fix: Cursor Agent install on Windows

### DIFF
--- a/jean-core/src/cursor_cli/commands.rs
+++ b/jean-core/src/cursor_cli/commands.rs
@@ -480,7 +480,7 @@ pub async fn get_cursor_install_command(_app: AppHandle) -> Result<CursorInstall
             args: vec![
                 "-NoProfile".to_string(),
                 "-Command".to_string(),
-                "irm https://cursor.com/install | iex".to_string(),
+                "irm 'https://cursor.com/install?win32=true' | iex".to_string(),
             ],
             description: "Installs Cursor Agent using Cursor's official installer".to_string(),
         })

--- a/jean-core/src/cursor_cli/commands.rs
+++ b/jean-core/src/cursor_cli/commands.rs
@@ -452,51 +452,55 @@ pub async fn list_cursor_models(app: AppHandle) -> Result<Vec<CursorModelInfo>, 
     }
 }
 
-pub async fn get_cursor_install_command(_app: AppHandle) -> Result<CursorInstallCommand, String> {
-    let wsl = crate::platform::get_wsl_config();
-    if wsl.enabled {
+const CURSOR_UNIX_INSTALLER: &str = "curl -fsSL https://cursor.com/install | bash";
+const CURSOR_WINDOWS_INSTALLER: &str = "irm 'https://cursor.com/install?win32=true' | iex";
+
+fn cursor_install_command(wsl_distro: Option<&str>, is_windows: bool) -> CursorInstallCommand {
+    if let Some(distro) = wsl_distro {
         // Run Cursor's Linux installer inside the WSL distro so the binary
         // ends up on the distro-side $PATH rather than on Windows.
-        return Ok(CursorInstallCommand {
+        return CursorInstallCommand {
             command: "wsl.exe".to_string(),
             args: vec![
                 "-d".to_string(),
-                wsl.distro,
+                distro.to_string(),
                 "--".to_string(),
                 "bash".to_string(),
                 "-lc".to_string(),
-                "curl -fsSL https://cursor.com/install | bash".to_string(),
+                CURSOR_UNIX_INSTALLER.to_string(),
             ],
             description:
                 "Installs Cursor Agent inside your WSL distro using Cursor's official installer"
                     .to_string(),
-        });
+        };
     }
 
-    #[cfg(target_os = "windows")]
-    {
-        Ok(CursorInstallCommand {
+    if is_windows {
+        CursorInstallCommand {
             command: "powershell".to_string(),
             args: vec![
                 "-NoProfile".to_string(),
                 "-Command".to_string(),
-                "irm 'https://cursor.com/install?win32=true' | iex".to_string(),
+                CURSOR_WINDOWS_INSTALLER.to_string(),
             ],
             description: "Installs Cursor Agent using Cursor's official installer".to_string(),
-        })
+        }
+    } else {
+        CursorInstallCommand {
+            command: "/bin/sh".to_string(),
+            args: vec!["-c".to_string(), CURSOR_UNIX_INSTALLER.to_string()],
+            description: "Installs Cursor Agent using Cursor's official installer".to_string(),
+        }
+    }
+}
+
+pub async fn get_cursor_install_command(_app: AppHandle) -> Result<CursorInstallCommand, String> {
+    let wsl = crate::platform::get_wsl_config();
+    if wsl.enabled {
+        return Ok(cursor_install_command(Some(&wsl.distro), false));
     }
 
-    #[cfg(not(target_os = "windows"))]
-    {
-        Ok(CursorInstallCommand {
-            command: "/bin/sh".to_string(),
-            args: vec![
-                "-c".to_string(),
-                "curl -fsSL https://cursor.com/install | bash".to_string(),
-            ],
-            description: "Installs Cursor Agent using Cursor's official installer".to_string(),
-        })
-    }
+    Ok(cursor_install_command(None, cfg!(windows)))
 }
 
 #[cfg(test)]
@@ -571,5 +575,58 @@ Tip: use --model <id> (or /model <id> in interactive mode) to switch.
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "kimi-k2.5");
         assert_eq!(models[0].label, "Kimi K2.5");
+    }
+
+    #[test]
+    fn windows_install_command_uses_official_win32_installer() {
+        let cmd = cursor_install_command(None, true);
+
+        assert_eq!(cmd.command, "powershell");
+        assert_eq!(
+            cmd.args,
+            vec![
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "irm 'https://cursor.com/install?win32=true' | iex".to_string(),
+            ]
+        );
+        assert!(
+            !cmd.args.iter().any(|arg| arg.contains("curl")),
+            "native Windows must not pipe the Unix installer into PowerShell"
+        );
+    }
+
+    #[test]
+    fn unix_install_command_uses_bash_installer() {
+        let cmd = cursor_install_command(None, false);
+
+        assert_eq!(cmd.command, "/bin/sh");
+        assert_eq!(
+            cmd.args,
+            vec![
+                "-c".to_string(),
+                "curl -fsSL https://cursor.com/install | bash".to_string(),
+            ]
+        );
+        assert!(!cmd.args.iter().any(|arg| arg.contains("win32=true")));
+    }
+
+    #[test]
+    fn wsl_install_command_uses_unix_installer_inside_distro() {
+        let cmd = cursor_install_command(Some("Ubuntu"), true);
+
+        assert_eq!(cmd.command, "wsl.exe");
+        assert_eq!(
+            cmd.args,
+            vec![
+                "-d".to_string(),
+                "Ubuntu".to_string(),
+                "--".to_string(),
+                "bash".to_string(),
+                "-lc".to_string(),
+                "curl -fsSL https://cursor.com/install | bash".to_string(),
+            ]
+        );
+        assert!(!cmd.args.iter().any(|arg| arg.contains("win32=true")));
     }
 }

--- a/jean-core/src/cursor_cli/config.rs
+++ b/jean-core/src/cursor_cli/config.rs
@@ -36,11 +36,28 @@ fn local_install_candidates(home: &Path) -> [PathBuf; 2] {
     ]
 }
 
+/// Official native Windows installer layout (`%LOCALAPPDATA%\cursor-agent`).
+///
+/// Cursor copies `cursor-agent.exe` / `.cmd` into this directory and aliases
+/// them as `agent.exe` / `agent.cmd`, then adds the directory to the user PATH.
+/// Jean's process PATH is not refreshed until restart, so we look here directly.
+fn windows_install_dir_candidates(local_app_data: &Path) -> [PathBuf; 4] {
+    let dir = local_app_data.join("cursor-agent");
+    [
+        dir.join("cursor-agent.exe"),
+        dir.join("cursor-agent.cmd"),
+        dir.join("agent.exe"),
+        dir.join("agent.cmd"),
+    ]
+}
+
 /// Resolve the Cursor Agent binary from system PATH.
 ///
 /// Cursor's installer places the binary on PATH, so Jean resolves the
 /// discovered system binary when available and returns a non-existent fallback
-/// path otherwise.
+/// path otherwise. On native Windows, also check the official
+/// `%LOCALAPPDATA%\cursor-agent` install directory so detection works before
+/// Jean is restarted and picks up the updated user PATH.
 pub fn resolve_cli_binary(_app: &AppHandle) -> PathBuf {
     let wsl = get_wsl_config();
     if wsl.enabled {
@@ -65,6 +82,16 @@ pub fn resolve_cli_binary(_app: &AppHandle) -> PathBuf {
         for candidate in local_install_candidates(&home) {
             if candidate.is_file() {
                 return candidate;
+            }
+        }
+    }
+
+    if cfg!(windows) {
+        if let Some(local_app_data) = dirs::data_local_dir() {
+            for candidate in windows_install_dir_candidates(&local_app_data) {
+                if candidate.is_file() {
+                    return candidate;
+                }
             }
         }
     }
@@ -107,5 +134,32 @@ mod tests {
             candidates[1],
             PathBuf::from("/home/tester/.local/bin").join(CLI_BINARY_NAME)
         );
+    }
+
+    #[test]
+    fn windows_install_dir_matches_official_cursor_agent_layout() {
+        let local_app_data = Path::new(r"C:\Users\u\AppData\Local");
+        let dir = local_app_data.join("cursor-agent");
+        let candidates = windows_install_dir_candidates(local_app_data);
+
+        assert_eq!(candidates[0], dir.join("cursor-agent.exe"));
+        assert_eq!(candidates[1], dir.join("cursor-agent.cmd"));
+        assert_eq!(candidates[2], dir.join("agent.exe"));
+        assert_eq!(candidates[3], dir.join("agent.cmd"));
+    }
+
+    #[test]
+    fn windows_install_dir_prefers_cursor_agent_exe_when_present() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("cursor-agent");
+        std::fs::create_dir_all(&dir).unwrap();
+        let exe = dir.join("cursor-agent.exe");
+        std::fs::write(&exe, b"").unwrap();
+
+        let found = windows_install_dir_candidates(tmp.path())
+            .into_iter()
+            .find(|path| path.is_file());
+
+        assert_eq!(found.as_deref(), Some(exe.as_path()));
     }
 }


### PR DESCRIPTION
## Summary
Installing Cursor Agent from Jean on native Windows was feeding PowerShell the Unix installer, so it blew up with parse errors (if [, ||, function syntax, and so on). This points that command at Cursor's official Windows installer (?win32=true).

WSL and macOS/Linux are unchanged.

## Test plan
- [ ] On native Windows, click Install Cursor Agent in Settings or onboarding
- [ ] Confirm PowerShell no longer fails on bash syntax
- [ ] Confirm Jean detects `cursor-agent` after install