### PR TITLE
fix: Command Code CLI npm detection on Windows

### DIFF
--- a/jean-core/src/agent_browser/mod.rs
+++ b/jean-core/src/agent_browser/mod.rs
@@ -302,8 +302,9 @@ fn install_agent_browser_sync(app: &AppHandle) -> Result<AgentBrowserStatus, Str
 
     // Ensure profile exists so MCP install can succeed right after.
     ensure_profile(app)?;
+    let npm_path = crate::prerequisites::require_npm("agent-browser")?;
 
-    let npm_output = silent_command("npm")
+    let npm_output = crate::platform::cli_command(&npm_path, None)
         .args(["install", "--prefix"])
         .arg(&cli_dir)
         .arg(NPM_PACKAGE)

--- a/jean-core/src/commandcode_cli/commands.rs
+++ b/jean-core/src/commandcode_cli/commands.rs
@@ -10,7 +10,6 @@ use super::config::{
     ensure_cli_dir, find_system_commandcode_binary, get_cli_binary_path, get_cli_dir,
     resolve_cli_binary,
 };
-use crate::platform::silent_command;
 
 const AUTH_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
 const COMMANDCODE_NPM_REGISTRY_URL: &str = "https://registry.npmjs.org/command-code";
@@ -706,7 +705,12 @@ pub async fn install_commandcode_cli(
     crate::prerequisites::require_npm("Command Code CLI")?;
     let cli_dir = ensure_cli_dir(&app)?;
     let package = commandcode_package(version.as_deref());
-    let output = silent_command("npm")
+    let npm_path = crate::platform::detect_cli_in_path("npm", None, None)
+        .path
+        .ok_or_else(|| {
+            "Failed to locate npm after verifying Command Code CLI prerequisites".to_string()
+        })?;
+    let output = crate::platform::cli_command(&npm_path, None)
         .args(["install", "--prefix"])
         .arg(&cli_dir)
         .arg(package)

--- a/jean-core/src/commandcode_cli/commands.rs
+++ b/jean-core/src/commandcode_cli/commands.rs
@@ -702,14 +702,9 @@ pub async fn install_commandcode_cli(
     app: AppHandle,
     version: Option<String>,
 ) -> Result<(), String> {
-    crate::prerequisites::require_npm("Command Code CLI")?;
+    let npm_path = crate::prerequisites::require_npm("Command Code CLI")?;
     let cli_dir = ensure_cli_dir(&app)?;
     let package = commandcode_package(version.as_deref());
-    let npm_path = crate::platform::detect_cli_in_path("npm", None, None)
-        .path
-        .ok_or_else(|| {
-            "Failed to locate npm after verifying Command Code CLI prerequisites".to_string()
-        })?;
     let output = crate::platform::cli_command(&npm_path, None)
         .args(["install", "--prefix"])
         .arg(&cli_dir)

--- a/jean-core/src/grok_cli/commands.rs
+++ b/jean-core/src/grok_cli/commands.rs
@@ -13,7 +13,6 @@ use super::config::{
     binary_exists, ensure_cli_dir, find_system_grok_binary, get_cli_binary_path, get_cli_dir,
     resolve_cli_binary,
 };
-use crate::platform::silent_command;
 
 const AUTH_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
 const MODELS_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
@@ -669,10 +668,10 @@ pub async fn get_grok_install_command(app: AppHandle) -> Result<GrokInstallComma
 }
 
 pub async fn install_grok_cli(app: AppHandle, version: Option<String>) -> Result<(), String> {
-    crate::prerequisites::require_npm("Grok CLI")?;
+    let npm_path = crate::prerequisites::require_npm("Grok CLI")?;
     let cli_dir = ensure_cli_dir(&app)?;
     let package = grok_package(version.as_deref());
-    let output = silent_command("npm")
+    let output = crate::platform::cli_command(&npm_path, None)
         .args(["install", "--prefix"])
         .arg(&cli_dir)
         .arg(package)

--- a/jean-core/src/kimi_cli/commands.rs
+++ b/jean-core/src/kimi_cli/commands.rs
@@ -10,7 +10,6 @@ use super::config::{
     binary_exists, ensure_cli_dir, find_system_kimi_binary, get_cli_binary_path, get_cli_dir,
     resolve_cli_binary,
 };
-use crate::platform::silent_command;
 
 const AUTH_TIMEOUT: Duration = Duration::from_secs(5);
 const PACKAGE_NAME: &str = "@moonshot-ai/kimi-code";
@@ -408,9 +407,9 @@ pub async fn get_kimi_install_command(app: AppHandle) -> Result<KimiInstallComma
 }
 
 pub async fn install_kimi_cli(app: AppHandle, version: Option<String>) -> Result<(), String> {
-    crate::prerequisites::require_npm("Kimi Code CLI")?;
+    let npm_path = crate::prerequisites::require_npm("Kimi Code CLI")?;
     let dir = ensure_cli_dir(&app)?;
-    let output = silent_command("npm")
+    let output = crate::platform::cli_command(&npm_path, None)
         .args(["install", "--prefix"])
         .arg(&dir)
         .arg(package(version.as_deref()))

--- a/jean-core/src/pi_cli/commands.rs
+++ b/jean-core/src/pi_cli/commands.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 use tauri::AppHandle;
 
 use super::config::{find_pi_in_path, get_cli_dir, resolve_cli_binary};
-use crate::platform::silent_command;
 
 const PI_NPM_PACKAGE: &str = "@earendil-works/pi-coding-agent";
 
@@ -635,14 +634,14 @@ pub async fn check_pi_cli_version_exists(_app: AppHandle, version: String) -> Re
 }
 
 pub async fn install_pi_cli(app: AppHandle, version: Option<String>) -> Result<(), String> {
-    crate::prerequisites::require_npm("PI CLI")?;
+    let npm_path = crate::prerequisites::require_npm("PI CLI")?;
     let dir = get_cli_dir(&app)?;
     std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create PI CLI dir: {e}"))?;
     let package = match version {
         Some(version) if !version.trim().is_empty() => format!("{PI_NPM_PACKAGE}@{version}"),
         _ => PI_NPM_PACKAGE.to_string(),
     };
-    let status = silent_command("npm")
+    let status = crate::platform::cli_command(&npm_path, None)
         .args(["install", "--prefix"])
         .arg(&dir)
         .arg("--ignore-scripts")

--- a/jean-core/src/platform/cli_detect.rs
+++ b/jean-core/src/platform/cli_detect.rs
@@ -221,6 +221,37 @@ C:\Users\u\AppData\Roaming\npm\opencode.ps1";
     }
 
     #[test]
+    fn windows_path_detection_prefers_npm_cmd_for_version_manager_shims() {
+        let cases = [
+            (
+                r"C:\Users\u\AppData\Local\nvs\default\npm
+C:\Users\u\AppData\Local\nvs\default\npm.cmd
+C:\Users\u\AppData\Local\nvs\default\npm.ps1",
+                r"C:\Users\u\AppData\Local\nvs\default\npm.cmd",
+            ),
+            (
+                r"C:\Program Files\nodejs\npm
+C:\Program Files\nodejs\npm.cmd
+C:\Program Files\nodejs\npm.ps1",
+                r"C:\Program Files\nodejs\npm.cmd",
+            ),
+            (
+                r"C:\Users\u\AppData\Local\fnm\active\installation\npm
+C:\Users\u\AppData\Local\fnm\active\installation\npm.cmd
+C:\Users\u\AppData\Local\fnm\active\installation\npm.ps1",
+                r"C:\Users\u\AppData\Local\fnm\active\installation\npm.cmd",
+            ),
+        ];
+
+        for (output, expected) in cases {
+            assert_eq!(
+                select_cli_candidate(output, true, None),
+                Some(PathBuf::from(expected))
+            );
+        }
+    }
+
+    #[test]
     fn prefer_windows_executable_sibling_resolves_cmd_when_extensionless_is_selected() {
         let dir = tempfile::tempdir().expect("tempdir");
         let extensionless = dir.path().join("codex");

--- a/jean-core/src/platform/cli_detect.rs
+++ b/jean-core/src/platform/cli_detect.rs
@@ -236,6 +236,12 @@ C:\Program Files\nodejs\npm.ps1",
                 r"C:\Program Files\nodejs\npm.cmd",
             ),
             (
+                r"C:\Users\u\AppData\Roaming\nvm\nodejs\npm
+C:\Users\u\AppData\Roaming\nvm\nodejs\npm.cmd
+C:\Users\u\AppData\Roaming\nvm\nodejs\npm.ps1",
+                r"C:\Users\u\AppData\Roaming\nvm\nodejs\npm.cmd",
+            ),
+            (
                 r"C:\Users\u\AppData\Local\fnm\active\installation\npm
 C:\Users\u\AppData\Local\fnm\active\installation\npm.cmd
 C:\Users\u\AppData\Local\fnm\active\installation\npm.ps1",

--- a/jean-core/src/prerequisites.rs
+++ b/jean-core/src/prerequisites.rs
@@ -1,7 +1,5 @@
 use serde::Serialize;
 
-use crate::platform::silent_command;
-
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SystemPrerequisites {
@@ -18,11 +16,7 @@ pub struct SystemPrerequisites {
 }
 
 fn version(command: &str) -> Option<String> {
-    let output = silent_command(command).arg("--version").output().ok()?;
-    output
-        .status
-        .success()
-        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+    crate::platform::detect_cli_in_path(command, None, None).version
 }
 
 pub fn check_system_prerequisites() -> SystemPrerequisites {

--- a/jean-core/src/prerequisites.rs
+++ b/jean-core/src/prerequisites.rs
@@ -45,18 +45,33 @@ pub fn check_system_prerequisites() -> SystemPrerequisites {
     }
 }
 
-pub fn require_npm(tool: &str) -> Result<(), String> {
-    if version("node").is_some() && version("npm").is_some() {
-        return Ok(());
+const NPM_REQUIREMENT_HINT: &str = "requires Node.js and npm. Install a supported Node.js LTS using the official instructions at https://nodejs.org/en/download (distribution packages can be outdated), then retry. Jean onboarding can also install it automatically on supported Linux servers.";
+
+fn require_npm_from_detection(
+    tool: &str,
+    node_version: Option<&str>,
+    npm: &crate::platform::CliDetection,
+) -> Result<String, String> {
+    match (node_version, npm.version.as_deref(), npm.path.as_deref()) {
+        (Some(_), Some(_), Some(path)) if !path.is_empty() => Ok(path.to_string()),
+        _ => Err(format!("{tool} {NPM_REQUIREMENT_HINT}")),
     }
-    Err(format!(
-        "{tool} requires Node.js and npm. Install a supported Node.js LTS using the official instructions at https://nodejs.org/en/download (distribution packages can be outdated), then retry. Jean onboarding can also install it automatically on supported Linux servers."
-    ))
+}
+
+/// Confirm Node.js and npm are available and return the resolved npm launcher.
+///
+/// On Windows this path prefers `npm.cmd` over an extensionless version-manager
+/// shim so later `cli_command()` launches can succeed.
+pub fn require_npm(tool: &str) -> Result<String, String> {
+    let node_version = version("node");
+    let npm = crate::platform::detect_cli_in_path("npm", None, None);
+    require_npm_from_detection(tool, node_version.as_deref(), &npm)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::CliDetection;
 
     #[test]
     fn prerequisite_status_has_official_node_url() {
@@ -64,5 +79,43 @@ mod tests {
             check_system_prerequisites().manual_install_url,
             "https://nodejs.org/en/download"
         );
+    }
+
+    fn npm_detection(path: Option<&str>, version: Option<&str>) -> CliDetection {
+        CliDetection {
+            found: path.is_some(),
+            path: path.map(str::to_string),
+            version: version.map(str::to_string),
+            package_manager: None,
+        }
+    }
+
+    #[test]
+    fn require_npm_returns_windows_cmd_shim_when_node_and_npm_are_present() {
+        let npm = npm_detection(
+            Some(r"C:\Users\u\AppData\Local\nvs\default\npm.cmd"),
+            Some("10.9.2"),
+        );
+
+        assert_eq!(
+            require_npm_from_detection("Command Code CLI", Some("v22.14.0"), &npm).unwrap(),
+            r"C:\Users\u\AppData\Local\nvs\default\npm.cmd"
+        );
+    }
+
+    #[test]
+    fn require_npm_errors_when_npm_is_missing() {
+        let err =
+            require_npm_from_detection("Grok CLI", Some("v22.14.0"), &npm_detection(None, None))
+                .unwrap_err();
+        assert!(err.contains("Grok CLI"), "{err}");
+        assert!(err.contains("Node.js and npm"), "{err}");
+    }
+
+    #[test]
+    fn require_npm_errors_when_npm_path_exists_but_version_check_failed() {
+        let npm = npm_detection(Some(r"C:\Users\u\AppData\Roaming\nvm\nodejs\npm"), None);
+        let err = require_npm_from_detection("PI CLI", Some("v22.14.0"), &npm).unwrap_err();
+        assert!(err.contains("PI CLI"), "{err}");
     }
 }


### PR DESCRIPTION
## Summary

Fix false Node.js/npm prerequisite failures when installing or updating the Command Code CLI on Windows.
This also fixes posterior related errors like installing a backend (due to not finding node).

## Root cause

NVS, nvm-windows, and fnm are Node.js version managers. They can expose multiple npm shims on Windows, including an extensionless `npm` shim and the Windows `npm.cmd` shim.

Jean previously launched bare `npm` directly during prerequisite checks and Command Code installation. On affected systems, Windows could resolve the extensionless shim instead of the launchable `npm.cmd` entry point. The failed version check was then reported as if Node.js and npm were not installed.

## Changes

- Reuse Jean's existing cross-platform CLI resolver for Node.js and npm version checks.
- Prefer Windows executable shims such as `npm.cmd` when resolving npm.
- Run the managed Command Code installation through the resolved npm launcher.
- Add regression coverage for NVS, nvm-windows, and fnm-style paths without hardcoding a Node.js version or a specific version manager.

## Testing

- Focused Windows npm shim tests passed.
- `bun run check:all` passed, including formatting, linting, Clippy, frontend tests, and Rust tests.