### PR TITLE
fix(cursor): use allowlist mode on native Windows

### DIFF
--- a/docs/developer/architecture-guide.md
+++ b/docs/developer/architecture-guide.md
@@ -233,6 +233,7 @@ Cursor-specific notes:
 
 - Cursor auth/status checks must use short timeouts; `cursor-agent status/about` can hang indefinitely
 - Cursor chat integration should use `cursor-agent --print --output-format stream-json` and parse structured NDJSON, not terminal text scraping
+- Native Windows does not provide Cursor's OS sandbox, so Jean uses Cursor's `--sandbox disabled` allowlist mode there; enable WSL and use the Linux CLI when OS-level sandboxing is required
 - Cursor only supports `--mode plan` and `--mode ask`; build/yolo omit `--mode` (defaults to full agent) and use `--sandbox disabled --force`
 - Cursor `plan` runs synthesize an `EnterPlanMode` timeline item from Jean so the native plan banner/instructions survive streaming + JSONL reload
 - Cursor history repair should prefer complete message snapshots / repeated-prefix cleanup; avoid destructive suffix trimming during reload

--- a/jean-core/src/chat/cursor.rs
+++ b/jean-core/src/chat/cursor.rs
@@ -815,6 +815,14 @@ fn effective_execution_mode(execution_mode: Option<&str>) -> &'static str {
     }
 }
 
+fn cursor_sandbox_mode(is_windows: bool, wsl_enabled: bool) -> &'static str {
+    if is_windows && !wsl_enabled {
+        "disabled"
+    } else {
+        "enabled"
+    }
+}
+
 fn parse_cursor_stream(
     app: &AppHandle,
     session_id: &str,
@@ -1082,15 +1090,19 @@ pub fn execute_cursor(
     }
 
     let effective_mode = effective_execution_mode(execution_mode);
+    let sandbox_mode = cursor_sandbox_mode(
+        cfg!(target_os = "windows"),
+        crate::platform::get_wsl_config().enabled,
+    );
     match effective_mode {
         "plan" => {
-            cmd.args(["--mode", "plan", "--sandbox", "enabled"]);
+            cmd.args(["--mode", "plan", "--sandbox", sandbox_mode]);
         }
         "build" | "yolo" => {
             cmd.args(["--yolo", "--sandbox", "disabled", "--force"]);
         }
         _ => {
-            cmd.args(["--sandbox", "enabled"]);
+            cmd.args(["--sandbox", sandbox_mode]);
         }
     }
 
@@ -1213,13 +1225,17 @@ pub fn execute_one_shot_cursor(
     }
 
     let dir = working_dir.unwrap_or_else(|| Path::new("."));
+    let sandbox_mode = cursor_sandbox_mode(
+        cfg!(target_os = "windows"),
+        crate::platform::get_wsl_config().enabled,
+    );
     let mut cmd = crate::platform::cli_command(&cli_path.to_string_lossy(), None);
     cmd.arg("--print")
         .args(["--output-format", "stream-json"])
         .arg("--trust")
         .args(["--workspace"])
         .arg(dir)
-        .args(["--mode", "ask", "--sandbox", "enabled"]);
+        .args(["--mode", "ask", "--sandbox", sandbox_mode]);
 
     let model = raw_cursor_model(Some(model)).unwrap_or("auto");
     cmd.args(["--model", model])
@@ -1315,6 +1331,13 @@ mod tests {
     #[test]
     fn build_mode_falls_back_to_yolo() {
         assert_eq!(effective_execution_mode(Some("build")), "yolo");
+    }
+
+    #[test]
+    fn native_windows_cursor_uses_allowlist_mode() {
+        assert_eq!(cursor_sandbox_mode(true, false), "disabled");
+        assert_eq!(cursor_sandbox_mode(true, true), "enabled");
+        assert_eq!(cursor_sandbox_mode(false, false), "enabled");
     }
 
     #[test]

--- a/jean-core/src/chat/cursor.rs
+++ b/jean-core/src/chat/cursor.rs
@@ -1338,6 +1338,7 @@ mod tests {
         assert_eq!(cursor_sandbox_mode(true, false), "disabled");
         assert_eq!(cursor_sandbox_mode(true, true), "enabled");
         assert_eq!(cursor_sandbox_mode(false, false), "enabled");
+        assert_eq!(cursor_sandbox_mode(false, true), "enabled");
     }
 
     #[test]

--- a/src/components/onboarding/WslSetupStep.test.tsx
+++ b/src/components/onboarding/WslSetupStep.test.tsx
@@ -18,5 +18,8 @@ describe('WslSetupStep', () => {
 
     expect(screen.getByText('WSL')).toBeInTheDocument()
     expect(screen.getByText('Beta')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Cursor runs without OS sandboxing/)
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/onboarding/WslSetupStep.test.tsx
+++ b/src/components/onboarding/WslSetupStep.test.tsx
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
 import { render, screen } from '@/test/test-utils'
 import { WslSetupStep } from './WslSetupStep'
 
 vi.mock('@/lib/transport', () => ({
-  invoke: vi.fn(),
+  invoke: vi.fn().mockResolvedValue([]),
 }))
 
 vi.mock('@/services/preferences', () => ({
@@ -18,8 +19,24 @@ describe('WslSetupStep', () => {
 
     expect(screen.getByText('WSL')).toBeInTheDocument()
     expect(screen.getByText('Beta')).toBeInTheDocument()
+  })
+
+  it('explains that native Windows Cursor uses allowlist mode', () => {
+    render(<WslSetupStep onComplete={vi.fn()} />)
+
     expect(
-      screen.getByText(/Cursor runs without OS sandboxing/)
+      screen.getByText(/Native Windows uses Cursor's allowlist mode/)
     ).toBeInTheDocument()
+  })
+
+  it('hides the native Cursor sandbox note when WSL is selected', async () => {
+    const user = userEvent.setup()
+    render(<WslSetupStep onComplete={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: /WSL/ }))
+
+    expect(
+      screen.queryByText(/Native Windows uses Cursor's allowlist mode/)
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/components/onboarding/WslSetupStep.tsx
+++ b/src/components/onboarding/WslSetupStep.tsx
@@ -193,6 +193,13 @@ export function WslSetupStep({ onComplete }: WslSetupStepProps) {
         </button>
       </div>
 
+      {mode === 'native' && (
+        <p className="text-muted-foreground text-xs">
+          Native Windows uses Cursor&apos;s allowlist mode instead of OS
+          sandboxing. Choose WSL for sandboxed execution.
+        </p>
+      )}
+
       {/* WSL distro selection */}
       {mode === 'wsl' && (
         <div className="space-y-3">

--- a/src/components/onboarding/WslSetupStep.tsx
+++ b/src/components/onboarding/WslSetupStep.tsx
@@ -123,6 +123,7 @@ export function WslSetupStep({ onComplete }: WslSetupStepProps) {
         queryClient.invalidateQueries({ queryKey: ['codex-cli'] }),
         queryClient.invalidateQueries({ queryKey: ['opencode-cli'] }),
         queryClient.invalidateQueries({ queryKey: ['gh-cli'] }),
+        queryClient.invalidateQueries({ queryKey: ['cursor-cli'] }),
       ])
       onComplete()
     } catch {


### PR DESCRIPTION
## Summary

- Use Cursor’s allowlist mode on native Windows, avoiding the unsupported OS sandbox.
- Preserve sandbox mode when Cursor runs through WSL or on non-Windows platforms.
- Explain the native Windows versus WSL behavior during onboarding and in developer documentation.

## Validation

- Local NSIS installer build completed successfully.
- Added coverage for native Windows, WSL, and non-Windows sandbox selection.