### PR TITLE
fix(chat): don't report a crashed Antigravity run as a success

### DIFF
--- a/jean-core/src/chat/antigravity.rs
+++ b/jean-core/src/chat/antigravity.rs
@@ -33,6 +33,27 @@ fn permission_diagnostic(response: &AntigravityResponse) -> Option<&str> {
     })
 }
 
+/// Message for a CLI that exited without emitting a terminal event and without
+/// producing any output. Diagnostics are unparsed CLI lines, so only the last few
+/// are surfaced — the tail is where a startup or auth failure prints.
+fn exit_without_result_error(diagnostics: &[String]) -> String {
+    const MAX_DIAGNOSTIC_LINES: usize = 5;
+    let base = "Antigravity CLI exited before it produced a result. Open Settings → Antigravity CLI to check authentication and permissions.";
+    let tail = diagnostics
+        .iter()
+        .rev()
+        .take(MAX_DIAGNOSTIC_LINES)
+        .rev()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+    if tail.is_empty() {
+        base.to_string()
+    } else {
+        format!("{base}\n\n{tail}")
+    }
+}
+
 pub struct AntigravityExecutionOptions<'a> {
     pub app: &'a AppHandle,
     pub jean_session_id: &'a str,
@@ -618,6 +639,18 @@ pub fn tail_antigravity_output(
         }
         if !crate::platform::is_process_alive(pid) && start.elapsed() > Duration::from_secs(2) {
             response.content = response.content.trim().to_string();
+            // The process is gone without a terminal event. Run the same checks the
+            // terminal-event path above runs, otherwise a crashed run reports success.
+            if let Some(error) = response.terminal_error.clone() {
+                return Err(error);
+            }
+            if let Some(denial) = permission_diagnostic(&response) {
+                return Err(format!("Antigravity permission denied: {denial}"));
+            }
+            if !response.cancelled && response.content.is_empty() && response.tool_calls.is_empty()
+            {
+                return Err(exit_without_result_error(&response.diagnostics));
+            }
             return Ok(response);
         }
         std::thread::sleep(next_poll_interval(had_data, start.elapsed()));
@@ -806,5 +839,15 @@ mod tests {
             terminal_error: None,
             diagnostics: vec![],
         }
+    }
+
+    #[test]
+    fn exit_without_result_surfaces_the_last_diagnostics() {
+        assert!(!exit_without_result_error(&[]).contains("\n\n"));
+
+        let lines: Vec<String> = (1..=8).map(|n| format!("line {n}")).collect();
+        let message = exit_without_result_error(&lines);
+        assert!(message.ends_with("line 4\nline 5\nline 6\nline 7\nline 8"));
+        assert!(!message.contains("line 3"));
     }
 }

--- a/jean-core/src/chat/antigravity.rs
+++ b/jean-core/src/chat/antigravity.rs
@@ -39,19 +39,32 @@ fn permission_diagnostic(response: &AntigravityResponse) -> Option<&str> {
 fn exit_without_result_error(diagnostics: &[String]) -> String {
     const MAX_DIAGNOSTIC_LINES: usize = 5;
     let base = "Antigravity CLI exited before it produced a result. Open Settings → Antigravity CLI to check authentication and permissions.";
-    let tail = diagnostics
-        .iter()
-        .rev()
-        .take(MAX_DIAGNOSTIC_LINES)
-        .rev()
-        .cloned()
-        .collect::<Vec<_>>()
-        .join("\n");
+    let start = diagnostics.len().saturating_sub(MAX_DIAGNOSTIC_LINES);
+    let tail = diagnostics[start..].join("\n");
     if tail.is_empty() {
         base.to_string()
     } else {
         format!("{base}\n\n{tail}")
     }
+}
+
+/// The process is gone without a terminal `result` event. Run the same checks
+/// the terminal-event path runs, then fail when nothing was produced — otherwise
+/// a crashed run reports success.
+fn finalize_dead_process_response(
+    mut response: AntigravityResponse,
+) -> Result<AntigravityResponse, String> {
+    response.content = response.content.trim().to_string();
+    if let Some(error) = response.terminal_error.take() {
+        return Err(error);
+    }
+    if let Some(denial) = permission_diagnostic(&response) {
+        return Err(format!("Antigravity permission denied: {denial}"));
+    }
+    if !response.cancelled && response.content.is_empty() && response.tool_calls.is_empty() {
+        return Err(exit_without_result_error(&response.diagnostics));
+    }
+    Ok(response)
 }
 
 pub struct AntigravityExecutionOptions<'a> {
@@ -553,6 +566,7 @@ pub fn execute_antigravity(
             terminal_error: None,
             diagnostics: vec![],
         };
+        let mut saw_terminal_event = false;
         for line in BufReader::new(stdout).lines() {
             let line =
                 line.map_err(|error| format!("Failed to read Antigravity output: {error}"))?;
@@ -560,7 +574,9 @@ pub fn execute_antigravity(
                 .map_err(|error| format!("Failed to save Antigravity output: {error}"))?;
             if let Ok(value) = serde_json::from_str::<Value>(&line) {
                 let before = response.content_blocks.len();
-                merge_event(&mut response, &value);
+                if merge_event(&mut response, &value) {
+                    saw_terminal_event = true;
+                }
                 emit_new(
                     options.app,
                     options.jean_session_id,
@@ -579,7 +595,17 @@ pub fn execute_antigravity(
         if !status.success() {
             return Err("Antigravity CLI exited before it completed. Open Settings → Antigravity CLI to check authentication and permissions.".to_string());
         }
-        if let Some(error) = response.terminal_error.clone() {
+        if !saw_terminal_event {
+            let response = finalize_dead_process_response(response)?;
+            return Ok(finish_antigravity_response(
+                options.app,
+                options.jean_session_id,
+                options.worktree_id,
+                options.execution_mode,
+                response,
+            ));
+        }
+        if let Some(error) = response.terminal_error.take() {
             return Err(error);
         }
         if let Some(denial) = permission_diagnostic(&response) {
@@ -638,20 +664,7 @@ pub fn tail_antigravity_output(
             }
         }
         if !crate::platform::is_process_alive(pid) && start.elapsed() > Duration::from_secs(2) {
-            response.content = response.content.trim().to_string();
-            // The process is gone without a terminal event. Run the same checks the
-            // terminal-event path above runs, otherwise a crashed run reports success.
-            if let Some(error) = response.terminal_error.clone() {
-                return Err(error);
-            }
-            if let Some(denial) = permission_diagnostic(&response) {
-                return Err(format!("Antigravity permission denied: {denial}"));
-            }
-            if !response.cancelled && response.content.is_empty() && response.tool_calls.is_empty()
-            {
-                return Err(exit_without_result_error(&response.diagnostics));
-            }
-            return Ok(response);
+            return finalize_dead_process_response(response);
         }
         std::thread::sleep(next_poll_interval(had_data, start.elapsed()));
     }
@@ -849,5 +862,73 @@ mod tests {
         let message = exit_without_result_error(&lines);
         assert!(message.ends_with("line 4\nline 5\nline 6\nline 7\nline 8"));
         assert!(!message.contains("line 3"));
+    }
+
+    #[test]
+    fn dead_process_without_output_is_an_error() {
+        let Err(err) = finalize_dead_process_response(empty_response()) else {
+            panic!("empty dead process should be an error");
+        };
+        assert!(err.contains("exited before it produced a result"));
+        assert!(!err.contains("\n\n"));
+
+        let mut with_diagnostics = empty_response();
+        with_diagnostics.diagnostics = vec!["auth failed".to_string()];
+        let Err(err) = finalize_dead_process_response(with_diagnostics) else {
+            panic!("dead process with diagnostics should be an error");
+        };
+        assert!(err.contains("auth failed"));
+    }
+
+    #[test]
+    fn dead_process_cancelled_or_with_output_is_ok() {
+        let mut cancelled = empty_response();
+        cancelled.cancelled = true;
+        assert!(finalize_dead_process_response(cancelled).unwrap().cancelled);
+
+        let mut with_content = empty_response();
+        with_content.content = "  hello  ".to_string();
+        assert_eq!(
+            finalize_dead_process_response(with_content)
+                .unwrap()
+                .content,
+            "hello"
+        );
+
+        let mut with_tool = empty_response();
+        with_tool.tool_calls.push(ToolCall {
+            id: "t1".to_string(),
+            name: "run_command".to_string(),
+            input: Value::Null,
+            output: None,
+            parent_tool_use_id: None,
+        });
+        assert_eq!(
+            finalize_dead_process_response(with_tool)
+                .unwrap()
+                .tool_calls
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn dead_process_honors_terminal_and_permission_failures() {
+        let mut failed = empty_response();
+        failed.terminal_error = Some("question needs input".to_string());
+        failed.content = "partial".to_string();
+        let Err(err) = finalize_dead_process_response(failed) else {
+            panic!("terminal_error should fail the dead-process path");
+        };
+        assert_eq!(err, "question needs input");
+
+        let mut denied = empty_response();
+        denied
+            .diagnostics
+            .push("Tool command(git) was soft-denied by permission policy".to_string());
+        let Err(err) = finalize_dead_process_response(denied) else {
+            panic!("permission denial should fail the dead-process path");
+        };
+        assert!(err.starts_with("Antigravity permission denied:"));
     }
 }

--- a/jean-core/src/chat/commands.rs
+++ b/jean-core/src/chat/commands.rs
@@ -35,7 +35,7 @@ const QUEUE_DEFAULT_ALLOWED_TOOLS: [&str; 4] = ["Bash(git:*)", "Read", "Glob", "
 const IMAGE_ONLY_DEFAULT_PROMPT: &str = "Please check this image and tell me what is wrong.";
 const TEXT_ONLY_DEFAULT_PROMPT: &str = "Please check the attached text as reference.";
 
-fn resumed_grok_tail_error_event(
+fn resumed_tail_error_event(
     session_id: &str,
     worktree_id: &str,
     error: &str,
@@ -8382,6 +8382,9 @@ pub async fn resume_session(
                         {
                             let _ = writer.crash();
                         }
+                        let (event_name, event) =
+                            resumed_tail_error_event(&session_id_clone, &worktree_id_clone, &error);
+                        let _ = app_clone.emit_all(event_name, &event);
                     }
                 }
             });
@@ -8544,11 +8547,8 @@ pub async fn resume_session(
                                 log::error!("Failed to mark Grok run as crashed: {e}");
                             }
                         }
-                        let (event_name, event) = resumed_grok_tail_error_event(
-                            &session_id_clone,
-                            &worktree_id_clone,
-                            &e,
-                        );
+                        let (event_name, event) =
+                            resumed_tail_error_event(&session_id_clone, &worktree_id_clone, &e);
                         let _ = app_clone.emit_all(event_name, &event);
                         return;
                     }
@@ -10234,7 +10234,7 @@ mod tests {
     #[test]
     fn resumed_grok_host_error_uses_chat_error_event() {
         let (event_name, event) =
-            resumed_grok_tail_error_event("session-1", "worktree-1", "rate limit reached");
+            resumed_tail_error_event("session-1", "worktree-1", "rate limit reached");
 
         assert_eq!(event_name, "chat:error");
         assert_eq!(event.session_id, "session-1");


### PR DESCRIPTION
## The problem

`tail_antigravity_output` (`jean-core/src/chat/antigravity.rs`) ends the run as soon as the process is gone and 2s have elapsed:

```rust
if !crate::platform::is_process_alive(pid) && start.elapsed() > Duration::from_secs(2) {
    response.content = response.content.trim().to_string();
    return Ok(response);
}
```

That path skips every check the terminal-event path twenty lines above performs — `terminal_error` and `permission_diagnostic` are both computed and both ignored here.

So a CLI that exits *without* emitting a terminal event returns an empty successful response, and Jean emits `chat:done` for a run that never ran. A startup failure, an auth failure, or an external kill all look identical to a completed turn.

This is the Unix path, so it is the one that runs on Linux and macOS.

## The change

Run the same checks on the dead-process path, then fail explicitly when the process produced neither content nor tool calls:

- an observed `terminal_error` is returned as `Err`, as it already is on the normal path
- a permission denial is returned as `Err`, likewise
- a process that exited with nothing at all is an error, not an empty success
- `cancelled` still returns `Ok` — that is a deliberate stop, not a failure

Unparsed CLI output already accumulates in `diagnostics`, so the error message surfaces the last few lines. That tail is where a startup or auth failure prints. It is capped at 5 lines to keep an unbounded log out of a UI error.

The wording matches the existing message on the non-Unix branch.

## Verification

- `cargo test` in `jean-core`: 1110 passed, 0 failed
- `cargo clippy --all-targets`: no findings on the changed file
- `cargo fmt --check`: clean
- one added unit test covering the empty and truncated diagnostics cases

## Not in scope

While reading this function I noticed two related things, left alone deliberately to keep the change reviewable:

- a second `tool_call_update` for an existing tool mutates `tool.output` without appending a content block, so `emit_new` never emits a live `chat:tool_result` for it (the value does reach the final response, so hydration repairs the UI afterwards)
- text that only arrives in the terminal `result` event is merged, but the function returns before `emit_new` runs, so it is not streamed

Happy to follow up on either if you want them fixed.