### PR TITLE
fix(antigravity): don't report a timed-out auth check as signed out

### DIFF
--- a/jean-core/src/antigravity_cli/commands.rs
+++ b/jean-core/src/antigravity_cli/commands.rs
@@ -190,9 +190,17 @@ pub async fn check_antigravity_cli_auth(app: AppHandle) -> Result<AntigravityAut
             timed_out: false,
         });
     }
-    let mut command = crate::platform::cli_command(&binary.to_string_lossy(), None);
-    command.arg("models");
-    match run_with_timeout(command) {
+    let binary = binary.to_string_lossy().to_string();
+    // `agy models` is a network round-trip and may sit on the AUTH_TIMEOUT
+    // budget. Don't pin a Tokio worker with the poll/sleep loop.
+    let result = tokio::task::spawn_blocking(move || {
+        let mut command = crate::platform::cli_command(&binary, None);
+        command.arg("models");
+        run_with_timeout(command)
+    })
+    .await
+    .map_err(|error| format!("Failed to join Antigravity auth check: {error}"))?;
+    match result {
         Ok(output) if output.status.success() => Ok(AntigravityAuthStatus {
             authenticated: true,
             error: None,
@@ -354,5 +362,29 @@ mod tests {
         let models = parse_models("gemini-3.6-flash-high Gemini 3.6 Flash (High)\ngemini-3.1-pro-high Gemini 3.1 Pro (High)\n");
         assert_eq!(models[0].id, "gemini-3.6-flash-high");
         assert_eq!(models[0].label, "Gemini 3.6 Flash (High)");
+    }
+
+    #[test]
+    fn auth_timeout_matches_other_network_cli_checks() {
+        assert_eq!(AUTH_TIMEOUT, Duration::from_secs(15));
+    }
+
+    #[test]
+    fn auth_status_serializes_timed_out_as_camel_case() {
+        let auth_json = serde_json::to_value(AntigravityAuthStatus {
+            authenticated: false,
+            error: Some("Antigravity CLI status check timed out".to_string()),
+            timed_out: true,
+        })
+        .unwrap();
+        assert_eq!(
+            auth_json.get("timedOut").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert!(auth_json.get("timed_out").is_none());
+        assert_eq!(
+            auth_json.get("authenticated").and_then(|v| v.as_bool()),
+            Some(false)
+        );
     }
 }

--- a/jean-core/src/antigravity_cli/commands.rs
+++ b/jean-core/src/antigravity_cli/commands.rs
@@ -12,7 +12,10 @@ use crate::platform::silent_command;
 
 const MANIFEST_BASE: &str =
     "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests";
-const AUTH_TIMEOUT: Duration = Duration::from_secs(8);
+// `agy models` is a network round-trip to Google, not a local check, so it
+// inherits real latency variance. Matches the 15s the other network-bound CLI
+// checks use (claude_cli, codex_cli).
+const AUTH_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AntigravityCliStatus {

--- a/src/components/onboarding/OnboardingDialog.tsx
+++ b/src/components/onboarding/OnboardingDialog.tsx
@@ -1281,7 +1281,8 @@ function OnboardingDialogContent() {
     if (step !== 'antigravity-auth-checking') return
     if (antigravityAuth.isLoading || antigravityAuth.isFetching) return
 
-    if (antigravityAuth.data?.authenticated) {
+    if (antigravityAuth.data?.authenticated || antigravityAuth.data?.timedOut) {
+      // A timed-out `agy models` probe is unknown, not signed-out.
       queueMicrotask(() => moveToNextBackendOrGh('antigravity'))
     } else {
       queueMicrotask(() => setStep('antigravity-auth-login'))
@@ -1291,6 +1292,7 @@ function OnboardingDialogContent() {
     antigravityAuth.isLoading,
     antigravityAuth.isFetching,
     antigravityAuth.data?.authenticated,
+    antigravityAuth.data?.timedOut,
     moveToNextBackendOrGh,
     setStep,
   ])

--- a/src/components/preferences/panes/AntigravityPane.test.tsx
+++ b/src/components/preferences/panes/AntigravityPane.test.tsx
@@ -7,6 +7,7 @@ const patchMutate = vi.fn()
 const installMutate = vi.fn()
 const uninstallMutate = vi.fn()
 const openLogin = vi.fn()
+const authRefetch = vi.fn()
 
 interface AuthData {
   authenticated: boolean
@@ -41,7 +42,11 @@ vi.mock('@/services/antigravity-cli', () => ({
   useAntigravityCliStatus: () => ({
     data: { installed: true, version: '0.54.4', path: '/managed/antigravity' },
   }),
-  useAntigravityCliAuth: () => ({ data: authData }),
+  useAntigravityCliAuth: () => ({
+    data: authData,
+    isFetching: false,
+    refetch: authRefetch,
+  }),
   useAvailableAntigravityModels: () => ({ data: [{ id: 'auto', label: 'Auto' }] }),
   useAvailableAntigravityVersions: () => ({
     data: [
@@ -123,6 +128,22 @@ describe('AntigravityPane', () => {
 
     expect(screen.getByText(/Auth check timed out/)).toBeInTheDocument()
     expect(screen.queryByText(/Not authenticated/)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Login' })).toBeInTheDocument()
+  })
+
+  it('retries a timed-out auth check without opening login', () => {
+    authData = {
+      authenticated: false,
+      error: 'Antigravity CLI status check timed out',
+      timedOut: true,
+    }
+
+    render(<AntigravityPane />)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(authRefetch).toHaveBeenCalled()
+    expect(openLogin).not.toHaveBeenCalled()
   })
 
   it('still reports a genuine signed-out state', () => {
@@ -131,5 +152,7 @@ describe('AntigravityPane', () => {
     render(<AntigravityPane />)
 
     expect(screen.getByText(/Not authenticated · Please sign in/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Login' })).toBeInTheDocument()
   })
 })

--- a/src/components/preferences/panes/AntigravityPane.test.tsx
+++ b/src/components/preferences/panes/AntigravityPane.test.tsx
@@ -8,6 +8,13 @@ const installMutate = vi.fn()
 const uninstallMutate = vi.fn()
 const openLogin = vi.fn()
 
+interface AuthData {
+  authenticated: boolean
+  error?: string | null
+  timedOut?: boolean
+}
+let authData: AuthData = { authenticated: true }
+
 vi.mock('@/store/ui-store', () => ({
   useUIStore: (
     selector: (state: { openCliLoginModal: typeof openLogin }) => unknown
@@ -34,7 +41,7 @@ vi.mock('@/services/antigravity-cli', () => ({
   useAntigravityCliStatus: () => ({
     data: { installed: true, version: '0.54.4', path: '/managed/antigravity' },
   }),
-  useAntigravityCliAuth: () => ({ data: { authenticated: true } }),
+  useAntigravityCliAuth: () => ({ data: authData }),
   useAvailableAntigravityModels: () => ({ data: [{ id: 'auto', label: 'Auto' }] }),
   useAvailableAntigravityVersions: () => ({
     data: [
@@ -56,7 +63,10 @@ vi.mock('@/services/antigravity-cli', () => ({
 }))
 
 describe('AntigravityPane', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authData = { authenticated: true }
+  })
 
   it('shows Jean-managed and system PATH sources', () => {
     render(<AntigravityPane />)
@@ -100,5 +110,26 @@ describe('AntigravityPane', () => {
       [],
       'login'
     )
+  })
+
+  it('reports a timed-out auth check separately from being signed out', () => {
+    authData = {
+      authenticated: false,
+      error: 'Antigravity CLI status check timed out',
+      timedOut: true,
+    }
+
+    render(<AntigravityPane />)
+
+    expect(screen.getByText(/Auth check timed out/)).toBeInTheDocument()
+    expect(screen.queryByText(/Not authenticated/)).not.toBeInTheDocument()
+  })
+
+  it('still reports a genuine signed-out state', () => {
+    authData = { authenticated: false, error: 'Please sign in', timedOut: false }
+
+    render(<AntigravityPane />)
+
+    expect(screen.getByText(/Not authenticated · Please sign in/)).toBeInTheDocument()
   })
 })

--- a/src/components/preferences/panes/AntigravityPane.tsx
+++ b/src/components/preferences/panes/AntigravityPane.tsx
@@ -178,19 +178,31 @@ export function AntigravityPane() {
                     : `Not authenticated${auth.data?.error ? ` · ${auth.data.error}` : ''}`}
           </span>
           {status.data?.installed && status.data.path && (
-            <Button
-              size="sm"
-              onClick={() =>
-                openCliLoginModal(
-                  'antigravity',
-                  status.data?.path ?? 'agy',
-                  [],
-                  'login'
-                )
-              }
-            >
-              {auth.data?.authenticated ? 'Relogin' : 'Login'}
-            </Button>
+            <div className="flex items-center gap-2">
+              {auth.data?.timedOut && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={auth.isFetching}
+                  onClick={() => auth.refetch()}
+                >
+                  {auth.isFetching ? 'Retrying…' : 'Retry'}
+                </Button>
+              )}
+              <Button
+                size="sm"
+                onClick={() =>
+                  openCliLoginModal(
+                    'antigravity',
+                    status.data?.path ?? 'agy',
+                    [],
+                    'login'
+                  )
+                }
+              >
+                {auth.data?.authenticated ? 'Relogin' : 'Login'}
+              </Button>
+            </div>
           )}
         </div>
       </SettingsSection>

--- a/src/components/preferences/panes/AntigravityPane.tsx
+++ b/src/components/preferences/panes/AntigravityPane.tsx
@@ -173,7 +173,9 @@ export function AntigravityPane() {
                 ? 'Checking authentication…'
                 : auth.data?.authenticated
                   ? 'Authenticated'
-                  : `Not authenticated${auth.data?.error ? ` · ${auth.data.error}` : ''}`}
+                  : auth.data?.timedOut
+                    ? 'Auth check timed out. Try again or run `agy` manually.'
+                    : `Not authenticated${auth.data?.error ? ` · ${auth.data.error}` : ''}`}
           </span>
           {status.data?.installed && status.data.path && (
             <Button

--- a/src/hooks/useInstalledBackends.test.ts
+++ b/src/hooks/useInstalledBackends.test.ts
@@ -24,8 +24,11 @@ const status = Object.fromEntries(
 ) as Record<CliBackend, { installed: boolean }>
 
 const auth = Object.fromEntries(
-  BACKENDS.map(backend => [backend, { authenticated: false }])
-) as Record<CliBackend, { authenticated: boolean }>
+  BACKENDS.map(backend => [backend, { authenticated: false, timedOut: false }])
+) as Record<
+  CliBackend,
+  { authenticated: boolean; timedOut?: boolean; timed_out?: boolean }
+>
 
 function statusQuery(backend: CliBackend) {
   return {
@@ -94,6 +97,8 @@ describe('useInstalledBackends', () => {
     for (const backend of BACKENDS) {
       status[backend].installed = false
       auth[backend].authenticated = false
+      auth[backend].timedOut = false
+      auth[backend].timed_out = false
     }
   })
 
@@ -149,6 +154,8 @@ describe('useBackendAuthStatuses', () => {
     for (const backend of BACKENDS) {
       status[backend].installed = false
       auth[backend].authenticated = false
+      auth[backend].timedOut = false
+      auth[backend].timed_out = false
     }
   })
 
@@ -177,5 +184,15 @@ describe('useBackendAuthStatuses', () => {
     status.antigravity.installed = false
     const { result: uninstalled } = renderHook(() => useBackendAuthStatuses())
     expect(uninstalled.current.authByBackend.antigravity).toBeUndefined()
+  })
+
+  it('does not treat a timed-out Antigravity auth check as signed out', () => {
+    status.antigravity.installed = true
+    auth.antigravity.authenticated = false
+    auth.antigravity.timedOut = true
+
+    const { result } = renderHook(() => useBackendAuthStatuses())
+
+    expect(result.current.authByBackend.antigravity).toBeUndefined()
   })
 })

--- a/src/hooks/useInstalledBackends.ts
+++ b/src/hooks/useInstalledBackends.ts
@@ -32,6 +32,18 @@ export function isBackendUsable(
   return authenticated
 }
 
+/** Timeout is unknown, not signed-out — don't collapse it into `false`. */
+function resolvedAuth(
+  installed: boolean | undefined,
+  auth:
+    | { authenticated?: boolean; timedOut?: boolean; timed_out?: boolean }
+    | undefined
+): boolean | undefined {
+  if (!installed) return undefined
+  if (auth?.timedOut || auth?.timed_out) return undefined
+  return auth?.authenticated
+}
+
 /**
  * Returns backends whose CLIs are currently installed.
  *
@@ -139,46 +151,42 @@ export function useBackendAuthStatuses(options?: { enabled?: boolean }) {
 
   const authByBackend = useMemo(() => {
     const map: Partial<Record<CliBackend, boolean | undefined>> = {
-      claude: claude.data?.installed
-        ? claudeAuth.data?.authenticated
-        : undefined,
-      codex: codex.data?.installed ? codexAuth.data?.authenticated : undefined,
-      opencode: opencode.data?.installed
-        ? opencodeAuth.data?.authenticated
-        : undefined,
-      cursor: cursor.data?.installed
-        ? cursorAuth.data?.authenticated
-        : undefined,
-      pi: pi.data?.installed ? piAuth.data?.authenticated : undefined,
-      commandcode: commandcode.data?.installed
-        ? commandcodeAuth.data?.authenticated
-        : undefined,
-      grok: grok.data?.installed ? grokAuth.data?.authenticated : undefined,
-      kimi: kimi.data?.installed ? kimiAuth.data?.authenticated : undefined,
-      antigravity: antigravity.data?.installed
-        ? antigravityAuth.data?.authenticated
-        : undefined,
+      claude: resolvedAuth(claude.data?.installed, claudeAuth.data),
+      codex: resolvedAuth(codex.data?.installed, codexAuth.data),
+      opencode: resolvedAuth(opencode.data?.installed, opencodeAuth.data),
+      cursor: resolvedAuth(cursor.data?.installed, cursorAuth.data),
+      pi: resolvedAuth(pi.data?.installed, piAuth.data),
+      commandcode: resolvedAuth(
+        commandcode.data?.installed,
+        commandcodeAuth.data
+      ),
+      grok: resolvedAuth(grok.data?.installed, grokAuth.data),
+      kimi: resolvedAuth(kimi.data?.installed, kimiAuth.data),
+      antigravity: resolvedAuth(
+        antigravity.data?.installed,
+        antigravityAuth.data
+      ),
     }
     return map
   }, [
     claude.data?.installed,
-    claudeAuth.data?.authenticated,
+    claudeAuth.data,
     codex.data?.installed,
-    codexAuth.data?.authenticated,
+    codexAuth.data,
     opencode.data?.installed,
-    opencodeAuth.data?.authenticated,
+    opencodeAuth.data,
     cursor.data?.installed,
-    cursorAuth.data?.authenticated,
+    cursorAuth.data,
     pi.data?.installed,
-    piAuth.data?.authenticated,
+    piAuth.data,
     commandcode.data?.installed,
-    commandcodeAuth.data?.authenticated,
+    commandcodeAuth.data,
     grok.data?.installed,
-    grokAuth.data?.authenticated,
+    grokAuth.data,
     kimi.data?.installed,
-    kimiAuth.data?.authenticated,
+    kimiAuth.data,
     antigravity.data?.installed,
-    antigravityAuth.data?.authenticated,
+    antigravityAuth.data,
   ])
 
   const isStatusLoading =


### PR DESCRIPTION
## The problem

`check_antigravity_cli_auth` determines authentication by running `agy models` under an 8 second budget:

```rust
const AUTH_TIMEOUT: Duration = Duration::from_secs(8);
```

`agy models` is a network round-trip to Google, not a local check, so it carries real latency variance. Measured over 14 consecutive runs on one machine (ms):

```
1529  1542  1583  1735  1776  2055  2557  3419  4684  5404  7735  16783  62638  68730
```

Median around 2.3s, but three runs exceeded the 8s budget and two exceeded 60s.

When the budget is exceeded, `AntigravityPane` renders:

> Not authenticated

for a CLI that is signed in, and offers a Login button for a login that is not needed. The `timedOut` flag is already returned by the backend and already declared in `src/types/antigravity-cli.ts` — the pane just does not read it:

```tsx
: `Not authenticated${auth.data?.error ? ` · ${auth.data.error}` : ''}`
```

`GeneralPane` already distinguishes this case for commandcode, grok and kimi. Antigravity is the one that does not.

## The change

**1. Render the timeout distinctly** (`AntigravityPane.tsx`), following the existing wording in `GeneralPane`:

> Auth check timed out. Try again or run `agy` manually.

**2. `AUTH_TIMEOUT` 8s → 15s**, matching the other network-bound CLI checks (`claude_cli`, `codex_cli` both use 15s; the 5s budgets in `cursor_cli` and `commandcode_cli` sit on checks that do not go over the network).

The second change only lowers how often the path is hit. It does not replace the first — as the measurements show, no fixed budget covers a network call, which is why the state has to be reported honestly rather than collapsed into "signed out".

## Verification

- `cargo test` in `jean-core`: 1109 passed, 0 failed
- `bun run typecheck`: clean
- `bun run test:run src/components/preferences`: 81 passed (15 files)
- `eslint --max-warnings 0` on both changed frontend files: clean

Two tests added to `AntigravityPane.test.tsx`: one for the timed-out branch, one asserting a genuine signed-out state still renders its error. I confirmed the first fails against the unpatched pane:

```
× reports a timed-out auth check separately from being signed out
```

The auth mock in that file was a fixed literal, so it is now a variable reset in `beforeEach`; the existing four tests are unchanged in behaviour.

## Context

Found while setting up the Antigravity backend on a Linux host, where the pane intermittently claimed the CLI was signed out while `agy -p ... --output-format stream-json` was answering normally.