### PR TITLE
fix(chat): restore cancelled runs to input when no output streamed

### DIFF
--- a/src/components/chat/hooks/useStreamingEvents.test.tsx
+++ b/src/components/chat/hooks/useStreamingEvents.test.tsx
@@ -898,9 +898,23 @@ describe('useStreamingEvents cancellation sanitization', () => {
     expect(useChatStore.getState().isSessionReviewing('session-1')).toBe(true)
   })
 
-  it('does not restore input when cancelling an already-running prompt with no streamed content yet', async () => {
+  it('restores input when cancelling an already-running prompt with no streamed content yet', async () => {
     const queryClient = createQueryClient()
     const wrapper = createWrapper(queryClient)
+    const hiddenRunSession = {
+      id: 'session-1',
+      name: 'Test',
+      order: 0,
+      created_at: 1,
+      updated_at: 1,
+      messages: [],
+    }
+
+    mockInvoke.mockImplementation((command: string) => {
+      if (command === 'list_pending_wakeups') return Promise.resolve([])
+      if (command === 'get_session') return Promise.resolve(hiddenRunSession)
+      return Promise.resolve(undefined)
+    })
 
     queryClient.setQueryData(['chat', 'session', 'session-1'], {
       id: 'session-1',
@@ -952,15 +966,130 @@ describe('useStreamingEvents cancellation sanitization', () => {
       messages: { id: string; role: string; content: string }[]
     }>(['chat', 'session', 'session-1'])
 
-    // Prompt already started — keep the user message, do not put it back in input.
-    expect(session?.messages.map(message => message.id)).toEqual([
-      'current-user',
-      'cancelled-session-1-2000',
-    ])
-    expect(useChatStore.getState().inputDrafts['session-1']).toBe('')
+    // Live cancel with no assistant output — backend hides the run, so restore
+    // the prompt to the composer instead of leaving an empty cancelled turn.
+    expect(session?.messages.map(message => message.id)).toEqual([])
+    expect(useChatStore.getState().inputDrafts['session-1']).toBe(
+      'already running'
+    )
     expect(useChatStore.getState().lastSentMessages['session-1']).toBe(
       undefined
     )
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('get_session', {
+        sessionId: 'session-1',
+        worktreeId: 'worktree-1',
+        worktreePath: '/tmp/worktree',
+      })
+    )
+    expect(useChatStore.getState().inputDrafts['session-1']).toBe(
+      'already running'
+    )
+  })
+
+  it('clears a restored draft when backend hydrates a persisted cancelled turn', async () => {
+    const queryClient = createQueryClient()
+    const wrapper = createWrapper(queryClient)
+    const hydratedSession = {
+      id: 'session-1',
+      name: 'Test',
+      order: 0,
+      created_at: 1,
+      updated_at: 4,
+      last_run_status: 'cancelled',
+      messages: [
+        {
+          id: 'current-user',
+          session_id: 'session-1',
+          role: 'user',
+          content: 'already running',
+          timestamp: 3,
+          tool_calls: [],
+        },
+        {
+          id: 'persisted-cancelled-assistant',
+          session_id: 'session-1',
+          role: 'assistant',
+          content: 'Persisted cancelled answer.',
+          timestamp: 4,
+          tool_calls: [],
+          content_blocks: [
+            { type: 'text', text: 'Persisted cancelled answer.' },
+          ],
+          cancelled: true,
+        },
+      ],
+    }
+
+    mockInvoke.mockImplementation((command: string) => {
+      if (command === 'list_pending_wakeups') return Promise.resolve([])
+      if (command === 'get_session') return Promise.resolve(hydratedSession)
+      return Promise.resolve(undefined)
+    })
+
+    queryClient.setQueryData(['chat', 'session', 'session-1'], {
+      id: 'session-1',
+      name: 'Test',
+      order: 0,
+      created_at: 1,
+      updated_at: 3,
+      messages: [
+        {
+          id: 'current-user',
+          session_id: 'session-1',
+          role: 'user',
+          content: 'already running',
+          timestamp: 3,
+          tool_calls: [],
+        },
+      ],
+    })
+
+    useChatStore.setState({
+      streamingContents: {},
+      streamingContentBlocks: {},
+      streamingThinkingContent: {},
+      activeToolCalls: {},
+      sendingSessionIds: { 'session-1': true },
+      sendStartedAt: { 'session-1': 1000 },
+      sessionWorktreeMap: { 'session-1': 'worktree-1' },
+      worktreePaths: { 'worktree-1': '/tmp/worktree' },
+      lastSentMessages: { 'session-1': 'already running' },
+      inputDrafts: { 'session-1': '' },
+    })
+
+    renderHook(() => useStreamingEvents({ queryClient }), { wrapper })
+
+    await waitFor(() =>
+      expect(registeredListeners.has('chat:cancelled')).toBe(true)
+    )
+
+    registeredListeners.get('chat:cancelled')?.({
+      payload: {
+        session_id: 'session-1',
+        worktree_id: 'worktree-1',
+        undo_send: false,
+        emitted_at_ms: 2000,
+        run_id: 'run-with-persisted-output',
+      },
+    })
+
+    expect(useChatStore.getState().inputDrafts['session-1']).toBe(
+      'already running'
+    )
+
+    await waitFor(() => {
+      const session = queryClient.getQueryData<{
+        messages: { id: string }[]
+      }>(['chat', 'session', 'session-1'])
+      expect(session?.messages.map(message => message.id)).toEqual([
+        'current-user',
+        'persisted-cancelled-assistant',
+      ])
+    })
+
+    expect(useChatStore.getState().inputDrafts['session-1'] ?? '').toBe('')
   })
 
   it('restores an instant-cancelled prompt while keeping prior history visible', async () => {

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -1929,12 +1929,14 @@ export default function useStreamingEvents({
         // Clear compacting state (safety net)
         useChatStore.getState().setCompacting(session_id, false)
 
-        // Restore message to input ONLY when the prompt never started
-        // (backend undo_send=true: process not registered / pending cancel).
-        // If the prompt is already running, do not restore even when no
-        // assistant content has streamed yet — cancel of a live run leaves
-        // the input empty. Also skip restore when queued messages exist
-        // ("Skip to Next").
+        // Restore message to input when the prompt never started
+        // (backend undo_send=true: process not registered / pending cancel),
+        // OR when a live run was cancelled before any assistant content
+        // streamed (!hasContent) — the backend hides such no-content cancelled
+        // runs from history (RunEntry::is_renderable_in_chat_history requires an
+        // assistant_message_id), so restoring the prompt matches backend truth.
+        // Skip restore when partial output exists (kept in history, marked
+        // cancelled) or when queued messages exist ("Skip to Next").
         const hasToolCalls = toolCalls && toolCalls.length > 0
         const hasText = sanitizedContent.trim().length > 0
         const hasThinking = !!streamingThinkingContent[session_id]
@@ -1945,7 +1947,8 @@ export default function useStreamingEvents({
         const hasQueuedMessages =
           (useChatStore.getState().messageQueues[session_id] ?? []).length > 0
         const shouldHydrateCancelledFromBackend = !undo_send && !hasContent
-        const shouldRestoreMessage = !hasQueuedMessages && undo_send
+        const shouldRestoreMessage =
+          !hasQueuedMessages && (undo_send || !hasContent)
 
         const removeLatestUserMessageFromCache = () => {
           queryClient.setQueryData<Session>(

--- a/src/components/chat/hooks/useStreamingEvents.ts
+++ b/src/components/chat/hooks/useStreamingEvents.ts
@@ -1949,6 +1949,7 @@ export default function useStreamingEvents({
         const shouldHydrateCancelledFromBackend = !undo_send && !hasContent
         const shouldRestoreMessage =
           !hasQueuedMessages && (undo_send || !hasContent)
+        let restoredDraft: string | null = null
 
         const removeLatestUserMessageFromCache = () => {
           queryClient.setQueryData<Session>(
@@ -2008,6 +2009,7 @@ export default function useStreamingEvents({
             // Only restore if input is empty (user hasn't typed new content)
             if (!currentDraft.trim()) {
               setInputDraft(session_id, lastMessage)
+              restoredDraft = lastMessage
               // Restore any attachments that were sent with the message
               useChatStore.getState().restoreAttachments(session_id)
               toast.info('Message restored to input')
@@ -2137,7 +2139,13 @@ export default function useStreamingEvents({
                   lastHydratedMessage.cancelled === true
                 const currentDraft =
                   useChatStore.getState().inputDrafts[session_id] ?? ''
-                if (hydratedCancelledAssistant && !currentDraft) {
+                // Backend kept the cancelled turn (frontend missed streamed
+                // output). Drop a composer restore that would duplicate the
+                // prompt, but keep a draft the user typed after cancelling.
+                if (
+                  hydratedCancelledAssistant &&
+                  (!currentDraft.trim() || currentDraft === restoredDraft)
+                ) {
                   useChatStore.getState().clearInputDraft(session_id)
                 }
               })


### PR DESCRIPTION
## Summary

- Restore the cancelled prompt to the composer when a live run is cancelled before any assistant content streams (`undo_send` **or** `!hasContent`).
- Backend hides those no-content cancelled runs (`RunEntry::is_renderable_in_chat_history` requires an `assistant_message_id`), so restoring the prompt matches persisted history.
- If `get_session` later hydrates a persisted cancelled turn, drop the restored draft so the prompt is not duplicated. Keep a draft the user typed after cancelling.
- Partial output still stays in history, marked cancelled. Queued “Skip to Next” messages still do not restore.

Originally proposed in https://github.com/coollabsio/jean/pull/726 (fork PR; maintainer edits were off, so this is the in-repo follow-up).

fixes https://github.com/coollabsio/jean/issues/725

## Test plan

- [ ] Send a message and cancel **before** any assistant text/thinking/tools: prompt returns to the composer; no empty cancelled turn in history.
- [ ] Cancel **after** partial output: history keeps the prompt + cancelled partial reply; input stays empty.
- [ ] `bun run test:run src/components/chat/hooks/useStreamingEvents.test.tsx`